### PR TITLE
LPD-18328 Arabic localization causes issue with Web Content filtering on date with API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -26,6 +26,7 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -146,8 +147,7 @@ public class EntityFieldsProvider {
 		try {
 			Date date = indexDateFormat.parse(String.valueOf(fieldValue));
 
-			DateFormat searchDateFormat =
-				DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
+			DateFormat searchDateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
 			return searchDateFormat.format(date);
 		}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-18328)

There are issues when filtering with dates when using the headless API

## Change summary:

* Don't use DateFormatFactoryUtil since it will expect a locale, use SimpleDateFormat


## Test Scenario

* Follow the steps in the ticket