### PR TITLE
LPD-17066 Reuse injected instead use Util or reInject

### DIFF
--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -53,7 +53,7 @@ public abstract class BaseDLAppTestCase {
 		targetGroup = GroupTestUtil.addGroup();
 
 		try {
-			_dlAppService.deleteFolder(
+			dlAppService.deleteFolder(
 				group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				"Test Folder");
 		}
@@ -63,7 +63,7 @@ public abstract class BaseDLAppTestCase {
 			}
 		}
 
-		parentFolder = _dlAppService.addFolder(
+		parentFolder = dlAppService.addFolder(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test Folder",
 			RandomTestUtil.randomString(),
@@ -93,7 +93,7 @@ public abstract class BaseDLAppTestCase {
 		BaseDLAppTestCase.class);
 
 	@Inject
-	protected DLAppService _dlAppService;
+	protected DLAppService dlAppService;
 
 	private String _name;
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -81,6 +81,9 @@ public abstract class BaseDLAppTestCase {
 		PrincipalThreadLocal.setName(_name);
 	}
 
+	@Inject
+	protected DLAppService dlAppService;
+
 	@DeleteAfterTestRun
 	protected Group group;
 
@@ -91,9 +94,6 @@ public abstract class BaseDLAppTestCase {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseDLAppTestCase.class);
-
-	@Inject
-	protected DLAppService dlAppService;
 
 	private String _name;
 

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/BaseDLAppTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseDLAppTestCase {
 		BaseDLAppTestCase.class);
 
 	@Inject
-	private DLAppService _dlAppService;
+	protected DLAppService _dlAppService;
 
 	private String _name;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -16,7 +16,6 @@ import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.lang.SafeCloseable;
@@ -94,7 +93,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
 
-		fileEntry = DLAppServiceUtil.getFileEntryByExternalReferenceCode(
+		fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
 			group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
@@ -116,7 +115,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
 
-		fileEntry = DLAppServiceUtil.getFileEntryByExternalReferenceCode(
+		fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
 			group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
@@ -327,7 +326,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldInferValidMimeType() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+		FileEntry fileEntry = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.APPLICATION_OCTET_STREAM, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, CONTENT.getBytes(), null, null,
@@ -393,7 +392,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullBytes() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		DLAppServiceUtil.addFileEntry(
+		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, (byte[])null, null, null,
@@ -404,7 +403,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullFile() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		DLAppServiceUtil.addFileEntry(
+		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, (File)null, null, null,
@@ -415,7 +414,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullInputStream() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		DLAppServiceUtil.addFileEntry(
+		_dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, null, 0, null, null,
@@ -486,7 +485,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		@Override
 		protected void doRun() throws Exception {
 			try {
-				FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+				FileEntry fileEntry = _dlAppService.getFileEntry(
 					_fileEntryIds[_index]);
 
 				InputStream inputStream = fileEntry.getContentStream();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -93,7 +93,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
 
-		fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
+		fileEntry = dlAppService.getFileEntryByExternalReferenceCode(
 			group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
@@ -115,7 +115,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
 
-		fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
+		fileEntry = dlAppService.getFileEntryByExternalReferenceCode(
 			group.getGroupId(), externalReferenceCode);
 
 		Assert.assertEquals(
@@ -326,7 +326,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldInferValidMimeType() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.APPLICATION_OCTET_STREAM, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, CONTENT.getBytes(), null, null,
@@ -392,7 +392,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullBytes() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, (byte[])null, null, null,
@@ -403,7 +403,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullFile() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, (File)null, null, null,
@@ -414,7 +414,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 	public void testShouldSucceedWithNullInputStream() throws Exception {
 		String fileName = RandomTestUtil.randomString();
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, null, 0, null, null,
@@ -485,7 +485,7 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		@Override
 		protected void doRun() throws Exception {
 			try {
-				FileEntry fileEntry = _dlAppService.getFileEntry(
+				FileEntry fileEntry = dlAppService.getFileEntry(
 					_fileEntryIds[_index]);
 
 				InputStream inputStream = fileEntry.getContentStream();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -38,7 +37,7 @@ public class DLAppServiceWhenAddingAFolderTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldAddAssetEntry() throws PortalException {
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFolderTest.java
@@ -37,7 +37,7 @@ public class DLAppServiceWhenAddingAFolderTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldAddAssetEntry() throws PortalException {
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
@@ -14,7 +14,6 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
@@ -69,7 +68,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-			DLAppServiceUtil.checkOutFileEntry(
+			_dlAppService.checkOutFileEntry(
 				fileEntry.getFileEntryId(), serviceContext);
 
 			Assert.assertEquals(
@@ -86,7 +85,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			DLAppServiceUtil.checkInFileEntry(
+			_dlAppService.checkInFileEntry(
 				fileEntry.getFileEntryId(), DLVersionNumberIncrease.MINOR,
 				RandomTestUtil.randomString(), serviceContext);
 
@@ -105,7 +104,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+		FileEntry fileEntry = _dlAppService.addFileEntry(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
@@ -117,10 +116,10 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 
 		Assert.assertEquals(0, dlFileEntry.getFileEntryTypeId());
 
-		DLAppServiceUtil.checkOutFileEntry(
+		_dlAppService.checkOutFileEntry(
 			fileEntry.getFileEntryId(), serviceContext);
 
-		FileEntry checkedOutFileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry checkedOutFileEntry = _dlAppService.getFileEntry(
 			fileEntry.getFileEntryId());
 
 		serviceContext.setAttribute(
@@ -133,7 +132,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			"fileEntryTypeId",
 			basicDocumentDLFileEntryType.getFileEntryTypeId());
 
-		FileEntry updatedFileEntry = DLAppServiceUtil.updateFileEntry(
+		FileEntry updatedFileEntry = _dlAppService.updateFileEntry(
 			checkedOutFileEntry.getFileEntryId(),
 			checkedOutFileEntry.getFileName(),
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
@@ -141,11 +140,11 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
 			null, null, serviceContext);
 
-		DLAppServiceUtil.checkInFileEntry(
+		_dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,
 			StringUtil.randomString(), serviceContext);
 
-		FileEntry checkedInFileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry checkedInFileEntry = _dlAppService.getFileEntry(
 			updatedFileEntry.getFileEntryId());
 
 		DLFileEntry checkedInDLFileEntry =
@@ -170,10 +169,10 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		DLAppServiceUtil.checkOutFileEntry(
+		_dlAppService.checkOutFileEntry(
 			fileEntry.getFileEntryId(), serviceContext);
 
-		FileEntry checkedOutFileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry checkedOutFileEntry = _dlAppService.getFileEntry(
 			fileEntry.getFileEntryId());
 
 		FileVersion latestFileVersion =
@@ -190,7 +189,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 
 		serviceContext.setAssetTagNames(new String[] {"tag3", "tag4"});
 
-		FileEntry updatedFileEntry = DLAppServiceUtil.updateFileEntry(
+		FileEntry updatedFileEntry = _dlAppService.updateFileEntry(
 			checkedOutFileEntry.getFileEntryId(),
 			checkedOutFileEntry.getFileName(),
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
@@ -198,11 +197,11 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
 			null, null, serviceContext);
 
-		DLAppServiceUtil.checkInFileEntry(
+		_dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,
 			StringUtil.randomString(), serviceContext);
 
-		FileEntry checkedInFileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry checkedInFileEntry = _dlAppService.getFileEntry(
 			updatedFileEntry.getFileEntryId());
 
 		FileVersion lastFileVersion = checkedInFileEntry.getFileVersion();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
@@ -68,7 +68,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-			_dlAppService.checkOutFileEntry(
+			dlAppService.checkOutFileEntry(
 				fileEntry.getFileEntryId(), serviceContext);
 
 			Assert.assertEquals(
@@ -85,7 +85,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			_dlAppService.checkInFileEntry(
+			dlAppService.checkInFileEntry(
 				fileEntry.getFileEntryId(), DLVersionNumberIncrease.MINOR,
 				RandomTestUtil.randomString(), serviceContext);
 
@@ -104,7 +104,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
@@ -116,10 +116,10 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 
 		Assert.assertEquals(0, dlFileEntry.getFileEntryTypeId());
 
-		_dlAppService.checkOutFileEntry(
+		dlAppService.checkOutFileEntry(
 			fileEntry.getFileEntryId(), serviceContext);
 
-		FileEntry checkedOutFileEntry = _dlAppService.getFileEntry(
+		FileEntry checkedOutFileEntry = dlAppService.getFileEntry(
 			fileEntry.getFileEntryId());
 
 		serviceContext.setAttribute(
@@ -132,7 +132,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			"fileEntryTypeId",
 			basicDocumentDLFileEntryType.getFileEntryTypeId());
 
-		FileEntry updatedFileEntry = _dlAppService.updateFileEntry(
+		FileEntry updatedFileEntry = dlAppService.updateFileEntry(
 			checkedOutFileEntry.getFileEntryId(),
 			checkedOutFileEntry.getFileName(),
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
@@ -140,11 +140,11 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
 			null, null, serviceContext);
 
-		_dlAppService.checkInFileEntry(
+		dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,
 			StringUtil.randomString(), serviceContext);
 
-		FileEntry checkedInFileEntry = _dlAppService.getFileEntry(
+		FileEntry checkedInFileEntry = dlAppService.getFileEntry(
 			updatedFileEntry.getFileEntryId());
 
 		DLFileEntry checkedInDLFileEntry =
@@ -169,10 +169,10 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		_dlAppService.checkOutFileEntry(
+		dlAppService.checkOutFileEntry(
 			fileEntry.getFileEntryId(), serviceContext);
 
-		FileEntry checkedOutFileEntry = _dlAppService.getFileEntry(
+		FileEntry checkedOutFileEntry = dlAppService.getFileEntry(
 			fileEntry.getFileEntryId());
 
 		FileVersion latestFileVersion =
@@ -189,7 +189,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 
 		serviceContext.setAssetTagNames(new String[] {"tag3", "tag4"});
 
-		FileEntry updatedFileEntry = _dlAppService.updateFileEntry(
+		FileEntry updatedFileEntry = dlAppService.updateFileEntry(
 			checkedOutFileEntry.getFileEntryId(),
 			checkedOutFileEntry.getFileName(),
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
@@ -197,11 +197,11 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
 			null, null, serviceContext);
 
-		_dlAppService.checkInFileEntry(
+		dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,
 			StringUtil.randomString(), serviceContext);
 
-		FileEntry checkedInFileEntry = _dlAppService.getFileEntry(
+		FileEntry checkedInFileEntry = dlAppService.getFileEntry(
 			updatedFileEntry.getFileEntryId());
 
 		FileVersion lastFileVersion = checkedInFileEntry.getFileVersion();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
@@ -155,7 +155,7 @@ public class DLAppServiceWhenCopyingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			sourceGroupId, sourceFolderId);
 
-		DLAppServiceUtil.copyFileEntry(
+		_dlAppService.copyFileEntry(
 			fileEntry.getFileEntryId(), targetFolderId, targetGroupId,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
@@ -155,7 +155,7 @@ public class DLAppServiceWhenCopyingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			sourceGroupId, sourceFolderId);
 
-		_dlAppService.copyFileEntry(
+		dlAppService.copyFileEntry(
 			fileEntry.getFileEntryId(), targetFolderId, targetGroupId,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileShortcutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileShortcutTest.java
@@ -8,7 +8,6 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -45,14 +44,14 @@ public class DLAppServiceWhenCopyingAFileShortcutTest
 		fileEntry = DLAppServiceTestUtil.addFileEntry(
 			parentFolder.getGroupId(), parentFolder.getFolderId());
 
-		newParentFolder = DLAppServiceUtil.addFolder(
+		newParentFolder = _dlAppService.addFolder(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "New Test Folder",
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
-		targetParentFolder = DLAppServiceUtil.addFolder(
+		targetParentFolder = _dlAppService.addFolder(
 			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Target Test Folder",
 			RandomTestUtil.randomString(),
@@ -160,11 +159,11 @@ public class DLAppServiceWhenCopyingAFileShortcutTest
 			long targetFolderId)
 		throws Exception {
 
-		FileShortcut fileShortcut = DLAppServiceUtil.addFileShortcut(
+		FileShortcut fileShortcut = _dlAppService.addFileShortcut(
 			sourceGroupId, sourceFolderId, fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(sourceGroupId));
 
-		DLAppServiceUtil.copyFileShortcut(
+		_dlAppService.copyFileShortcut(
 			fileShortcut.getFileShortcutId(), targetFolderId, targetGroupId,
 			ServiceContextTestUtil.getServiceContext(targetGroupId));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileShortcutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileShortcutTest.java
@@ -44,14 +44,14 @@ public class DLAppServiceWhenCopyingAFileShortcutTest
 		fileEntry = DLAppServiceTestUtil.addFileEntry(
 			parentFolder.getGroupId(), parentFolder.getFolderId());
 
-		newParentFolder = _dlAppService.addFolder(
+		newParentFolder = dlAppService.addFolder(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "New Test Folder",
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 
-		targetParentFolder = _dlAppService.addFolder(
+		targetParentFolder = dlAppService.addFolder(
 			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Target Test Folder",
 			RandomTestUtil.randomString(),
@@ -159,11 +159,11 @@ public class DLAppServiceWhenCopyingAFileShortcutTest
 			long targetFolderId)
 		throws Exception {
 
-		FileShortcut fileShortcut = _dlAppService.addFileShortcut(
+		FileShortcut fileShortcut = dlAppService.addFileShortcut(
 			sourceGroupId, sourceFolderId, fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(sourceGroupId));
 
-		_dlAppService.copyFileShortcut(
+		dlAppService.copyFileShortcut(
 			fileShortcut.getFileShortcutId(), targetFolderId, targetGroupId,
 			ServiceContextTestUtil.getServiceContext(targetGroupId));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
@@ -12,7 +12,6 @@ import com.liferay.document.library.kernel.exception.InvalidFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.string.StringPool;
@@ -60,7 +59,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-			Folder folder = DLAppServiceUtil.addFolder(
+			Folder folder = _dlAppService.addFolder(
 				null, group.getGroupId(), parentFolder.getFolderId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				serviceContext);
@@ -73,7 +72,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			DLAppServiceUtil.copyFolder(
+			_dlAppService.copyFolder(
 				folder.getRepositoryId(), folder.getFolderId(),
 				parentFolder.getParentFolderId(), folder.getName(),
 				folder.getDescription(), serviceContext);
@@ -93,7 +92,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		try {
-			DLAppServiceUtil.copyFolder(
+			_dlAppService.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
 				group.getGroupId(), parentFolder.getFolderId(), new HashMap<>(),
 				null, serviceContext);
@@ -122,12 +121,12 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		try {
-			DLAppServiceUtil.copyFolder(
+			_dlAppService.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
 				group.getGroupId(), folder.getFolderId(), new HashMap<>(), null,
 				serviceContext);
@@ -153,7 +152,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 	public void testShouldFailIfUsingSameNameAndDestinationIsParentFolder()
 		throws PortalException {
 
-		DLAppServiceUtil.copyFolder(
+		_dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
 			parentFolder.getParentFolderId(), new HashMap<>(), null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -168,7 +167,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 
 		_addFoldersAndFileEntries(fileNamesMap, serviceContext);
 
-		Folder folder = DLAppServiceUtil.copyFolder(
+		Folder folder = _dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, new HashMap<>(), null,
@@ -184,7 +183,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		throws Exception {
 
 		for (Map.Entry<String, List<String>> entry : fileNamesMap.entrySet()) {
-			Folder folder = DLAppServiceUtil.addFolder(
+			Folder folder = _dlAppService.addFolder(
 				null, group.getGroupId(), parentFolder.getFolderId(),
 				entry.getKey(), StringPool.BLANK, serviceContext);
 
@@ -220,11 +219,11 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 
 		Map<String, List<String>> fileNamesMap = new HashMap<>();
 
-		List<Folder> folders = DLAppServiceUtil.getFolders(
+		List<Folder> folders = _dlAppService.getFolders(
 			parentFolder.getRepositoryId(), parentFolder.getFolderId());
 
 		for (Folder folder : folders) {
-			List<FileEntry> fileEntries = DLAppServiceUtil.getFileEntries(
+			List<FileEntry> fileEntries = _dlAppService.getFileEntries(
 				parentFolder.getRepositoryId(), folder.getFolderId());
 
 			List<String> fileNames = new ArrayList<>();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFolderTest.java
@@ -59,7 +59,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-			Folder folder = _dlAppService.addFolder(
+			Folder folder = dlAppService.addFolder(
 				null, group.getGroupId(), parentFolder.getFolderId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				serviceContext);
@@ -72,7 +72,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			_dlAppService.copyFolder(
+			dlAppService.copyFolder(
 				folder.getRepositoryId(), folder.getFolderId(),
 				parentFolder.getParentFolderId(), folder.getName(),
 				folder.getDescription(), serviceContext);
@@ -92,7 +92,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		try {
-			_dlAppService.copyFolder(
+			dlAppService.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
 				group.getGroupId(), parentFolder.getFolderId(), new HashMap<>(),
 				null, serviceContext);
@@ -121,12 +121,12 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		try {
-			_dlAppService.copyFolder(
+			dlAppService.copyFolder(
 				group.getGroupId(), parentFolder.getFolderId(),
 				group.getGroupId(), folder.getFolderId(), new HashMap<>(), null,
 				serviceContext);
@@ -152,7 +152,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 	public void testShouldFailIfUsingSameNameAndDestinationIsParentFolder()
 		throws PortalException {
 
-		_dlAppService.copyFolder(
+		dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
 			parentFolder.getParentFolderId(), new HashMap<>(), null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -167,7 +167,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 
 		_addFoldersAndFileEntries(fileNamesMap, serviceContext);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, new HashMap<>(), null,
@@ -183,7 +183,7 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 		throws Exception {
 
 		for (Map.Entry<String, List<String>> entry : fileNamesMap.entrySet()) {
-			Folder folder = _dlAppService.addFolder(
+			Folder folder = dlAppService.addFolder(
 				null, group.getGroupId(), parentFolder.getFolderId(),
 				entry.getKey(), StringPool.BLANK, serviceContext);
 
@@ -219,11 +219,11 @@ public class DLAppServiceWhenCopyingAFolderTest extends BaseDLAppTestCase {
 
 		Map<String, List<String>> fileNamesMap = new HashMap<>();
 
-		List<Folder> folders = _dlAppService.getFolders(
+		List<Folder> folders = dlAppService.getFolders(
 			parentFolder.getRepositoryId(), parentFolder.getFolderId());
 
 		for (Folder folder : folders) {
-			List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+			List<FileEntry> fileEntries = dlAppService.getFileEntries(
 				parentFolder.getRepositoryId(), folder.getFolderId());
 
 			List<String> fileNames = new ArrayList<>();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
@@ -16,7 +16,6 @@ import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
@@ -679,9 +678,6 @@ public class
 				_assetTagLocalService.getTagNames(
 					className, fileEntry2.getFileEntryId())));
 	}
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	private AssetCategory _assetCategory;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithAssetCategoriesRatingsEntriesAndAssetTagsTest.java
@@ -77,13 +77,13 @@ public class
 
 		_childGroup = GroupTestUtil.addGroup(group.getGroupId());
 
-		_newParentFolder = _dlAppService.addFolder(
+		_newParentFolder = dlAppService.addFolder(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "New Test Folder",
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
-		_targetParentFolder = _dlAppService.addFolder(
+		_targetParentFolder = dlAppService.addFolder(
 			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Target Test Folder",
 			RandomTestUtil.randomString(),
@@ -101,7 +101,7 @@ public class
 		serviceContext.setAssetCategoryIds(
 			new long[] {_assetCategory.getCategoryId()});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -116,7 +116,7 @@ public class
 			_assetCategoryLocalService.getCategoryIds(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			_childGroup.getGroupId(),
@@ -141,7 +141,7 @@ public class
 		serviceContext.setAssetCategoryIds(
 			new long[] {_assetCategory.getCategoryId()});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -156,7 +156,7 @@ public class
 			_assetCategoryLocalService.getCategoryIds(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
 			_newParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
@@ -202,7 +202,7 @@ public class
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -228,7 +228,7 @@ public class
 
 		Assert.assertEquals(score, ratingsEntry1.getScore(), 0.1);
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
 			_newParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
@@ -258,7 +258,7 @@ public class
 		serviceContext.setAssetCategoryIds(
 			new long[] {_assetCategory.getCategoryId()});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -273,7 +273,7 @@ public class
 			_assetCategoryLocalService.getCategoryIds(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
 			_targetParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
@@ -319,21 +319,21 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			_childGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, new HashMap<>(),
 			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			_childGroup.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -369,20 +369,20 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
 			_newParentFolder.getFolderId(), new HashMap<>(),
 			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			group.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -411,7 +411,7 @@ public class
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
@@ -436,13 +436,13 @@ public class
 
 		Assert.assertEquals(score, ratingsEntry1.getScore(), 0.1);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
 			_newParentFolder.getFolderId(), new HashMap<>(),
 			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			group.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -484,7 +484,7 @@ public class
 
 		Assert.assertEquals(score, ratingsEntry1.getScore(), 0.1);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(), group.getGroupId(),
 			_newParentFolder.getFolderId(), new HashMap<>(),
 			new long[] {group.getGroupId()},
@@ -518,20 +518,20 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			ContentTypes.TEXT_PLAIN, DLAppServiceTestUtil.FILE_NAME,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			BaseDLAppTestCase.CONTENT.getBytes(), null, null, serviceContext);
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
 			new HashMap<>(), new long[] {targetGroup.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			targetGroup.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -564,7 +564,7 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -579,7 +579,7 @@ public class
 			_assetTagLocalService.getTagNames(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			_childGroup.getGroupId(),
@@ -607,7 +607,7 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -622,7 +622,7 @@ public class
 			_assetTagLocalService.getTagNames(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
 			_newParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
@@ -650,7 +650,7 @@ public class
 
 		serviceContext.setAssetTagNames(new String[] {assetTagName});
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
@@ -665,7 +665,7 @@ public class
 			_assetTagLocalService.getTagNames(
 				className, fileEntry1.getFileEntryId()));
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
 			_targetParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
@@ -13,7 +13,6 @@ import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
@@ -308,9 +307,6 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			StringPool.BLANK, BaseDLAppTestCase.CONTENT.getBytes(), null, null,
 			serviceContext);
 	}
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	@Inject
 	private static DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingWithDLFileEntryTypeTest.java
@@ -87,13 +87,13 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 
 		_childGroup = GroupTestUtil.addGroup(group.getGroupId());
 
-		_newParentFolder = _dlAppService.addFolder(
+		_newParentFolder = dlAppService.addFolder(
 			null, group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "New Test Folder",
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
-		_targetParentFolder = _dlAppService.addFolder(
+		_targetParentFolder = dlAppService.addFolder(
 			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Target Test Folder",
 			RandomTestUtil.randomString(),
@@ -114,7 +114,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			_dlFileEntryType.getFileEntryTypeId(),
 			dlFileEntry1.getFileEntryTypeId());
 
-		_dlAppService.copyFileEntry(
+		dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _targetParentFolder.getFolderId(),
 			_targetParentFolder.getGroupId(),
 			_dlFileEntryType.getFileEntryTypeId(),
@@ -136,7 +136,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			_dlFileEntryType.getFileEntryTypeId(),
 			dlFileEntry1.getFileEntryTypeId());
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			_childGroup.getGroupId(), _dlFileEntryType.getFileEntryTypeId(),
@@ -163,7 +163,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			_dlFileEntryType.getFileEntryTypeId(),
 			dlFileEntry1.getFileEntryTypeId());
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
 			_newParentFolder.getGroupId(),
 			_dlFileEntryType.getFileEntryTypeId(),
@@ -191,7 +191,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			_dlFileEntryType.getFileEntryTypeId(),
 			dlFileEntry1.getFileEntryTypeId());
 
-		FileEntry fileEntry2 = _dlAppService.copyFileEntry(
+		FileEntry fileEntry2 = dlAppService.copyFileEntry(
 			fileEntry1.getFileEntryId(), _newParentFolder.getFolderId(),
 			_newParentFolder.getGroupId(),
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
@@ -215,7 +215,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		_dlAppService.copyFolder(
+		dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
 			HashMapBuilder.put(
@@ -234,7 +234,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 
 		DLFileEntry dlFileEntry1 = (DLFileEntry)fileEntry1.getModel();
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			_childGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -244,7 +244,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(_childGroup.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			_childGroup.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -271,13 +271,13 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 			_dlFileEntryType.getFileEntryTypeId(),
 			dlFileEntry1.getFileEntryTypeId());
 
-		Folder folder = _dlAppService.copyFolder(
+		Folder folder = dlAppService.copyFolder(
 			group.getGroupId(), parentFolder.getFolderId(),
 			targetGroup.getGroupId(), _targetParentFolder.getFolderId(),
 			new HashMap<>(), new long[] {targetGroup.getGroupId()},
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		List<FileEntry> fileEntries = _dlAppService.getFileEntries(
+		List<FileEntry> fileEntries = dlAppService.getFileEntries(
 			targetGroup.getGroupId(), folder.getFolderId());
 
 		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
@@ -300,7 +300,7 @@ public class DLAppServiceWhenCopyingWithDLFileEntryTypeTest
 		serviceContext.setAttribute(
 			"fileEntryTypeId", _dlFileEntryType.getFileEntryTypeId());
 
-		return _dlAppService.addFileEntry(
+		return dlAppService.addFileEntry(
 			RandomTestUtil.randomString(), groupId, parentFolder,
 			DLAppServiceTestUtil.FILE_NAME, ContentTypes.TEXT_PLAIN,
 			DLAppServiceTestUtil.FILE_NAME, StringPool.BLANK, StringPool.BLANK,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFileEntryTest.java
@@ -8,7 +8,6 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -37,7 +36,7 @@ public class DLAppServiceWhenDeletingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		DLAppServiceUtil.deleteFileEntry(fileEntry.getFileEntryId());
+		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
 
 		Assert.assertFalse(
 			CommentManagerUtil.hasDiscussion(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFileEntryTest.java
@@ -36,7 +36,7 @@ public class DLAppServiceWhenDeletingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
+		dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
 
 		Assert.assertFalse(
 			CommentManagerUtil.hasDiscussion(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
@@ -6,7 +6,6 @@
 package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -38,33 +37,33 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 	public void testShouldDeleteImplicitlyTrashedChildFolder()
 		throws Exception {
 
-		int initialFoldersCount = DLAppServiceUtil.getFoldersCount(
+		int initialFoldersCount = _dlAppService.getFoldersCount(
 			group.getGroupId(), parentFolder.getFolderId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		DLAppServiceUtil.addFolder(
+		_dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		folder = DLAppServiceUtil.getFolder(folder.getFolderId());
+		folder = _dlAppService.getFolder(folder.getFolderId());
 
-		DLAppServiceUtil.deleteFolder(
+		_dlAppService.deleteFolder(
 			folder.getRepositoryId(), folder.getParentFolderId(),
 			folder.getName());
 
 		Assert.assertEquals(
 			initialFoldersCount,
-			DLAppServiceUtil.getFoldersCount(
+			_dlAppService.getFoldersCount(
 				group.getGroupId(), parentFolder.getFolderId()));
 	}
 
@@ -73,12 +72,12 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		Folder subfolder = DLAppServiceUtil.addFolder(
+		Folder subfolder = _dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -87,13 +86,13 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		folder = DLAppServiceUtil.getFolder(folder.getFolderId());
+		folder = _dlAppService.getFolder(folder.getFolderId());
 
-		DLAppServiceUtil.deleteFolder(
+		_dlAppService.deleteFolder(
 			folder.getRepositoryId(), folder.getParentFolderId(),
 			folder.getName());
 
-		DLAppServiceUtil.getFolder(subfolder.getFolderId());
+		_dlAppService.getFolder(subfolder.getFolderId());
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderByNameTest.java
@@ -37,33 +37,33 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 	public void testShouldDeleteImplicitlyTrashedChildFolder()
 		throws Exception {
 
-		int initialFoldersCount = _dlAppService.getFoldersCount(
+		int initialFoldersCount = dlAppService.getFoldersCount(
 			group.getGroupId(), parentFolder.getFolderId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		_dlAppService.addFolder(
+		dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		folder = _dlAppService.getFolder(folder.getFolderId());
+		folder = dlAppService.getFolder(folder.getFolderId());
 
-		_dlAppService.deleteFolder(
+		dlAppService.deleteFolder(
 			folder.getRepositoryId(), folder.getParentFolderId(),
 			folder.getName());
 
 		Assert.assertEquals(
 			initialFoldersCount,
-			_dlAppService.getFoldersCount(
+			dlAppService.getFoldersCount(
 				group.getGroupId(), parentFolder.getFolderId()));
 	}
 
@@ -72,12 +72,12 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		Folder subfolder = _dlAppService.addFolder(
+		Folder subfolder = dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -86,13 +86,13 @@ public class DLAppServiceWhenDeletingAFolderByNameTest
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		folder = _dlAppService.getFolder(folder.getFolderId());
+		folder = dlAppService.getFolder(folder.getFolderId());
 
-		_dlAppService.deleteFolder(
+		dlAppService.deleteFolder(
 			folder.getRepositoryId(), folder.getParentFolderId(),
 			folder.getName());
 
-		_dlAppService.getFolder(subfolder.getFolderId());
+		dlAppService.getFolder(subfolder.getFolderId());
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
@@ -6,7 +6,6 @@
 package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -37,29 +36,29 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 	public void testShouldDeleteImplicitlyTrashedChildFolder()
 		throws Exception {
 
-		int initialFoldersCount = DLAppServiceUtil.getFoldersCount(
+		int initialFoldersCount = _dlAppService.getFoldersCount(
 			group.getGroupId(), parentFolder.getFolderId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		DLAppServiceUtil.addFolder(
+		_dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		DLAppServiceUtil.deleteFolder(folder.getFolderId());
+		_dlAppService.deleteFolder(folder.getFolderId());
 
 		Assert.assertEquals(
 			initialFoldersCount,
-			DLAppServiceUtil.getFoldersCount(
+			_dlAppService.getFoldersCount(
 				group.getGroupId(), parentFolder.getFolderId()));
 	}
 
@@ -68,12 +67,12 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		Folder subfolder = DLAppServiceUtil.addFolder(
+		Folder subfolder = _dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -82,9 +81,9 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		DLAppServiceUtil.deleteFolder(folder.getFolderId());
+		_dlAppService.deleteFolder(folder.getFolderId());
 
-		DLAppServiceUtil.getFolder(subfolder.getFolderId());
+		_dlAppService.getFolder(subfolder.getFolderId());
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenDeletingAFolderTest.java
@@ -36,29 +36,29 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 	public void testShouldDeleteImplicitlyTrashedChildFolder()
 		throws Exception {
 
-		int initialFoldersCount = _dlAppService.getFoldersCount(
+		int initialFoldersCount = dlAppService.getFoldersCount(
 			group.getGroupId(), parentFolder.getFolderId());
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		_dlAppService.addFolder(
+		dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		_dlAppService.deleteFolder(folder.getFolderId());
+		dlAppService.deleteFolder(folder.getFolderId());
 
 		Assert.assertEquals(
 			initialFoldersCount,
-			_dlAppService.getFoldersCount(
+			dlAppService.getFoldersCount(
 				group.getGroupId(), parentFolder.getFolderId()));
 	}
 
@@ -67,12 +67,12 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
 
-		Folder subfolder = _dlAppService.addFolder(
+		Folder subfolder = dlAppService.addFolder(
 			null, group.getGroupId(), folder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -81,9 +81,9 @@ public class DLAppServiceWhenDeletingAFolderTest extends BaseDLAppTestCase {
 
 		DLTrashServiceUtil.moveFolderToTrash(folder.getFolderId());
 
-		_dlAppService.deleteFolder(folder.getFolderId());
+		dlAppService.deleteFolder(folder.getFolderId());
 
-		_dlAppService.getFolder(subfolder.getFolderId());
+		dlAppService.getFolder(subfolder.getFolderId());
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -35,7 +34,7 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 
 	@Test(expected = NoSuchFileEntryException.class)
 	public void testShouldFailIfNotPresentInRootFolder() throws Exception {
-		DLAppServiceUtil.getFileEntry(
+		_dlAppService.getFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString());
 	}
@@ -45,7 +44,7 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry1 = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-		FileEntry fileEntry2 = DLAppServiceUtil.getFileEntry(
+		FileEntry fileEntry2 = _dlAppService.getFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			fileEntry1.getTitle());
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenGettingAFileEntryTest.java
@@ -34,7 +34,7 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 
 	@Test(expected = NoSuchFileEntryException.class)
 	public void testShouldFailIfNotPresentInRootFolder() throws Exception {
-		_dlAppService.getFileEntry(
+		dlAppService.getFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString());
 	}
@@ -44,7 +44,7 @@ public class DLAppServiceWhenGettingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry1 = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-		FileEntry fileEntry2 = _dlAppService.getFileEntry(
+		FileEntry fileEntry2 = dlAppService.getFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			fileEntry1.getTitle());
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
@@ -8,7 +8,6 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -40,7 +39,7 @@ public class DLAppServiceWhenMovingAFileEntryTest extends BaseDLAppTestCase {
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 
-		FileEntry copiedFileEntry = DLAppServiceUtil.moveFileEntry(
+		FileEntry copiedFileEntry = _dlAppService.moveFileEntry(
 			fileEntry.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			ServiceContextTestUtil.getServiceContext(targetGroup.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryTest.java
@@ -39,7 +39,7 @@ public class DLAppServiceWhenMovingAFileEntryTest extends BaseDLAppTestCase {
 			parentFolder.getFolderId(), DLAppServiceTestUtil.FILE_NAME,
 			DLAppServiceTestUtil.STRIPPED_FILE_NAME, null, null, null);
 
-		FileEntry copiedFileEntry = _dlAppService.moveFileEntry(
+		FileEntry copiedFileEntry = dlAppService.moveFileEntry(
 			fileEntry.getFileEntryId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			ServiceContextTestUtil.getServiceContext(targetGroup.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryToTrashTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryToTrashTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -50,14 +49,14 @@ public class DLAppServiceWhenMovingAFileEntryToTrashTest
 	@After
 	@Override
 	public void tearDown() throws Exception {
-		DLAppServiceUtil.deleteFileEntry(_fileEntry.getFileEntryId());
+		_dlAppService.deleteFileEntry(_fileEntry.getFileEntryId());
 
 		super.tearDown();
 	}
 
 	@Test
 	public void testShouldCancelCheckout() throws Exception {
-		DLAppServiceUtil.checkOutFileEntry(
+		_dlAppService.checkOutFileEntry(
 			_fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -65,14 +64,14 @@ public class DLAppServiceWhenMovingAFileEntryToTrashTest
 
 		DLTrashServiceUtil.moveFileEntryToTrash(_fileEntry.getFileEntryId());
 
-		_fileEntry = DLAppServiceUtil.getFileEntry(_fileEntry.getFileEntryId());
+		_fileEntry = _dlAppService.getFileEntry(_fileEntry.getFileEntryId());
 
 		Assert.assertFalse(_fileEntry.isCheckedOut());
 	}
 
 	@Test
 	public void testShouldDeletePWCAssetEntry() throws Exception {
-		DLAppServiceUtil.checkOutFileEntry(
+		_dlAppService.checkOutFileEntry(
 			_fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryToTrashTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenMovingAFileEntryToTrashTest.java
@@ -49,14 +49,14 @@ public class DLAppServiceWhenMovingAFileEntryToTrashTest
 	@After
 	@Override
 	public void tearDown() throws Exception {
-		_dlAppService.deleteFileEntry(_fileEntry.getFileEntryId());
+		dlAppService.deleteFileEntry(_fileEntry.getFileEntryId());
 
 		super.tearDown();
 	}
 
 	@Test
 	public void testShouldCancelCheckout() throws Exception {
-		_dlAppService.checkOutFileEntry(
+		dlAppService.checkOutFileEntry(
 			_fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
@@ -64,14 +64,14 @@ public class DLAppServiceWhenMovingAFileEntryToTrashTest
 
 		DLTrashServiceUtil.moveFileEntryToTrash(_fileEntry.getFileEntryId());
 
-		_fileEntry = _dlAppService.getFileEntry(_fileEntry.getFileEntryId());
+		_fileEntry = dlAppService.getFileEntry(_fileEntry.getFileEntryId());
 
 		Assert.assertFalse(_fileEntry.isCheckedOut());
 	}
 
 	@Test
 	public void testShouldDeletePWCAssetEntry() throws Exception {
-		_dlAppService.checkOutFileEntry(
+		dlAppService.checkOutFileEntry(
 			_fileEntry.getFileEntryId(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
@@ -8,7 +8,6 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -62,7 +61,7 @@ public class DLAppServiceWhenRevertingAFileEntryTest extends BaseDLAppTestCase {
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			DLAppServiceUtil.revertFileEntry(
+			_dlAppService.revertFileEntry(
 				fileEntry.getFileEntryId(), version,
 				ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
@@ -61,7 +61,7 @@ public class DLAppServiceWhenRevertingAFileEntryTest extends BaseDLAppTestCase {
 				workflowHandlerInvocationCounter.getCount(
 					"updateStatus", Object.class, int.class, Map.class));
 
-			_dlAppService.revertFileEntry(
+			dlAppService.revertFileEntry(
 				fileEntry.getFileEntryId(), version,
 				ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -75,7 +74,7 @@ public class DLAppServiceWhenSearchingFileEntriesTest
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, description, changeLog,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
@@ -74,7 +74,7 @@ public class DLAppServiceWhenSearchingFileEntriesTest
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, description, changeLog,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -14,7 +14,6 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.string.StringPool;
@@ -73,7 +72,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		serviceContext.setAssetTagNames(assetTagNames);
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
@@ -120,7 +119,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		serviceContext.setAssetTagNames(assetTagNames);
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, null, 0, null, null, serviceContext);
@@ -162,7 +161,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
@@ -206,7 +205,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+		FileEntry fileEntry = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, null, 0, null, null,
@@ -222,7 +221,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 			byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-			DLAppServiceUtil.updateFileEntry(
+			_dlAppService.updateFileEntry(
 				fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				StringPool.BLANK, DLVersionNumberIncrease.MAJOR, bytes, null,
@@ -261,7 +260,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			group.getGroupId(), fileEntry.getFileEntryId(), fileName, null,
 			null, false);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.repeatByteArray(2),
@@ -280,7 +279,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, null, fileName,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
@@ -292,7 +291,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldSucceedForRootFolder() throws Exception {
-		DLAppServiceUtil.updateFolder(
+		_dlAppService.updateFolder(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -308,7 +307,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		DLAppServiceUtil.updateFileEntry(
+		_dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null,
@@ -325,7 +324,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		DLAppServiceUtil.updateFileEntry(
+		_dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (File)null, null, null,
@@ -342,7 +341,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		DLAppServiceUtil.updateFileEntry(
+		_dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, null, 0, null, null, serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -72,7 +72,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		serviceContext.setAssetTagNames(assetTagNames);
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
@@ -119,7 +119,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		serviceContext.setAssetTagNames(assetTagNames);
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, null, 0, null, null, serviceContext);
@@ -161,7 +161,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
@@ -205,7 +205,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
 			ContentTypes.TEXT_PLAIN, fileName, StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, null, 0, null, null,
@@ -221,7 +221,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 			byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-			_dlAppService.updateFileEntry(
+			dlAppService.updateFileEntry(
 				fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				StringPool.BLANK, DLVersionNumberIncrease.MAJOR, bytes, null,
@@ -260,7 +260,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			group.getGroupId(), fileEntry.getFileEntryId(), fileName, null,
 			null, false);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.repeatByteArray(2),
@@ -279,7 +279,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, null, fileName,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
@@ -291,7 +291,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldSucceedForRootFolder() throws Exception {
-		_dlAppService.updateFolder(
+		dlAppService.updateFolder(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -307,7 +307,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		_dlAppService.updateFileEntry(
+		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null,
@@ -324,7 +324,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		_dlAppService.updateFileEntry(
+		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (File)null, null, null,
@@ -341,7 +341,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		_dlAppService.updateFileEntry(
+		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, null, 0, null, null, serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
@@ -7,7 +7,6 @@ package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -33,7 +32,7 @@ public class DLAppServiceWhenUpdatingAFolderTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldSucceedForDefaultParentFolder() throws Exception {
-		DLAppServiceUtil.updateFolder(
+		_dlAppService.updateFolder(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFolderTest.java
@@ -32,7 +32,7 @@ public class DLAppServiceWhenUpdatingAFolderTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testShouldSucceedForDefaultParentFolder() throws Exception {
-		_dlAppService.updateFolder(
+		dlAppService.updateFolder(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
@@ -11,7 +11,6 @@ import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -45,7 +44,7 @@ public class DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		fileEntry = DLAppServiceUtil.updateFileEntryAndCheckIn(
+		fileEntry = _dlAppService.updateFileEntryAndCheckIn(
 			fileEntry.getFileEntryId(), fileEntry.getFileName(),
 			fileEntry.getMimeType(), fileEntry.getTitle(),
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
@@ -44,7 +44,7 @@ public class DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			group.getGroupId(), parentFolder.getFolderId());
 
-		fileEntry = _dlAppService.updateFileEntryAndCheckIn(
+		fileEntry = dlAppService.updateFileEntryAndCheckIn(
 			fileEntry.getFileEntryId(), fileEntry.getFileName(),
 			fileEntry.getMimeType(), fileEntry.getTitle(),
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
@@ -8,7 +8,6 @@ package com.liferay.document.library.app.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelReadCountComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
@@ -367,9 +366,6 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 	@Inject
 	private static ClassNameLocalService _classNameLocalService;
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	@Inject
 	private static UserLocalService _userLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenViewingFolderContentsTest.java
@@ -59,7 +59,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -67,7 +67,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -75,7 +75,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		Assert.assertEquals(
 			2,
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
 				group.getGroupId(), parentFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED, false));
 	}
@@ -85,7 +85,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -93,7 +93,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -106,7 +106,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 			Assert.assertEquals(
 				1,
-				_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+				dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
 					group.getGroupId(), parentFolder.getFolderId(),
 					WorkflowConstants.STATUS_APPROVED, false));
 		}
@@ -122,18 +122,18 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		Folder targetGroupFolder = _dlAppService.addFolder(
+		Folder targetGroupFolder = dlAppService.addFolder(
 			null, targetGroup.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(targetGroup.getGroupId()));
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, targetGroup.getGroupId(), targetGroupFolder.getFolderId(),
 			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			"title1", null, StringUtil.randomString(), StringPool.BLANK,
 			(byte[])null, null, null, serviceContext);
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, targetGroup.getGroupId(), targetGroupFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", null, StringUtil.randomString(), StringPool.BLANK,
@@ -141,7 +141,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		Assert.assertEquals(
 			0,
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
 				group.getGroupId(), targetGroupFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED,
 				ArrayUtil.toStringArray(DLUtil.getAllMediaGalleryMimeTypes()),
@@ -153,7 +153,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -161,7 +161,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -173,7 +173,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 				user)) {
 
 			List<Object> foldersAndFileEntriesAndFileShortcuts =
-				_dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
+				dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
 					group.getGroupId(), parentFolder.getFolderId(),
 					WorkflowConstants.STATUS_APPROVED, false, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS);
@@ -192,25 +192,25 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
 			"title1", null, StringUtil.randomString(), StringPool.BLANK,
 			(byte[])null, null, null, serviceContext);
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", null, StringUtil.randomString(), StringPool.BLANK,
 			(byte[])null, null, null, serviceContext);
 
-		_dlAppService.addFolder(
+		dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		Assert.assertEquals(
 			2,
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcutsCount(
 				group.getGroupId(), parentFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED,
 				ArrayUtil.toStringArray(DLUtil.getAllMediaGalleryMimeTypes()),
@@ -222,7 +222,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
@@ -230,14 +230,14 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		_dlAppService.addFileEntry(
+		dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), null, StringUtil.randomString(),
 			StringPool.BLANK, (byte[])null, null, null, serviceContext);
 
 		List<Object> foldersAndFileEntriesAndFileShortcuts =
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
 				group.getGroupId(), parentFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED, false, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);
@@ -254,7 +254,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		List<FileEntry> expectedFileEntries = new ArrayList<>();
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title1", null, StringUtil.randomString(), StringPool.BLANK,
@@ -265,7 +265,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 			_classNameLocalService.getClassNameId(DLFileEntry.class),
 			fileEntry1.getFileEntryId(), 2);
 
-		FileEntry fileEntry2 = _dlAppService.addFileEntry(
+		FileEntry fileEntry2 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", null, StringUtil.randomString(), StringPool.BLANK,
@@ -276,7 +276,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 			_classNameLocalService.getClassNameId(DLFileEntry.class),
 			fileEntry2.getFileEntryId(), 1);
 
-		FileEntry fileEntry3 = _dlAppService.addFileEntry(
+		FileEntry fileEntry3 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title3", null, StringUtil.randomString(), StringPool.BLANK,
@@ -292,7 +292,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		expectedFileEntries.add(fileEntry3);
 
 		List<Object> actualFoldersAndFileEntriesAndFileShortcuts =
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
 				group.getGroupId(), parentFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED, false, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS,
@@ -320,19 +320,19 @@ public class DLAppServiceWhenViewingFolderContentsTest
 
 		List<FileEntry> expectedFileEntries = new ArrayList<>();
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title2", null, StringUtil.randomString(), StringPool.BLANK,
 			(byte[])null, null, null, serviceContext);
 
-		FileEntry fileEntry2 = _dlAppService.addFileEntry(
+		FileEntry fileEntry2 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title1", null, StringUtil.randomString(), StringPool.BLANK,
 			(byte[])null, null, null, serviceContext);
 
-		FileEntry fileEntry3 = _dlAppService.addFileEntry(
+		FileEntry fileEntry3 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			"title3", null, StringUtil.randomString(), StringPool.BLANK,
@@ -343,7 +343,7 @@ public class DLAppServiceWhenViewingFolderContentsTest
 		expectedFileEntries.add(fileEntry3);
 
 		List<Object> actualFoldersAndFileEntriesAndFileShortcuts =
-			_dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
+			dlAppService.getFoldersAndFileEntriesAndFileShortcuts(
 				group.getGroupId(), parentFolder.getFolderId(),
 				WorkflowConstants.STATUS_APPROVED, false, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
@@ -7,7 +7,6 @@ package com.liferay.document.library.internal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLTrashService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
@@ -313,9 +312,6 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 
 		Assert.assertEquals("urltitle", friendlyURLEntry.getUrlTitle());
 	}
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	@Inject
 	private static FriendlyURLEntryLocalService _friendlyURLEntryLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
@@ -49,7 +49,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testAddFileEntryBytesAddsFriendlyURLEntry() throws Exception {
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
@@ -70,7 +70,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 	public void testAddFileEntryBytesAddsFriendlyURLEntryOnTrashUniqueURLTitle()
 		throws Exception {
 
-		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+		FileEntry fileEntry1 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
@@ -87,7 +87,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 
 		_dlTrashService.moveFileEntryToTrash(fileEntry1.getFileEntryId());
 
-		FileEntry fileEntry2 = _dlAppService.addFileEntry(
+		FileEntry fileEntry2 = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
@@ -105,7 +105,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testAddFileEntryFileAddsFriendlyURLEntry() throws Exception {
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
@@ -130,7 +130,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 	public void testAddFileEntryInputStreamAddsFriendlyURLEntry()
 		throws Exception {
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
@@ -160,14 +160,14 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, file, null, null,
 			serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntryAndCheckIn(
+		fileEntry = dlAppService.updateFileEntryAndCheckIn(
 			fileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
@@ -194,13 +194,13 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
 			StringPool.BLANK, inputStream, size, null, null, serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntryAndCheckIn(
+		fileEntry = dlAppService.updateFileEntryAndCheckIn(
 			fileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
@@ -225,14 +225,14 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, bytes, null, null,
 			serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
@@ -258,14 +258,14 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			StringUtil.randomString(), StringPool.BLANK, file, null, null,
 			serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
@@ -292,13 +292,13 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
 			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
 			StringPool.BLANK, inputStream, size, null, null, serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
@@ -643,9 +642,6 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 
 		Assert.assertEquals("url-title", mainFriendlyURLEntry.getUrlTitle());
 	}
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	@Inject
 	private static DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -130,7 +130,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 		Assert.assertNotNull(friendlyURLEntry1);
 		Assert.assertEquals("urltitle", friendlyURLEntry1.getUrlTitle());
 
-		Folder folder = _dlAppService.addFolder(
+		Folder folder = dlAppService.addFolder(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryService;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
@@ -111,9 +110,6 @@ public class FriendlyURLDLFileEntryServiceWrapperTest
 
 		Assert.assertEquals("urltitle", friendlyURLEntry.getUrlTitle());
 	}
-
-	@Inject
-	private static DLAppService _dlAppService;
 
 	@Inject
 	private static DLFileEntryService _dlFileEntryService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
@@ -10,7 +10,6 @@ import com.liferay.document.library.kernel.exception.DuplicateFileEntryException
 import com.liferay.document.library.kernel.exception.FileNameException;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
@@ -356,7 +355,7 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 			FileEntry fileEntry, String sourceFileName, String title)
 		throws Exception {
 
-		DLAppServiceUtil.updateFileEntry(
+		_dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), sourceFileName, ContentTypes.TEXT_PLAIN,
 			title, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
@@ -355,7 +355,7 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 			FileEntry fileEntry, String sourceFileName, String title)
 		throws Exception {
 
-		_dlAppService.updateFileEntry(
+		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), sourceFileName, ContentTypes.TEXT_PLAIN,
 			title, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
@@ -10,7 +10,6 @@ import com.liferay.document.library.kernel.exception.InvalidFileVersionException
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
@@ -101,7 +100,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 	protected void assertFileEntryTitle(String fileName)
 		throws PortalException {
 
-		FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry fileEntry = _dlAppService.getFileEntry(
 			_fileEntry.getFileEntryId());
 
 		Assert.assertEquals(fileName, fileEntry.getTitle());
@@ -121,8 +120,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 			String version, String fileName, boolean pwc)
 		throws PortalException {
 
-		DLAppServiceUtil.deleteFileVersion(
-			_fileEntry.getFileEntryId(), version);
+		_dlAppService.deleteFileVersion(_fileEntry.getFileEntryId(), version);
 
 		if (fileName != null) {
 			if (pwc) {
@@ -142,7 +140,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		long fileEntryId = _fileEntry.getFileEntryId();
 
 		if (versioned) {
-			DLAppServiceUtil.updateFileEntry(
+			_dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -152,10 +150,9 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 
 		if (leaveCheckedOut) {
-			DLAppServiceUtil.checkOutFileEntry(
-				fileEntryId, new ServiceContext());
+			_dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
 
-			DLAppServiceUtil.updateFileEntry(
+			_dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -238,7 +235,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 	protected void revertFileVersion(String version, String fileName)
 		throws PortalException {
 
-		DLAppServiceUtil.revertFileEntry(
+		_dlAppService.revertFileEntry(
 			_fileEntry.getFileEntryId(), version, new ServiceContext());
 
 		if (fileName != null) {
@@ -254,7 +251,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		long fileEntryId = _fileEntry.getFileEntryId();
 
 		if (versioned) {
-			DLAppServiceUtil.updateFileEntry(
+			_dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -264,10 +261,9 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 
 		if (leaveCheckedOut) {
-			DLAppServiceUtil.checkOutFileEntry(
-				fileEntryId, new ServiceContext());
+			_dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
 
-			DLAppServiceUtil.updateFileEntry(
+			_dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
@@ -100,7 +100,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 	protected void assertFileEntryTitle(String fileName)
 		throws PortalException {
 
-		FileEntry fileEntry = _dlAppService.getFileEntry(
+		FileEntry fileEntry = dlAppService.getFileEntry(
 			_fileEntry.getFileEntryId());
 
 		Assert.assertEquals(fileName, fileEntry.getTitle());
@@ -120,7 +120,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 			String version, String fileName, boolean pwc)
 		throws PortalException {
 
-		_dlAppService.deleteFileVersion(_fileEntry.getFileEntryId(), version);
+		dlAppService.deleteFileVersion(_fileEntry.getFileEntryId(), version);
 
 		if (fileName != null) {
 			if (pwc) {
@@ -140,7 +140,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		long fileEntryId = _fileEntry.getFileEntryId();
 
 		if (versioned) {
-			_dlAppService.updateFileEntry(
+			dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -150,9 +150,9 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 
 		if (leaveCheckedOut) {
-			_dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
+			dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
 
-			_dlAppService.updateFileEntry(
+			dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -235,7 +235,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 	protected void revertFileVersion(String version, String fileName)
 		throws PortalException {
 
-		_dlAppService.revertFileEntry(
+		dlAppService.revertFileEntry(
 			_fileEntry.getFileEntryId(), version, new ServiceContext());
 
 		if (fileName != null) {
@@ -251,7 +251,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		long fileEntryId = _fileEntry.getFileEntryId();
 
 		if (versioned) {
-			_dlAppService.updateFileEntry(
+			dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
@@ -261,9 +261,9 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 
 		if (leaveCheckedOut) {
-			_dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
+			dlAppService.checkOutFileEntry(fileEntryId, new ServiceContext());
 
-			_dlAppService.updateFileEntry(
+			dlAppService.updateFileEntry(
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
@@ -7,7 +7,6 @@ package com.liferay.document.library.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -78,12 +77,12 @@ public class DLFileVersionUpdateTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+		FileEntry fileEntry = _dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), addFileName,
 			addMimeType, addFileName, null, description, changeLog, addBytes,
 			null, null, serviceContext);
 
-		fileEntry = DLAppServiceUtil.updateFileEntry(
+		fileEntry = _dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), updateFileName, updateMimeType,
 			updateFileName, null, description, changeLog,
 			DLVersionNumberIncrease.MINOR, updateBytes, new Date(), new Date(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
@@ -77,12 +77,12 @@ public class DLFileVersionUpdateTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(), addFileName,
 			addMimeType, addFileName, null, description, changeLog, addBytes,
 			null, null, serviceContext);
 
-		fileEntry = _dlAppService.updateFileEntry(
+		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), updateFileName, updateMimeType,
 			updateFileName, null, description, changeLog,
 			DLVersionNumberIncrease.MINOR, updateBytes, new Date(), new Date(),


### PR DESCRIPTION
When doing the displayDate task I realized that some of the test were failing on my local (NPE on the injected class) and were extension of a base class that have an injected class that can be reused