### PR TITLE
:PD-17937 Bulk action warning message in DL

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -241,6 +241,8 @@ public class DLAdminManagementToolbarDisplayContext
 			() -> stagedActions && !user.isGuestUser(),
 			dropdownItem -> {
 				dropdownItem.putData("action", "permissions");
+				dropdownItem.putData(
+					"maxItemsToShowInfoMessage", String.valueOf(200));
 				dropdownItem.setIcon("password-policies");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "permissions"));

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -352,7 +352,7 @@ export default function propsTransformer({
 		});
 	};
 
-	const permissions = () => {
+	const permissions = (item) => {
 		const map = new Map();
 
 		getAllSelectedElements().each((element) => {
@@ -384,10 +384,48 @@ export default function propsTransformer({
 
 		const permissionsURL = permissionsURLs[selectedModelClassName];
 
-		openChangePermissionsSelectionModal(
-			permissionsURL,
-			selectedFileEntries
-		);
+		if (
+			selectedFileEntries.length > item?.data?.maxItemsToShowInfoMessage
+		) {
+			openModal({
+				bodyHTML: `<p class="text-secondary">
+					${sub(
+						Liferay.Language.get(
+							'you-have-selected-more-than-x-x-info-message'
+						),
+						item?.data?.maxItemsToShowInfoMessage,
+						Liferay.Language.get('documents')
+					)}
+				</p>`,
+				buttons: [
+					{
+						displayType: 'secondary',
+						label: Liferay.Language.get('cancel'),
+						type: 'cancel',
+					},
+					{
+						displayType: 'info',
+						label: Liferay.Language.get('continue'),
+						onClick: ({processClose}) => {
+							processClose();
+							openChangePermissionsSelectionModal(
+								permissionsURL,
+								selectedFileEntries
+							);
+						},
+						type: 'button',
+					},
+				],
+				status: 'info',
+				title: Liferay.Language.get('bulk-action-performance'),
+			});
+		}
+		else {
+			openChangePermissionsSelectionModal(
+				permissionsURL,
+				selectedFileEntries
+			);
+		}
 	};
 
 	return {
@@ -426,7 +464,7 @@ export default function propsTransformer({
 				move();
 			}
 			else if (action === 'permissions') {
-				permissions();
+				permissions(item);
 			}
 		},
 		onCreationMenuItemClick: (event, {item}) => {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -340,6 +340,18 @@ export default function propsTransformer({
 		}
 	};
 
+	const openChangePermissionsSelectionModal = (
+		changePermissionsURL,
+		selectedFileEntries
+	) => {
+		openSelectionModal({
+			title: Liferay.Language.get('permissions'),
+			url: createPortletURL(changePermissionsURL, {
+				resourcePrimKey: selectedFileEntries.join(','),
+			}),
+		});
+	};
+
 	const permissions = () => {
 		const map = new Map();
 
@@ -372,19 +384,10 @@ export default function propsTransformer({
 
 		const permissionsURL = permissionsURLs[selectedModelClassName];
 
-		const url = new URL(permissionsURL);
-
-		openSelectionModal({
-			title: Liferay.Language.get('permissions'),
-			url: addParams(
-				{
-					[`_${url.searchParams.get(
-						'p_p_id'
-					)}_resourcePrimKey`]: selectedFileEntries.join(','),
-				},
-				permissionsURL
-			),
-		});
+		openChangePermissionsSelectionModal(
+			permissionsURL,
+			selectedFileEntries
+		);
 	};
 
 	return {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLManagementToolbarPropsTransformer.js
@@ -385,6 +385,7 @@ export default function propsTransformer({
 		const permissionsURL = permissionsURLs[selectedModelClassName];
 
 		if (
+			Liferay.FeatureFlags['LPD-16469'] &&
 			selectedFileEntries.length > item?.data?.maxItemsToShowInfoMessage
 		) {
 			openModal({


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-17937)

We are adding an info message when the user selects a large amount of items for bulk permission editing. This PR handles DL

## Change summary:

* Adds an information message when the user selects a large amount of file entries for bulk permission changing


## Test Scenario

* Start the portal with FF LPD-16469 enabled
* Go to Documents and Media
* Upload 201 files
* Select all of them
* In the toolbar select "Permissions"

A "Bulk action" message will be shown