### PR TITLE
LPD-19621 Web Content field values are not saved from API submission if Field is not Localizable

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -217,8 +217,7 @@ public class DDMValueUtil {
 			}
 
 			if ((values.size() == 1) &&
-				(DDMFormFieldType.RADIO.equals(ddmFormField.getType()) ||
-				 DDMFormFieldType.SELECT.equals(ddmFormField.getType()))) {
+				DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
 
 				return values.get(0);
 			}


### PR DESCRIPTION
This is a follow up PR. For select type fields even if they don't are not multiselect, the value is expected to be a json string. So basically I'm reverting the last commit of https://github.com/liferay-content-management/liferay-portal/pull/5205