### PR TITLE
LPD-16053 

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/search_resources.jsp
@@ -157,8 +157,6 @@ entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletRespons
 															%>
 
 															<%= rowChecker.getRowCheckBox(request, row) %>
-
-															<span class="custom-control-label"></span>
 														</c:if>
 
 														<c:choose>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -102,8 +102,6 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 
 													<%= rowChecker.getRowCheckBox(request, row) %>
 
-													<span class="custom-control-label"></span>
-
 													<c:choose>
 														<c:when test="<%= dlViewFileVersionDisplayContext.hasCustomThumbnail() %>">
 


### PR DESCRIPTION
# Issue: https://liferay.atlassian.net/browse/LPD-16053

After the [LPS-199447](https://liferay.atlassian.net/browse/LPD-1753) fix, custom checkbox markup is duplicated

## How to test it
1. Navigate to DM admin
2. Upload some files
3. Reload
4. Try to select them

## Before this PR
Checkbox on file cards never `checked` 😢 :

### DM
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/70280c0c-1c8e-4bbf-9a5a-36ac215c799d)

### DM Seach
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/b2fc4cac-3718-42f5-aa5c-3d294e579681)

### Asset Library > DM
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/cad24998-8aee-4e42-8500-ce6908ae6cc2)

## After this PR
Checkbox works correctly

### DM
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/b97f4fa3-d17f-4eb4-9c43-9b7fd7fa3e2c)

### DM Seach
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/cc4faf4d-1847-4b29-b6ab-84fa0c1bbab2)

### Asset Library > DM
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/a2cc663a-0bda-4588-8a50-50cc5e71a955)
