### PR TITLE
LPD-18328 Arabic localization causes issue with Web Content filtering on date with API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -14,6 +14,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -147,7 +148,8 @@ public class EntityFieldsProvider {
 			Date date = indexDateFormat.parse(String.valueOf(fieldValue));
 
 			DateFormat searchDateFormat =
-				DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
+				DateFormatFactoryUtil.getSimpleDateFormat(
+					"yyyy-MM-dd", LocaleUtil.US);
 
 			return searchDateFormat.format(date);
 		}


### PR DESCRIPTION
Hey,

[LPD-18328](https://liferay.atlassian.net/browse/LPD-18328)

I looked into the issue and it seems, that we always index the locale in a US format. The fix seems a bit dirty, however it looks safe. Please review it.

Thanks,