### PR TITLE
LPD-17827 Do not clear these maps as they aren't recalculated like the group mime type

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLSizeLimitConfigurationHelper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/configuration/helper/DLSizeLimitConfigurationHelper.java
@@ -131,8 +131,6 @@ public class DLSizeLimitConfigurationHelper {
 			_companyConfigurationBeans.remove(companyId);
 			_companyMimeTypeSizeLimitsMap.remove(companyId);
 
-			_groupConfigurationBeans.clear();
-			_groupIds.clear();
 			_groupMimeTypeSizeLimitsMap.clear();
 		}
 		else if (_groupIds.containsKey(pid)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-17827

The issue is that upon saving the Instance Settings the group's settings are cleared from memory. This causes the group to fall back on the instance's settings. The fix is to simply not clear these maps to retain the information about the groups with specific configurations in place.

If there are any questions or concerns please let me know.