### PR TITLE
LPD-16308 Use same logic to generate the description than used in MetaTagsTag.java

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/servlet/taglib/OpenGraphTopHeadDynamicInclude.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.KeyValuePair;
+import com.liferay.portal.kernel.util.ListMergeable;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -198,6 +199,23 @@ public class OpenGraphTopHeadDynamicInclude extends BaseDynamicInclude {
 				else {
 					description = layout.getDescription(
 						themeDisplay.getLocale());
+				}
+			}
+
+			ListMergeable<String> pageDescriptionListMergeable =
+				(ListMergeable<String>)httpServletRequest.getAttribute(
+					WebKeys.PAGE_DESCRIPTION);
+
+			if (pageDescriptionListMergeable != null) {
+				if (Validator.isNotNull(description)) {
+					description = StringBundler.concat(
+						pageDescriptionListMergeable.mergeToString(
+							StringPool.SPACE),
+						StringPool.PERIOD, StringPool.SPACE, description);
+				}
+				else {
+					description = pageDescriptionListMergeable.mergeToString(
+						StringPool.SPACE);
 				}
 			}
 


### PR DESCRIPTION
In some cases the meta tag and the og:description have different values since they are generated using different logic.

In this pull this is fixed and both cases call the same logic in order to set the value of both tags