### PR TITLE
LPD-19497 the friendly url must return a value for the default language not the site default language

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -503,14 +503,14 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 				locale, friendlyURLEntryLocalization.getUrlTitle());
 		}
 
-		Locale defaultSiteLocale = LocaleUtil.getSiteDefault();
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			getDefaultLanguageId());
 
-		if (Validator.isNull(friendlyURLMap.get(defaultSiteLocale))) {
-			Locale defaultLocale = LocaleUtil.fromLanguageId(
-				getDefaultLanguageId());
+		if (Validator.isNull(friendlyURLMap.get(defaultLocale))) {
+			Locale defaultSiteLocale = LocaleUtil.getSiteDefault();
 
 			friendlyURLMap.put(
-				defaultSiteLocale, friendlyURLMap.get(defaultLocale));
+				defaultLocale, friendlyURLMap.get(defaultSiteLocale));
 		}
 
 		return friendlyURLMap;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -268,81 +268,81 @@ public class JournalArticleLocalServiceImpl
 	 * </code>
 	 * </pre></p>
 	 *
-	 * @param externalReferenceCode the external reference code of the web
-	 *                              content article
-	 * @param userId                the primary key of the web content article's creator/owner
-	 * @param groupId               the primary key of the web content article's group
-	 * @param folderId              the primary key of the web content article folder
-	 * @param classNameId           the primary key of the DDMStructure class if the web
-	 *                              content article is related to a DDM structure, the primary key of
-	 *                              the class name associated with the article, or
-	 *                              JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
-	 *                              module otherwise
-	 * @param classPK               the primary key of the DDM structure, if the primary key
-	 *                              of the DDMStructure class is given as the
-	 *                              <code>classNameId</code> parameter, the primary key of the class
-	 *                              associated with the web content article, or <code>0</code>
-	 *                              otherwise
-	 * @param articleId             the primary key of the web content article
-	 * @param autoArticleId         whether to auto generate the web content article ID
-	 * @param version               the web content article's version
-	 * @param titleMap              the web content article's locales and localized titles
-	 * @param descriptionMap        the web content article's locales and localized
-	 *                              descriptions
-	 * @param friendlyURLMap        the web content article's locales and localized
-	 *                              friendly URLs
-	 * @param content               the HTML content wrapped in XML
-	 * @param ddmStructureId        the primary key of the web content article's DDM
-	 *                              structure, if the article is related to a DDM structure, or
-	 *                              <code>0</code> otherwise
-	 * @param ddmTemplateKey        the primary key of the web content article's DDM
-	 *                              template
-	 * @param layoutUuid            the unique string identifying the web content
-	 *                              article's display page
-	 * @param displayDateMonth      the month the web content article is set to
-	 *                              display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 *                              display
-	 * @param displayDateYear       the year the web content article is set to
-	 *                              display
-	 * @param displayDateHour       the hour the web content article is set to
-	 *                              display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 *                              display
-	 * @param expirationDateMonth   the month the web content article is set to
-	 *                              expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 *                              to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 *                              expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 *                              expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 *                              expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 *                              expire
-	 * @param reviewDateMonth       the month the web content article is set for
-	 *                              review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 *                              review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 *                              review
-	 * @param neverReview           whether the web content article is not set for review
-	 * @param indexable             whether the web content article is searchable
-	 * @param smallImage            whether the web content article has a small image
-	 * @param smallImageSource      the web content article's small image source
-	 * @param smallImageURL         the web content article's small image URL
-	 * @param smallImageFile        the web content article's small image file
-	 * @param images                the web content's images
-	 * @param articleURL            the web content article's accessible URL
-	 * @param serviceContext        the service context to be applied. Can set the
-	 *                              UUID, creation date, modification date, expando bridge
-	 *                              attributes, guest permissions, group permissions, asset category
-	 *                              IDs, asset tag names, asset link entry IDs, URL title, and
-	 *                              workflow actions for the web content article. Can also set
-	 *                              whether to add the default guest and group permissions.
+	 * @param  externalReferenceCode the external reference code of the web
+	 *         content article
+	 * @param  userId the primary key of the web content article's creator/owner
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  classNameId the primary key of the DDMStructure class if the web
+	 *         content article is related to a DDM structure, the primary key of
+	 *         the class name associated with the article, or
+	 *         JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 *         module otherwise
+	 * @param  classPK the primary key of the DDM structure, if the primary key
+	 *         of the DDMStructure class is given as the
+	 *         <code>classNameId</code> parameter, the primary key of the class
+	 *         associated with the web content article, or <code>0</code>
+	 *         otherwise
+	 * @param  articleId the primary key of the web content article
+	 * @param  autoArticleId whether to auto generate the web content article ID
+	 * @param  version the web content article's version
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML
+	 * @param  ddmStructureId the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>0</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content article is searchable
+	 * @param  smallImage whether the web content article has a small image
+	 * @param  smallImageSource the web content article's small image source
+	 * @param  smallImageURL the web content article's small image URL
+	 * @param  smallImageFile the web content article's small image file
+	 * @param  images the web content's images
+	 * @param  articleURL the web content article's accessible URL
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, expando bridge
+	 *         attributes, guest permissions, group permissions, asset category
+	 *         IDs, asset tag names, asset link entry IDs, URL title, and
+	 *         workflow actions for the web content article. Can also set
+	 *         whether to add the default guest and group permissions.
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
@@ -3722,8 +3722,8 @@ public class JournalArticleLocalServiceImpl
 	/**
 	 * Returns the web content articles matching the DDM structure keys.
 	 *
-	 * @param  ddmStructureId the primary key of the web content article's
-	 *         DDM structure
+	 * @param  ddmStructureId the primary key of the web content article's DDM
+	 *         structure
 	 * @return the web content articles matching the DDM structure keys
 	 */
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -67,81 +67,81 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * parameters (display date, expiration date, and review date) use the
 	 * current user's timezone.
 	 *
-	 * @param externalReferenceCode the external reference code of the web
-	 *                              content article
-	 * @param groupId               the primary key of the web content article's group
-	 * @param folderId              the primary key of the web content article folder
-	 * @param classNameId           the primary key of the DDMStructure class if the web
-	 *                              content article is related to a DDM structure, the primary key of
-	 *                              the class name associated with the article, or
-	 *                              JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
-	 *                              module otherwise
-	 * @param classPK               the primary key of the DDM structure, if the primary key
-	 *                              of the DDMStructure class is given as the
-	 *                              <code>classNameId</code> parameter, the primary key of the class
-	 *                              associated with the web content article, or <code>0</code>
-	 *                              otherwise
-	 * @param articleId             the primary key of the web content article
-	 * @param autoArticleId         whether to auto generate the web content article ID
-	 * @param titleMap              the web content article's locales and localized titles
-	 * @param descriptionMap        the web content article's locales and localized
-	 *                              descriptions
-	 * @param friendlyURLMap        the web content article's locales and localized
-	 *                              friendly URLs
-	 * @param content               the HTML content wrapped in XML. For more information,
-	 *                              see the content example in the {@link #updateArticle(long, long,
-	 *                              String, double, String, ServiceContext)} description.
-	 * @param ddmStructureId        the primary key of the web content article's DDM
-	 *                              structure, if the article is related to a DDM structure, or
-	 *                              <code>0</code> otherwise
-	 * @param ddmTemplateKey        the primary key of the web content article's DDM
-	 *                              template
-	 * @param layoutUuid            the unique string identifying the web content
-	 *                              article's display page
-	 * @param displayDateMonth      the month the web content article is set to
-	 *                              display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 *                              display
-	 * @param displayDateYear       the year the web content article is set to
-	 *                              display
-	 * @param displayDateHour       the hour the web content article is set to
-	 *                              display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 *                              display
-	 * @param expirationDateMonth   the month the web content article is set to
-	 *                              expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 *                              to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 *                              expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 *                              expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 *                              expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 *                              expire
-	 * @param reviewDateMonth       the month the web content article is set for
-	 *                              review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 *                              review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 *                              review
-	 * @param neverReview           whether the web content article is not set for review
-	 * @param indexable             whether the web content article is searchable
-	 * @param smallImage            whether the web content article has a small image
-	 * @param smallImageSource      the web content article's small image source
-	 * @param smallImageURL         the web content article's small image URL
-	 * @param smallFile             the web content article's small image file
-	 * @param images                the web content's images
-	 * @param articleURL            the web content article's accessible URL
-	 * @param serviceContext        the service context to be applied. Can set the
-	 *                              UUID, creation date, modification date, expando bridge
-	 *                              attributes, guest permissions, group permissions, asset category
-	 *                              IDs, asset tag names, asset link entry IDs, asset priority, URL
-	 *                              title, and workflow actions for the web content article. Can also
-	 *                              set whether to add the default guest and group permissions.
+	 * @param  externalReferenceCode the external reference code of the web
+	 *         content article
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  classNameId the primary key of the DDMStructure class if the web
+	 *         content article is related to a DDM structure, the primary key of
+	 *         the class name associated with the article, or
+	 *         JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 *         module otherwise
+	 * @param  classPK the primary key of the DDM structure, if the primary key
+	 *         of the DDMStructure class is given as the
+	 *         <code>classNameId</code> parameter, the primary key of the class
+	 *         associated with the web content article, or <code>0</code>
+	 *         otherwise
+	 * @param  articleId the primary key of the web content article
+	 * @param  autoArticleId whether to auto generate the web content article ID
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML. For more information,
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
+	 * @param  ddmStructureId the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>0</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content article is searchable
+	 * @param  smallImage whether the web content article has a small image
+	 * @param  smallImageSource the web content article's small image source
+	 * @param  smallImageURL the web content article's small image URL
+	 * @param  smallFile the web content article's small image file
+	 * @param  images the web content's images
+	 * @param  articleURL the web content article's accessible URL
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, expando bridge
+	 *         attributes, guest permissions, group permissions, asset category
+	 *         IDs, asset tag names, asset link entry IDs, asset priority, URL
+	 *         title, and workflow actions for the web content article. Can also
+	 *         set whether to add the default guest and group permissions.
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
@@ -1963,77 +1963,77 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * scheduling parameters (display date, expiration date, and review date)
 	 * use the current user's timezone.
 	 *
-	 * @param groupId              the primary key of the web content article's group
-	 * @param folderId             the primary key of the web content article folder
-	 * @param articleId            the primary key of the web content article
-	 * @param version              the web content article's version
-	 * @param titleMap             the web content article's locales and localized titles
-	 * @param descriptionMap       the web content article's locales and localized
-	 *                             descriptions
-	 * @param friendlyURLMap       the web content article's locales and localized
-	 *                             friendly URLs
-	 * @param content              the HTML content wrapped in XML. For more information,
-	 *                             see the content example in the {@link #updateArticle(long, long,
-	 *                             String, double, String, ServiceContext)} description.
-	 * @param ddmTemplateKey       the primary key of the web content article's DDM
-	 *                             template
-	 * @param layoutUuid           the unique string identifying the web content
-	 *                             article's display page
-	 * @param displayDateMonth     the month the web content article is set to
-	 *                             display
-	 * @param displayDateDay       the calendar day the web content article is set to
-	 *                             display
-	 * @param displayDateYear      the year the web content article is set to
-	 *                             display
-	 * @param displayDateHour      the hour the web content article is set to
-	 *                             display
-	 * @param displayDateMinute    the minute the web content article is set to
-	 *                             display
-	 * @param expirationDateMonth  the month the web content article is set to
-	 *                             expire
-	 * @param expirationDateDay    the calendar day the web content article is set
-	 *                             to expire
-	 * @param expirationDateYear   the year the web content article is set to
-	 *                             expire
-	 * @param expirationDateHour   the hour the web content article is set to
-	 *                             expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 *                             expire
-	 * @param neverExpire          whether the web content article is not set to auto
-	 *                             expire
-	 * @param reviewDateMonth      the month the web content article is set for
-	 *                             review
-	 * @param reviewDateDay        the calendar day the web content article is set for
-	 *                             review
-	 * @param reviewDateYear       the year the web content article is set for review
-	 * @param reviewDateHour       the hour the web content article is set for review
-	 * @param reviewDateMinute     the minute the web content article is set for
-	 *                             review
-	 * @param neverReview          whether the web content article is not set for review
-	 * @param indexable            whether the web content is searchable
-	 * @param smallImage           whether to update web content article's a small image.
-	 *                             A file must be passed in as <code>smallImageFile</code> value,
-	 *                             otherwise the current small image is deleted.
-	 * @param smallImageSource     the web content article's small image source
-	 *                             (optionally <code>null</code>)
-	 * @param smallImageURL        the web content article's small image URL
-	 *                             (optionally <code>null</code>)
-	 * @param smallFile            the web content article's new small image file
-	 *                             (optionally <code>null</code>). Must pass in
-	 *                             <code>smallImage</code> value of <code>true</code> to replace the
-	 *                             article's small image file.
-	 * @param images               the web content's images (optionally <code>null</code>)
-	 * @param articleURL           the web content article's accessible URL (optionally
-	 *                             <code>null</code>)
-	 * @param serviceContext       the service context to be applied. Can set the
-	 *                             modification date, expando bridge attributes, asset category IDs,
-	 *                             asset tag names, asset link entry IDs, asset priority, workflow
-	 *                             actions, URL title, and can set whether to add the default
-	 *                             command update for the web content article. With respect to
-	 *                             social activities, by setting the service context's command to
-	 *                             {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
-	 *                             invocation is considered a web content update activity; otherwise
-	 *                             it is considered a web content add activity.
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  articleId the primary key of the web content article
+	 * @param  version the web content article's version
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML. For more information,
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content is searchable
+	 * @param  smallImage whether to update web content article's a small image.
+	 *         A file must be passed in as <code>smallImageFile</code> value,
+	 *         otherwise the current small image is deleted.
+	 * @param  smallImageSource the web content article's small image source
+	 *         (optionally <code>null</code>)
+	 * @param  smallImageURL the web content article's small image URL
+	 *         (optionally <code>null</code>)
+	 * @param  smallFile the web content article's new small image file
+	 *         (optionally <code>null</code>). Must pass in
+	 *         <code>smallImage</code> value of <code>true</code> to replace the
+	 *         article's small image file.
+	 * @param  images the web content's images (optionally <code>null</code>)
+	 * @param  articleURL the web content article's accessible URL (optionally
+	 *         <code>null</code>)
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         modification date, expando bridge attributes, asset category IDs,
+	 *         asset tag names, asset link entry IDs, asset priority, workflow
+	 *         actions, URL title, and can set whether to add the default
+	 *         command update for the web content article. With respect to
+	 *         social activities, by setting the service context's command to
+	 *         {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
+	 *         invocation is considered a web content update activity; otherwise
+	 *         it is considered a web content add activity.
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
@@ -139,21 +139,29 @@ public class JournalArticleFriendlyURLTest {
 	public void testFriendlyURLShouldNotHaveSiteLanguageNotEqualDefaultLanguage()
 		throws Exception {
 
-		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
+		Locale originalSiteDefaultLocale =
+			LocaleThreadLocal.getSiteDefaultLocale();
 
-		String title = RandomTestUtil.randomString();
-		Locale[] locales = {LocaleUtil.SPAIN};
+		try {
+			LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
 
-		Map<Locale, String> titleMap = _getLocalizedMap(title, locales);
+			String title = RandomTestUtil.randomString();
+			Locale[] locales = {LocaleUtil.SPAIN};
 
-		JournalArticle article = _addJournalArticleWithTitleMap(
-			LocaleUtil.SPAIN, titleMap);
+			Map<Locale, String> titleMap = _getLocalizedMap(title, locales);
 
-		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
+			JournalArticle article = _addJournalArticleWithTitleMap(
+				LocaleUtil.SPAIN, titleMap);
 
-		Assert.assertNull(friendlyURLMap.get(LocaleUtil.getSiteDefault()));
-		Assert.assertEquals(
-			friendlyURLMap.toString(), 1, friendlyURLMap.size());
+			Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
+
+			Assert.assertNull(friendlyURLMap.get(LocaleUtil.getSiteDefault()));
+			Assert.assertEquals(
+				friendlyURLMap.toString(), 1, friendlyURLMap.size());
+		}
+		finally {
+			LocaleThreadLocal.setSiteDefaultLocale(originalSiteDefaultLocale);
+		}
 	}
 
 	@Test

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
@@ -58,6 +58,7 @@ public class JournalArticleFriendlyURLTest {
 		String usTitle = RandomTestUtil.randomString();
 
 		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US,
 			HashMapBuilder.put(
 				LocaleUtil.US, usTitle
 			).build());
@@ -99,6 +100,7 @@ public class JournalArticleFriendlyURLTest {
 	@Test
 	public void testFriendlyURLAfterUpdate() throws Exception {
 		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US,
 			_getLocalizedMap(
 				RandomTestUtil.randomString(),
 				new Locale[] {LocaleUtil.FRANCE, LocaleUtil.US}));
@@ -139,13 +141,14 @@ public class JournalArticleFriendlyURLTest {
 
 		Map<Locale, String> titleMap1 = _getLocalizedMap(title1, locales);
 
-		JournalArticle article = _addJournalArticleWithTitleMap(titleMap1);
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US, titleMap1);
 
 		String title2 = RandomTestUtil.randomString();
 
 		Map<Locale, String> titleMap2 = _getLocalizedMap(title2, locales);
 
-		_addJournalArticleWithTitleMap(titleMap2);
+		_addJournalArticleWithTitleMap(LocaleUtil.US, titleMap2);
 
 		JournalArticle updatedArticle = _updateJournalArticleWithTitleMap(
 			article, titleMap2);
@@ -166,6 +169,7 @@ public class JournalArticleFriendlyURLTest {
 		String usTitle = RandomTestUtil.randomString();
 
 		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US,
 			HashMapBuilder.put(
 				LocaleUtil.FRANCE, frTitle
 			).put(
@@ -189,9 +193,10 @@ public class JournalArticleFriendlyURLTest {
 		Map<Locale, String> titleMap = _getLocalizedMap(
 			title, new Locale[] {LocaleUtil.US});
 
-		_addJournalArticleWithTitleMap(titleMap);
+		_addJournalArticleWithTitleMap(LocaleUtil.US, titleMap);
 
-		JournalArticle article = _addJournalArticleWithTitleMap(titleMap);
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US, titleMap);
 
 		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
 
@@ -207,7 +212,8 @@ public class JournalArticleFriendlyURLTest {
 
 		Map<Locale, String> titleMap = _getLocalizedMap(title, locales);
 
-		JournalArticle article = _addJournalArticleWithTitleMap(titleMap);
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US, titleMap);
 
 		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
 
@@ -226,6 +232,7 @@ public class JournalArticleFriendlyURLTest {
 		String frTitle = RandomTestUtil.randomString();
 
 		_addJournalArticleWithTitleMap(
+			LocaleUtil.US,
 			HashMapBuilder.put(
 				LocaleUtil.FRANCE, frTitle
 			).put(
@@ -233,6 +240,7 @@ public class JournalArticleFriendlyURLTest {
 			).build());
 
 		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US,
 			HashMapBuilder.put(
 				LocaleUtil.US, frTitle
 			).build());
@@ -253,9 +261,10 @@ public class JournalArticleFriendlyURLTest {
 
 		Map<Locale, String> titleMap = _getLocalizedMap(title, locales);
 
-		_addJournalArticleWithTitleMap(titleMap);
+		_addJournalArticleWithTitleMap(LocaleUtil.US, titleMap);
 
-		JournalArticle article = _addJournalArticleWithTitleMap(titleMap);
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.US, titleMap);
 
 		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
 
@@ -268,14 +277,14 @@ public class JournalArticleFriendlyURLTest {
 	}
 
 	private JournalArticle _addJournalArticleWithTitleMap(
-			Map<Locale, String> titleMap)
+			Locale defaultLocale, Map<Locale, String> titleMap)
 		throws Exception {
 
 		return JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, titleMap, titleMap,
-			titleMap, LocaleUtil.US, false, true,
+			titleMap, defaultLocale, false, true,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/friendly/url/test/JournalArticleFriendlyURLTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -132,6 +133,27 @@ public class JournalArticleFriendlyURLTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(friendlyURLMap, updatedArticle.getFriendlyURLMap());
+	}
+
+	@Test
+	public void testFriendlyURLShouldNotHaveSiteLanguageNotEqualDefaultLanguage()
+		throws Exception {
+
+		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
+
+		String title = RandomTestUtil.randomString();
+		Locale[] locales = {LocaleUtil.SPAIN};
+
+		Map<Locale, String> titleMap = _getLocalizedMap(title, locales);
+
+		JournalArticle article = _addJournalArticleWithTitleMap(
+			LocaleUtil.SPAIN, titleMap);
+
+		Map<Locale, String> friendlyURLMap = article.getFriendlyURLMap();
+
+		Assert.assertNull(friendlyURLMap.get(LocaleUtil.getSiteDefault()));
+		Assert.assertEquals(
+			friendlyURLMap.toString(), 1, friendlyURLMap.size());
 	}
 
 	@Test


### PR DESCRIPTION

Steps to reproduce:

Execute the JournalArticleFriendlyURLTest



- **LPD-19497 when adding the journal article on the test allow to set the default language**
- **LPD-19497 add test to check that the site default language is not generated if the default language is different on the creation of the**
- **LPD-19497 the default locale should be the one that not can be null**
- **LPD-19497 autoSF**
