### PR TITLE
LPD-6962 update status and show info on the file

### DIFF
--- a/modules/apps/document-library/document-library-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library API
 Bundle-SymbolicName: com.liferay.document.library.api
-Bundle-Version: 24.2.1
+Bundle-Version: 24.3.0
 Export-Package:\
 	com.liferay.document.library.asset,\
 	com.liferay.document.library.asset.model,\

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/BaseDLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/BaseDLViewFileVersionDisplayContext.java
@@ -95,6 +95,11 @@ public class BaseDLViewFileVersionDisplayContext
 	}
 
 	@Override
+	public boolean hasApprovedVersion() {
+		return parentDisplayContext.hasApprovedVersion();
+	}
+
+	@Override
 	public boolean hasCustomThumbnail() {
 		return parentDisplayContext.hasCustomThumbnail();
 	}

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/display/context/DLViewFileVersionDisplayContext.java
@@ -48,6 +48,8 @@ public interface DLViewFileVersionDisplayContext extends DLDisplayContext {
 		return "document-default";
 	}
 
+	public boolean hasApprovedVersion();
+
 	public default boolean hasCustomThumbnail() {
 		return false;
 	}

--- a/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/display/context/packageinfo
+++ b/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/display/context/packageinfo
@@ -1,1 +1,1 @@
-version 9.3.0
+version 9.4.0

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
@@ -388,6 +388,9 @@ public class CMISFileVersion extends BaseCMISModel implements FileVersion {
 	public boolean isPending() {
 		return false;
 	}
+	public boolean isScheduled() {
+		return false;
+	}
 
 	@Override
 	public void setCompanyId(long companyId) {

--- a/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/src/main/java/com/liferay/document/library/repository/cmis/internal/model/CMISFileVersion.java
@@ -388,6 +388,7 @@ public class CMISFileVersion extends BaseCMISModel implements FileVersion {
 	public boolean isPending() {
 		return false;
 	}
+
 	public boolean isScheduled() {
 		return false;
 	}

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
@@ -204,6 +204,7 @@ public class ExtRepositoryFileVersionAdapter
 	public boolean isPending() {
 		return false;
 	}
+
 	@Override
 	public boolean isScheduled() {
 		return false;

--- a/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
+++ b/modules/apps/document-library/document-library-repository-external-api/src/main/java/com/liferay/document/library/repository/external/model/ExtRepositoryFileVersionAdapter.java
@@ -204,6 +204,10 @@ public class ExtRepositoryFileVersionAdapter
 	public boolean isPending() {
 		return false;
 	}
+	@Override
+	public boolean isScheduled() {
+		return false;
+	}
 
 	private final ExtRepositoryFileEntryAdapter _extRepositoryFileEntryAdapter;
 	private final ExtRepositoryFileVersion _extRepositoryFileVersion;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
@@ -10,7 +10,9 @@ import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.document.library.web.internal.constants.DLWebKeys;
@@ -23,6 +25,7 @@ import com.liferay.document.library.web.internal.security.permission.resource.DL
 import com.liferay.document.library.web.internal.security.permission.resource.DLFolderPermission;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -40,6 +43,7 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.servlet.BrowserSnifferUtil;
 import com.liferay.portal.util.RepositoryUtil;
 
@@ -282,6 +286,22 @@ public class DLViewEntriesDisplayContext {
 		).setParameter(
 			"fileEntryId", fileEntry.getFileEntryId()
 		).buildString();
+	}
+
+	public boolean hasApprovedVersion(long fileEntryId) {
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-10701")) {
+			return false;
+		}
+
+		DLFileVersion dlFileVersion =
+			DLFileVersionLocalServiceUtil.fetchLatestFileVersion(
+				fileEntryId, false, WorkflowConstants.STATUS_APPROVED);
+
+		if (dlFileVersion == null) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public boolean isDescriptiveDisplayStyle() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLViewFileVersionDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DefaultDLViewFileVersionDisplayContext.java
@@ -12,7 +12,9 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileVersionLocalServiceUtil;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.preview.DLPreviewRenderer;
 import com.liferay.document.library.preview.DLPreviewRendererProvider;
@@ -37,6 +39,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -45,6 +48,7 @@ import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.IOException;
 
@@ -248,6 +252,24 @@ public class DefaultDLViewFileVersionDisplayContext
 	@Override
 	public UUID getUuid() {
 		return _UUID;
+	}
+
+	@Override
+	public boolean hasApprovedVersion() {
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-10701")) {
+			return false;
+		}
+
+		DLFileVersion dlFileVersion =
+			DLFileVersionLocalServiceUtil.fetchLatestFileVersion(
+				_fileVersion.getFileEntryId(), false,
+				WorkflowConstants.STATUS_APPROVED);
+
+		if (dlFileVersion == null) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -46,6 +46,7 @@ import com.liferay.dynamic.data.mapping.util.DDMBeanTranslator;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidationException;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -396,8 +397,11 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		Date displayDate = _getDisplayDate(
 			uploadPortletRequest, neverExpireDefaultValue, user.getTimeZone());
+
 		Date expirationDate = _getExpirationDate(
-			uploadPortletRequest, neverExpireDefaultValue, user.getTimeZone());
+			uploadPortletRequest, displayDate, neverExpireDefaultValue,
+			user.getTimeZone());
+
 		Date reviewDate = _getReviewDate(
 			uploadPortletRequest, neverExpireDefaultValue, user.getTimeZone());
 
@@ -962,7 +966,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private Date _getExpirationDate(
-			UploadPortletRequest uploadPortletRequest,
+			UploadPortletRequest uploadPortletRequest, Date displayDate,
 			boolean neverExpireDefaultValue, TimeZone timeZone)
 		throws PortalException {
 
@@ -998,6 +1002,15 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		if ((expirationDate != null) && expirationDate.before(new Date())) {
 			throw new FileEntryExpirationDateException(
 				"Expiration date " + expirationDate + " is in the past");
+		}
+
+		if ((displayDate != null) && (expirationDate != null) &&
+			displayDate.after(expirationDate)) {
+
+			throw new FileEntryExpirationDateException(
+				StringBundler.concat(
+					"Expiration date ", expirationDate,
+					" is prior to display date ", displayDate));
 		}
 
 		return expirationDate;
@@ -1347,8 +1360,11 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			Date displayDate = _getDisplayDate(
 				uploadPortletRequest, addDynamic, user.getTimeZone());
+
 			Date expirationDate = _getExpirationDate(
-				uploadPortletRequest, addDynamic, user.getTimeZone());
+				uploadPortletRequest, displayDate, addDynamic,
+				user.getTimeZone());
+
 			Date reviewDate = _getReviewDate(
 				uploadPortletRequest, addDynamic, user.getTimeZone());
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -45,14 +45,14 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 				<aui:model-context bean="<%= fileVersion %>" model="<%= DLFileVersion.class %>" />
 
+				<aui:workflow-status model="<%= DLFileEntry.class %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= fileVersion.getStatus() %>" />
+
 				<c:if test="<%= !fileVersion.isApproved() && dlViewFileVersionDisplayContext.hasApprovedVersion() %>">
 					<clay:label
 						displayType="success"
 						label="approved"
 					/>
 				</c:if>
-
-				<aui:workflow-status model="<%= DLFileEntry.class %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= fileVersion.getStatus() %>" />
 			</clay:content-section>
 		</clay:content-col>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -45,6 +45,13 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 
 				<aui:model-context bean="<%= fileVersion %>" model="<%= DLFileVersion.class %>" />
 
+				<c:if test="<%= !fileVersion.isApproved() && dlViewFileVersionDisplayContext.hasApprovedVersion() %>">
+					<clay:label
+						displayType="success"
+						label="approved"
+					/>
+				</c:if>
+
 				<aui:workflow-status model="<%= DLFileEntry.class %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= fileVersion.getStatus() %>" />
 			</clay:content-section>
 		</clay:content-col>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -149,7 +149,23 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 															/>
 														</c:if>
 
-														<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+														<c:choose>
+															<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-10701") && latestFileVersion.isScheduled() %>'>
+
+																<%
+																String displayDateString = StringPool.BLANK;
+
+																if (latestFileVersion.getDisplayDate() != null) {
+																	displayDateString = dateTimeFormat.format(latestFileVersion.getDisplayDate());
+																}
+																%>
+
+																<aui:workflow-status helpMessage="<%= latestFileVersion.isScheduled() ? displayDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= latestFileVersion.isScheduled() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+															</c:when>
+															<c:otherwise>
+																<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+															</c:otherwise>
+														</c:choose>
 
 														<c:choose>
 															<c:when test="<%= fileShortcut != null %>">
@@ -299,7 +315,23 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 												/>
 											</c:if>
 
-											<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+											<c:choose>
+												<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-10701") && latestFileVersion.isScheduled() %>'>
+
+													<%
+													String displayDateString = StringPool.BLANK;
+
+													if (latestFileVersion.getDisplayDate() != null) {
+														displayDateString = dateTimeFormat.format(latestFileVersion.getDisplayDate());
+													}
+													%>
+
+													<aui:workflow-status helpMessage="<%= latestFileVersion.isScheduled() ? displayDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= latestFileVersion.isScheduled() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+												</c:when>
+												<c:otherwise>
+													<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+												</c:otherwise>
+											</c:choose>
 										</liferay-ui:search-container-column-text>
 									</c:when>
 									<c:when test='<%= curEntryColumn.equals("downloads") %>'>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -144,6 +144,13 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 													<div class="card-detail">
 														<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
 
+														<c:if test="<%= !latestFileVersion.isApproved() && dlViewEntriesDisplayContext.hasApprovedVersion(latestFileVersion.getFileEntryId()) %>">
+															<clay:label
+																displayType="success"
+																label="approved"
+															/>
+														</c:if>
+
 														<c:choose>
 															<c:when test="<%= fileShortcut != null %>">
 																<clay:icon
@@ -281,11 +288,19 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 										/>
 									</c:when>
 									<c:when test='<%= curEntryColumn.equals("status") %>'>
-										<liferay-ui:search-container-column-status
+										<liferay-ui:search-container-column-text
 											cssClass="table-cell-expand-smallest"
 											name="status"
-											status="<%= latestFileVersion.getStatus() %>"
-										/>
+										>
+											<c:if test="<%= !latestFileVersion.isApproved() && dlViewEntriesDisplayContext.hasApprovedVersion(latestFileVersion.getFileEntryId()) %>">
+												<clay:label
+													displayType="success"
+													label="approved"
+												/>
+											</c:if>
+
+											<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+										</liferay-ui:search-container-column-text>
 									</c:when>
 									<c:when test='<%= curEntryColumn.equals("downloads") %>'>
 										<c:if test="<%= ViewCountManagerUtil.isViewCountEnabled(PortalUtil.getClassNameId(DLFileEntryConstants.getClassName())) %>">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -142,14 +142,14 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 													</div>
 
 													<div class="card-detail">
-														<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
-
 														<c:if test="<%= !latestFileVersion.isApproved() && dlViewEntriesDisplayContext.hasApprovedVersion(latestFileVersion.getFileEntryId()) %>">
 															<clay:label
 																displayType="success"
 																label="approved"
 															/>
 														</c:if>
+
+														<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
 
 														<c:choose>
 															<c:when test="<%= fileShortcut != null %>">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
@@ -110,7 +110,23 @@ else {
 		/>
 	</c:if>
 
-	<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+	<c:choose>
+		<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-10701") && latestFileVersion.isScheduled() %>'>
+
+			<%
+			String displayDateString = StringPool.BLANK;
+
+			if (latestFileVersion.getDisplayDate() != null) {
+				displayDateString = dateTimeFormat.format(latestFileVersion.getDisplayDate());
+			}
+			%>
+
+			<aui:workflow-status helpMessage="<%= latestFileVersion.isScheduled() ? displayDateString : StringPool.BLANK %>" markupView="lexicon" showHelpMessage="<%= latestFileVersion.isScheduled() %>" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+		</c:when>
+		<c:otherwise>
+			<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
+		</c:otherwise>
+	</c:choose>
 
 	<c:choose>
 		<c:when test="<%= fileShortcut != null %>">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive.jsp
@@ -103,6 +103,13 @@ else {
 </c:if>
 
 <span class="file-entry-status">
+	<c:if test="<%= !latestFileVersion.isApproved() && dlViewFileVersionDisplayContext.hasApprovedVersion() %>">
+		<clay:label
+			displayType="success"
+			label="approved"
+		/>
+	</c:if>
+
 	<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= latestFileVersion.getStatus() %>" />
 
 	<c:choose>

--- a/modules/apps/document-library/source-formatter-suppressions.xml
+++ b/modules/apps/document-library/source-formatter-suppressions.xml
@@ -9,5 +9,7 @@
 	</checkstyle>
 	<source-check>
 		<suppress checks="BNDDefinitionKeysCheck" files="document-library-preview-pdf/bnd\.bnd" />
+		<suppress checks="IllegalTaglibsCheck" files="document-library-web/src/main/resources/META-INF/resources/document_library/view_entries\.jsp" />
+		<suppress checks="IllegalTaglibsCheck" files="document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_descriptive\.jsp" />
 	</source-check>
 </suppressions>

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileVersion.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileVersion.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.RepositoryModelOperation;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.InputStream;
 import java.io.Serializable;
@@ -328,6 +329,15 @@ public class LiferayFileVersion extends LiferayModel implements FileVersion {
 	@Override
 	public boolean isPending() {
 		return _dlFileVersion.isPending();
+	}
+
+	@Override
+	public boolean isScheduled() {
+		if (getStatus() == WorkflowConstants.STATUS_SCHEDULED) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -375,7 +375,13 @@ public class DLFileEntryLocalServiceImpl
 			companyId,
 			key -> new Date(date.getTime() - (checkInterval * Time.MINUTE)));
 
-		_checkFileEntriesByExpirationDate(companyId, date);
+		long userId = _getActiveCompanyAdminUserId(companyId);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-10701")) {
+			_checkFileEntriesByDisplayDate(companyId, date, userId);
+		}
+
+		_checkFileEntriesByExpirationDate(companyId, date, userId);
 
 		_checkFileEntriesByReviewDate(companyId, date);
 
@@ -2311,8 +2317,24 @@ public class DLFileEntryLocalServiceImpl
 		return entryURL;
 	}
 
+	private void _checkFileEntriesByDisplayDate(
+			long companyId, Date displayDate, long userId)
+		throws PortalException {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				StringBundler.concat(
+					"Publishing file entries with display date less than ",
+					displayDate, " for companyId ", companyId));
+		}
+
+		_publishFileEntriesByCompanyId(
+			companyId, displayDate, userId, Collections.emptyMap(),
+			new ServiceContext());
+	}
+
 	private void _checkFileEntriesByExpirationDate(
-			long companyId, Date expirationDate)
+			long companyId, Date expirationDate, long userId)
 		throws PortalException {
 
 		if (_log.isDebugEnabled()) {
@@ -2323,7 +2345,7 @@ public class DLFileEntryLocalServiceImpl
 		}
 
 		_expireFileEntriesByCompanyId(
-			companyId, expirationDate, Collections.emptyMap(),
+			companyId, expirationDate, userId, Collections.emptyMap(),
 			new ServiceContext());
 	}
 
@@ -2659,12 +2681,10 @@ public class DLFileEntryLocalServiceImpl
 	}
 
 	private void _expireFileEntriesByCompanyId(
-			long companyId, Date expirationDate,
+			long companyId, Date expirationDate, long userId,
 			Map<String, Serializable> workflowContext,
 			ServiceContext serviceContext)
 		throws PortalException {
-
-		long userId = _getActiveCompanyAdminUserId(companyId);
 
 		List<DLFileEntry> fileEntries =
 			_getFileEntriesByCompanyIdAndExpirationDate(
@@ -2789,6 +2809,23 @@ public class DLFileEntryLocalServiceImpl
 		}
 
 		return null;
+	}
+
+	private List<DLFileEntry> _getFileEntriesByCompanyIdAndDisplayDate(
+		long companyId, Date displayDate) {
+
+		return dlFileEntryPersistence.dslQuery(
+			DSLQueryFactoryUtil.select(
+				DLFileEntryTable.INSTANCE
+			).from(
+				DLFileEntryTable.INSTANCE
+			).where(
+				DLFileEntryTable.INSTANCE.companyId.eq(
+					companyId
+				).and(
+					DLFileEntryTable.INSTANCE.displayDate.lte(displayDate)
+				)
+			));
 	}
 
 	private List<DLFileEntry> _getFileEntriesByCompanyIdAndExpirationDate(
@@ -3458,6 +3495,35 @@ public class DLFileEntryLocalServiceImpl
 				dlFileEntry));
 
 		actionableDynamicQuery.performActions();
+	}
+
+	private void _publishFileEntriesByCompanyId(
+			long companyId, Date displayDate, long userId,
+			Map<String, Serializable> workflowContext,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		List<DLFileEntry> fileEntries =
+			_getFileEntriesByCompanyIdAndDisplayDate(companyId, displayDate);
+
+		for (DLFileEntry fileEntry : fileEntries) {
+			if (fileEntry.isInTrash()) {
+				continue;
+			}
+
+			DLFileVersion latestFileVersion =
+				_dlFileVersionLocalService.fetchLatestFileVersion(
+					fileEntry.getFileEntryId(), false);
+
+			if (WorkflowConstants.STATUS_SCHEDULED ==
+					latestFileVersion.getStatus()) {
+
+				updateStatus(
+					userId, fileEntry, latestFileVersion,
+					WorkflowConstants.STATUS_APPROVED, serviceContext,
+					workflowContext);
+			}
+		}
 	}
 
 	private void _registerPWCDeletionCallback(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1983,6 +1983,15 @@ public class DLFileEntryLocalServiceImpl
 
 		int oldStatus = dlFileVersion.getStatus();
 
+		Date date = new Date();
+
+		if ((status == WorkflowConstants.STATUS_APPROVED) &&
+			(dlFileVersion.getDisplayDate() != null) &&
+			date.before(dlFileVersion.getDisplayDate())) {
+
+			status = WorkflowConstants.STATUS_SCHEDULED;
+		}
+
 		dlFileVersion.setStatus(status);
 		dlFileVersion.setStatusByUserId(user.getUserId());
 		dlFileVersion.setStatusByUserName(user.getFullName());
@@ -2079,6 +2088,7 @@ public class DLFileEntryLocalServiceImpl
 		if (((status == WorkflowConstants.STATUS_APPROVED) ||
 			 (status == WorkflowConstants.STATUS_EXPIRED) ||
 			 (status == WorkflowConstants.STATUS_IN_TRASH) ||
+			 (status == WorkflowConstants.STATUS_SCHEDULED) ||
 			 (oldStatus == WorkflowConstants.STATUS_IN_TRASH)) &&
 			((serviceContext == null) || serviceContext.isIndexingEnabled())) {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.interval.IntervalActionProcessor;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.lock.InvalidLockException;
@@ -909,6 +910,8 @@ public class DLFileEntryLocalServiceImpl
 					dlFileEntry.setFileEntryTypeId(fileEntryTypeId);
 					dlFileEntry.setVersion(dlLatestFileVersion.getVersion());
 					dlFileEntry.setSize(dlLatestFileVersion.getSize());
+					dlFileEntry.setDisplayDate(
+						dlLatestFileVersion.getDisplayDate());
 					dlFileEntry.setExpirationDate(
 						dlLatestFileVersion.getExpirationDate());
 					dlFileEntry.setReviewDate(
@@ -1983,13 +1986,15 @@ public class DLFileEntryLocalServiceImpl
 
 		int oldStatus = dlFileVersion.getStatus();
 
-		Date date = new Date();
+		if (FeatureFlagManagerUtil.isEnabled("LPD-10701")) {
+			Date date = new Date();
 
-		if ((status == WorkflowConstants.STATUS_APPROVED) &&
-			(dlFileVersion.getDisplayDate() != null) &&
-			date.before(dlFileVersion.getDisplayDate())) {
+			if ((status == WorkflowConstants.STATUS_APPROVED) &&
+				(dlFileVersion.getDisplayDate() != null) &&
+				date.before(dlFileVersion.getDisplayDate())) {
 
-			status = WorkflowConstants.STATUS_SCHEDULED;
+				status = WorkflowConstants.STATUS_SCHEDULED;
+			}
 		}
 
 		dlFileVersion.setStatus(status);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -11,7 +11,6 @@ import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.kernel.util.comparator.DLFileVersionVersionComparator;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.kernel.util.comparator.DLFileVersionVersionComparator;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -56,6 +57,18 @@ public class DLFileVersionLocalServiceImpl
 		}
 
 		return dlFileVersion;
+	}
+
+	@Override
+	public DLFileVersion fetchLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy, int status) {
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return fetchLatestFileVersion(fileEntryId, excludeWorkingCopy);
+		}
+
+		return dlFileVersionPersistence.fetchByF_S_Last(
+			fileEntryId, status, new DLFileVersionVersionComparator());
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalService.java
@@ -221,6 +221,10 @@ public interface DLFileVersionLocalService
 		long fileEntryId, boolean excludeWorkingCopy);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DLFileVersion fetchLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceUtil.java
@@ -222,6 +222,13 @@ public class DLFileVersionLocalServiceUtil {
 			fileEntryId, excludeWorkingCopy);
 	}
 
+	public static DLFileVersion fetchLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy, int status) {
+
+		return getService().fetchLatestFileVersion(
+			fileEntryId, excludeWorkingCopy, status);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileVersionLocalServiceWrapper.java
@@ -245,6 +245,14 @@ public class DLFileVersionLocalServiceWrapper
 	}
 
 	@Override
+	public DLFileVersion fetchLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy, int status) {
+
+		return _dlFileVersionLocalService.fetchLatestFileVersion(
+			fileEntryId, excludeWorkingCopy, status);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileVersion.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileVersion.java
@@ -98,4 +98,6 @@ public interface FileVersion extends RepositoryModel<FileVersion> {
 
 	public boolean isPending();
 
+	public boolean isScheduled();
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileVersionWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/FileVersionWrapper.java
@@ -301,6 +301,11 @@ public class FileVersionWrapper
 	}
 
 	@Override
+	public boolean isScheduled() {
+		return _fileVersion.isScheduled();
+	}
+
+	@Override
 	public void setCompanyId(long companyId) {
 		_fileVersion.setCompanyId(companyId);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/model/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 13.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileVersionProxyBean.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/proxy/FileVersionProxyBean.java
@@ -283,6 +283,11 @@ public class FileVersionProxyBean
 	}
 
 	@Override
+	public boolean isScheduled() {
+		return _fileVersion.isScheduled();
+	}
+
+	@Override
 	public void setCompanyId(long companyId) {
 		_fileVersion.setCompanyId(companyId);
 	}


### PR DESCRIPTION






- LPD-6962 add validation for the display date - expiration date relation
- LPD-6962 update status taking into account the display date
- LPD-6962 create method to obtain only the last version by status
- LPD-6962 buildService
- LPD-6962 baseline
- LPD-6962 create method on displayContext to know if a file has an approved version
- LPD-6962 show labels if is not approved but hasApprovedVersion
- LPD-6962 update status
- LPD-6962 create method to publish document every interval check
- LPD-6962 show
- LPD-6962 create isScheduled method on fileVersion class
- LPD-6962 semantic version
- LPD-6962 implement isScheduled methods
- LPD-6962 show info with the display date
- LPD-6962 suppress IllegalTaglibsCheck on show info tag
