### PR TITLE
LPD-19579 check dates make test flaky

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseArticleResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseArticleResourceTest.java
@@ -25,8 +25,7 @@ import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
 
-import org.apache.commons.lang.time.DateUtils;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -105,24 +104,23 @@ public class KnowledgeBaseArticleResourceTest
 			knowledgeBaseArticleResource.postSiteKnowledgeBaseArticle(
 				testGroup.getGroupId(), randomKnowledgeBaseArticle);
 
-		Date postKnowledgeBaseArticleDatePublished =
-			postknowledgeBaseArticle.getDatePublished();
-
-		postknowledgeBaseArticle.setDatePublished(
-			DateUtils.addHours(postKnowledgeBaseArticleDatePublished, 1));
+		String randomTitle = RandomTestUtil.randomString();
 
 		KnowledgeBaseArticle patchKnowledgeBaseArticle =
 			knowledgeBaseArticleResource.patchKnowledgeBaseArticle(
-				postknowledgeBaseArticle.getId(), postknowledgeBaseArticle);
+				postknowledgeBaseArticle.getId(),
+				new KnowledgeBaseArticle() {
+					{
+						title = randomTitle;
+					}
+				});
 
 		assertValid(patchKnowledgeBaseArticle);
 
-		DateTestUtil.assertEquals(
-			postknowledgeBaseArticle.getDatePublished(),
-			patchKnowledgeBaseArticle.getDatePublished());
-		DateTestUtil.assertNotEquals(
-			postknowledgeBaseArticle.getDateModified(),
-			patchKnowledgeBaseArticle.getDateModified());
+		Assert.assertEquals(randomTitle, patchKnowledgeBaseArticle.getTitle());
+		Assert.assertNotEquals(
+			postknowledgeBaseArticle.getTitle(),
+			patchKnowledgeBaseArticle.getTitle());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseArticleResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseArticleResourceTest.java
@@ -13,9 +13,12 @@ import com.liferay.knowledge.base.service.KBArticleLocalServiceUtil;
 import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.DateTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -25,6 +28,8 @@ import java.util.Date;
 import org.apache.commons.lang.time.DateUtils;
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,6 +39,13 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class KnowledgeBaseArticleResourceTest
 	extends BaseKnowledgeBaseArticleResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	@Override


### PR DESCRIPTION
- **LPD-19579 Add PermissionCheckerMethodTestRule to avoid NoSuchUserException**
- **LPD-19579 instead of using dates to check the patch that causes the test be flaky use other field**
