### PR TITLE
LPD-18667 Remove public render parameter for nodeId

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/WikiPortlet.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/WikiPortlet.java
@@ -50,7 +50,6 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.resource-bundle=content.Language",
 		"javax.portlet.security-role-ref=power-user,user",
 		"javax.portlet.supported-public-render-parameter=categoryId",
-		"javax.portlet.supported-public-render-parameter=nodeId;http://www.liferay.com/public-render-parameters/wiki",
 		"javax.portlet.supported-public-render-parameter=nodeName;http://www.liferay.com/public-render-parameters/wiki",
 		"javax.portlet.supported-public-render-parameter=resetCur",
 		"javax.portlet.supported-public-render-parameter=tag",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-18667

With nodeId being a public render parameter it is stored in the request as "p_r_p_http://www.liferay.com/public-render-parameters/wiki_nodeId" rather than "nodeId". Do we still need to have nodeId as a public render parameter? Do the other public render parameters in this same file need to be adjusted as well?