### PR TITLE
LPD-18667 Use action request instead of uploadPortletRequest

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/action/EditPageAttachmentMVCActionCommand.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/portlet/action/EditPageAttachmentMVCActionCommand.java
@@ -198,13 +198,10 @@ public class EditPageAttachmentMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		UploadPortletRequest uploadPortletRequest =
-			_portal.getUploadPortletRequest(actionRequest);
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		long nodeId = ParamUtil.getLong(uploadPortletRequest, "nodeId");
+		long nodeId = ParamUtil.getLong(actionRequest, "nodeId");
 		String fileName = ParamUtil.getString(actionRequest, "fileName");
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-18667

Resending with a new fix as mentioned here: https://github.com/liferay-content-management/liferay-portal/pull/5169#issuecomment-1964769675

We need to use the actionRequest to get the correct nodeId instead of the uploadPortletRequest.