### PR TITLE
LPD-16993 Modify updateFile methods to propage the new field 

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library/src/main/java/com/liferay/adaptive/media/document/library/internal/service/AMDLAppServiceWrapper.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library/src/main/java/com/liferay/adaptive/media/document/library/internal/service/AMDLAppServiceWrapper.java
@@ -33,14 +33,15 @@ public class AMDLAppServiceWrapper extends DLAppServiceWrapper {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		return AMCleanUpOnUpdateAndCheckInThreadLocal.enable(
 			() -> super.updateFileEntryAndCheckIn(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext));
+				displayDate, expirationDate, reviewDate, serviceContext));
 	}
 
 	@Override
@@ -48,15 +49,15 @@ public class AMDLAppServiceWrapper extends DLAppServiceWrapper {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return AMCleanUpOnUpdateAndCheckInThreadLocal.enable(
 			() -> super.updateFileEntryAndCheckIn(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, inputStream,
-				size, expirationDate, reviewDate, serviceContext));
+				size, displayDate, expirationDate, reviewDate, serviceContext));
 	}
 
 	@Reference

--- a/modules/apps/archived/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
+++ b/modules/apps/archived/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/util/FileSystemImporter.java
@@ -765,8 +765,8 @@ public class FileSystemImporter extends BaseImporter {
 					mimeTypes.getContentType(fileName), fileName,
 					StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 					DLVersionNumberIncrease.MAJOR, inputStream, length,
-					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-					serviceContext);
+					fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+					fileEntry.getReviewDate(), serviceContext);
 
 				dlFileEntryLocalService.deleteFileVersion(
 					fileEntry.getUserId(), fileEntry.getFileEntryId(),

--- a/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/internal/test/AssetAutoTaggerTest.java
+++ b/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/internal/test/AssetAutoTaggerTest.java
@@ -84,8 +84,8 @@ public class AssetAutoTaggerTest extends BaseAssetAutoTaggerTestCase {
 			StringUtil.randomString(), fileEntry.getDescription(),
 			RandomTestUtil.randomString(), DLVersionNumberIncrease.MAJOR,
 			fileEntry.getContentStream(), fileEntry.getSize(),
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), serviceContext);
 
 		AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());

--- a/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/test/BaseAssetAutoTaggerTestCase.java
+++ b/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/test/BaseAssetAutoTaggerTestCase.java
@@ -153,7 +153,7 @@ public abstract class BaseAssetAutoTaggerTestCase {
 			fileEntry.getFileEntryId(), fileEntry.getFileName(), null,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			DLVersionNumberIncrease.AUTOMATIC, new byte[0], null, null,
+			DLVersionNumberIncrease.AUTOMATIC, new byte[0], null, null, null,
 			serviceContext);
 
 		return AssetEntryLocalServiceUtil.getEntry(

--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/action/EditCommerceChannelMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/action/EditCommerceChannelMVCActionCommand.java
@@ -439,7 +439,7 @@ public class EditCommerceChannelMVCActionCommand
 				existingFileEntry.getTitle(), StringPool.BLANK,
 				existingFileEntry.getDescription(), StringPool.BLANK,
 				DLVersionNumberIncrease.NONE, newFileEntry.getContentStream(),
-				newFileEntry.getSize(), null, null, new ServiceContext());
+				newFileEntry.getSize(), null, null, null, new ServiceContext());
 		}
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/test/RevertFileVersionContentDashboardItemVersionActionProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/action/provider/test/RevertFileVersionContentDashboardItemVersionActionProviderTest.java
@@ -237,8 +237,9 @@ public class RevertFileVersionContentDashboardItemVersionActionProviderTest {
 					fileEntry.getTitle(), StringUtil.randomString(),
 					fileEntry.getDescription(), RandomTestUtil.randomString(),
 					DLVersionNumberIncrease.MINOR, fileEntry.getContentStream(),
-					fileEntry.getSize(), fileEntry.getExpirationDate(),
-					fileEntry.getReviewDate(), serviceContext);
+					fileEntry.getSize(), fileEntry.getDisplayDate(),
+					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+					serviceContext);
 			}
 		}
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -667,8 +667,9 @@ public class FileEntryContentDashboardItemTest {
 					fileEntry.getTitle(), StringUtil.randomString(),
 					fileEntry.getDescription(), RandomTestUtil.randomString(),
 					DLVersionNumberIncrease.MINOR, fileEntry.getContentStream(),
-					fileEntry.getSize(), fileEntry.getExpirationDate(),
-					fileEntry.getReviewDate(), _serviceContext);
+					fileEntry.getSize(), fileEntry.getDisplayDate(),
+					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+					_serviceContext);
 			}
 		}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryFileEntryFriendlyURLTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/staging/test/DepotEntryFileEntryFriendlyURLTest.java
@@ -229,7 +229,7 @@ public class DepotEntryFileEntryFriendlyURLTest {
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "modifiedurltitle",
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			(byte[])null, null, null, serviceContext);
+			(byte[])null, null, null, null, serviceContext);
 
 		friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/service/DLOpenerGoogleDriveDLAppServiceWrapper.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/service/DLOpenerGoogleDriveDLAppServiceWrapper.java
@@ -157,7 +157,8 @@ public class DLOpenerGoogleDriveDLAppServiceWrapper
 				fileEntry.getFileEntryId(), sourceFileName,
 				fileEntry.getMimeType(), title, StringPool.BLANK,
 				fileEntry.getDescription(), StringPool.BLANK,
-				DLVersionNumberIncrease.NONE, file, null, null, serviceContext);
+				DLVersionNumberIncrease.NONE, file, null, null, null,
+				serviceContext);
 		}
 		finally {
 			if ((file != null) && !file.delete()) {

--- a/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/BaseCmisRepository.java
+++ b/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/BaseCmisRepository.java
@@ -49,7 +49,8 @@ public abstract class BaseCmisRepository extends BaseRepositoryImpl {
 	public abstract FileEntry updateFileEntry(
 			String objectId, String mimeType, Map<String, Object> properties,
 			InputStream inputStream, String sourceFileName, long size,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/CMISRepositoryHandler.java
+++ b/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/CMISRepositoryHandler.java
@@ -557,14 +557,14 @@ public abstract class CMISRepositoryHandler
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return _baseCmisRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	public FileEntry updateFileEntry(

--- a/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/CMISRepositoryHandler.java
+++ b/modules/apps/document-library/document-library-repository-cmis-api/src/main/java/com/liferay/document/library/repository/cmis/CMISRepositoryHandler.java
@@ -570,12 +570,13 @@ public abstract class CMISRepositoryHandler
 	public FileEntry updateFileEntry(
 			String objectId, String mimeType, Map<String, Object> properties,
 			InputStream inputStream, String sourceFileName, long size,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		return _baseCmisRepository.updateFileEntry(
 			objectId, mimeType, properties, inputStream, sourceFileName, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/CMISRepository.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/CMISRepository.java
@@ -1395,7 +1395,8 @@ public class CMISRepository extends BaseCmisRepository {
 	public FileEntry updateFileEntry(
 			String objectId, String mimeType, Map<String, Object> properties,
 			InputStream inputStream, String sourceFileName, long size,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		try {

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/CMISRepository.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/CMISRepository.java
@@ -1182,7 +1182,7 @@ public class CMISRepository extends BaseCmisRepository {
 				userId, fileEntryId, contentStream.getFileName(), mimeType,
 				title, StringPool.BLANK, StringPool.BLANK, changeLog,
 				DLVersionNumberIncrease.MAJOR, contentStream.getStream(),
-				contentStream.getLength(), null, null, serviceContext);
+				contentStream.getLength(), null, null, null, serviceContext);
 		}
 		catch (PortalException | SystemException exception) {
 			throw exception;
@@ -1290,8 +1290,8 @@ public class CMISRepository extends BaseCmisRepository {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		Document document = null;

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/RepositoryProxyBean.java
@@ -670,13 +670,13 @@ public class RepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
@@ -687,14 +687,14 @@ public class RepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
 	}

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/ExtRepositoryAdapter.java
@@ -1014,8 +1014,8 @@ public class ExtRepositoryAdapter extends BaseRepositoryImpl {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		boolean needsCheckIn = false;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/FileEntryStagedModelDataHandler.java
@@ -571,6 +571,7 @@ public class FileEntryStagedModelDataHandler
 									fileEntry.getDescription(), null,
 									DLVersionNumberIncrease.MINOR, inputStream,
 									fileEntry.getSize(),
+									fileEntry.getDisplayDate(),
 									fileEntry.getExpirationDate(),
 									fileEntry.getReviewDate(), serviceContext);
 						}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayVersioningCapability.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/LiferayVersioningCapability.java
@@ -76,6 +76,26 @@ public class LiferayVersioningCapability
 					String mimeType, String title, String urlTitle,
 					String description, String changeLog,
 					DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+					Date displayDate, Date expirationDate, Date reviewDate,
+					ServiceContext serviceContext)
+				throws PortalException {
+
+				return _purgeVersions(
+					dlAppServiceAdapter,
+					super.updateFileEntry(
+						userId, fileEntryId, sourceFileName, mimeType, title,
+						urlTitle, description, changeLog,
+						dlVersionNumberIncrease, file, displayDate,
+						expirationDate, reviewDate, serviceContext));
+			}
+
+			@Override
+			public FileEntry updateFileEntry(
+					long userId, long fileEntryId, String sourceFileName,
+					String mimeType, String title, String urlTitle,
+					String description, String changeLog,
+					DLVersionNumberIncrease dlVersionNumberIncrease,
+					InputStream inputStream, long size, Date displayDate,
 					Date expirationDate, Date reviewDate,
 					ServiceContext serviceContext)
 				throws PortalException {
@@ -85,26 +105,7 @@ public class LiferayVersioningCapability
 					super.updateFileEntry(
 						userId, fileEntryId, sourceFileName, mimeType, title,
 						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, file, expirationDate,
-						reviewDate, serviceContext));
-			}
-
-			@Override
-			public FileEntry updateFileEntry(
-					long userId, long fileEntryId, String sourceFileName,
-					String mimeType, String title, String urlTitle,
-					String description, String changeLog,
-					DLVersionNumberIncrease dlVersionNumberIncrease,
-					InputStream inputStream, long size, Date expirationDate,
-					Date reviewDate, ServiceContext serviceContext)
-				throws PortalException {
-
-				return _purgeVersions(
-					dlAppServiceAdapter,
-					super.updateFileEntry(
-						userId, fileEntryId, sourceFileName, mimeType, title,
-						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, inputStream, size,
+						dlVersionNumberIncrease, inputStream, size, displayDate,
 						expirationDate, reviewDate, serviceContext));
 			}
 
@@ -139,6 +140,26 @@ public class LiferayVersioningCapability
 					String mimeType, String title, String urlTitle,
 					String description, String changeLog,
 					DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+					Date displayDate, Date expirationDate, Date reviewDate,
+					ServiceContext serviceContext)
+				throws PortalException {
+
+				return _purgeVersions(
+					dlAppServiceAdapter,
+					super.updateFileEntry(
+						userId, fileEntryId, sourceFileName, mimeType, title,
+						urlTitle, description, changeLog,
+						dlVersionNumberIncrease, file, displayDate,
+						expirationDate, reviewDate, serviceContext));
+			}
+
+			@Override
+			public FileEntry updateFileEntry(
+					long userId, long fileEntryId, String sourceFileName,
+					String mimeType, String title, String urlTitle,
+					String description, String changeLog,
+					DLVersionNumberIncrease dlVersionNumberIncrease,
+					InputStream inputStream, long size, Date displayDate,
 					Date expirationDate, Date reviewDate,
 					ServiceContext serviceContext)
 				throws PortalException {
@@ -148,26 +169,7 @@ public class LiferayVersioningCapability
 					super.updateFileEntry(
 						userId, fileEntryId, sourceFileName, mimeType, title,
 						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, file, expirationDate,
-						reviewDate, serviceContext));
-			}
-
-			@Override
-			public FileEntry updateFileEntry(
-					long userId, long fileEntryId, String sourceFileName,
-					String mimeType, String title, String urlTitle,
-					String description, String changeLog,
-					DLVersionNumberIncrease dlVersionNumberIncrease,
-					InputStream inputStream, long size, Date expirationDate,
-					Date reviewDate, ServiceContext serviceContext)
-				throws PortalException {
-
-				return _purgeVersions(
-					dlAppServiceAdapter,
-					super.updateFileEntry(
-						userId, fileEntryId, sourceFileName, mimeType, title,
-						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, inputStream, size,
+						dlVersionNumberIncrease, inputStream, size, displayDate,
 						expirationDate, reviewDate, serviceContext));
 			}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/FriendlyURLDLFileEntryLocalServiceWrapper.java
@@ -84,15 +84,15 @@ public class FriendlyURLDLFileEntryLocalServiceWrapper
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
-			File file, InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			File file, InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		DLFileEntry dlFileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 
 		if (!ExportImportThreadLocal.isImportInProcess()) {
 			_updateFriendlyURL(dlFileEntry, title, urlTitle);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppLocalServiceWrapper.java
@@ -176,45 +176,7 @@ public class SubscriptionDLAppLocalServiceWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			byte[] bytes, Date expirationDate, Date reviewDate,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		serviceContext.setAttribute(
-			"hasAssetDisplayPage",
-			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
-
-		return super.updateFileEntry(
-			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, bytes,
-			expirationDate, reviewDate, serviceContext);
-	}
-
-	@Override
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String urlTitle, String description,
-			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		serviceContext.setAttribute(
-			"hasAssetDisplayPage",
-			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
-
-		return super.updateFileEntry(
-			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
-			expirationDate, reviewDate, serviceContext);
-	}
-
-	@Override
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String urlTitle, String description,
-			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
+			byte[] bytes, Date displayDate, Date expirationDate,
 			Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -224,8 +186,46 @@ public class SubscriptionDLAppLocalServiceWrapper
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, inputStream, size,
+			description, changeLog, dlVersionNumberIncrease, bytes, displayDate,
 			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String urlTitle, String description,
+			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String urlTitle, String description,
+			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
+			description, changeLog, dlVersionNumberIncrease, inputStream, size,
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/SubscriptionDLAppServiceWrapper.java
@@ -88,7 +88,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, byte[] bytes,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		serviceContext.setAttribute(
@@ -97,8 +98,8 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, bytes, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, bytes, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override
@@ -106,6 +107,26 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"hasAssetDisplayPage",
+			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
+			changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String urlTitle, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease,
+			InputStream inputStream, long size, Date displayDate,
 			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -115,26 +136,7 @@ public class SubscriptionDLAppServiceWrapper extends DLAppServiceWrapper {
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, file, expirationDate,
-			reviewDate, serviceContext);
-	}
-
-	@Override
-	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String urlTitle, String description, String changeLog,
-			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
-		throws PortalException {
-
-		serviceContext.setAttribute(
-			"hasAssetDisplayPage",
-			DLAssetDisplayPageUtil.hasAssetDisplayPage(serviceContext));
-
-		return super.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -131,6 +131,7 @@ public class RepositoryBrowserServlet extends HttpServlet {
 				_dlAppService.updateFileEntry(
 					fileEntryId, null, null, name, null, null, null,
 					DLVersionNumberIncrease.NONE, (byte[])null, null, null,
+					null,
 					ServiceContextFactory.getInstance(
 						FileEntry.class.getName(), httpServletRequest));
 			}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCheckingInAFileEntryTest.java
@@ -78,7 +78,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 
 			DLAppServiceTestUtil.updateFileEntry(
 				group.getGroupId(), fileEntry.getFileEntryId(),
-				RandomTestUtil.randomString(), null, null, true);
+				RandomTestUtil.randomString(), null, null, null, true);
 
 			Assert.assertEquals(
 				1,
@@ -138,7 +138,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
 			StringPool.BLANK, checkedOutFileEntry.getDescription(),
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 
 		dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,
@@ -195,7 +195,7 @@ public class DLAppServiceWhenCheckingInAFileEntryTest
 			checkedOutFileEntry.getMimeType(), checkedOutFileEntry.getTitle(),
 			StringPool.BLANK, checkedOutFileEntry.getDescription(),
 			StringUtil.randomString(), DLVersionNumberIncrease.NONE, null, 0,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 
 		dlAppService.checkInFileEntry(
 			updatedFileEntry.getFileEntryId(), DLVersionNumberIncrease.NONE,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenRevertingAFileEntryTest.java
@@ -54,7 +54,7 @@ public class DLAppServiceWhenRevertingAFileEntryTest extends BaseDLAppTestCase {
 
 			DLAppServiceTestUtil.updateFileEntry(
 				group.getGroupId(), fileEntry.getFileEntryId(),
-				RandomTestUtil.randomString(), null, null, true);
+				RandomTestUtil.randomString(), null, null, null, true);
 
 			Assert.assertEquals(
 				2,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenSearchingFileEntriesTest.java
@@ -77,7 +77,8 @@ public class DLAppServiceWhenSearchingFileEntriesTest
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, description, changeLog,
-			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
+			DLVersionNumberIncrease.MINOR, bytes, null, null, null,
+			serviceContext);
 
 		DLAppServiceTestUtil.search(fileEntry, "hello", true);
 		DLAppServiceTestUtil.search(fileEntry, "world", true);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -75,7 +75,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
+			DLVersionNumberIncrease.MINOR, bytes, null, null, null,
+			serviceContext);
 
 		FileVersion fileVersion = fileEntry.getLatestFileVersion();
 
@@ -122,7 +123,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MINOR, null, 0, null, null, serviceContext);
+			DLVersionNumberIncrease.MINOR, null, 0, null, null, null,
+			serviceContext);
 
 		FileVersion fileVersion = fileEntry.getLatestFileVersion();
 
@@ -164,7 +166,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MINOR, bytes, null, null, serviceContext);
+			DLVersionNumberIncrease.MINOR, bytes, null, null, null,
+			serviceContext);
 
 		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
@@ -189,7 +192,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 			DLAppServiceTestUtil.updateFileEntry(
 				group.getGroupId(), fileEntry.getFileEntryId(),
-				RandomTestUtil.randomString(), null, null, true);
+				RandomTestUtil.randomString(), null, null, null, true);
 
 			Assert.assertEquals(
 				2,
@@ -225,7 +228,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 				fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				StringPool.BLANK, DLVersionNumberIncrease.MAJOR, bytes, null,
-				null, serviceContext);
+				null, null, serviceContext);
 		}
 	}
 
@@ -238,11 +241,11 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		fileEntry = DLAppServiceTestUtil.updateFileEntry(
 			group.getGroupId(), fileEntry.getFileEntryId(), fileName, null,
-			null, true);
+			null, null, true);
 
 		fileEntry = DLAppServiceTestUtil.updateFileEntry(
 			group.getGroupId(), fileEntry.getFileEntryId(), fileName, null,
-			null, true);
+			null, null, true);
 
 		Assert.assertEquals(
 			"Version label incorrect after major update", "3.0",
@@ -258,13 +261,13 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		fileEntry = DLAppServiceTestUtil.updateFileEntry(
 			group.getGroupId(), fileEntry.getFileEntryId(), fileName, null,
-			null, false);
+			null, null, false);
 
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.repeatByteArray(2),
-			null, null,
+			null, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		Assert.assertEquals(
@@ -283,7 +286,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			fileEntry.getFileEntryId(), fileName, null, fileName,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		Assert.assertEquals(ContentTypes.TEXT_PLAIN, fileEntry.getMimeType());
@@ -310,7 +314,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null,
+			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null, null,
 			serviceContext);
 	}
 
@@ -327,7 +331,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MAJOR, (File)null, null, null,
+			DLVersionNumberIncrease.MAJOR, (File)null, null, null, null,
 			serviceContext);
 	}
 
@@ -344,7 +348,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
 			fileName, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MAJOR, null, 0, null, null, serviceContext);
+			DLVersionNumberIncrease.MAJOR, null, 0, null, null, null,
+			serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.io.File;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -173,6 +174,84 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		AssertUtils.assertEqualsSorted(assetTagNames, assetEntry.getTagNames());
+	}
+
+	@Test
+	public void testFileEntryShouldUpdateDisplayDate() throws Exception {
+		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, null, null);
+
+		Assert.assertNull(fileEntry.getDisplayDate());
+		Assert.assertNull(fileEntry.getExpirationDate());
+		Assert.assertNull(fileEntry.getReviewDate());
+
+		Date displayDate = new Date();
+
+		fileEntry = dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
+			displayDate, fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertEquals(displayDate, fileEntry.getDisplayDate());
+		Assert.assertNull(fileEntry.getExpirationDate());
+		Assert.assertNull(fileEntry.getReviewDate());
+	}
+
+	@Test
+	public void testFileEntryShouldUpdateExpirationDate() throws Exception {
+		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, null, null);
+
+		Assert.assertNull(fileEntry.getDisplayDate());
+		Assert.assertNull(fileEntry.getExpirationDate());
+		Assert.assertNull(fileEntry.getReviewDate());
+
+		Date expirationDate = new Date();
+
+		fileEntry = dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
+			fileEntry.getDisplayDate(), expirationDate,
+			fileEntry.getReviewDate(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertNull(fileEntry.getDisplayDate());
+		Assert.assertEquals(expirationDate, fileEntry.getExpirationDate());
+		Assert.assertNull(fileEntry.getReviewDate());
+	}
+
+	@Test
+	public void testFileEntryShouldUpdateReviewDate() throws Exception {
+		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, null, null);
+
+		Assert.assertNull(fileEntry.getDisplayDate());
+		Assert.assertNull(fileEntry.getExpirationDate());
+		Assert.assertNull(fileEntry.getReviewDate());
+
+		Date reviewDate = new Date();
+
+		fileEntry = dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, CONTENT.getBytes(),
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			reviewDate,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertNull(fileEntry.getDisplayDate());
+		Assert.assertNull(fileEntry.getExpirationDate());
+		Assert.assertEquals(reviewDate, fileEntry.getReviewDate());
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest.java
@@ -48,7 +48,7 @@ public class DLAppServiceWhenUpdatingAndCheckingInAFileEntryTest
 			fileEntry.getFileEntryId(), fileEntry.getFileName(),
 			fileEntry.getMimeType(), fileEntry.getTitle(),
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MINOR, null, null, null,
+			DLVersionNumberIncrease.MINOR, null, null, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/util/DLAppServiceTestUtil.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/util/DLAppServiceTestUtil.java
@@ -164,7 +164,7 @@ public class DLAppServiceTestUtil {
 	}
 
 	public static FileEntry updateFileEntry(
-			long groupId, long fileEntryId, String fileName,
+			long groupId, long fileEntryId, String fileName, Date displayDate,
 			Date expirationDate, Date reviewDate, boolean majorVersion)
 		throws Exception {
 
@@ -172,8 +172,8 @@ public class DLAppServiceTestUtil {
 			fileEntryId, fileName, ContentTypes.TEXT_PLAIN, fileName,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(majorVersion),
-			TestDataConstants.TEST_BYTE_ARRAY, expirationDate, reviewDate,
-			ServiceContextTestUtil.getServiceContext(groupId));
+			TestDataConstants.TEST_BYTE_ARRAY, displayDate, expirationDate,
+			reviewDate, ServiceContextTestUtil.getServiceContext(groupId));
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/DLFileVersionTableReferenceDefinitionTest.java
@@ -82,7 +82,7 @@ public class DLFileVersionTableReferenceDefinitionTest
 			StringUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null,
+			Collections.emptyMap(), null, inputStream, 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		return _dlFileEntry.getFileVersion();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -120,7 +120,7 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			(byte[])null, null, null, serviceContext);
+			(byte[])null, null, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -244,7 +244,7 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			(byte[])null, null, null, serviceContext);
+			(byte[])null, null, null, null, serviceContext);
 
 		FriendlyURLEntry mainFriendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -329,7 +329,7 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, fileEntry.getTitle(), "urltitle",
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			(byte[])null, null, null, serviceContext);
+			(byte[])null, null, null, null, serviceContext);
 
 		exportImportStagedModel(fileEntry);
 
@@ -373,7 +373,7 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, title, StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR, (byte[])null, null,
-			null, serviceContext);
+			null, null, serviceContext);
 
 		exportImportStagedModel(fileEntry);
 
@@ -701,7 +701,7 @@ public class FileEntryStagedModelDataHandlerTest
 			fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			DLVersionNumberIncrease.MINOR, (byte[])null, null, null,
+			DLVersionNumberIncrease.MINOR, (byte[])null, null, null, null,
 			ServiceContextThreadLocal.getServiceContext());
 	}
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/helper/test/DLURLHelperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/helper/test/DLURLHelperTest.java
@@ -317,7 +317,7 @@ public class DLURLHelperTest {
 			_user.getUserId(), fileEntry.getFileEntryId(), StringPool.BLANK,
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), StringPool.BLANK, null,
-			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null,
+			DLVersionNumberIncrease.MAJOR, (byte[])null, null, null, null,
 			serviceContext);
 
 		String previewURL = _dlURLHelper.getPreviewURL(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppLocalServiceWrapperTest.java
@@ -140,7 +140,7 @@ public class FriendlyURLDLAppLocalServiceWrapperTest extends BaseDLAppTestCase {
 			serviceContext.getUserId(), fileEntry.getFileEntryId(),
 			StringPool.BLANK, ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK, null,
-			DLVersionNumberIncrease.AUTOMATIC, bytes, null, null,
+			DLVersionNumberIncrease.AUTOMATIC, bytes, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
@@ -173,7 +173,7 @@ public class FriendlyURLDLAppLocalServiceWrapperTest extends BaseDLAppTestCase {
 			serviceContext.getUserId(), fileEntry.getFileEntryId(),
 			StringPool.BLANK, ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK, null,
-			DLVersionNumberIncrease.AUTOMATIC, file, null, null,
+			DLVersionNumberIncrease.AUTOMATIC, file, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
@@ -208,7 +208,7 @@ public class FriendlyURLDLAppLocalServiceWrapperTest extends BaseDLAppTestCase {
 			StringPool.BLANK, ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK, null,
 			DLVersionNumberIncrease.AUTOMATIC, inputStream, size, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLAppServiceWrapperTest.java
@@ -175,7 +175,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, file, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -209,7 +209,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, inputStream, size,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -241,7 +241,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, bytes, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -274,7 +274,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, file, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -308,7 +308,7 @@ public class FriendlyURLDLAppServiceWrapperTest extends BaseDLAppTestCase {
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR, inputStream, size,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryLocalServiceWrapperTest.java
@@ -318,7 +318,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null,
+			Collections.emptyMap(), null, inputStream, 0, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry mainFriendlyURLEntry =
@@ -392,7 +392,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null,
+			Collections.emptyMap(), null, inputStream, 0, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry mainFriendlyURLEntry =
@@ -464,7 +464,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null,
+			Collections.emptyMap(), null, inputStream, 0, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
@@ -504,7 +504,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -543,7 +543,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry mainFriendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -591,7 +591,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(
@@ -638,7 +638,7 @@ public class FriendlyURLDLFileEntryLocalServiceWrapperTest
 			DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			Collections.emptyMap(), null, inputStream, bytes.length, null, null,
-			serviceContext);
+			null, serviceContext);
 
 		mainFriendlyURLEntry =
 			_friendlyURLEntryLocalService.getMainFriendlyURLEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/service/test/FriendlyURLDLFileEntryServiceWrapperTest.java
@@ -100,7 +100,7 @@ public class FriendlyURLDLFileEntryServiceWrapperTest
 			RandomTestUtil.randomString(), "urltitle", StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			Collections.emptyMap(), null, inputStream, 0, null, null,
+			Collections.emptyMap(), null, inputStream, 0, null, null, null,
 			serviceContext);
 
 		FriendlyURLEntry friendlyURLEntry =

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/notifications/test/DocumentLibraryUserNotificationTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/notifications/test/DocumentLibraryUserNotificationTest.java
@@ -111,7 +111,7 @@ public class DocumentLibraryUserNotificationTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 
 		return (BaseModel<?>)fileEntry.getModel();
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/repository/capabilities/test/LiferayVersioningCapabilityTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/repository/capabilities/test/LiferayVersioningCapabilityTest.java
@@ -155,8 +155,8 @@ public class LiferayVersioningCapabilityTest {
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, null, 0,
-				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-				serviceContext);
+				fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+				fileEntry.getReviewDate(), serviceContext);
 
 			expectedDLFileVersions.add(fileEntry.getFileVersion());
 		}
@@ -165,8 +165,8 @@ public class LiferayVersioningCapabilityTest {
 			fileEntry.getFileEntryId(), RandomTestUtil.randomString(), null,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR, null, 0,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), serviceContext);
 
 		fileEntry = _updateStatus(
 			fileEntry, WorkflowConstants.STATUS_DRAFT, serviceContext);
@@ -348,8 +348,8 @@ public class LiferayVersioningCapabilityTest {
 			fileEntry.getMimeType(), fileEntry.getTitle(), StringPool.BLANK,
 			fileEntry.getDescription(), RandomTestUtil.randomString(),
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), serviceContext);
 	}
 
 	private FileEntry _updateStatus(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -528,8 +528,8 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			dlFileEntry.getFileEntryId(), null, dlFileEntry.getMimeType(),
 			keywords, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (byte[])null,
-			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
-			serviceContext);
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
 
 		return (DLFileEntry)fileEntry.getModel();
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
@@ -569,7 +569,7 @@ public class DLCheckInCheckOutTest {
 		return DLAppServiceUtil.updateFileEntry(
 			fileEntryId, fileName, ContentTypes.TEXT_PLAIN, fileName, null,
 			null, null, DLVersionNumberIncrease.MINOR, inputStream,
-			content.length(), null, null, _serviceContext);
+			content.length(), null, null, null, _serviceContext);
 	}
 
 	private static final String _FILE_NAME = "test1.txt";

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryExtensionTest.java
@@ -359,7 +359,8 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 			fileEntry.getFileEntryId(), sourceFileName, ContentTypes.TEXT_PLAIN,
 			title, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
@@ -1508,8 +1508,9 @@ public class DLFileEntryFinderTest {
 			fileEntry.getFileEntryId(), "FE3.txt", ContentTypes.TEXT_PLAIN,
 			"FE3.txt".concat(titleSuffix), StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			TestDataConstants.TEST_BYTE_ARRAY, fileEntry.getExpirationDate(),
-			fileEntry.getReviewDate(), serviceContext);
+			TestDataConstants.TEST_BYTE_ARRAY, fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			serviceContext);
 
 		dlFileEntry = DLFileEntryLocalServiceUtil.getFileEntry(
 			fileEntry.getFileEntryId());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -208,7 +208,7 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testAddFileEntryWithExpirationDateReviewDateUpdateDeletingThem()
+	public void testAddFileEntryWithDisplayDateExpirationDateReviewDateUpdateDeletingThem()
 		throws Exception {
 
 		String content = StringUtil.randomString();
@@ -217,6 +217,7 @@ public class DLFileEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());
 
+		Date displayDate = new Date();
 		Date expirationDate = new Date();
 		Date reviewDate = new Date();
 
@@ -226,13 +227,15 @@ public class DLFileEntryLocalServiceTest {
 			"file.txt", ContentTypes.TEXT_PLAIN, "file.txt",
 			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK, -1,
 			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
-			0, null, expirationDate, reviewDate, serviceContext);
+			0, displayDate, expirationDate, reviewDate, serviceContext);
 
+		Assert.assertEquals(displayDate, dlFileEntry.getDisplayDate());
 		Assert.assertEquals(expirationDate, dlFileEntry.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileEntry.getReviewDate());
 
 		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
+		Assert.assertEquals(displayDate, dlFileVersion.getDisplayDate());
 		Assert.assertEquals(expirationDate, dlFileVersion.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileVersion.getReviewDate());
 
@@ -248,6 +251,7 @@ public class DLFileEntryLocalServiceTest {
 
 		dlFileVersion = dlFileEntry.getFileVersion();
 
+		Assert.assertNull(dlFileVersion.getDisplayDate());
 		Assert.assertNull(dlFileVersion.getExpirationDate());
 		Assert.assertNull(dlFileVersion.getReviewDate());
 
@@ -255,6 +259,7 @@ public class DLFileEntryLocalServiceTest {
 			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_APPROVED, serviceContext, new HashMap<>());
 
+		Assert.assertNull(dlFileEntry.getDisplayDate());
 		Assert.assertNull(dlFileEntry.getExpirationDate());
 		Assert.assertNull(dlFileEntry.getReviewDate());
 	}
@@ -428,6 +433,7 @@ public class DLFileEntryLocalServiceTest {
 			new ByteArrayInputStream(new byte[0]), 0, null, null, reviewDate,
 			serviceContext);
 
+		Assert.assertNull(dlFileEntry.getDisplayDate());
 		Assert.assertNull(dlFileEntry.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileEntry.getReviewDate());
 	}
@@ -449,8 +455,9 @@ public class DLFileEntryLocalServiceTest {
 			new ByteArrayInputStream(new byte[0]), 0, null, expirationDate,
 			null, serviceContext);
 
-		Assert.assertNull(dlFileEntry.getReviewDate());
+		Assert.assertNull(dlFileEntry.getDisplayDate());
 		Assert.assertEquals(expirationDate, dlFileEntry.getExpirationDate());
+		Assert.assertNull(dlFileEntry.getReviewDate());
 	}
 
 	@Test
@@ -1142,7 +1149,9 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testUpdateExpirationDateReviewDate() throws Exception {
+	public void testUpdateDisplayDateExpirationDateReviewDate()
+		throws Exception {
+
 		String content = StringUtil.randomString();
 
 		ServiceContext serviceContext =
@@ -1157,14 +1166,17 @@ public class DLFileEntryLocalServiceTest {
 			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
 			0, null, null, null, serviceContext);
 
+		Assert.assertNull(dlFileEntry.getDisplayDate());
 		Assert.assertNull(dlFileEntry.getExpirationDate());
 		Assert.assertNull(dlFileEntry.getReviewDate());
 
 		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
+		Assert.assertNull(dlFileVersion.getDisplayDate());
 		Assert.assertNull(dlFileVersion.getExpirationDate());
 		Assert.assertNull(dlFileVersion.getReviewDate());
 
+		Date displayDate = new Date();
 		Date expirationDate = new Date();
 		Date reviewDate = new Date();
 
@@ -1175,11 +1187,12 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(false),
 			dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
-			new ByteArrayInputStream(content.getBytes()), 0, null,
+			new ByteArrayInputStream(content.getBytes()), 0, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		dlFileVersion = dlFileEntry.getFileVersion();
 
+		Assert.assertEquals(displayDate, dlFileVersion.getDisplayDate());
 		Assert.assertEquals(expirationDate, dlFileVersion.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileVersion.getReviewDate());
 
@@ -1187,6 +1200,7 @@ public class DLFileEntryLocalServiceTest {
 			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_APPROVED, serviceContext, new HashMap<>());
 
+		Assert.assertEquals(displayDate, dlFileEntry.getDisplayDate());
 		Assert.assertEquals(expirationDate, dlFileEntry.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileEntry.getReviewDate());
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -243,7 +243,7 @@ public class DLFileEntryLocalServiceTest {
 			dlFileEntry.getTitle(), StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(false),
 			dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
-			new ByteArrayInputStream(content.getBytes()), 0, null, null,
+			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
 			serviceContext);
 
 		dlFileVersion = dlFileEntry.getFileVersion();
@@ -564,7 +564,7 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.NONE,
 			dlFileEntry.getFileEntryTypeId(), Collections.emptyMap(), null,
-			new ByteArrayInputStream(bytes), bytes.length, null, null,
+			new ByteArrayInputStream(bytes), bytes.length, null, null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		DLFileEntryLocalServiceUtil.checkInFileEntry(
@@ -1175,8 +1175,8 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(false),
 			dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
-			new ByteArrayInputStream(content.getBytes()), 0, expirationDate,
-			reviewDate, serviceContext);
+			new ByteArrayInputStream(content.getBytes()), 0, null,
+			expirationDate, reviewDate, serviceContext);
 
 		dlFileVersion = dlFileEntry.getFileVersion();
 
@@ -1217,7 +1217,7 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.NONE,
 			dlFileEntry.getFileEntryTypeId(), null, null,
-			new ByteArrayInputStream(new byte[0]), 0, null, null,
+			new ByteArrayInputStream(new byte[0]), 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		dlFileVersion = DLFileVersionLocalServiceUtil.getFileVersion(
@@ -1255,7 +1255,7 @@ public class DLFileEntryLocalServiceTest {
 				StringPool.BLANK,
 				DLVersionNumberIncrease.fromMajorVersion(false),
 				dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
-				new ByteArrayInputStream(new byte[0]), 0, null, null,
+				new ByteArrayInputStream(new byte[0]), 0, null, null, null,
 				serviceContext);
 		}
 	}
@@ -1474,8 +1474,8 @@ public class DLFileEntryLocalServiceTest {
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
 			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
 			ddmFormValuesMap, null, inputStream, 0,
-			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
-			serviceContext);
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
 
 		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -482,8 +482,8 @@ public class DLFileEntryLocalServiceTest {
 			dlFileEntry.getFileEntryId(), "file.pdf", null, "file.txt",
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(false), null, 0,
-			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
-			serviceContext);
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
 
 		Assert.assertEquals(
 			content, StringUtil.read(fileEntry.getContentStream()));
@@ -955,8 +955,8 @@ public class DLFileEntryLocalServiceTest {
 			ContentTypes.TEXT_PLAIN, "FE1.exe", StringPool.BLANK,
 			fileEntry.getDescription(), RandomTestUtil.randomString(),
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), serviceContext);
 
 		Assert.assertEquals("FE2.txt", fileEntry.getFileName());
 
@@ -1028,8 +1028,8 @@ public class DLFileEntryLocalServiceTest {
 			dlFileEntry.getFileEntryId(), "file.txt", null, "file.pdf",
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.fromMajorVersion(false), null, 0,
-			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
-			serviceContext);
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
 
 		Assert.assertEquals(
 			content, StringUtil.read(fileEntry.getContentStream()));

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
@@ -438,8 +438,8 @@ public class DLFileEntryServiceTest {
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR,
 			dlFileEntry.getFileEntryTypeId(), null, null,
 			dlFileEntry.getContentStream(), dlFileEntry.getSize(),
-			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
-			serviceContext);
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
 	}
 
 	protected DLFileEntry updateStatus(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionHistoryTest.java
@@ -144,7 +144,8 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
-				_fileEntry.getExpirationDate(), _fileEntry.getReviewDate(),
+				_fileEntry.getDisplayDate(), _fileEntry.getExpirationDate(),
+				_fileEntry.getReviewDate(),
 				ServiceContextTestUtil.getServiceContext(
 					group.getGroupId(), TestPropsValues.getUserId()));
 		}
@@ -156,7 +157,8 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
-				_fileEntry.getExpirationDate(), _fileEntry.getReviewDate(),
+				_fileEntry.getDisplayDate(), _fileEntry.getExpirationDate(),
+				_fileEntry.getReviewDate(),
 				ServiceContextTestUtil.getServiceContext(
 					group.getGroupId(), TestPropsValues.getUserId()));
 		}
@@ -255,7 +257,8 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_1_1,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
-				_fileEntry.getExpirationDate(), _fileEntry.getReviewDate(),
+				_fileEntry.getDisplayDate(), _fileEntry.getExpirationDate(),
+				_fileEntry.getReviewDate(),
 				ServiceContextTestUtil.getServiceContext(
 					group.getGroupId(), TestPropsValues.getUserId()));
 		}
@@ -267,7 +270,8 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 				fileEntryId, null, ContentTypes.TEXT_PLAIN, _VERSION_PWC,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 				DLVersionNumberIncrease.MINOR, (byte[])null,
-				_fileEntry.getExpirationDate(), _fileEntry.getReviewDate(),
+				_fileEntry.getDisplayDate(), _fileEntry.getExpirationDate(),
+				_fileEntry.getReviewDate(),
 				ServiceContextTestUtil.getServiceContext(
 					group.getGroupId(), TestPropsValues.getUserId()));
 		}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
@@ -73,8 +73,8 @@ public class DLFileVersionLocalServiceTest {
 			fileEntry.getFileEntryId(), null, ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.MINOR, (byte[])null,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), serviceContext);
 
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
 			fileEntry.getFileEntryId());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -198,6 +198,24 @@ public class DLFileVersionTest {
 	}
 
 	@Test
+	public void testUpdateDisplayDate() throws Exception {
+		updateServiceContext(
+			_UPDATE_VALUE, _dlFileEntryType.getFileEntryTypeId(),
+			StringPool.BLANK);
+
+		FileEntry fileEntry = DLAppServiceUtil.updateFileEntry(
+			_fileVersion.getFileEntryId(), _SOURCE_FILE_NAME,
+			_fileVersion.getMimeType(), _fileVersion.getTitle(),
+			StringPool.BLANK, _fileVersion.getDescription(),
+			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
+			_DATA_VERSION_1, new Date(), _fileVersion.getExpirationDate(),
+			_fileVersion.getReviewDate(), _serviceContext);
+
+		Assert.assertNotEquals(
+			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
+	}
+
+	@Test
 	public void testUpdateExpando() throws Exception {
 		updateServiceContext(
 			_UPDATE_VALUE, _dlFileEntryType.getFileEntryTypeId(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -138,24 +138,26 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		DLAppServiceUtil.updateFileEntry(
 			_fileVersion.getFileEntryId(), _SOURCE_FILE_NAME,
 			_fileVersion.getMimeType(), _UPDATE_VALUE, StringPool.BLANK,
 			_fileVersion.getDescription(), _fileVersion.getChangeLog(),
 			DLVersionNumberIncrease.MINOR, _DATA_VERSION_1,
-			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
-			_serviceContext);
+			_fileVersion.getDisplayDate(), _fileVersion.getExpirationDate(),
+			_fileVersion.getReviewDate(), _serviceContext);
 
 		FileEntry fileEntry = DLAppServiceUtil.updateFileEntry(
 			_fileVersion.getFileEntryId(), _SOURCE_FILE_NAME,
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		DLAppServiceUtil.revertFileEntry(
 			fileEntry.getFileEntryId(), DLFileEntryConstants.VERSION_DEFAULT,
@@ -173,8 +175,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_2, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_2, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -187,8 +190,8 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _UPDATE_VALUE, _fileVersion.getChangeLog(),
 			DLVersionNumberIncrease.MINOR, _DATA_VERSION_1,
-			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
-			_serviceContext);
+			_fileVersion.getDisplayDate(), _fileVersion.getExpirationDate(),
+			_fileVersion.getReviewDate(), _serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -205,8 +208,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -223,8 +227,8 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, new Date(), _fileVersion.getReviewDate(),
-			_serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(), new Date(),
+			_fileVersion.getReviewDate(), _serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -242,8 +246,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -260,8 +265,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -274,8 +280,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertEquals("1.1", fileEntry.getVersion());
 	}
@@ -291,8 +298,8 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getExpirationDate(), new Date(),
-			_serviceContext);
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), new Date(), _serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -305,8 +312,9 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_3, _fileVersion.getExpirationDate(),
-			_fileVersion.getReviewDate(), _serviceContext);
+			_DATA_VERSION_3, _fileVersion.getDisplayDate(),
+			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
@@ -319,8 +327,8 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _UPDATE_VALUE, StringPool.BLANK,
 			_fileVersion.getDescription(), _fileVersion.getChangeLog(),
 			DLVersionNumberIncrease.MINOR, _DATA_VERSION_1,
-			_fileVersion.getExpirationDate(), _fileVersion.getReviewDate(),
-			_serviceContext);
+			_fileVersion.getDisplayDate(), _fileVersion.getExpirationDate(),
+			_fileVersion.getReviewDate(), _serviceContext);
 
 		Assert.assertNotEquals(
 			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
@@ -86,7 +86,7 @@ public class DLFileVersionUpdateTest extends BaseDLAppTestCase {
 			fileEntry.getFileEntryId(), updateFileName, updateMimeType,
 			updateFileName, null, description, changeLog,
 			DLVersionNumberIncrease.MINOR, updateBytes, new Date(), new Date(),
-			serviceContext);
+			new Date(), serviceContext);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/PDFProcessorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/PDFProcessorTest.java
@@ -166,8 +166,8 @@ public class PDFProcessorTest {
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
 			FileUtil.getBytes(getClass(), "dependencies/test.pdf"),
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			_serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), _serviceContext);
 
 		Assert.assertTrue(cleanUp.get());
 	}
@@ -197,8 +197,9 @@ public class PDFProcessorTest {
 			ContentTypes.APPLICATION_PDF, StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
-			inputStream, bytes.length, fileEntry.getExpirationDate(),
-			fileEntry.getReviewDate(), _serviceContext);
+			inputStream, bytes.length, fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertTrue(cleanUp.get());
 	}
@@ -266,8 +267,8 @@ public class PDFProcessorTest {
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
 			FileUtil.getBytes(getClass(), "dependencies/test.pdf"),
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			_serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), _serviceContext);
 
 		Assert.assertNotEquals(version, fileEntry.getVersion());
 
@@ -298,8 +299,8 @@ public class PDFProcessorTest {
 			ContentTypes.APPLICATION_PDF, StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR, null, 0,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			_serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), _serviceContext);
 
 		Assert.assertEquals(2, count.get());
 	}
@@ -325,8 +326,9 @@ public class PDFProcessorTest {
 			ContentTypes.APPLICATION_PDF, StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
-			new byte[0], fileEntry.getExpirationDate(),
-			fileEntry.getReviewDate(), _serviceContext);
+			new byte[0], fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertEquals(1, count.get());
 	}
@@ -475,8 +477,9 @@ public class PDFProcessorTest {
 			ContentTypes.APPLICATION_PDF, StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
-			inputStream, bytes.length, fileEntry.getExpirationDate(),
-			fileEntry.getReviewDate(), _serviceContext);
+			inputStream, bytes.length, fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			_serviceContext);
 
 		Assert.assertEquals(2, count.get());
 	}
@@ -503,8 +506,8 @@ public class PDFProcessorTest {
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), DLVersionNumberIncrease.MAJOR,
 			FileUtil.getBytes(getClass(), "dependencies/test.pdf"),
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-			_serviceContext);
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(), _serviceContext);
 
 		Assert.assertEquals(2, count.get());
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/social/test/DLFileEntryActivityInterpreterTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/social/test/DLFileEntryActivityInterpreterTest.java
@@ -91,7 +91,8 @@ public class DLFileEntryActivityInterpreterTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			_fileEntry.getExpirationDate(), _fileEntry.getReviewDate(),
+			_fileEntry.getDisplayDate(), _fileEntry.getExpirationDate(),
+			_fileEntry.getReviewDate(),
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionAuthorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionAuthorTest.java
@@ -99,7 +99,7 @@ public class DLSubscriptionAuthorTest extends BaseSubscriptionAuthorTestCase {
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionClassTypeTest.java
@@ -132,7 +132,7 @@ public class DLSubscriptionClassTypeTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionContainerModelTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionContainerModelTest.java
@@ -101,7 +101,7 @@ public class DLSubscriptionContainerModelTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionLocalizedContentTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionLocalizedContentTest.java
@@ -108,7 +108,7 @@ public class DLSubscriptionLocalizedContentTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionRootContainerModelTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/subscription/test/DLSubscriptionRootContainerModelTest.java
@@ -101,7 +101,7 @@ public class DLSubscriptionRootContainerModelTest
 			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			null, null, serviceContext);
+			null, null, null, serviceContext);
 	}
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
@@ -238,8 +238,9 @@ public class DLFileEntryTrashHandlerTest
 			primaryKey, RandomTestUtil.randomString() + ".txt",
 			ContentTypes.TEXT_PLAIN, dlFileEntry.getTitle(), StringPool.BLANK,
 			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MINOR,
-			content.getBytes(), dlFileEntry.getExpirationDate(),
-			dlFileEntry.getReviewDate(), serviceContext);
+			content.getBytes(), dlFileEntry.getDisplayDate(),
+			dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
+			serviceContext);
 
 		LiferayFileEntry liferayFileEntry = (LiferayFileEntry)fileEntry;
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLDirectoryNameAndFileNameTest.java
@@ -259,7 +259,8 @@ public class DLDirectoryNameAndFileNameTest {
 			fileEntry.getFileEntryId(), name, ContentTypes.TEXT_PLAIN, name,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MINOR, TestDataConstants.TEST_BYTE_ARRAY,
-			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+			fileEntry.getReviewDate(),
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webdav/test/WebDAVOSXTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webdav/test/WebDAVOSXTest.java
@@ -124,7 +124,7 @@ public class WebDAVOSXTest extends BaseWebDAVTestCase {
 				TestPropsValues.getUserId(), fileEntryId, _TEST_FILE_NAME_2,
 				ContentTypes.APPLICATION_TEXT, _TEST_FILE_TITLE,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null,
+				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null, null,
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId()));
 
@@ -245,7 +245,7 @@ public class WebDAVOSXTest extends BaseWebDAVTestCase {
 				TestPropsValues.getUserId(), fileEntryId, _TEST_FILE_NAME_2,
 				ContentTypes.APPLICATION_TEXT, _TEST_FILE_TITLE_2_MOD,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null,
+				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null, null,
 				serviceContext);
 
 			fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
@@ -295,7 +295,7 @@ public class WebDAVOSXTest extends BaseWebDAVTestCase {
 				TestPropsValues.getUserId(), fileEntryId, _TEST_FILE_NAME_2,
 				ContentTypes.APPLICATION_TEXT, _TEST_FILE_TITLE_2_MOD,
 				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null,
+				DLVersionNumberIncrease.MAJOR, _testFileBytes, null, null, null,
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId()));
 

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
@@ -242,7 +242,9 @@ public class DLFileEntryUADAnonymizerTest
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			DLVersionNumberIncrease.fromMajorVersion(true),
-			dlFileEntry.getContentStream(), dlFileEntry.getSize(), null, null,
+			dlFileEntry.getContentStream(), dlFileEntry.getSize(),
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(),
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryImageEditorMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryImageEditorMVCActionCommand.java
@@ -356,8 +356,8 @@ public class EditFileEntryImageEditorMVCActionCommand
 				fileEntry.getTitle(), fileEntry.getTitle(),
 				fileEntry.getDescription(), changeLog,
 				DLVersionNumberIncrease.AUTOMATIC, inputStream, size,
-				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-				serviceContext);
+				fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+				fileEntry.getReviewDate(), serviceContext);
 
 			_assetDisplayPageEntryFormProcessor.process(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -1404,7 +1404,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 					fileEntry = _dlAppService.updateFileEntryAndCheckIn(
 						fileEntryId, sourceFileName, contentType, title,
 						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, inputStream, size,
+						dlVersionNumberIncrease, inputStream, size, displayDate,
 						expirationDate, reviewDate, serviceContext);
 				}
 				else {
@@ -1414,7 +1414,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 					fileEntry = _dlAppService.updateFileEntry(
 						fileEntryId, sourceFileName, contentType, title,
 						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, inputStream, size,
+						dlVersionNumberIncrease, inputStream, size, displayDate,
 						expirationDate, reviewDate, serviceContext);
 				}
 			}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
@@ -693,6 +693,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 						destFileEntry.getTitle(),
 						destFileEntry.getDescription(), StringPool.BLANK,
 						DLVersionNumberIncrease.MINOR, file,
+						destFileEntry.getDisplayDate(),
 						destFileEntry.getExpirationDate(),
 						destFileEntry.getReviewDate(), serviceContext);
 
@@ -713,7 +714,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 				fileEntry.getFileEntryId(), fileName, fileEntry.getMimeType(),
 				fileEntry.getTitle(), fileEntry.getTitle(),
 				fileEntry.getDescription(), StringPool.BLANK,
-				DLVersionNumberIncrease.MINOR, file,
+				DLVersionNumberIncrease.MINOR, file, fileEntry.getDisplayDate(),
 				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
 				serviceContext);
 
@@ -799,8 +800,8 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 					fileEntry.getTitle(), fileEntry.getTitle(),
 					fileEntry.getDescription(), StringPool.BLANK,
 					DLVersionNumberIncrease.MINOR, file,
-					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-					serviceContext);
+					fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+					fileEntry.getReviewDate(), serviceContext);
 			}
 			catch (NoSuchFileEntryException noSuchFileEntryException) {
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -279,7 +279,7 @@ public class DefaultExportImportContentProcessorTest {
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			_fileEntry.getTitle(), _fileEntry.getTitle(), StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.AUTOMATIC,
-			TestDataConstants.TEST_BYTE_ARRAY, null, null,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				_stagingGroup.getGroupId(), TestPropsValues.getUserId()));
 
@@ -338,7 +338,7 @@ public class DefaultExportImportContentProcessorTest {
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			_fileEntry.getTitle(), _fileEntry.getTitle(), StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.AUTOMATIC,
-			TestDataConstants.TEST_BYTE_ARRAY, null, null,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				_stagingGroup.getGroupId(), TestPropsValues.getUserId()));
 
@@ -1309,7 +1309,7 @@ public class DefaultExportImportContentProcessorTest {
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			_fileEntry.getTitle(), _fileEntry.getTitle(), StringPool.BLANK,
 			StringPool.BLANK, DLVersionNumberIncrease.AUTOMATIC,
-			TestDataConstants.TEST_BYTE_ARRAY, null, null,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				_stagingGroup.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -396,6 +396,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 				documentId, fileName, binaryFile.getContentType(), title, null,
 				description, null, DLVersionNumberIncrease.AUTOMATIC,
 				binaryFile.getInputStream(), binaryFile.getSize(),
+				existingFileEntry.getDisplayDate(),
 				existingFileEntry.getExpirationDate(),
 				existingFileEntry.getReviewDate(),
 				_createServiceContext(
@@ -979,8 +980,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 				fileEntry.getFileEntryId(), fileName,
 				binaryFile.getContentType(), title, null, description, null,
 				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
-				binaryFile.getSize(), fileEntry.getExpirationDate(),
-				fileEntry.getReviewDate(),
+				binaryFile.getSize(), fileEntry.getDisplayDate(),
+				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
 				_createServiceContext(
 					Constants.UPDATE, () -> new Long[0], () -> new String[0],
 					fileEntry.getFolderId(), document,

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -1994,7 +1994,7 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 			fileEntryId, StringPool.BLANK, ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			StringPool.BLANK, null, DLVersionNumberIncrease.AUTOMATIC, null, 0,
-			null, null, _serviceContext);
+			null, null, null, _serviceContext);
 
 		return fileEntry.getLatestFileVersion();
 	}

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -136,8 +136,9 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date revisionDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date revisionDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = getFileEntry(fileEntryId);
@@ -148,7 +149,8 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 			return super.updateFileEntryAndCheckIn(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, inputStream,
-				size, expirationDate, revisionDate, serviceContext);
+				size, displayDate, expirationDate, revisionDate,
+				serviceContext);
 		}
 
 		checkInFileEntry(
@@ -156,7 +158,7 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 
 		return super.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, revisionDate, serviceContext);
 	}
 
@@ -200,7 +202,8 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 				fileEntry.getFileEntryId(), sourceFileName,
 				fileEntry.getMimeType(), title, StringPool.BLANK,
 				fileEntry.getDescription(), StringPool.BLANK,
-				DLVersionNumberIncrease.NONE, file, null, null, serviceContext);
+				DLVersionNumberIncrease.NONE, file, null, null, null,
+				serviceContext);
 		}
 		finally {
 			if ((file != null) && !file.delete()) {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/ContactsCSVHelper.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/ContactsCSVHelper.java
@@ -316,8 +316,9 @@ public class ContactsCSVHelper {
 				dlFileEntry.getFileEntryTypeId(),
 				dlFileEntry.getDDMFormValuesMap(
 					dlFileVersion.getFileVersionId()),
-				file, null, file.length(), dlFileEntry.getExpirationDate(),
-				dlFileEntry.getReviewDate(), serviceContext);
+				file, null, file.length(), dlFileEntry.getDisplayDate(),
+				dlFileEntry.getExpirationDate(), dlFileEntry.getReviewDate(),
+				serviceContext);
 		}
 		else {
 			Repository repository = _portletFileRepository.addPortletRepository(

--- a/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/InitializedDocumentRepository.java
@@ -448,7 +448,7 @@ public abstract class InitializedDocumentRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -456,7 +456,7 @@ public abstract class InitializedDocumentRepository
 
 		return documentRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -465,8 +465,8 @@ public abstract class InitializedDocumentRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		checkDocumentRepository();
@@ -474,7 +474,7 @@ public abstract class InitializedDocumentRepository
 		return documentRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -528,7 +528,7 @@ public class CapabilityLocalRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -536,7 +536,7 @@ public class CapabilityLocalRepository
 
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_repositoryEventTrigger.trigger(
@@ -550,8 +550,8 @@ public class CapabilityLocalRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		LocalRepository localRepository = getRepository();
@@ -559,7 +559,7 @@ public class CapabilityLocalRepository
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_repositoryEventTrigger.trigger(
 			RepositoryEventType.Update.class, FileEntry.class, fileEntry);

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -837,7 +837,7 @@ public class CapabilityRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -845,7 +845,7 @@ public class CapabilityRepository
 
 		FileEntry fileEntry = repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_repositoryEventTrigger.trigger(
@@ -859,8 +859,8 @@ public class CapabilityRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		Repository repository = getRepository();
@@ -868,7 +868,7 @@ public class CapabilityRepository
 		FileEntry fileEntry = repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_repositoryEventTrigger.trigger(
 			RepositoryEventType.Update.class, FileEntry.class, fileEntry);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -624,11 +624,13 @@ public class LiferayLocalRepository
 			size = file.length();
 		}
 
+		Date displayDate = null;
+
 		DLFileEntry dlFileEntry = dlFileEntryLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, null, size, expirationDate, reviewDate,
-			serviceContext);
+			ddmFormValuesMap, file, null, size, displayDate, expirationDate,
+			reviewDate, serviceContext);
 
 		return new LiferayFileEntry(dlFileEntry);
 	}
@@ -647,12 +649,13 @@ public class LiferayLocalRepository
 
 		Map<String, DDMFormValues> ddmFormValuesMap = getDDMFormValuesMap(
 			serviceContext, fileEntryTypeId);
+		Date displayDate = null;
 
 		DLFileEntry dlFileEntry = dlFileEntryLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, null, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, null, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 
 		return new LiferayFileEntry(dlFileEntry);
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -608,7 +608,7 @@ public class LiferayLocalRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -624,8 +624,6 @@ public class LiferayLocalRepository
 			size = file.length();
 		}
 
-		Date displayDate = null;
-
 		DLFileEntry dlFileEntry = dlFileEntryLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
@@ -640,8 +638,8 @@ public class LiferayLocalRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		long fileEntryTypeId = ParamUtil.getLong(
@@ -649,7 +647,6 @@ public class LiferayLocalRepository
 
 		Map<String, DDMFormValues> ddmFormValuesMap = getDDMFormValuesMap(
 			serviceContext, fileEntryTypeId);
-		Date displayDate = null;
 
 		DLFileEntry dlFileEntry = dlFileEntryLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayProcessorLocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayProcessorLocalRepositoryWrapper.java
@@ -123,13 +123,13 @@ public class LiferayProcessorLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_processorCapability.cleanUp(fileEntry.getLatestFileVersion(true));
@@ -143,8 +143,8 @@ public class LiferayProcessorLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileVersion oldFileVersion = null;
@@ -158,7 +158,7 @@ public class LiferayProcessorLocalRepositoryWrapper
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		if (inputStream == null) {
 			_processorCapability.copy(fileEntry, oldFileVersion);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayProcessorRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayProcessorRepositoryWrapper.java
@@ -178,13 +178,13 @@ public class LiferayProcessorRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_processorCapability.cleanUp(fileEntry.getLatestFileVersion());
@@ -198,8 +198,8 @@ public class LiferayProcessorRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileVersion oldFileVersion = null;
@@ -213,7 +213,7 @@ public class LiferayProcessorRepositoryWrapper extends RepositoryWrapper {
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		if (inputStream == null) {
 			_processorCapability.copy(fileEntry, oldFileVersion);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -917,11 +917,13 @@ public class LiferayRepository
 			size = file.length();
 		}
 
+		Date displayDate = null;
+
 		DLFileEntry dlFileEntry = dlFileEntryService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, null, size, expirationDate, reviewDate,
-			serviceContext);
+			ddmFormValuesMap, file, null, size, displayDate, expirationDate,
+			reviewDate, serviceContext);
 
 		return new LiferayFileEntry(dlFileEntry);
 	}
@@ -941,11 +943,13 @@ public class LiferayRepository
 		Map<String, DDMFormValues> ddmFormValuesMap = getDDMFormValuesMap(
 			serviceContext, fileEntryTypeId);
 
+		Date displayDate = null;
+
 		DLFileEntry dlFileEntry = dlFileEntryService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, null, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, null, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 
 		return new LiferayFileEntry(dlFileEntry);
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -901,7 +901,7 @@ public class LiferayRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -917,8 +917,6 @@ public class LiferayRepository
 			size = file.length();
 		}
 
-		Date displayDate = null;
-
 		DLFileEntry dlFileEntry = dlFileEntryService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, fileEntryTypeId,
@@ -933,8 +931,8 @@ public class LiferayRepository
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		long fileEntryTypeId = ParamUtil.getLong(
@@ -942,8 +940,6 @@ public class LiferayRepository
 
 		Map<String, DDMFormValues> ddmFormValuesMap = getDDMFormValuesMap(
 			serviceContext, fileEntryTypeId);
-
-		Date displayDate = null;
 
 		DLFileEntry dlFileEntry = dlFileEntryService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowLocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowLocalRepositoryWrapper.java
@@ -140,13 +140,13 @@ public class LiferayWorkflowLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_workflowSupport.updateFileEntry(
@@ -160,14 +160,14 @@ public class LiferayWorkflowLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_workflowSupport.updateFileEntry(
 			userId, fileEntry, dlVersionNumberIncrease, serviceContext);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
@@ -139,13 +139,13 @@ public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_workflowSupport.updateFileEntry(
@@ -159,14 +159,14 @@ public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_workflowSupport.updateFileEntry(
 			userId, fileEntry, dlVersionNumberIncrease, serviceContext);

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorLocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorLocalRepositoryWrapper.java
@@ -85,7 +85,7 @@ public class ModelValidatorLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -98,7 +98,7 @@ public class ModelValidatorLocalRepositoryWrapper
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -107,8 +107,8 @@ public class ModelValidatorLocalRepositoryWrapper
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileContentReference fileContentReference =
@@ -122,7 +122,7 @@ public class ModelValidatorLocalRepositoryWrapper
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	private final ModelValidator<FileContentReference> _modelValidator;

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/ModelValidatorRepositoryWrapper.java
@@ -84,7 +84,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -97,7 +97,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -106,8 +106,8 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileContentReference fileContentReference =
@@ -121,7 +121,7 @@ public class ModelValidatorRepositoryWrapper extends RepositoryWrapper {
 		return super.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	private final ModelValidator<FileContentReference> _modelValidator;

--- a/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
@@ -427,13 +427,13 @@ public class LocalRepositoryWrapper implements LocalRepository {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return _localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -442,14 +442,14 @@ public class LocalRepositoryWrapper implements LocalRepository {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return _localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
@@ -686,13 +686,13 @@ public class RepositoryWrapper implements Repository {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return _repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -701,14 +701,14 @@ public class RepositoryWrapper implements Repository {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		return _repository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
@@ -4268,8 +4268,8 @@ public class DLAppServiceHttp {
 				String urlTitle, String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				byte[] bytes, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				byte[] bytes, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -4281,7 +4281,7 @@ public class DLAppServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease,
-				bytes, expirationDate, reviewDate, serviceContext);
+				bytes, displayDate, expirationDate, reviewDate, serviceContext);
 
 			Object returnObj = null;
 
@@ -4319,8 +4319,8 @@ public class DLAppServiceHttp {
 				String urlTitle, String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -4332,7 +4332,7 @@ public class DLAppServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 
 			Object returnObj = null;
 
@@ -4371,7 +4371,8 @@ public class DLAppServiceHttp {
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
 				java.io.InputStream inputStream, long size,
-				java.util.Date expirationDate, java.util.Date reviewDate,
+				java.util.Date displayDate, java.util.Date expirationDate,
+				java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -4383,7 +4384,8 @@ public class DLAppServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease,
-				inputStream, size, expirationDate, reviewDate, serviceContext);
+				inputStream, size, displayDate, expirationDate, reviewDate,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -4421,8 +4423,8 @@ public class DLAppServiceHttp {
 				String urlTitle, String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -4434,7 +4436,7 @@ public class DLAppServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 
 			Object returnObj = null;
 
@@ -4473,7 +4475,8 @@ public class DLAppServiceHttp {
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
 				java.io.InputStream inputStream, long size,
-				java.util.Date expirationDate, java.util.Date reviewDate,
+				java.util.Date displayDate, java.util.Date expirationDate,
+				java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -4485,7 +4488,8 @@ public class DLAppServiceHttp {
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease,
-				inputStream, size, expirationDate, reviewDate, serviceContext);
+				inputStream, size, displayDate, expirationDate, reviewDate,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -5080,6 +5084,7 @@ public class DLAppServiceHttp {
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
 			byte[].class, java.util.Date.class, java.util.Date.class,
+			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _updateFileEntryParameterTypes101 =
@@ -5089,6 +5094,7 @@ public class DLAppServiceHttp {
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
 			java.io.File.class, java.util.Date.class, java.util.Date.class,
+			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _updateFileEntryParameterTypes102 =
@@ -5098,7 +5104,7 @@ public class DLAppServiceHttp {
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
 			java.io.InputStream.class, long.class, java.util.Date.class,
-			java.util.Date.class,
+			java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
@@ -5108,6 +5114,7 @@ public class DLAppServiceHttp {
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
 			java.io.File.class, java.util.Date.class, java.util.Date.class,
+			java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
@@ -5117,7 +5124,7 @@ public class DLAppServiceHttp {
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease.
 				class,
 			java.io.InputStream.class, long.class, java.util.Date.class,
-			java.util.Date.class,
+			java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _updateFileShortcutParameterTypes105 =

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLFileEntryServiceHttp.java
@@ -2002,7 +2002,8 @@ public class DLFileEntryServiceHttp {
 					 com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
 						ddmFormValuesMap,
 				java.io.File file, java.io.InputStream inputStream, long size,
-				java.util.Date expirationDate, java.util.Date reviewDate,
+				java.util.Date displayDate, java.util.Date expirationDate,
+				java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -2015,7 +2016,7 @@ public class DLFileEntryServiceHttp {
 				methodKey, fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease,
 				fileEntryTypeId, ddmFormValuesMap, file, inputStream, size,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 
 			Object returnObj = null;
 
@@ -2347,7 +2348,7 @@ public class DLFileEntryServiceHttp {
 				class,
 			long.class, java.util.Map.class, java.io.File.class,
 			java.io.InputStream.class, long.class, java.util.Date.class,
-			java.util.Date.class,
+			java.util.Date.class, java.util.Date.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _updateStatusParameterTypes48 =

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -1147,9 +1147,11 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		LocalRepository localRepository =
 			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
 
+		Date displayDate = null;
+
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_dlAppHelperLocalService.updateFileEntry(
@@ -1240,10 +1242,12 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 		LocalRepository localRepository =
 			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
 
+		Date displayDate = null;
+
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_dlAppHelperLocalService.updateFileEntry(
 			userId, fileEntry, null, fileEntry.getFileVersion(),
@@ -1387,6 +1391,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 						DLAppUtil.isMajorVersion(
 							fileVersion, previousFileVersion)),
 					fileVersion.getContentStream(false), fileVersion.getSize(),
+					fileVersion.getDisplayDate(),
 					fileVersion.getExpirationDate(),
 					fileVersion.getReviewDate(), serviceContext);
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -1045,6 +1045,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	 * @param  dlVersionNumberIncrease the kind of version number increase to
 	 *         apply for these changes.
 	 * @param  bytes the file's data (optionally <code>null</code>)
+	 * @param  displayDate the file's display date (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -1062,8 +1064,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			byte[] bytes, Date expirationDate, Date reviewDate,
-			ServiceContext serviceContext)
+			byte[] bytes, Date displayDate, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		File file = null;
@@ -1076,7 +1078,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			return updateFileEntry(
 				userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -1114,6 +1116,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	 * @param  dlVersionNumberIncrease the kind of version number increase to
 	 *         apply for these changes.
 	 * @param  file the file's data (optionally <code>null</code>)
+	 * @param  displayDate the file's display date (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -1131,7 +1135,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -1139,15 +1143,13 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			return updateFileEntry(
 				userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, null, 0,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 
 		mimeType = DLAppUtil.getMimeType(sourceFileName, mimeType, title, file);
 
 		LocalRepository localRepository =
 			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
-
-		Date displayDate = null;
 
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
@@ -1189,6 +1191,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 	 *         apply for these changes.
 	 * @param  inputStream the file's data (optionally <code>null</code>)
 	 * @param  size the file's size (optionally <code>0</code>)
+	 * @param  displayDate the file's displaydate (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -1206,8 +1210,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		if (Validator.isNull(mimeType) ||
@@ -1226,8 +1230,8 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 					return updateFileEntry(
 						userId, fileEntryId, sourceFileName, mimeType, title,
 						urlTitle, description, changeLog,
-						dlVersionNumberIncrease, file, expirationDate,
-						reviewDate, serviceContext);
+						dlVersionNumberIncrease, file, displayDate,
+						expirationDate, reviewDate, serviceContext);
 				}
 				catch (IOException ioException) {
 					throw new SystemException(
@@ -1241,8 +1245,6 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		LocalRepository localRepository =
 			RepositoryProviderUtil.getFileEntryLocalRepository(fileEntryId);
-
-		Date displayDate = null;
 
 		FileEntry fileEntry = localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -2771,6 +2771,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 * @param  dlVersionNumberIncrease the kind of version number increase to
 	 *         apply for these changes.
 	 * @param  bytes the file's data (optionally <code>null</code>)
+	 * @param  displayDate the file's display date (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -2788,7 +2790,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, byte[] bytes,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		File file = null;
@@ -2801,7 +2804,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			return updateFileEntry(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -2838,6 +2841,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 * @param  dlVersionNumberIncrease the kind of version number increase to
 	 *         apply for these changes.
 	 * @param  file the file's data (optionally <code>null</code>)
+	 * @param  displayDate the file's display date (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -2855,22 +2860,21 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		if ((file == null) || !file.exists() || (file.length() == 0)) {
 			return updateFileEntry(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, null, 0,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 
 		mimeType = DLAppUtil.getMimeType(sourceFileName, mimeType, title, file);
 
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
-
-		Date displayDate = null;
 
 		FileEntry fileEntry = repository.updateFileEntry(
 			getUserId(), fileEntryId, sourceFileName, mimeType, title, urlTitle,
@@ -2911,6 +2915,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 *         apply for these changes.
 	 * @param  inputStream the file's data (optionally <code>null</code>)
 	 * @param  size the file's size (optionally <code>0</code>)
+	 * @param  displayDate the file's display date (optionally <code>null
+	 *         </code>)
 	 * @param  expirationDate the file's expiration date (optionally <code>null
 	 *         </code>)
 	 * @param  reviewDate the file's review date (optionally <code>null</code>)
@@ -2928,8 +2934,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		if (Validator.isNull(mimeType) ||
@@ -2948,7 +2954,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 					return updateFileEntry(
 						fileEntryId, sourceFileName, mimeType, title, urlTitle,
 						description, changeLog, dlVersionNumberIncrease, file,
-						expirationDate, reviewDate, serviceContext);
+						displayDate, expirationDate, reviewDate,
+						serviceContext);
 				}
 				catch (IOException ioException) {
 					throw new SystemException(
@@ -2962,8 +2969,6 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
-
-		Date displayDate = null;
 
 		FileEntry fileEntry = repository.updateFileEntry(
 			getUserId(), fileEntryId, sourceFileName, mimeType, title, urlTitle,
@@ -2982,20 +2987,19 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		if ((file == null) || !file.exists() || (file.length() == 0)) {
 			return updateFileEntryAndCheckIn(
 				fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, null, 0,
-				expirationDate, reviewDate, serviceContext);
+				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
-
-		Date displayDate = null;
 
 		_withDLAppHelperDisabled(
 			() -> repository.updateFileEntry(
@@ -3021,14 +3025,12 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
-
-		Date displayDate = null;
 
 		_withDLAppHelperDisabled(
 			() -> repository.updateFileEntry(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -2870,9 +2870,11 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
 
+		Date displayDate = null;
+
 		FileEntry fileEntry = repository.updateFileEntry(
 			getUserId(), fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		_dlAppHelperLocalService.updateFileEntry(
@@ -2961,10 +2963,12 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
 
+		Date displayDate = null;
+
 		FileEntry fileEntry = repository.updateFileEntry(
 			getUserId(), fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		_dlAppHelperLocalService.updateFileEntry(
 			getUserId(), fileEntry, null, fileEntry.getLatestFileVersion(),
@@ -2991,11 +2995,13 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
 
+		Date displayDate = null;
+
 		_withDLAppHelperDisabled(
 			() -> repository.updateFileEntry(
 				getUserId(), fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease, file,
-				expirationDate, reviewDate, serviceContext));
+				displayDate, expirationDate, reviewDate, serviceContext));
 
 		repository.checkInFileEntry(
 			getUserId(), fileEntryId, dlVersionNumberIncrease, changeLog,
@@ -3022,11 +3028,14 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
 			fileEntryId);
 
+		Date displayDate = null;
+
 		_withDLAppHelperDisabled(
 			() -> repository.updateFileEntry(
 				getUserId(), fileEntryId, sourceFileName, mimeType, title,
 				urlTitle, description, changeLog, dlVersionNumberIncrease,
-				inputStream, size, expirationDate, reviewDate, serviceContext));
+				inputStream, size, displayDate, expirationDate, reviewDate,
+				serviceContext));
 
 		repository.checkInFileEntry(
 			getUserId(), fileEntryId, dlVersionNumberIncrease, changeLog,
@@ -3221,6 +3230,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 						DLAppUtil.isMajorVersion(
 							previousFileVersion, fileVersion)),
 					fileVersion.getContentStream(false), fileVersion.getSize(),
+					fileVersion.getDisplayDate(),
 					fileVersion.getExpirationDate(),
 					fileVersion.getReviewDate(), serviceContext);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1767,8 +1767,8 @@ public class DLFileEntryLocalServiceImpl
 			dlFileVersion.getDescription(), changeLog, dlVersionNumberIncrease,
 			dlFileVersion.getExtraSettings(), fileEntryTypeId, ddmFormValuesMap,
 			null, inputStream, dlFileVersion.getSize(),
-			dlFileVersion.getExpirationDate(), dlFileVersion.getReviewDate(),
-			serviceContext);
+			dlFileVersion.getDisplayDate(), dlFileVersion.getExpirationDate(),
+			dlFileVersion.getReviewDate(), serviceContext);
 
 		DLFileVersion newDLFileVersion =
 			_dlFileVersionLocalService.getLatestFileVersion(fileEntryId, false);
@@ -1887,8 +1887,8 @@ public class DLFileEntryLocalServiceImpl
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
-			File file, InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			File file, InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
@@ -1939,7 +1939,7 @@ public class DLFileEntryLocalServiceImpl
 			userId, fileEntryId, sourceFileName, extension, mimeType, title,
 			description, changeLog, dlVersionNumberIncrease, extraSettings,
 			fileEntryTypeId, ddmFormValuesMap, file, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override
@@ -2008,6 +2008,7 @@ public class DLFileEntryLocalServiceImpl
 					dlFileVersion.getFileEntryTypeId());
 				dlFileEntry.setVersion(dlFileVersion.getVersion());
 				dlFileEntry.setSize(dlFileVersion.getSize());
+				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
 				dlFileEntry.setExpirationDate(
 					dlFileVersion.getExpirationDate());
 				dlFileEntry.setReviewDate(dlFileVersion.getReviewDate());
@@ -2425,6 +2426,7 @@ public class DLFileEntryLocalServiceImpl
 					existingDLFileVersion.getFileEntryTypeId(), null,
 					DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION, null,
 					null, existingDLFileVersion.getSize(),
+					existingDLFileVersion.getDisplayDate(),
 					existingDLFileVersion.getExpirationDate(),
 					existingDLFileVersion.getReviewDate(),
 					WorkflowConstants.STATUS_DRAFT,
@@ -3336,6 +3338,7 @@ public class DLFileEntryLocalServiceImpl
 		dlFileEntry.setFileEntryTypeId(
 			latestDLFileVersion.getFileEntryTypeId());
 		dlFileEntry.setSize(latestDLFileVersion.getSize());
+		dlFileEntry.setDisplayDate(latestDLFileVersion.getDisplayDate());
 		dlFileEntry.setExpirationDate(lastDLFileVersion.getExpirationDate());
 		dlFileEntry.setReviewDate(lastDLFileVersion.getReviewDate());
 
@@ -3359,6 +3362,7 @@ public class DLFileEntryLocalServiceImpl
 			latestDLFileVersion.getFileEntryTypeId());
 		lastDLFileVersion.setSize(latestDLFileVersion.getSize());
 		lastDLFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
+		lastDLFileVersion.setDisplayDate(latestDLFileVersion.getDisplayDate());
 		lastDLFileVersion.setExpirationDate(
 			latestDLFileVersion.getExpirationDate());
 		lastDLFileVersion.setReviewDate(latestDLFileVersion.getReviewDate());
@@ -3490,8 +3494,8 @@ public class DLFileEntryLocalServiceImpl
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
 			String extraSettings, long fileEntryTypeId,
 			Map<String, DDMFormValues> ddmFormValuesMap, File file,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = _userPersistence.findByPrimaryKey(userId);
@@ -3580,8 +3584,9 @@ public class DLFileEntryLocalServiceImpl
 				user, dlFileVersion, sourceFileName, fileName, extension,
 				mimeType, title, description, changeLog, extraSettings,
 				fileEntryTypeId, ddmFormValuesMap, version, file, inputStream,
-				size, expirationDate, reviewDate, dlFileVersion.getStatus(),
-				serviceContext.getModifiedDate(date), serviceContext);
+				size, displayDate, expirationDate, reviewDate,
+				dlFileVersion.getStatus(), serviceContext.getModifiedDate(date),
+				serviceContext);
 
 			// Folder
 
@@ -3655,8 +3660,8 @@ public class DLFileEntryLocalServiceImpl
 			String description, String changeLog, String extraSettings,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
 			String version, File file, InputStream inputStream, long size,
-			Date expirationDate, Date reviewDate, int status, Date statusDate,
-			ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate, int status,
+			Date statusDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		dlFileVersion.setUserId(user.getUserId());
@@ -3681,6 +3686,7 @@ public class DLFileEntryLocalServiceImpl
 			dlFileVersion.setStoreUUID(String.valueOf(UUID.randomUUID()));
 		}
 
+		dlFileVersion.setDisplayDate(displayDate);
 		dlFileVersion.setExpirationDate(expirationDate);
 		dlFileVersion.setReviewDate(reviewDate);
 		dlFileVersion.setStatus(status);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
@@ -867,8 +867,8 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
-			File file, InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			File file, InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		ModelResourcePermission<FileEntry> fileEntryModelResourcePermission =
@@ -892,8 +892,8 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 		return dlFileEntryLocalService.updateFileEntry(
 			getUserId(), fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -482,7 +482,7 @@ public class DLFileEntryTypeLocalServiceImpl
 			null, null, null, null, null,
 			DLVersionNumberIncrease.fromMajorVersion(false),
 			getDefaultFileEntryTypeId(folderId), null, null, null, 0, null,
-			null, serviceContext);
+			null, null, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/sharepoint/DLSharepointStorageImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/sharepoint/DLSharepointStorageImpl.java
@@ -285,8 +285,8 @@ public class DLSharepointStorageImpl extends BaseSharepointStorageImpl {
 					fileEntryId, newName, mimeType, newName, StringPool.BLANK,
 					description, changeLog,
 					DLVersionNumberIncrease.fromMajorVersion(false), file,
-					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-					serviceContext);
+					fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+					fileEntry.getReviewDate(), serviceContext);
 
 				if (folderId != newParentFolderId) {
 					fileEntry = DLAppServiceUtil.moveFileEntry(
@@ -380,8 +380,8 @@ public class DLSharepointStorageImpl extends BaseSharepointStorageImpl {
 					fileEntry.getFileEntryId(), title, contentType, title,
 					StringPool.BLANK, description, changeLog,
 					DLVersionNumberIncrease.fromMajorVersion(false), file,
-					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-					serviceContext);
+					fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+					fileEntry.getReviewDate(), serviceContext);
 			}
 			catch (NoSuchFileEntryException noSuchFileEntryException) {
 				if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalService.java
@@ -606,6 +606,8 @@ public interface DLAppLocalService extends BaseLocalService {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -622,8 +624,8 @@ public interface DLAppLocalService extends BaseLocalService {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			byte[] bytes, Date expirationDate, Date reviewDate,
-			ServiceContext serviceContext)
+			byte[] bytes, Date displayDate, Date expirationDate,
+			Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -653,6 +655,8 @@ public interface DLAppLocalService extends BaseLocalService {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -669,7 +673,7 @@ public interface DLAppLocalService extends BaseLocalService {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -701,6 +705,8 @@ public interface DLAppLocalService extends BaseLocalService {
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's displaydate (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -717,8 +723,8 @@ public interface DLAppLocalService extends BaseLocalService {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceUtil.java
@@ -741,6 +741,8 @@ public class DLAppLocalServiceUtil {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -760,14 +762,14 @@ public class DLAppLocalServiceUtil {
 				String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				byte[] bytes, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				byte[] bytes, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, bytes,
+			description, changeLog, dlVersionNumberIncrease, bytes, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -798,6 +800,8 @@ public class DLAppLocalServiceUtil {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -817,14 +821,14 @@ public class DLAppLocalServiceUtil {
 				String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -856,6 +860,8 @@ public class DLAppLocalServiceUtil {
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's displaydate (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -875,7 +881,7 @@ public class DLAppLocalServiceUtil {
 				String description, String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				InputStream inputStream, long size,
+				InputStream inputStream, long size, java.util.Date displayDate,
 				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
@@ -883,7 +889,7 @@ public class DLAppLocalServiceUtil {
 		return getService().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppLocalServiceWrapper.java
@@ -773,6 +773,8 @@ public class DLAppLocalServiceWrapper
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -792,14 +794,14 @@ public class DLAppLocalServiceWrapper
 			String changeLog,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
-			byte[] bytes, java.util.Date expirationDate,
-			java.util.Date reviewDate,
+			byte[] bytes, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, bytes,
+			description, changeLog, dlVersionNumberIncrease, bytes, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -830,6 +832,8 @@ public class DLAppLocalServiceWrapper
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -849,14 +853,14 @@ public class DLAppLocalServiceWrapper
 			String changeLog,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
-			java.io.File file, java.util.Date expirationDate,
-			java.util.Date reviewDate,
+			java.io.File file, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -888,6 +892,8 @@ public class DLAppLocalServiceWrapper
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's displaydate (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -908,14 +914,15 @@ public class DLAppLocalServiceWrapper
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
 			java.io.InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppService.java
@@ -1797,6 +1797,8 @@ public interface DLAppService extends BaseService {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -1813,7 +1815,8 @@ public interface DLAppService extends BaseService {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, byte[] bytes,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -1842,6 +1845,8 @@ public interface DLAppService extends BaseService {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -1858,7 +1863,8 @@ public interface DLAppService extends BaseService {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -1888,6 +1894,8 @@ public interface DLAppService extends BaseService {
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -1904,23 +1912,24 @@ public interface DLAppService extends BaseService {
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
-		throws PortalException;
-
-	public FileEntry updateFileEntryAndCheckIn(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String urlTitle, String description, String changeLog,
-			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+			InputStream inputStream, long size, Date displayDate,
 			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	public FileEntry updateFileEntryAndCheckIn(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String urlTitle, String description, String changeLog,
+			DLVersionNumberIncrease dlVersionNumberIncrease, File file,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public FileEntry updateFileEntryAndCheckIn(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceUtil.java
@@ -2179,6 +2179,8 @@ public class DLAppServiceUtil {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2198,15 +2200,15 @@ public class DLAppServiceUtil {
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				byte[] bytes, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				byte[] bytes, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, bytes, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, bytes, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	/**
@@ -2235,6 +2237,8 @@ public class DLAppServiceUtil {
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2254,15 +2258,15 @@ public class DLAppServiceUtil {
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, file, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	/**
@@ -2292,6 +2296,8 @@ public class DLAppServiceUtil {
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2311,14 +2317,14 @@ public class DLAppServiceUtil {
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				InputStream inputStream, long size,
+				InputStream inputStream, long size, java.util.Date displayDate,
 				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -2329,15 +2335,15 @@ public class DLAppServiceUtil {
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntryAndCheckIn(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, file, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	public static com.liferay.portal.kernel.repository.model.FileEntry
@@ -2347,14 +2353,14 @@ public class DLAppServiceUtil {
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				InputStream inputStream, long size,
+				InputStream inputStream, long size, java.util.Date displayDate,
 				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntryAndCheckIn(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLAppServiceWrapper.java
@@ -2273,6 +2273,8 @@ public class DLAppServiceWrapper
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param bytes the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2291,15 +2293,15 @@ public class DLAppServiceWrapper
 			String title, String urlTitle, String description, String changeLog,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
-			byte[] bytes, java.util.Date expirationDate,
-			java.util.Date reviewDate,
+			byte[] bytes, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, bytes, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, bytes, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	/**
@@ -2328,6 +2330,8 @@ public class DLAppServiceWrapper
 	 * @param dlVersionNumberIncrease the kind of version number increase to
 	 apply for these changes.
 	 * @param file the file's data (optionally <code>null</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2346,15 +2350,15 @@ public class DLAppServiceWrapper
 			String title, String urlTitle, String description, String changeLog,
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
-			java.io.File file, java.util.Date expirationDate,
-			java.util.Date reviewDate,
+			java.io.File file, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, file, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	/**
@@ -2384,6 +2388,8 @@ public class DLAppServiceWrapper
 	 apply for these changes.
 	 * @param inputStream the file's data (optionally <code>null</code>)
 	 * @param size the file's size (optionally <code>0</code>)
+	 * @param displayDate the file's display date (optionally <code>null
+	 </code>)
 	 * @param expirationDate the file's expiration date (optionally <code>null
 	 </code>)
 	 * @param reviewDate the file's review date (optionally <code>null</code>)
@@ -2403,13 +2409,14 @@ public class DLAppServiceWrapper
 			com.liferay.document.library.kernel.model.DLVersionNumberIncrease
 				dlVersionNumberIncrease,
 			java.io.InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 
@@ -2421,15 +2428,15 @@ public class DLAppServiceWrapper
 				String changeLog,
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
-				java.io.File file, java.util.Date expirationDate,
-				java.util.Date reviewDate,
+				java.io.File file, java.util.Date displayDate,
+				java.util.Date expirationDate, java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.updateFileEntryAndCheckIn(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, file, expirationDate,
-			reviewDate, serviceContext);
+			changeLog, dlVersionNumberIncrease, file, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override
@@ -2441,13 +2448,14 @@ public class DLAppServiceWrapper
 				com.liferay.document.library.kernel.model.
 					DLVersionNumberIncrease dlVersionNumberIncrease,
 				java.io.InputStream inputStream, long size,
-				java.util.Date expirationDate, java.util.Date reviewDate,
+				java.util.Date displayDate, java.util.Date expirationDate,
+				java.util.Date reviewDate,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlAppService.updateFileEntryAndCheckIn(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
-			changeLog, dlVersionNumberIncrease, inputStream, size,
+			changeLog, dlVersionNumberIncrease, inputStream, size, displayDate,
 			expirationDate, reviewDate, serviceContext);
 	}
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -693,8 +693,8 @@ public interface DLFileEntryLocalService
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
-			File file, InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			File file, InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	public DLFileEntry updateFileEntryType(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceUtil.java
@@ -956,15 +956,16 @@ public class DLFileEntryLocalServiceUtil {
 			Map<String, com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
 				ddmFormValuesMap,
 			java.io.File file, InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	public static DLFileEntry updateFileEntryType(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalServiceWrapper.java
@@ -1098,15 +1098,16 @@ public class DLFileEntryLocalServiceWrapper
 				<String, com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
 					ddmFormValuesMap,
 			java.io.File file, java.io.InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFileEntryLocalService.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
@@ -287,8 +287,8 @@ public interface DLFileEntryService extends BaseService {
 			String title, String urlTitle, String description, String changeLog,
 			DLVersionNumberIncrease dlVersionNumberIncrease,
 			long fileEntryTypeId, Map<String, DDMFormValues> ddmFormValuesMap,
-			File file, InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			File file, InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	public DLFileEntry updateStatus(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceUtil.java
@@ -429,15 +429,16 @@ public class DLFileEntryServiceUtil {
 			Map<String, com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
 				ddmFormValuesMap,
 			java.io.File file, InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	public static DLFileEntry updateStatus(

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryServiceWrapper.java
@@ -482,15 +482,16 @@ public class DLFileEntryServiceWrapper
 				<String, com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
 					ddmFormValuesMap,
 			java.io.File file, java.io.InputStream inputStream, long size,
-			java.util.Date expirationDate, java.util.Date reviewDate,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _dlFileEntryService.updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, urlTitle, description,
 			changeLog, dlVersionNumberIncrease, fileEntryTypeId,
-			ddmFormValuesMap, file, inputStream, size, expirationDate,
-			reviewDate, serviceContext);
+			ddmFormValuesMap, file, inputStream, size, displayDate,
+			expirationDate, reviewDate, serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
@@ -390,7 +390,7 @@ public abstract class BaseRepositoryImpl
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -398,7 +398,8 @@ public abstract class BaseRepositoryImpl
 			return updateFileEntry(
 				userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 				description, changeLog, dlVersionNumberIncrease, inputStream,
-				file.length(), expirationDate, reviewDate, serviceContext);
+				file.length(), displayDate, expirationDate, reviewDate,
+				serviceContext);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(ioException);
@@ -410,8 +411,8 @@ public abstract class BaseRepositoryImpl
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
@@ -379,7 +379,8 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 		long userId, long fileEntryId, String sourceFileName, String mimeType,
 		String title, String urlTitle, String description, String changeLog,
 		DLVersionNumberIncrease dlVersionNumberIncrease, File file,
-		Date expirationDate, Date reviewDate, ServiceContext serviceContext) {
+		Date displayDate, Date expirationDate, Date reviewDate,
+		ServiceContext serviceContext) {
 
 		throw new UnsupportedOperationException();
 	}
@@ -389,8 +390,8 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 		long userId, long fileEntryId, String sourceFileName, String mimeType,
 		String title, String urlTitle, String description, String changeLog,
 		DLVersionNumberIncrease dlVersionNumberIncrease,
-		InputStream inputStream, long size, Date expirationDate,
-		Date reviewDate, ServiceContext serviceContext) {
+		InputStream inputStream, long size, Date displayDate,
+		Date expirationDate, Date reviewDate, ServiceContext serviceContext) {
 
 		throw new UnsupportedOperationException();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -231,7 +231,7 @@ public interface DocumentRepository extends CapabilityProvider {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -239,8 +239,8 @@ public interface DocumentRepository extends CapabilityProvider {
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException;
 
 	public FileShortcut updateFileShortcut(

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/BaseRepositoryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/BaseRepositoryProxyBean.java
@@ -799,13 +799,13 @@ public class BaseRepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _baseRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
@@ -816,14 +816,14 @@ public class BaseRepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _baseRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/LocalRepositoryProxyBean.java
@@ -398,13 +398,13 @@ public class LocalRepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			File file, Date expirationDate, Date reviewDate,
+			File file, Date displayDate, Date expirationDate, Date reviewDate,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
-			description, changeLog, dlVersionNumberIncrease, file,
+			description, changeLog, dlVersionNumberIncrease, file, displayDate,
 			expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
@@ -415,14 +415,14 @@ public class LocalRepositoryProxyBean
 			long userId, long fileEntryId, String sourceFileName,
 			String mimeType, String title, String urlTitle, String description,
 			String changeLog, DLVersionNumberIncrease dlVersionNumberIncrease,
-			InputStream inputStream, long size, Date expirationDate,
-			Date reviewDate, ServiceContext serviceContext)
+			InputStream inputStream, long size, Date displayDate,
+			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
 		FileEntry fileEntry = _localRepository.updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, urlTitle,
 			description, changeLog, dlVersionNumberIncrease, inputStream, size,
-			expirationDate, reviewDate, serviceContext);
+			displayDate, expirationDate, reviewDate, serviceContext);
 
 		return newFileEntryProxyBean(fileEntry);
 	}


### PR DESCRIPTION
On this PR the update methods where modified to be added the new field (displayDate)

[LPD-6960](https://github.com/liferay-content-management/liferay-portal/pull/5091) and LPD-17066 are needed to forward this PR



Commits:
- LPD-16993 change updateFileEntry adding displayDate field
- LPD-16993 buildService
- LPD-16993 fix calls to updateFileEntry with displayDate field
- LPD-16993 modify tests to match the new methods
- LPD-16993 fix methods on extended classes
- LPD-16993 add displayDate att to the updateFileEntry methods to take into account the new field on all the repositories.
- LPD-16993 modify cmis repository methods
- LPD-16993 add Date displayDate on the update methods of the DLApp Services
- LPD-16993 buildService
- LPD-16993 fix calls to update methods
- LPD-16993 add test to check if the update is done
