### PR TITLE
LPD-18804 Do not show a blank option in the distribution scope selection

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/entry_select_scope.jspf
@@ -9,7 +9,7 @@
 boolean hasDistributionScope = false;
 %>
 
-<aui:select changesContext="<%= submitOnChange %>" name="distributionScope" onChange='<%= submitOnChange ? liferayPortletResponse.getNamespace() + "selectDistributionScope(this.value);" : "" %>' showEmptyOption="<%= true %>">
+<aui:select changesContext="<%= submitOnChange %>" name="distributionScope" onChange='<%= submitOnChange ? liferayPortletResponse.getNamespace() + "selectDistributionScope(this.value);" : "" %>'>
 	<c:if test="<%= PortalPermissionUtil.contains(permissionChecker, ActionKeys.ADD_GENERAL_ANNOUNCEMENTS) %>">
 
 		<%


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-18804

The blank option has been in the code as far back as revisions go. Since there doesn't seem to be a reason why it is there I feel it is safe to remove. If there are any doubts please let me know.

By default one of the select options will be selected (usually this will be _General_). Even if the blank option was selected there is protection in the back end to change it to the _General_ scope - https://github.com/liferay/liferay-portal/blob/master/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/portlet/action/EditEntryMVCActionCommand.java#L103-L112

Again, let me know if there's a reason why the blank option should remain and I can inform the client.