### PR TITLE
LPD-19082 Index Asset Vocabulary Ids for assets

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -137,6 +137,38 @@ public class AssetCategoryDocumentContributor
 			filteredAssetVocabularyCategoryStrings.toArray(new String[0]));
 	}
 
+	private Map<Integer, Map<Long, List<AssetCategory>>> _getAssetVocabularyVisibilityTypeMap(
+		List<AssetCategory> assetCategories) {
+
+		Map<Integer, Map<Long, List<AssetCategory>>>
+			assetVocabularyVisibilityTypeMap = new HashMap<>();
+		Map<Long, Integer> assetVocabularyMap = new HashMap<>();
+
+		for (AssetCategory assetCategory : assetCategories) {
+			Integer visibilityType = assetVocabularyMap.computeIfAbsent(
+				assetCategory.getVocabularyId(),
+				vocabularyId -> {
+					AssetVocabulary assetVocabulary =
+						_assetVocabularyLocalService.fetchAssetVocabulary(
+							assetCategory.getVocabularyId());
+
+					return assetVocabulary.getVisibilityType();
+				});
+
+			Map<Long, List<AssetCategory>> assetVocabularyAssetCategoriesMap =
+				assetVocabularyVisibilityTypeMap.computeIfAbsent(
+					visibilityType, key -> new HashMap<>());
+
+			List<AssetCategory> assetVocabularyAssetCategories =
+				assetVocabularyAssetCategoriesMap.computeIfAbsent(
+					assetCategory.getVocabularyId(), key -> new ArrayList<>());
+
+			assetVocabularyAssetCategories.add(assetCategory);
+		}
+
+		return assetVocabularyVisibilityTypeMap;
+	}
+
 	private <T> void _populate(
 		Document document, List<T> list, int visibilityType,
 		Function<AssetCategory, T> function) {

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -60,11 +60,13 @@ public class AssetCategoryDocumentContributor
 
 		_addAssetCategoriesFields(
 			document, Field.ASSET_CATEGORY_IDS, Field.ASSET_CATEGORY_TITLES,
+			Field.ASSET_VOCABULARY_IDS,
 			assetVocabularyVisibilityTypeMap.get(
 				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC));
 		_addAssetCategoriesFields(
 			document, Field.ASSET_INTERNAL_CATEGORY_IDS,
 			Field.ASSET_INTERNAL_CATEGORY_TITLES,
+			Field.ASSET_INTERNAL_VOCABULARY_IDS,
 			assetVocabularyVisibilityTypeMap.get(
 				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL));
 		_addAssetVocabularyCategoriesFields(
@@ -75,16 +77,20 @@ public class AssetCategoryDocumentContributor
 
 	private void _addAssetCategoriesFields(
 		Document document, String assetCategoryIdsFieldName,
-		String assetCategoryTitlesFieldName,
+		String assetCategoryTitlesFieldName, String assetVocabularyIdsFieldName,
 		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
 		List<AssetCategory> assetCategories = new ArrayList<>();
+		long[] assetVocabularyIds = {};
 
 		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
 			for (Map.Entry<Long, List<AssetCategory>> entry :
 					assetVocabularyMap.entrySet()) {
 
 				assetCategories.addAll(entry.getValue());
+
+				assetVocabularyIds = ArrayUtil.append(
+					assetVocabularyIds, entry.getKey());
 			}
 		}
 
@@ -92,6 +98,8 @@ public class AssetCategoryDocumentContributor
 			assetCategories, AssetCategory.CATEGORY_ID_ACCESSOR);
 
 		document.addKeyword(assetCategoryIdsFieldName, assetCategoryIds);
+
+		document.addKeyword(assetVocabularyIdsFieldName, assetVocabularyIds);
 
 		_addAssetCategoryTitles(
 			document, assetCategoryTitlesFieldName, assetCategories);

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -18,6 +19,7 @@ import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -26,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,31 +46,46 @@ public class AssetCategoryDocumentContributor
 		String className = document.get(Field.ENTRY_CLASS_NAME);
 		long classPK = GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK));
 
-		if(Validator.isNull(className) || (classPK <= 0)) {
+		if (Validator.isNull(className) || (classPK <= 0)) {
 			return;
 		}
 
+		List<AssetCategory> assetCategories =
+			_assetCategoryLocalService.getCategories(className, classPK);
+
+		Map<Integer, Map<Long, List<AssetCategory>>>
+			assetVocabularyVisibilityTypeMap =
+				_getAssetVocabularyVisibilityTypeMap(assetCategories);
+
 		_addAssetCategoriesFields(
 			document, Field.ASSET_CATEGORY_IDS, Field.ASSET_CATEGORY_TITLES,
-			AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC);
+			assetVocabularyVisibilityTypeMap.get(
+				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC));
 		_addAssetCategoriesFields(
 			document, Field.ASSET_INTERNAL_CATEGORY_IDS,
 			Field.ASSET_INTERNAL_CATEGORY_TITLES,
-			AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL);
+			assetVocabularyVisibilityTypeMap.get(
+				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL));
 		_addAssetVocabularyCategoriesFields(
 			document, "assetVocabularyCategoryIds",
-			AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC);
+			assetVocabularyVisibilityTypeMap.get(
+				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC));
 	}
 
 	private void _addAssetCategoriesFields(
 		Document document, String assetCategoryIdsFieldName,
-		String assetCategoryTitlesFieldName, int visibilityType) {
+		String assetCategoryTitlesFieldName,
+		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
 		List<AssetCategory> filteredAssetCategories = new ArrayList<>();
 
-		_populate(
-			document, filteredAssetCategories, visibilityType,
-			assetCategory -> assetCategory);
+		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
+			for (Map.Entry<Long, List<AssetCategory>> entry :
+					assetVocabularyMap.entrySet()) {
+
+				filteredAssetCategories.addAll(entry.getValue());
+			}
+		}
 
 		long[] filteredAssetCategoryIds = ListUtil.toLongArray(
 			filteredAssetCategories, AssetCategory.CATEGORY_ID_ACCESSOR);
@@ -122,23 +138,31 @@ public class AssetCategoryDocumentContributor
 
 	private void _addAssetVocabularyCategoriesFields(
 		Document document, String assetVocabularyCategoryIdsFieldName,
-		int visibilityType) {
+		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
 		List<String> filteredAssetVocabularyCategoryStrings = new ArrayList<>();
 
-		_populate(
-			document, filteredAssetVocabularyCategoryStrings, visibilityType,
-			assetCategory ->
-				assetCategory.getVocabularyId() + StringPool.DASH +
-					assetCategory.getCategoryId());
+		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
+			for (Map.Entry<Long, List<AssetCategory>> entry :
+					assetVocabularyMap.entrySet()) {
+
+				filteredAssetVocabularyCategoryStrings.addAll(
+					TransformUtil.transform(
+						entry.getValue(),
+						assetCategory ->
+							assetCategory.getVocabularyId() + StringPool.DASH +
+								assetCategory.getCategoryId()));
+			}
+		}
 
 		document.addKeyword(
 			assetVocabularyCategoryIdsFieldName,
 			filteredAssetVocabularyCategoryStrings.toArray(new String[0]));
 	}
 
-	private Map<Integer, Map<Long, List<AssetCategory>>> _getAssetVocabularyVisibilityTypeMap(
-		List<AssetCategory> assetCategories) {
+	private Map<Integer, Map<Long, List<AssetCategory>>>
+		_getAssetVocabularyVisibilityTypeMap(
+			List<AssetCategory> assetCategories) {
 
 		Map<Integer, Map<Long, List<AssetCategory>>>
 			assetVocabularyVisibilityTypeMap = new HashMap<>();
@@ -167,34 +191,6 @@ public class AssetCategoryDocumentContributor
 		}
 
 		return assetVocabularyVisibilityTypeMap;
-	}
-
-	private <T> void _populate(
-		Document document, List<T> list, int visibilityType,
-		Function<AssetCategory, T> function) {
-
-		Map<Long, AssetVocabulary> assetVocabulariesMap = new HashMap<>();
-
-		String className = document.get(Field.ENTRY_CLASS_NAME);
-		long classPK = GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK));
-
-		List<AssetCategory> assetCategories =
-			_assetCategoryLocalService.getCategories(className, classPK);
-
-		for (AssetCategory assetCategory : assetCategories) {
-			AssetVocabulary assetVocabulary =
-				assetVocabulariesMap.computeIfAbsent(
-					assetCategory.getVocabularyId(),
-					vocabularyId ->
-						_assetVocabularyLocalService.fetchAssetVocabulary(
-							vocabularyId));
-
-			if ((assetVocabulary != null) &&
-				(assetVocabulary.getVisibilityType() == visibilityType)) {
-
-				list.add((T)function.apply(assetCategory));
-			}
-		}
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentContributor;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -140,24 +141,26 @@ public class AssetCategoryDocumentContributor
 		Document document, String assetVocabularyCategoryIdsFieldName,
 		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
-		List<String> filteredAssetVocabularyCategoryStrings = new ArrayList<>();
+		String[] filteredAssetVocabularyCategories = {};
 
 		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
 			for (Map.Entry<Long, List<AssetCategory>> entry :
 					assetVocabularyMap.entrySet()) {
 
-				filteredAssetVocabularyCategoryStrings.addAll(
-					TransformUtil.transform(
+				filteredAssetVocabularyCategories = ArrayUtil.append(
+					filteredAssetVocabularyCategories,
+					TransformUtil.transformToArray(
 						entry.getValue(),
 						assetCategory ->
 							assetCategory.getVocabularyId() + StringPool.DASH +
-								assetCategory.getCategoryId()));
+								assetCategory.getCategoryId(),
+						String.class));
 			}
 		}
 
 		document.addKeyword(
 			assetVocabularyCategoryIdsFieldName,
-			filteredAssetVocabularyCategoryStrings.toArray(new String[0]));
+			filteredAssetVocabularyCategories);
 	}
 
 	private Map<Integer, Map<Long, List<AssetCategory>>>

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -78,24 +78,23 @@ public class AssetCategoryDocumentContributor
 		String assetCategoryTitlesFieldName,
 		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
-		List<AssetCategory> filteredAssetCategories = new ArrayList<>();
+		List<AssetCategory> assetCategories = new ArrayList<>();
 
 		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
 			for (Map.Entry<Long, List<AssetCategory>> entry :
 					assetVocabularyMap.entrySet()) {
 
-				filteredAssetCategories.addAll(entry.getValue());
+				assetCategories.addAll(entry.getValue());
 			}
 		}
 
-		long[] filteredAssetCategoryIds = ListUtil.toLongArray(
-			filteredAssetCategories, AssetCategory.CATEGORY_ID_ACCESSOR);
+		long[] assetCategoryIds = ListUtil.toLongArray(
+			assetCategories, AssetCategory.CATEGORY_ID_ACCESSOR);
 
-		document.addKeyword(
-			assetCategoryIdsFieldName, filteredAssetCategoryIds);
+		document.addKeyword(assetCategoryIdsFieldName, assetCategoryIds);
 
 		_addAssetCategoryTitles(
-			document, assetCategoryTitlesFieldName, filteredAssetCategories);
+			document, assetCategoryTitlesFieldName, assetCategories);
 	}
 
 	private void _addAssetCategoryTitles(
@@ -141,14 +140,14 @@ public class AssetCategoryDocumentContributor
 		Document document, String assetVocabularyCategoryIdsFieldName,
 		Map<Long, List<AssetCategory>> assetVocabularyMap) {
 
-		String[] filteredAssetVocabularyCategories = {};
+		String[] assetVocabularyCategories = {};
 
 		if (MapUtil.isNotEmpty(assetVocabularyMap)) {
 			for (Map.Entry<Long, List<AssetCategory>> entry :
 					assetVocabularyMap.entrySet()) {
 
-				filteredAssetVocabularyCategories = ArrayUtil.append(
-					filteredAssetVocabularyCategories,
+				assetVocabularyCategories = ArrayUtil.append(
+					assetVocabularyCategories,
 					TransformUtil.transformToArray(
 						entry.getValue(),
 						assetCategory ->
@@ -159,8 +158,7 @@ public class AssetCategoryDocumentContributor
 		}
 
 		document.addKeyword(
-			assetVocabularyCategoryIdsFieldName,
-			filteredAssetVocabularyCategories);
+			assetVocabularyCategoryIdsFieldName, assetVocabularyCategories);
 	}
 
 	private Map<Integer, Map<Long, List<AssetCategory>>>

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/search/spi/model/index/contributor/AssetCategoryDocumentContributor.java
@@ -42,6 +42,13 @@ public class AssetCategoryDocumentContributor
 	public void contribute(
 		Document document, BaseModel<AssetCategory> baseModel) {
 
+		String className = document.get(Field.ENTRY_CLASS_NAME);
+		long classPK = GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK));
+
+		if(Validator.isNull(className) || (classPK <= 0)) {
+			return;
+		}
+
 		_addAssetCategoriesFields(
 			document, Field.ASSET_CATEGORY_IDS, Field.ASSET_CATEGORY_TITLES,
 			AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC);

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryVocabularyVisibilitySearchTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryVocabularyVisibilitySearchTest.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -39,7 +38,6 @@ import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
-import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -100,7 +98,7 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 		_addJournalArticle(assetCategory, keyword);
 
 		_assertSearchInternalFields(
-			keyword, _getAssetCategoryIds(assetCategory),
+			keyword, Arrays.asList(assetCategory.getCategoryId()),
 			_getAssetCategoryTitles(assetCategory),
 			Arrays.asList(assetCategory.getVocabularyId()));
 		_assertSearchPublicFields(
@@ -121,7 +119,7 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 			keyword, Collections.emptyList(), Collections.emptyList(),
 			Collections.emptyList());
 		_assertSearchPublicFields(
-			keyword, _getAssetCategoryIds(assetCategory),
+			keyword, Arrays.asList(assetCategory.getCategoryId()),
 			_getAssetCategoryTitles(assetCategory),
 			Arrays.asList(assetCategory.getVocabularyId()));
 	}
@@ -215,7 +213,7 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 			String assetCategoryTitlesFieldName,
 			List<String> expectedAssetCategoryTitles,
 			List<Long> expectedAssetVocabularyIds)
-		throws Exception, SearchException {
+		throws Exception {
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
 			_group.getGroupId());
@@ -248,7 +246,7 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 	private void _assertSearchInternalFields(
 			String keyword, List<Long> assetCategoryIds,
 			List<String> assetCategoryTitles, List<Long> assetVocabularyIds)
-		throws Exception, SearchException {
+		throws Exception {
 
 		_assertSearch(
 			keyword, Field.ASSET_INTERNAL_CATEGORY_IDS,
@@ -261,17 +259,13 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 	private void _assertSearchPublicFields(
 			String keyword, List<Long> assetCategoryIds,
 			List<String> assetCategoryTitles, List<Long> assetVocabularyIds)
-		throws Exception, SearchException {
+		throws Exception {
 
 		_assertSearch(
 			keyword, Field.ASSET_CATEGORY_IDS, Field.ASSET_VOCABULARY_IDS,
 			assetCategoryIds,
 			Field.getLocalizedName(LocaleUtil.US, Field.ASSET_CATEGORY_TITLES),
 			assetCategoryTitles, assetVocabularyIds);
-	}
-
-	private List<Long> _getAssetCategoryIds(AssetCategory assetCategory) {
-		return Arrays.asList(assetCategory.getCategoryId());
 	}
 
 	private List<String> _getAssetCategoryTitles(AssetCategory assetCategory) {
@@ -312,8 +306,5 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 	private JournalArticleLocalService _journalArticleLocalService;
 
 	private JournalArticleSearchFixture _journalArticleSearchFixture;
-
-	@Inject
-	private SearchLocalizationHelper _searchLocalizationHelper;
 
 }

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryVocabularyVisibilitySearchTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/search/test/AssetCategoryVocabularyVisibilitySearchTest.java
@@ -101,9 +101,11 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 
 		_assertSearchInternalFields(
 			keyword, _getAssetCategoryIds(assetCategory),
-			_getAssetCategoryTitles(assetCategory));
+			_getAssetCategoryTitles(assetCategory),
+			Arrays.asList(assetCategory.getVocabularyId()));
 		_assertSearchPublicFields(
-			keyword, Collections.emptyList(), Collections.emptyList());
+			keyword, Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList());
 	}
 
 	@Test
@@ -116,10 +118,12 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 		_addJournalArticle(assetCategory, keyword);
 
 		_assertSearchInternalFields(
-			keyword, Collections.emptyList(), Collections.emptyList());
+			keyword, Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList());
 		_assertSearchPublicFields(
 			keyword, _getAssetCategoryIds(assetCategory),
-			_getAssetCategoryTitles(assetCategory));
+			_getAssetCategoryTitles(assetCategory),
+			Arrays.asList(assetCategory.getVocabularyId()));
 	}
 
 	@Rule
@@ -206,9 +210,11 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 
 	private void _assertSearch(
 			String keyword, String assetCategoryIdsFieldName,
+			String assetVocabularyIdsFieldName,
 			List<Long> expectedAssetCategoryIds,
 			String assetCategoryTitlesFieldName,
-			List<String> expectedAssetCategoryTitles)
+			List<String> expectedAssetCategoryTitles,
+			List<Long> expectedAssetVocabularyIds)
 		throws Exception, SearchException {
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
@@ -231,29 +237,37 @@ public class AssetCategoryVocabularyVisibilitySearchTest {
 		DocumentsAssert.assertValuesIgnoreRelevance(
 			(String)searchContext.getAttribute("queryString"), hits.getDocs(),
 			assetCategoryTitlesFieldName, expectedAssetCategoryTitles);
+
+		DocumentsAssert.assertValuesIgnoreRelevance(
+			(String)searchContext.getAttribute("queryString"), hits.getDocs(),
+			assetVocabularyIdsFieldName,
+			TransformUtil.transform(
+				expectedAssetVocabularyIds, String::valueOf));
 	}
 
 	private void _assertSearchInternalFields(
 			String keyword, List<Long> assetCategoryIds,
-			List<String> assetCategoryTitles)
+			List<String> assetCategoryTitles, List<Long> assetVocabularyIds)
 		throws Exception, SearchException {
 
 		_assertSearch(
-			keyword, Field.ASSET_INTERNAL_CATEGORY_IDS, assetCategoryIds,
+			keyword, Field.ASSET_INTERNAL_CATEGORY_IDS,
+			Field.ASSET_INTERNAL_VOCABULARY_IDS, assetCategoryIds,
 			Field.getLocalizedName(
 				LocaleUtil.US, Field.ASSET_INTERNAL_CATEGORY_TITLES),
-			assetCategoryTitles);
+			assetCategoryTitles, assetVocabularyIds);
 	}
 
 	private void _assertSearchPublicFields(
 			String keyword, List<Long> assetCategoryIds,
-			List<String> assetCategoryTitles)
+			List<String> assetCategoryTitles, List<Long> assetVocabularyIds)
 		throws Exception, SearchException {
 
 		_assertSearch(
-			keyword, Field.ASSET_CATEGORY_IDS, assetCategoryIds,
+			keyword, Field.ASSET_CATEGORY_IDS, Field.ASSET_VOCABULARY_IDS,
+			assetCategoryIds,
 			Field.getLocalizedName(LocaleUtil.US, Field.ASSET_CATEGORY_TITLES),
-			assetCategoryTitles);
+			assetCategoryTitles, assetVocabularyIds);
 	}
 
 	private List<Long> _getAssetCategoryIds(AssetCategory assetCategory) {

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 136.1.1
+Bundle-Version: 136.2.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
@@ -57,6 +57,9 @@ public class Field implements Serializable {
 	public static final String ASSET_INTERNAL_CATEGORY_TITLES =
 		"assetInternalCategoryTitles";
 
+	public static final String ASSET_INTERNAL_VOCABULARY_IDS =
+		"assetInternalVocabularyIds";
+
 	public static final String ASSET_PARENT_CATEGORY_ID = "parentCategoryId";
 
 	public static final String ASSET_PARENT_CATEGORY_IDS = "parentCategoryIds";

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 20.4.0
+version 20.5.0


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-19082)

Index vocabularyIds just as we do with categories

## Notes:

* We cannot do an early return when there are no categories, because otherwise the property won't be set and searching will fail
* It's not behind a feature flag since it's only adding information to the index
* There will be a follow up PR with logic for searching the vocabularies and the related test

## Change summary:

* Refactor AssetCategoryDocumentContributor so that we call the database only once instead of 3 times when retrieving the vocabularies
* Add assetVocabularyIds and assetInternalVocabularyIds to the index
* New field for assetInternalVocabularyIds
* Adapt existing test

## Test Scenario 1

* Create a new site
* Create a new internal vocabulary and add a category to it
* Create a new public vocabulary and add a category to it
* Create a new web content and assign the categories to it
* Query the index, you will see the two new properties indexed

## Test Scenario 2

* Run the provided integration test