### PR TITLE
LPS-19621 Web Content field values are not saved from API submission if Field is not Localizable

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -86,7 +86,7 @@ public class DDMValueUtil {
 
 				return _toLocalizedValue(
 					contentFieldValue, localizedContentFieldValues,
-					DDMValueUtil::_toLocalizedDateString, preferredLocale);
+					DDMValueUtil::_toDateString, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.DOCUMENT_LIBRARY,
@@ -97,9 +97,8 @@ public class DDMValueUtil {
 
 				return _toLocalizedValue(
 					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) ->
-						_toLocalizedDocument(
-							localizedContentFieldValue, dlAppService),
+					(localizedContentFieldValue, locale) -> _toDocumentString(
+						localizedContentFieldValue, dlAppService),
 					preferredLocale);
 			}
 			else if (Objects.equals(
@@ -110,7 +109,7 @@ public class DDMValueUtil {
 
 				return _toLocalizedValue(
 					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> _toLocalizedImage(
+					(localizedContentFieldValue, locale) -> _toImageString(
 						localizedContentFieldValue, dlAppService),
 					preferredLocale);
 			}
@@ -125,7 +124,7 @@ public class DDMValueUtil {
 				return _toLocalizedValue(
 					contentFieldValue, localizedContentFieldValues,
 					(localizedContentFieldValue, locale) ->
-						_toLocalizedJournalArticle(
+						_toJournalArticleString(
 							localizedContentFieldValue, journalArticleService,
 							locale),
 					preferredLocale);
@@ -193,10 +192,9 @@ public class DDMValueUtil {
 
 				return _toLocalizedValue(
 					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) ->
-						_toLocalizedLinkToPage(
-							localizedContentFieldValue, groupId,
-							layoutLocalService, locale),
+					(localizedContentFieldValue, locale) -> _toLinkToPageString(
+						localizedContentFieldValue, groupId, layoutLocalService,
+						locale),
 					preferredLocale);
 			}
 			else if (Objects.equals(
@@ -263,41 +261,7 @@ public class DDMValueUtil {
 		return layout;
 	}
 
-	private static String _toJSON(
-		String description, DLAppService dlAppService, long fileEntryId) {
-
-		FileEntry fileEntry = null;
-
-		try {
-			fileEntry = dlAppService.getFileEntry(fileEntryId);
-		}
-		catch (Exception exception) {
-			throw new BadRequestException(
-				"No document exists with ID " + fileEntryId, exception);
-		}
-
-		return JSONUtil.put(
-			"alt", description
-		).put(
-			"classPK", fileEntry.getFileEntryId()
-		).put(
-			"fileEntryId", fileEntry.getFileEntryId()
-		).put(
-			"groupId", fileEntry.getGroupId()
-		).put(
-			"name", fileEntry.getFileName()
-		).put(
-			"resourcePrimKey", fileEntry.getPrimaryKey()
-		).put(
-			"title", fileEntry.getFileName()
-		).put(
-			"type", "document"
-		).put(
-			"uuid", fileEntry.getUuid()
-		).toString();
-	}
-
-	private static String _toLocalizedDateString(
+	private static String _toDateString(
 		ContentFieldValue contentFieldValue, Locale locale) {
 
 		if (Validator.isNull(contentFieldValue.getData())) {
@@ -318,7 +282,7 @@ public class DDMValueUtil {
 		}
 	}
 
-	private static String _toLocalizedDocument(
+	private static String _toDocumentString(
 		ContentFieldValue contentFieldValue, DLAppService dlAppService) {
 
 		String valueString = StringPool.BLANK;
@@ -333,7 +297,7 @@ public class DDMValueUtil {
 		return valueString;
 	}
 
-	private static String _toLocalizedImage(
+	private static String _toImageString(
 		ContentFieldValue contentFieldValue, DLAppService dlAppService) {
 
 		String valueString = StringPool.BLANK;
@@ -349,7 +313,7 @@ public class DDMValueUtil {
 		return valueString;
 	}
 
-	private static String _toLocalizedJournalArticle(
+	private static String _toJournalArticleString(
 		ContentFieldValue contentFieldValue,
 		JournalArticleService journalArticleService, Locale locale) {
 
@@ -386,7 +350,41 @@ public class DDMValueUtil {
 		return valueString;
 	}
 
-	private static String _toLocalizedLinkToPage(
+	private static String _toJSON(
+		String description, DLAppService dlAppService, long fileEntryId) {
+
+		FileEntry fileEntry = null;
+
+		try {
+			fileEntry = dlAppService.getFileEntry(fileEntryId);
+		}
+		catch (Exception exception) {
+			throw new BadRequestException(
+				"No document exists with ID " + fileEntryId, exception);
+		}
+
+		return JSONUtil.put(
+			"alt", description
+		).put(
+			"classPK", fileEntry.getFileEntryId()
+		).put(
+			"fileEntryId", fileEntry.getFileEntryId()
+		).put(
+			"groupId", fileEntry.getGroupId()
+		).put(
+			"name", fileEntry.getFileName()
+		).put(
+			"resourcePrimKey", fileEntry.getPrimaryKey()
+		).put(
+			"title", fileEntry.getFileName()
+		).put(
+			"type", "document"
+		).put(
+			"uuid", fileEntry.getUuid()
+		).toString();
+	}
+
+	private static String _toLinkToPageString(
 		ContentFieldValue contentFieldValue, long groupId,
 		LayoutLocalService layoutLocalService, Locale locale) {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -192,6 +192,47 @@ public class DDMValueUtil {
 		return layout;
 	}
 
+	private static String _getOptionValues(
+		DDMFormField ddmFormField, Locale locale, String optionValues,
+		boolean transformValuesToKeys) {
+
+		try {
+			List<String> values = new ArrayList<>();
+
+			if (!ddmFormField.isMultiple() &&
+				!Objects.equals(
+					DDMFormFieldType.CHECKBOX_MULTIPLE,
+					ddmFormField.getType())) {
+
+				values.add(optionValues);
+			}
+			else {
+				values.addAll(
+					JSONUtil.toStringList(
+						JSONFactoryUtil.createJSONArray(optionValues)));
+			}
+
+			if (transformValuesToKeys) {
+				values = _transformValuesToKeys(ddmFormField, locale, values);
+			}
+
+			if ((values.size() == 1) &&
+				DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
+
+				return values.get(0);
+			}
+
+			return JSONUtil.toString(JSONFactoryUtil.createJSONArray(values));
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+
+			return null;
+		}
+	}
+
 	private static String _toDateString(
 		ContentFieldValue contentFieldValue, Locale locale) {
 
@@ -515,48 +556,19 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> {
-				try {
-					String data = localizedContentFieldValue.getData();
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> _getOptionValues(
+					ddmFormField, locale, localizedContentFieldValue.getData(),
+					true),
+				preferredLocale);
+		}
 
-					List<String> values = new ArrayList<>();
-
-					if (!ddmFormField.isMultiple() &&
-						!Objects.equals(
-							DDMFormFieldType.CHECKBOX_MULTIPLE,
-							ddmFormField.getType())) {
-
-						values.add(data);
-					}
-					else {
-						values.addAll(
-							JSONUtil.toStringList(
-								JSONFactoryUtil.createJSONArray(data)));
-					}
-
-					List<String> collect = _transformValuesToKeys(
-						ddmFormField, locale, values);
-
-					if ((collect.size() == 1) &&
-						DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
-
-						return collect.get(0);
-					}
-
-					return JSONUtil.toString(
-						JSONFactoryUtil.createJSONArray(collect));
-				}
-				catch (JSONException jsonException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(jsonException);
-					}
-
-					return null;
-				}
-			},
-			preferredLocale);
+		return new UnlocalizedValue(
+			_getOptionValues(
+				ddmFormField, preferredLocale, contentFieldValue.getValue(),
+				false));
 	}
 
 	private static List<String> _transformValuesToKeys(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -559,9 +559,21 @@ public class DDMValueUtil {
 		if (ddmFormField.isLocalizable()) {
 			return _toLocalizedValue(
 				contentFieldValue, localizedContentFieldValues,
-				(localizedContentFieldValue, locale) -> _getOptionValues(
-					ddmFormField, locale, localizedContentFieldValue.getData(),
-					true),
+				(localizedContentFieldValue, locale) -> {
+					String optionValues = localizedContentFieldValue.getData();
+					boolean transformValuesToKeys = true;
+
+					String value = localizedContentFieldValue.getValue();
+
+					if (Validator.isNotNull(value)) {
+						optionValues = value;
+						transformValuesToKeys = false;
+					}
+
+					return _getOptionValues(
+						ddmFormField, locale, optionValues,
+						transformValuesToKeys);
+				},
 				preferredLocale);
 		}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -84,9 +84,9 @@ public class DDMValueUtil {
 				Objects.equals(
 					DDMFormFieldTypeConstants.DATE, ddmFormField.getType())) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					DDMValueUtil::_toDateString, preferredLocale);
+				return _toDateValue(
+					contentFieldValue, ddmFormField,
+					localizedContentFieldValues, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.DOCUMENT_LIBRARY,
@@ -95,11 +95,9 @@ public class DDMValueUtil {
 						 ddmFormField.getType(),
 						 DDMFormFieldTypeConstants.DOCUMENT_LIBRARY)) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> _toDocumentString(
-						localizedContentFieldValue, dlAppService),
-					preferredLocale);
+				return _toDocumentLibraryValue(
+					contentFieldValue, ddmFormField, dlAppService,
+					localizedContentFieldValues, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.IMAGE, ddmFormField.getType()) ||
@@ -107,11 +105,9 @@ public class DDMValueUtil {
 						 DDMFormFieldTypeConstants.IMAGE,
 						 ddmFormField.getType())) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> _toImageString(
-						localizedContentFieldValue, dlAppService),
-					preferredLocale);
+				return _toImageValue(
+					contentFieldValue, ddmFormField, dlAppService,
+					localizedContentFieldValues, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.JOURNAL_ARTICLE,
@@ -121,13 +117,9 @@ public class DDMValueUtil {
 						 JournalArticleDDMFormFieldTypeConstants.
 							 JOURNAL_ARTICLE)) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) ->
-						_toJournalArticleString(
-							localizedContentFieldValue, journalArticleService,
-							locale),
-					preferredLocale);
+				return _toJournalArticleValue(
+					contentFieldValue, ddmFormField, journalArticleService,
+					localizedContentFieldValues, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldTypeConstants.RADIO,
@@ -139,49 +131,9 @@ public class DDMValueUtil {
 						 DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
 						 ddmFormField.getType())) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> {
-						try {
-							String data = localizedContentFieldValue.getData();
-
-							List<String> values = new ArrayList<>();
-
-							if (!ddmFormField.isMultiple() &&
-								!Objects.equals(
-									DDMFormFieldType.CHECKBOX_MULTIPLE,
-									ddmFormField.getType())) {
-
-								values.add(data);
-							}
-							else {
-								values.addAll(
-									JSONUtil.toStringList(
-										JSONFactoryUtil.createJSONArray(data)));
-							}
-
-							List<String> collect = _transformValuesToKeys(
-								ddmFormField, locale, values);
-
-							if ((collect.size() == 1) &&
-								DDMFormFieldType.RADIO.equals(
-									ddmFormField.getType())) {
-
-								return collect.get(0);
-							}
-
-							return JSONUtil.toString(
-								JSONFactoryUtil.createJSONArray(collect));
-						}
-						catch (JSONException jsonException) {
-							if (_log.isDebugEnabled()) {
-								_log.debug(jsonException);
-							}
-
-							return null;
-						}
-					},
-					preferredLocale);
+				return _toSelectValue(
+					contentFieldValue, ddmFormField,
+					localizedContentFieldValues, preferredLocale);
 			}
 			else if (Objects.equals(
 						DDMFormFieldType.LINK_TO_PAGE,
@@ -190,11 +142,9 @@ public class DDMValueUtil {
 						 LayoutDDMFormFieldTypeConstants.LINK_TO_LAYOUT,
 						 ddmFormField.getType())) {
 
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> _toLinkToPageString(
-						localizedContentFieldValue, groupId, layoutLocalService,
-						locale),
+				return _toLinkToPageValue(
+					contentFieldValue, ddmFormField, groupId,
+					layoutLocalService, localizedContentFieldValues,
 					preferredLocale);
 			}
 			else if (Objects.equals(
@@ -203,22 +153,9 @@ public class DDMValueUtil {
 						 DDMFormFieldTypeConstants.GEOLOCATION,
 						 ddmFormField.getType())) {
 
-				Geo geo = contentFieldValue.getGeo();
-
-				if (Objects.isNull(geo) || Objects.isNull(geo.getLatitude()) ||
-					Objects.isNull(geo.getLongitude())) {
-
-					throw new BadRequestException("Invalid geo " + geo);
-				}
-
-				return _toLocalizedValue(
-					contentFieldValue, localizedContentFieldValues,
-					(localizedContentFieldValue, locale) -> JSONUtil.put(
-						"lat", geo.getLatitude()
-					).put(
-						"lng", geo.getLongitude()
-					).toString(),
-					preferredLocale);
+				return _toGeolocationValue(
+					contentFieldValue, ddmFormField,
+					localizedContentFieldValues, preferredLocale);
 			}
 
 			return _toLocalizedValue(
@@ -282,6 +219,29 @@ public class DDMValueUtil {
 		}
 	}
 
+	private static Value _toDateValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			DDMValueUtil::_toDateString, preferredLocale);
+	}
+
+	private static Value _toDocumentLibraryValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		DLAppService dlAppService,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> _toDocumentString(
+				localizedContentFieldValue, dlAppService),
+			preferredLocale);
+	}
+
 	private static String _toDocumentString(
 		ContentFieldValue contentFieldValue, DLAppService dlAppService) {
 
@@ -295,6 +255,29 @@ public class DDMValueUtil {
 		}
 
 		return valueString;
+	}
+
+	private static Value _toGeolocationValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		Geo geo = contentFieldValue.getGeo();
+
+		if (Objects.isNull(geo) || Objects.isNull(geo.getLatitude()) ||
+			Objects.isNull(geo.getLongitude())) {
+
+			throw new BadRequestException("Invalid geo " + geo);
+		}
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> JSONUtil.put(
+				"lat", geo.getLatitude()
+			).put(
+				"lng", geo.getLongitude()
+			).toString(),
+			preferredLocale);
 	}
 
 	private static String _toImageString(
@@ -311,6 +294,19 @@ public class DDMValueUtil {
 		}
 
 		return valueString;
+	}
+
+	private static Value _toImageValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		DLAppService dlAppService,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> _toImageString(
+				localizedContentFieldValue, dlAppService),
+			preferredLocale);
 	}
 
 	private static String _toJournalArticleString(
@@ -348,6 +344,19 @@ public class DDMValueUtil {
 		}
 
 		return valueString;
+	}
+
+	private static Value _toJournalArticleValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		JournalArticleService journalArticleService,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> _toJournalArticleString(
+				localizedContentFieldValue, journalArticleService, locale),
+			preferredLocale);
 	}
 
 	private static String _toJSON(
@@ -424,6 +433,20 @@ public class DDMValueUtil {
 		return valueString;
 	}
 
+	private static Value _toLinkToPageValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		long groupId, LayoutLocalService layoutLocalService,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> _toLinkToPageString(
+				localizedContentFieldValue, groupId, layoutLocalService,
+				locale),
+			preferredLocale);
+	}
+
 	private static LocalizedValue _toLocalizedValue(
 		ContentFieldValue contentFieldValue,
 		Map<String, ContentFieldValue> localizedContentFieldValues,
@@ -454,6 +477,55 @@ public class DDMValueUtil {
 		}
 
 		return localizedValue;
+	}
+
+	private static Value _toSelectValue(
+		ContentFieldValue contentFieldValue, DDMFormField ddmFormField,
+		Map<String, ContentFieldValue> localizedContentFieldValues,
+		Locale preferredLocale) {
+
+		return _toLocalizedValue(
+			contentFieldValue, localizedContentFieldValues,
+			(localizedContentFieldValue, locale) -> {
+				try {
+					String data = localizedContentFieldValue.getData();
+
+					List<String> values = new ArrayList<>();
+
+					if (!ddmFormField.isMultiple() &&
+						!Objects.equals(
+							DDMFormFieldType.CHECKBOX_MULTIPLE,
+							ddmFormField.getType())) {
+
+						values.add(data);
+					}
+					else {
+						values.addAll(
+							JSONUtil.toStringList(
+								JSONFactoryUtil.createJSONArray(data)));
+					}
+
+					List<String> collect = _transformValuesToKeys(
+						ddmFormField, locale, values);
+
+					if ((collect.size() == 1) &&
+						DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
+
+						return collect.get(0);
+					}
+
+					return JSONUtil.toString(
+						JSONFactoryUtil.createJSONArray(collect));
+				}
+				catch (JSONException jsonException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(jsonException);
+					}
+
+					return null;
+				}
+			},
+			preferredLocale);
 	}
 
 	private static List<String> _transformValuesToKeys(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -76,88 +76,82 @@ public class DDMValueUtil {
 					ddmFormField.getFieldReference());
 		}
 
+		Map<String, ContentFieldValue> localizedContentFieldValues =
+			contentField.getContentFieldValue_i18n();
+
+		if (Objects.equals(DDMFormFieldType.DATE, ddmFormField.getType()) ||
+			Objects.equals(
+				DDMFormFieldTypeConstants.DATE, ddmFormField.getType())) {
+
+			return _toDateValue(
+				contentFieldValue, ddmFormField, localizedContentFieldValues,
+				preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldType.DOCUMENT_LIBRARY,
+					ddmFormField.getType()) ||
+				 Objects.equals(
+					 ddmFormField.getType(),
+					 DDMFormFieldTypeConstants.DOCUMENT_LIBRARY)) {
+
+			return _toDocumentLibraryValue(
+				contentFieldValue, ddmFormField, dlAppService,
+				localizedContentFieldValues, preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldType.IMAGE, ddmFormField.getType()) ||
+				 Objects.equals(
+					 DDMFormFieldTypeConstants.IMAGE, ddmFormField.getType())) {
+
+			return _toImageValue(
+				contentFieldValue, ddmFormField, dlAppService,
+				localizedContentFieldValues, preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldType.JOURNAL_ARTICLE, ddmFormField.getType()) ||
+				 Objects.equals(
+					 ddmFormField.getType(),
+					 JournalArticleDDMFormFieldTypeConstants.JOURNAL_ARTICLE)) {
+
+			return _toJournalArticleValue(
+				contentFieldValue, ddmFormField, journalArticleService,
+				localizedContentFieldValues, preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldTypeConstants.RADIO, ddmFormField.getType()) ||
+				 Objects.equals(
+					 DDMFormFieldTypeConstants.SELECT,
+					 ddmFormField.getType()) ||
+				 Objects.equals(
+					 DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
+					 ddmFormField.getType())) {
+
+			return _toSelectValue(
+				contentFieldValue, ddmFormField, localizedContentFieldValues,
+				preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldType.LINK_TO_PAGE, ddmFormField.getType()) ||
+				 Objects.equals(
+					 LayoutDDMFormFieldTypeConstants.LINK_TO_LAYOUT,
+					 ddmFormField.getType())) {
+
+			return _toLinkToPageValue(
+				contentFieldValue, ddmFormField, groupId, layoutLocalService,
+				localizedContentFieldValues, preferredLocale);
+		}
+		else if (Objects.equals(
+					DDMFormFieldType.GEOLOCATION, ddmFormField.getType()) ||
+				 Objects.equals(
+					 DDMFormFieldTypeConstants.GEOLOCATION,
+					 ddmFormField.getType())) {
+
+			return _toGeolocationValue(
+				contentFieldValue, ddmFormField, localizedContentFieldValues,
+				preferredLocale);
+		}
+
 		if (ddmFormField.isLocalizable()) {
-			Map<String, ContentFieldValue> localizedContentFieldValues =
-				contentField.getContentFieldValue_i18n();
-
-			if (Objects.equals(DDMFormFieldType.DATE, ddmFormField.getType()) ||
-				Objects.equals(
-					DDMFormFieldTypeConstants.DATE, ddmFormField.getType())) {
-
-				return _toDateValue(
-					contentFieldValue, ddmFormField,
-					localizedContentFieldValues, preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldType.DOCUMENT_LIBRARY,
-						ddmFormField.getType()) ||
-					 Objects.equals(
-						 ddmFormField.getType(),
-						 DDMFormFieldTypeConstants.DOCUMENT_LIBRARY)) {
-
-				return _toDocumentLibraryValue(
-					contentFieldValue, ddmFormField, dlAppService,
-					localizedContentFieldValues, preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldType.IMAGE, ddmFormField.getType()) ||
-					 Objects.equals(
-						 DDMFormFieldTypeConstants.IMAGE,
-						 ddmFormField.getType())) {
-
-				return _toImageValue(
-					contentFieldValue, ddmFormField, dlAppService,
-					localizedContentFieldValues, preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldType.JOURNAL_ARTICLE,
-						ddmFormField.getType()) ||
-					 Objects.equals(
-						 ddmFormField.getType(),
-						 JournalArticleDDMFormFieldTypeConstants.
-							 JOURNAL_ARTICLE)) {
-
-				return _toJournalArticleValue(
-					contentFieldValue, ddmFormField, journalArticleService,
-					localizedContentFieldValues, preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldTypeConstants.RADIO,
-						ddmFormField.getType()) ||
-					 Objects.equals(
-						 DDMFormFieldTypeConstants.SELECT,
-						 ddmFormField.getType()) ||
-					 Objects.equals(
-						 DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
-						 ddmFormField.getType())) {
-
-				return _toSelectValue(
-					contentFieldValue, ddmFormField,
-					localizedContentFieldValues, preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldType.LINK_TO_PAGE,
-						ddmFormField.getType()) ||
-					 Objects.equals(
-						 LayoutDDMFormFieldTypeConstants.LINK_TO_LAYOUT,
-						 ddmFormField.getType())) {
-
-				return _toLinkToPageValue(
-					contentFieldValue, ddmFormField, groupId,
-					layoutLocalService, localizedContentFieldValues,
-					preferredLocale);
-			}
-			else if (Objects.equals(
-						DDMFormFieldType.GEOLOCATION, ddmFormField.getType()) ||
-					 Objects.equals(
-						 DDMFormFieldTypeConstants.GEOLOCATION,
-						 ddmFormField.getType())) {
-
-				return _toGeolocationValue(
-					contentFieldValue, ddmFormField,
-					localizedContentFieldValues, preferredLocale);
-			}
-
 			return _toLocalizedValue(
 				contentFieldValue, localizedContentFieldValues,
 				(localizedContentFieldValue, locale) -> GetterUtil.getString(
@@ -224,9 +218,14 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			DDMValueUtil::_toDateString, preferredLocale);
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				DDMValueUtil::_toDateString, preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			_toDateString(contentFieldValue, preferredLocale));
 	}
 
 	private static Value _toDocumentLibraryValue(
@@ -235,11 +234,16 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> _toDocumentString(
-				localizedContentFieldValue, dlAppService),
-			preferredLocale);
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> _toDocumentString(
+					localizedContentFieldValue, dlAppService),
+				preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			_toDocumentString(contentFieldValue, dlAppService));
 	}
 
 	private static String _toDocumentString(
@@ -270,14 +274,23 @@ public class DDMValueUtil {
 			throw new BadRequestException("Invalid geo " + geo);
 		}
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> JSONUtil.put(
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> JSONUtil.put(
+					"lat", geo.getLatitude()
+				).put(
+					"lng", geo.getLongitude()
+				).toString(),
+				preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			JSONUtil.put(
 				"lat", geo.getLatitude()
 			).put(
 				"lng", geo.getLongitude()
-			).toString(),
-			preferredLocale);
+			).toString());
 	}
 
 	private static String _toImageString(
@@ -302,11 +315,16 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> _toImageString(
-				localizedContentFieldValue, dlAppService),
-			preferredLocale);
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> _toImageString(
+					localizedContentFieldValue, dlAppService),
+				preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			_toImageString(contentFieldValue, dlAppService));
 	}
 
 	private static String _toJournalArticleString(
@@ -352,11 +370,17 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> _toJournalArticleString(
-				localizedContentFieldValue, journalArticleService, locale),
-			preferredLocale);
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> _toJournalArticleString(
+					localizedContentFieldValue, journalArticleService, locale),
+				preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			_toJournalArticleString(
+				contentFieldValue, journalArticleService, preferredLocale));
 	}
 
 	private static String _toJSON(
@@ -439,12 +463,19 @@ public class DDMValueUtil {
 		Map<String, ContentFieldValue> localizedContentFieldValues,
 		Locale preferredLocale) {
 
-		return _toLocalizedValue(
-			contentFieldValue, localizedContentFieldValues,
-			(localizedContentFieldValue, locale) -> _toLinkToPageString(
-				localizedContentFieldValue, groupId, layoutLocalService,
-				locale),
-			preferredLocale);
+		if (ddmFormField.isLocalizable()) {
+			return _toLocalizedValue(
+				contentFieldValue, localizedContentFieldValues,
+				(localizedContentFieldValue, locale) -> _toLinkToPageString(
+					localizedContentFieldValue, groupId, layoutLocalService,
+					locale),
+				preferredLocale);
+		}
+
+		return new UnlocalizedValue(
+			_toLinkToPageString(
+				contentFieldValue, groupId, layoutLocalService,
+				preferredLocale));
 	}
 
 	private static LocalizedValue _toLocalizedValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -217,7 +217,8 @@ public class DDMValueUtil {
 			}
 
 			if ((values.size() == 1) &&
-				DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
+				(DDMFormFieldType.RADIO.equals(ddmFormField.getType()) ||
+				 DDMFormFieldType.SELECT.equals(ddmFormField.getType()))) {
 
 				return values.get(0);
 			}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-19621 )

This PR addresse the isssue were content fields are not saved when they are not localized. It also tries to standardize the way we handle the option references and values in localized fields

## Change summary:

* Take into account date, document library, image, journal article, link to page and geolocation fields when they are not localized
* Take into account the value field where the option references are defined instead of the values when the field is localized

## Notes

* Tests will be sent in a follow up PR
* There is no conversion for values to keys for fields that are not localized, we enforce using the reference of the options


## Test Scenarios

* Go to Content and Data > Web Content > Structures
* Create a new structure with ALL fields, and make all that allow it, non localizable (clicking on the field -> advanced tab)
* Save the structure and write down the structure ID
* Create a new web content and fill all of the fields, then press publish (write down the resourcePrimKey of the web content)
* Create a new folder and write down the ID of the folder
* To make it simple, query the endpoint of the web content, like this: http://localhost:8080/o/headless-delivery/v1.0/structured-contents/{resourcePrimKey}, this is the easiest way to get all the field references
* With the field references, post the definition to the endpoint like this http://localhost:8080/o/headless-delivery/v1.0/structured-content-folders/{folderID}/structured-contents and with the body, replacing the contentFields with the previous results and contentStructureId with the ID of the structure that was created (**note that you should replace with your fields**):

```
{
"availableLanguages": [
        "en-US"
      ],
      "contentFields": [
		{
			"contentFieldValue": {
				"data": "chooseTwo",
				"value": "Option76204058"
			},
			"dataType": "string",
			"inputControl": "select",
			"label": "Select from List",
			"name": "Select76946462",
			"nestedContentFields": [
			],
			"repeatable": false
		},
				{
			"contentFieldValue": {
				"value": "Option85829977"
			},
			"dataType": "string",
			"inputControl": "radio",
			"label": "Single Selection",
			"name": "Radio95647269",
			"nestedContentFields": [
			],
			"repeatable": false
		}
      ],
      "contentStructureId": 32963,
      "title": "test1",
	"viewableBy": "Anyone"
}
```

After posting, the web content should be created. Do the same, but changing all the fields to localized. The web content should be created
