### PR TITLE
LPD-1394 Avoid NPE in back button by checking portlet name

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.document.library.web.internal.display.context;
 
+import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.display.context.DLDisplayContextProvider;
 import com.liferay.document.library.display.context.DLViewFileVersionDisplayContext;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -231,21 +233,29 @@ public class DLViewFileEntryDisplayContext {
 			return _redirect;
 		}
 
-		long parentFolderId = _getParentFolderId();
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
-		String mvcRenderCommandName = "/document_library/view";
+		String portletName = portletDisplay.getPortletName();
 
-		if (parentFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			mvcRenderCommandName = "/document_library/view_folder";
+		if (portletName.equals(DLPortletKeys.DOCUMENT_LIBRARY) ||
+			portletName.equals(DLPortletKeys.DOCUMENT_LIBRARY_ADMIN)) {
+
+			long parentFolderId = _getParentFolderId();
+
+			String mvcRenderCommandName = "/document_library/view";
+
+			if (parentFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+				mvcRenderCommandName = "/document_library/view_folder";
+			}
+
+			_redirect = PortletURLBuilder.createRenderURL(
+				_renderResponse
+			).setMVCRenderCommandName(
+				mvcRenderCommandName
+			).setParameter(
+				"folderId", parentFolderId
+			).buildString();
 		}
-
-		_redirect = PortletURLBuilder.createRenderURL(
-			_renderResponse
-		).setMVCRenderCommandName(
-			mvcRenderCommandName
-		).setParameter(
-			"folderId", parentFolderId
-		).buildString();
 
 		return _redirect;
 	}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -23,9 +23,10 @@ if (addPortletBreadcrumbEntries) {
 }
 
 boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
+boolean showBackIcon = Validator.isNotNull(dlViewFileEntryDisplayContext.getRedirect());
 
 if (portletTitleBasedNavigation) {
-	portletDisplay.setShowBackIcon(true);
+	portletDisplay.setShowBackIcon(showBackIcon);
 	portletDisplay.setURLBack(dlViewFileEntryDisplayContext.getRedirect());
 
 	renderResponse.setTitle(fileVersion.getTitle());
@@ -84,15 +85,17 @@ if (portletTitleBasedNavigation) {
 			<div class="file-entry-actions management-bar management-bar-light navbar navbar-expand-md">
 				<ul class="navbar-nav navbar-nav-expand">
 					<li class="nav-item nav-item-expand">
-						<clay:link
-							aria-label='<%= LanguageUtil.get(request, "back") %>'
-							borderless="<%= true %>"
-							displayType="secondary"
-							href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
-							icon="angle-left"
-							monospaced="<%= true %>"
-							type="button"
-						/>
+						<c:if test="<%= showBackIcon %>">
+							<clay:link
+								aria-label='<%= LanguageUtil.get(request, "back") %>'
+								borderless="<%= true %>"
+								displayType="secondary"
+								href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
+								icon="angle-left"
+								monospaced="<%= true %>"
+								type="button"
+							/>
+						</c:if>
 
 						<h3 class="mb-1 text-secondary"><%= HtmlUtil.escape(dlViewFileEntryDisplayContext.getDocumentTitle()) %></h3>
 					</li>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-1394 - NPE after clicking back button in Result Rankings portlet after viewing Document preview

This is a particular edge case from the Search team's Result Rankings module, it happens when:
- another portlet is using the asset taglib to display a document
- document has no size or preview
- there is no `redirect` value already established in the request

When the user clicks on the back button, it'll throw a null pointer exception since there is no view `document_library/view` or `document_library/view_folder` in the search module. These changes are just checking that the portlet is from Documents and Media. If it is not, the URL will be null and the back icon won't be shown.

Let me know any changes to make, thank you for taking a look!