### PR TITLE
LPD-18323 Custom user rank labels in Message Boards do not work correctly

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBStatsUserLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBStatsUserLocalServiceImpl.java
@@ -258,7 +258,7 @@ public class MBStatsUserLocalServiceImpl
 					if (_isEntityRank(
 							companyId, user, entityType, entityValue)) {
 
-						rank[1] = curRank;
+						rank[1] = entityValue;
 
 						break;
 					}


### PR DESCRIPTION
Hey,

[LPD-18323](https://liferay.atlassian.net/browse/LPD-18323)

We passed down the whole entity instead of just the value, which we ended up rendering here: https://github.com/liferay-echo/liferay-portal/blob/master/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp#L91-L95

Please review my change,

Thanks