### PR TITLE
[TS] LPD-18327 Add LayoutClassedModelUsageUpgradeProcess for change DLFile…

### DIFF
--- a/modules/apps/layout/layout-service/bnd.bnd
+++ b/modules/apps/layout/layout-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Service
 Bundle-SymbolicName: com.liferay.layout.service
 Bundle-Version: 2.0.58
-Liferay-Require-SchemaVersion: 1.4.2
+Liferay-Require-SchemaVersion: 1.4.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
@@ -96,6 +96,11 @@ public class LayoutServiceUpgradeStepRegistrator
 			"1.4.1", "1.4.2",
 			new com.liferay.layout.internal.upgrade.v1_4_2.LayoutUpgradeProcess(
 				_layoutLocalService));
+
+		registry.register(
+			"1.4.2", "1.4.3",
+			new com.liferay.layout.internal.upgrade.v1_4_3.
+				LayoutClassedModelUsageUpgradeProcess(_classNameLocalService));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_3/LayoutClassedModelUsageUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_3/LayoutClassedModelUsageUpgradeProcess.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_4_3;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Gergely Szalay
+ */
+public class LayoutClassedModelUsageUpgradeProcess extends UpgradeProcess {
+
+	public LayoutClassedModelUsageUpgradeProcess(
+		ClassNameLocalService classNameLocalService) {
+
+		_dlFileEntryClassNameId = classNameLocalService.getClassNameId(
+			DLFileEntry.class.getName());
+		_fileEntryClassNameId = classNameLocalService.getClassNameId(
+			FileEntry.class.getName());
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update LayoutClassedModelUsage set classNameId = ? " +
+						"where classNameId = ?")) {
+
+			preparedStatement.setLong(1, _fileEntryClassNameId);
+			preparedStatement.setLong(2, _dlFileEntryClassNameId);
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final long _dlFileEntryClassNameId;
+	private final long _fileEntryClassNameId;
+
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_3/test/LayoutClassedModelUsageUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_3/test/LayoutClassedModelUsageUpgradeProcessTest.java
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_4_3.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.layout.model.LayoutClassedModelUsage;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Gergely Szalay
+ */
+@RunWith(Arquillian.class)
+public class LayoutClassedModelUsageUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_dlFileEntryClassNameId = _classNameLocalService.getClassNameId(
+			DLFileEntry.class.getName());
+
+		_fileEntryClassNameId = _classNameLocalService.getClassNameId(
+			FileEntry.class);
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		_layoutClassedModelUsage = addLayoutClassedModelUsage();
+
+		_runUpgrade();
+
+		LayoutClassedModelUsage newLayoutClassedModelUsage =
+			_layoutClassedModelUsageLocalService.getLayoutClassedModelUsage(
+				_layoutClassedModelUsage.getLayoutClassedModelUsageId());
+
+		Assert.assertEquals(
+			_fileEntryClassNameId, newLayoutClassedModelUsage.getClassNameId());
+	}
+
+	protected LayoutClassedModelUsage addLayoutClassedModelUsage()
+		throws Exception {
+
+		return _layoutClassedModelUsageLocalService.addLayoutClassedModelUsage(
+			_group.getGroupId(), _dlFileEntryClassNameId,
+			RandomTestUtil.nextLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextLong(), _serviceContext);
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.layout.internal.upgrade.v1_4_3." +
+			"LayoutClassedModelUsageUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.internal.upgrade.registry.LayoutServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private long _dlFileEntryClassNameId;
+	private long _fileEntryClassNameId;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private LayoutClassedModelUsage _layoutClassedModelUsage;
+
+	@Inject
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private ServiceContext _serviceContext;
+
+}


### PR DESCRIPTION
May I ask to review my PR?

The issue is from https://liferay.atlassian.net/browse/LPD-18327

Summary:  https://liferay.atlassian.net/browse/LPS-148385 We changed the class for LayoutClassedModelUsage from DLFileEntry to FileEntry, but if we upgrade from 7.3 or lower to 7.4 the class name isnt changed.

Solution: Created a new upgrade step "1.4.3" where in the query I request the entries with DLFileEntry in classnameid, I changed it to FileEntry and updated the entry in the end.

Thank you in advance!