### PR TITLE
LPD-19234 Web Content copy feature drops attached images if they are the same

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7457,6 +7457,8 @@ public class JournalArticleLocalServiceImpl
 			return;
 		}
 
+		Map<Long, FileEntry> fileEntryMap = new HashMap<>();
+
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
 			if (ListUtil.isNotEmpty(
 					ddmFormFieldValue.getNestedDDMFormFieldValues())) {
@@ -7502,15 +7504,29 @@ public class JournalArticleLocalServiceImpl
 					if (oldFileEntry.getRepositoryId() ==
 							portletRepository.getRepositoryId()) {
 
-						newFileEntry =
-							_portletFileRepository.addPortletFileEntry(
-								null, groupId, article.getUserId(),
-								JournalArticle.class.getName(),
-								article.getResourcePrimKey(),
-								JournalConstants.SERVICE_NAME, folderId,
-								oldFileEntry.getContentStream(),
-								oldFileEntry.getFileName(),
-								oldFileEntry.getMimeType(), false);
+						newFileEntry = fileEntryMap.computeIfAbsent(
+							oldFileEntry.getFileEntryId(),
+							key -> {
+								try {
+									return _portletFileRepository.
+										addPortletFileEntry(
+											null, groupId, article.getUserId(),
+											JournalArticle.class.getName(),
+											article.getResourcePrimKey(),
+											JournalConstants.SERVICE_NAME,
+											folderId,
+											oldFileEntry.getContentStream(),
+											oldFileEntry.getFileName(),
+											oldFileEntry.getMimeType(), false);
+								}
+								catch (PortalException portalException) {
+									if (_log.isDebugEnabled()) {
+										_log.debug(portalException);
+									}
+
+									throw new RuntimeException(portalException);
+								}
+							});
 					}
 
 					String previewURL = _dlURLHelper.getPreviewURL(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -120,6 +120,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermissionTable;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -7450,6 +7451,12 @@ public class JournalArticleLocalServiceImpl
 		JournalArticle article, List<DDMFormFieldValue> ddmFormFieldValues,
 		long groupId, long folderId) {
 
+		Repository portletRepository = _getRepository(groupId);
+
+		if (portletRepository == null) {
+			return;
+		}
+
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
 			if (ListUtil.isNotEmpty(
 					ddmFormFieldValue.getNestedDDMFormFieldValues())) {
@@ -7490,15 +7497,21 @@ public class JournalArticleLocalServiceImpl
 						continue;
 					}
 
-					FileEntry newFileEntry =
-						_portletFileRepository.addPortletFileEntry(
-							null, groupId, article.getUserId(),
-							JournalArticle.class.getName(),
-							article.getResourcePrimKey(),
-							JournalConstants.SERVICE_NAME, folderId,
-							oldFileEntry.getContentStream(),
-							oldFileEntry.getFileName(),
-							oldFileEntry.getMimeType(), false);
+					FileEntry newFileEntry = oldFileEntry;
+
+					if (oldFileEntry.getRepositoryId() ==
+							portletRepository.getRepositoryId()) {
+
+						newFileEntry =
+							_portletFileRepository.addPortletFileEntry(
+								null, groupId, article.getUserId(),
+								JournalArticle.class.getName(),
+								article.getResourcePrimKey(),
+								JournalConstants.SERVICE_NAME, folderId,
+								oldFileEntry.getContentStream(),
+								oldFileEntry.getFileName(),
+								oldFileEntry.getMimeType(), false);
+					}
 
 					String previewURL = _dlURLHelper.getPreviewURL(
 						newFileEntry, newFileEntry.getFileVersion(), null,
@@ -7807,6 +7820,31 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return UserNotificationDefinition.NOTIFICATION_TYPE_ADD_ENTRY;
+	}
+
+	private Repository _getRepository(long groupId) {
+		try {
+			Repository repository =
+				_portletFileRepository.fetchPortletRepository(
+					groupId, JournalConstants.SERVICE_NAME);
+
+			if (repository != null) {
+				return repository;
+			}
+
+			ServiceContext serviceContext = new ServiceContext();
+
+			serviceContext.setAddGroupPermissions(true);
+			serviceContext.setAddGuestPermissions(true);
+
+			return _portletFileRepository.addPortletRepository(
+				groupId, JournalConstants.SERVICE_NAME, serviceContext);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return null;
 	}
 
 	private int _getSmallImageSource(boolean smallImage, String smallImageURL) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -409,6 +409,43 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testCopyArticleWithDuplicatedImages() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.IMAGE_JPEG,
+			StringUtil.randomString(), "urltitle", StringUtil.randomString(),
+			StringUtil.randomString(), new byte[0], null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		String fileEntryJSONString = _toJSON(fileEntry);
+
+		DataDefinition dataDefinition =
+			DataDefinitionTestUtil.addDataDefinition(
+				"journal", _dataDefinitionResourceFactory, _group.getGroupId(),
+				_readFileToString("ddm_form_with_multiple_images.json"),
+				TestPropsValues.getUser());
+
+		JournalArticle oldArticle = JournalTestUtil.addArticleWithXMLContent(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			StringUtil.replace(
+				_readFileToString("journal_content_with_multiple_images.xml"),
+				new String[] {"[$IMAGE_JSON_1$]", "[$IMAGE_JSON_2$]"},
+				new String[] {fileEntryJSONString, fileEntryJSONString}),
+			dataDefinition.getDataDefinitionKey(), null, LocaleUtil.US);
+
+		JournalArticle newArticle = _journalArticleLocalService.copyArticle(
+			oldArticle.getUserId(), oldArticle.getGroupId(),
+			oldArticle.getArticleId(), null, true, oldArticle.getVersion());
+
+		Assert.assertEquals(0, newArticle.getImagesFileEntriesCount());
+
+		_validateDDMFormValuesImages(newArticle);
+	}
+
+	@Test
 	public void testCopyArticleWithImages() throws Exception {
 		DataDefinition dataDefinition =
 			DataDefinitionTestUtil.addDataDefinition(

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/ddm_form_with_multiple_images.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/ddm_form_with_multiple_images.json
@@ -1,0 +1,127 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"dataType": "image",
+				"fieldNamespace": "",
+				"fieldReference": "Image47928126",
+				"objectFieldName": "",
+				"requiredDescription": true,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": {
+				}
+			},
+			"fieldType": "image",
+			"indexType": "text",
+			"indexable": true,
+			"label": {
+				"en_US": "Image"
+			},
+			"localizable": true,
+			"name": "Image47928126",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "image",
+				"fieldNamespace": "",
+				"fieldReference": "Image47928127",
+				"objectFieldName": "",
+				"requiredDescription": true,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": {
+				}
+			},
+			"fieldType": "image",
+			"indexType": "text",
+			"indexable": true,
+			"label": {
+				"en_US": "Image"
+			},
+			"localizable": true,
+			"name": "Image47928127",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Image47928126"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Image47928127"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "Image"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "Image"
+	},
+	"storageType": "default"
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/journal_content_with_multiple_images.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/service/test/dependencies/journal_content_with_multiple_images.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="Image47928126" index-type="text" instance-id="a4NC7xMP" name="Image47928126" type="image">
+		<dynamic-content language-id="en_US"><![CDATA[[$IMAGE_JSON_1$]]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element field-reference="Image47928127" index-type="text" instance-id="b4NC7xMP" name="Image47928127" type="image">
+		<dynamic-content language-id="en_US"><![CDATA[[$IMAGE_JSON_2$]]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-19234)

Avoid copying the image when it's not in the journal repository. This is also a performance improvement since we don't want to create the image several times

## Change summary:

* Adds check so that only images from the resources forlder of web content are copied
* Adds integration test

## Notes

For the test we don't want to use a temporary file entry, since it will be stored in the web content repository, so use a normal file entry

## Test Scenario 1

* Add a new image to documents and media
* Create a new folder, and add the same image to the folder
* Create a new web content structure with 2 image fields and save
* Create a new web content based on the structure and select both images that were created in the previous steps (they have the same name but are in different folders)
* Click on the kebab of the web content and select "Make a copy"
* Open the new web content and you will see both images

## Test Scenario 1

* Create a new web content structure with 2 image fields and save
* Create a new web content based on the structure and for the first image select "Web Content Images" and upload a new image and select it
* Publish and edit the web content again
* Select the same image for the second image field and publish
* Click on the kebab of the web content and select "Make a copy"
* Open the new web content and you will see both images