### PR TITLE
LPD-15725 Add sections to "Recent" view

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/dao/search/JournalRecentArticlesResultRowSplitter.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/dao/search/JournalRecentArticlesResultRowSplitter.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.dao.search;
+
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.dao.search.ResultRow;
+import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
+import com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class JournalRecentArticlesResultRowSplitter
+	implements ResultRowSplitter {
+
+	public JournalRecentArticlesResultRowSplitter(ThemeDisplay themeDisplay) {
+		_themeDisplay = themeDisplay;
+	}
+
+	@Override
+	public List<ResultRowSplitterEntry> split(List<ResultRow> resultRows) {
+		List<ResultRowSplitterEntry> resultRowSplitterEntries =
+			new ArrayList<>();
+
+		User user = _themeDisplay.getUser();
+
+		Date date = new Date();
+
+		Calendar currentCalendar = CalendarFactoryUtil.getCalendar(
+			date.getTime(), _themeDisplay.getTimeZone());
+
+		Calendar calendar = CalendarFactoryUtil.getCalendar(
+			currentCalendar.get(Calendar.YEAR),
+			currentCalendar.get(Calendar.MONTH),
+			currentCalendar.get(Calendar.DATE), 0, 0, 0, 0,
+			_themeDisplay.getTimeZone());
+
+		LocalDateTime todayDateTime = _toLocalDateTime(
+			calendar.getTime(), ZoneId.of(user.getTimeZoneId()));
+
+		LocalDateTime sevenDaysAgoDateTime = todayDateTime.minusDays(7);
+		LocalDateTime thirtyDaysAgoDateTime = todayDateTime.minusDays(30);
+
+		List<ResultRow> todayJournalArticleResultRows = new ArrayList<>();
+		List<ResultRow> lastSevenDaysJournalArticleResultRows =
+			new ArrayList<>();
+		List<ResultRow> lastThirtyDaysJournalArticleResultRows =
+			new ArrayList<>();
+		List<ResultRow> olderJournalArticleResultRows = new ArrayList<>();
+
+		for (ResultRow resultRow : resultRows) {
+			JournalArticle journalArticle =
+				(JournalArticle)resultRow.getObject();
+
+			LocalDateTime localDateTime = _toLocalDateTime(
+				journalArticle.getModifiedDate(),
+				ZoneId.of(user.getTimeZoneId()));
+
+			if (localDateTime.isBefore(thirtyDaysAgoDateTime)) {
+				olderJournalArticleResultRows.add(resultRow);
+			}
+			else if (localDateTime.isBefore(sevenDaysAgoDateTime)) {
+				lastThirtyDaysJournalArticleResultRows.add(resultRow);
+			}
+			else if (localDateTime.isBefore(todayDateTime)) {
+				lastSevenDaysJournalArticleResultRows.add(resultRow);
+			}
+			else {
+				todayJournalArticleResultRows.add(resultRow);
+			}
+		}
+
+		if (!todayJournalArticleResultRows.isEmpty()) {
+			resultRowSplitterEntries.add(
+				new ResultRowSplitterEntry(
+					LanguageUtil.get(_themeDisplay.getLocale(), "today"),
+					todayJournalArticleResultRows));
+		}
+
+		if (!lastSevenDaysJournalArticleResultRows.isEmpty()) {
+			resultRowSplitterEntries.add(
+				new ResultRowSplitterEntry(
+					LanguageUtil.get(_themeDisplay.getLocale(), "last-7-days"),
+					lastSevenDaysJournalArticleResultRows));
+		}
+
+		if (!lastThirtyDaysJournalArticleResultRows.isEmpty()) {
+			resultRowSplitterEntries.add(
+				new ResultRowSplitterEntry(
+					LanguageUtil.get(_themeDisplay.getLocale(), "last-30-days"),
+					lastThirtyDaysJournalArticleResultRows));
+		}
+
+		if (!olderJournalArticleResultRows.isEmpty()) {
+			resultRowSplitterEntries.add(
+				new ResultRowSplitterEntry(
+					LanguageUtil.get(_themeDisplay.getLocale(), "older"),
+					olderJournalArticleResultRows));
+		}
+
+		return resultRowSplitterEntries;
+	}
+
+	private LocalDateTime _toLocalDateTime(Date date, ZoneId zoneId) {
+		if (date == null) {
+			date = new Date();
+		}
+
+		Instant instant = date.toInstant();
+
+		ZonedDateTime zonedDateTime = instant.atZone(zoneId);
+
+		return zonedDateTime.toLocalDateTime();
+	}
+
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -129,6 +129,7 @@ import java.text.Format;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -273,6 +274,37 @@ public class JournalDisplayContext {
 		throws Exception {
 
 		return getArticleActionDropdownItems(article);
+	}
+
+	public String getArticleSubtitle(JournalArticle article) {
+		if (FeatureFlagManagerUtil.isEnabled("LPS-202534") &&
+			isNavigationMine()) {
+
+			Date createDate = article.getCreateDate();
+
+			String dateDescription = LanguageUtil.getTimeDescription(
+				_httpServletRequest,
+				System.currentTimeMillis() - createDate.getTime(), true);
+
+			return LanguageUtil.format(
+				_httpServletRequest, "created-x-ago-by-x",
+				new String[] {
+					dateDescription, HtmlUtil.escape(article.getUserName())
+				});
+		}
+
+		Date modifiedDate = article.getModifiedDate();
+
+		String modifiedDateDescription = LanguageUtil.getTimeDescription(
+			_httpServletRequest,
+			System.currentTimeMillis() - modifiedDate.getTime(), true);
+
+		return LanguageUtil.format(
+			_httpServletRequest, "modified-x-ago-by-x",
+			new String[] {
+				modifiedDateDescription,
+				HtmlUtil.escape(article.getStatusByUserName())
+			});
 	}
 
 	public List<DropdownItem> getArticleVersionActionDropdownItems(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -2338,8 +2338,10 @@ public class JournalDisplayContext {
 		searchContext.setCompanyId(_themeDisplay.getCompanyId());
 		searchContext.setEnd(end);
 
-		if (FeatureFlagManagerUtil.isEnabled("LPS-196768") &&
-			(isHighlightedDDMStructure() || isNavigationStructure())) {
+		if ((FeatureFlagManagerUtil.isEnabled("LPS-196768") &&
+			 (isHighlightedDDMStructure() || isNavigationStructure())) ||
+			(FeatureFlagManagerUtil.isEnabled("LPS-202534") &&
+			 isNavigationMine())) {
 
 			searchContext.setEntryClassNames(
 				new String[] {JournalArticle.class.getName()});

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -43,6 +43,8 @@ import com.liferay.journal.util.comparator.FolderArticleTitleComparator;
 import com.liferay.journal.web.internal.asset.model.JournalArticleAssetRenderer;
 import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.constants.JournalWebConstants;
+import com.liferay.journal.web.internal.dao.search.JournalRecentArticlesResultRowSplitter;
+import com.liferay.journal.web.internal.dao.search.JournalResultRowSplitter;
 import com.liferay.journal.web.internal.display.context.helper.JournalWebRequestHelper;
 import com.liferay.journal.web.internal.portlet.action.ActionUtil;
 import com.liferay.journal.web.internal.search.EntriesChecker;
@@ -62,6 +64,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
+import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -1002,6 +1005,20 @@ public class JournalDisplayContext {
 		}
 
 		return _restrictionType;
+	}
+
+	public ResultRowSplitter getResultRowSplitter() {
+		if (isNavigationRecent() &&
+			FeatureFlagManagerUtil.isEnabled("LPS-202534")) {
+
+			return new JournalRecentArticlesResultRowSplitter(_themeDisplay);
+		}
+
+		if (Objects.equals(getDisplayStyle(), "icon")) {
+			return new JournalResultRowSplitter();
+		}
+
+		return null;
 	}
 
 	public String getScheduledArticleMessage(JournalArticle journalArticle) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
@@ -11,12 +11,11 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.display.context.JournalDisplayContext;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.servlet.taglib.util.JournalArticleActionDropdownItemsProvider;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.RowChecker;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -33,7 +32,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.trash.TrashHelper;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -51,7 +49,7 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 		BaseModel<?> baseModel, RenderRequest renderRequest,
 		RenderResponse renderResponse, RowChecker rowChecker,
 		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
-		TrashHelper trashHelper, boolean navigationMine) {
+		TrashHelper trashHelper, JournalDisplayContext journalDisplayContext) {
 
 		super(baseModel, renderRequest, rowChecker);
 
@@ -59,7 +57,7 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 		_assetDisplayPageFriendlyURLProvider =
 			assetDisplayPageFriendlyURLProvider;
 		_trashHelper = trashHelper;
-		_navigationMine = navigationMine;
+		_journalDisplayContext = journalDisplayContext;
 
 		_article = (JournalArticle)baseModel;
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
@@ -201,32 +199,7 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 
 	@Override
 	public String getSubtitle() {
-		if (FeatureFlagManagerUtil.isEnabled("LPS-202534") && _navigationMine) {
-			Date createDate = _article.getCreateDate();
-
-			String dateDescription = LanguageUtil.getTimeDescription(
-				_httpServletRequest,
-				System.currentTimeMillis() - createDate.getTime(), true);
-
-			return LanguageUtil.format(
-				_httpServletRequest, "created-x-ago-by-x",
-				new String[] {
-					dateDescription, HtmlUtil.escape(_article.getUserName())
-				});
-		}
-
-		Date modifiedDate = _article.getModifiedDate();
-
-		String modifiedDateDescription = LanguageUtil.getTimeDescription(
-			_httpServletRequest,
-			System.currentTimeMillis() - modifiedDate.getTime(), true);
-
-		return LanguageUtil.format(
-			_httpServletRequest, "modified-x-ago-by-x",
-			new String[] {
-				modifiedDateDescription,
-				HtmlUtil.escape(_article.getStatusByUserName())
-			});
+		return _journalDisplayContext.getArticleSubtitle(_article);
 	}
 
 	@Override
@@ -250,7 +223,7 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
 	private final HttpServletRequest _httpServletRequest;
-	private final boolean _navigationMine;
+	private final JournalDisplayContext _journalDisplayContext;
 	private final RenderResponse _renderResponse;
 	private final TrashHelper _trashHelper;
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -105,7 +105,6 @@ page import="com.liferay.journal.util.comparator.ArticleVersionComparator" %><%@
 page import="com.liferay.journal.web.internal.asset.model.JournalArticleAssetRenderer" %><%@
 page import="com.liferay.journal.web.internal.configuration.JournalWebConfiguration" %><%@
 page import="com.liferay.journal.web.internal.constants.JournalWebConstants" %><%@
-page import="com.liferay.journal.web.internal.dao.search.JournalResultRowSplitter" %><%@
 page import="com.liferay.journal.web.internal.display.context.EditJournalFeedDisplayContext" %><%@
 page import="com.liferay.journal.web.internal.display.context.JournalArticleCommentsManagementToolbarDisplayContext" %><%@
 page import="com.liferay.journal.web.internal.display.context.JournalArticleVersionsManagementToolbarDisplayContext" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -112,29 +112,8 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 								</c:choose>
 							</div>
 
-							<span class="c-pt-1 text-secondary">
-								<c:choose>
-									<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPS-202534") && journalDisplayContext.isNavigationMine() %>'>
-
-										<%
-										Date createDate = curArticle.getCreateDate();
-
-										String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - createDate.getTime(), true);
-										%>
-
-										<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription, HtmlUtil.escape(curArticle.getUserName())} %>" key="created-x-ago-by-x" />
-									</c:when>
-									<c:otherwise>
-
-										<%
-										Date modifiedDate = curArticle.getModifiedDate();
-
-										String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-										%>
-
-										<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription, HtmlUtil.escape(curArticle.getStatusByUserName())} %>" key="modified-x-ago-by-x" />
-									</c:otherwise>
-								</c:choose>
+							<span class="c-pb-1 c-pt-1 text-secondary">
+								<%= journalDisplayContext.getArticleSubtitle(curArticle) %>
 							</span>
 
 							<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
@@ -208,7 +187,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 									).build()
 								%>'
 								propsTransformer="js/ElementsDefaultPropsTransformer"
-								verticalCard="<%= new JournalArticleVerticalCard(curArticle, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper, journalDisplayContext.isNavigationMine()) %>"
+								verticalCard="<%= new JournalArticleVerticalCard(curArticle, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper, journalDisplayContext) %>"
 							/>
 						</liferay-ui:search-container-column-text>
 					</c:when>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -583,7 +583,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 	<liferay-ui:search-iterator
 		displayStyle="<%= journalDisplayContext.getDisplayStyle() %>"
 		markupView="lexicon"
-		resultRowSplitter='<%= Objects.equals(journalDisplayContext.getDisplayStyle(), "icon") ? new JournalResultRowSplitter() : null %>'
+		resultRowSplitter="<%= journalDisplayContext.getResultRowSplitter() %>"
 		searchContainer="<%= searchContainer %>"
 	/>
 </liferay-ui:search-container>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
@@ -172,6 +172,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 	<liferay-ui:search-iterator
 		displayStyle="<%= journalDisplayContext.getDisplayStyle() %>"
 		markupView="lexicon"
+		resultRowSplitter="<%= journalDisplayContext.getResultRowSplitter() %>"
 		searchContainer="<%= searchContainer %>"
 	/>
 </liferay-ui:search-container>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-15725)

This task changes the way we show web content in "recent" view, that is, those articles that have been recently modified. It does not alter the articles and order of them, it just groups them in sections: today, seven days ago, thirty days ago, and older

## Change summary:

* Adds a new rowsplitter to take care of the sections that we are showing


## Test Scenario

* Enable Feature Flag LPS-202534
* Adds some web content (to test, I changed the modified the modified date of the web contents to reflect the dates of the sections)
* In the management toolbar select "Recent"

The articles should be grouped

![Sections](https://github.com/liferay-content-management/liferay-portal/assets/4267448/df968327-eabe-45cc-b573-4b6c7e5c804f)


