### PR TITLE
LPD-17503 

### DIFF
--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
@@ -81,7 +81,7 @@ public class IFrameSanitizerImpl implements Sanitizer {
 	}
 
 	private Document _getDocument(String content) {
-		Document document = Jsoup.parse(content);
+		Document document = Jsoup.parseBodyFragment(content);
 
 		document.outputSettings(
 			new Document.OutputSettings() {


### PR DESCRIPTION
Motivation
----
Fix the issue [LPD-17503](https://liferay.atlassian.net/browse/LPD-17503), where we are returning an empty string when we are calling IFrameSanitizerImpl#sanitize

Proposed Solution
-----
Uses parseBodyFragment, in that way we are going to parse the content into the body, if not if we have something like: <script>alert('Hello')</script>, we are going to parse it into the head