### PR TITLE
LPD-20016 Allow showing scheduled articles as the permission is already being checked elsewhere

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -120,9 +120,7 @@ public class JournalArticleInfoItemObjectProvider
 				"Unable to get journal article " + infoItemIdentifier);
 		}
 
-		if (article.isScheduled() || article.isInTrash() ||
-			(article.isPending() && !_isSignedIn())) {
-
+		if (article.isInTrash() || (article.isPending() && !_isSignedIn())) {
 			return null;
 		}
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -175,8 +175,7 @@ public class JournalArticleLayoutDisplayPageProvider
 
 		if ((article == null) || article.isExpired() || article.isInTrash() ||
 			(article.isPending() && (permissionChecker != null) &&
-			 !permissionChecker.isSignedIn()) ||
-			article.isScheduled()) {
+			 !permissionChecker.isSignedIn())) {
 
 			return false;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20016

This change allows users to preview scheduled articles again. This partially reverts the changes made in https://liferay.atlassian.net/browse/LPS-188040. However, if a guest user accesses the preview URL (ie http://localhost:8080/w/test?p_l_mode=preview&version=1.0) then they receive a 404 page so there doesn't seem to be an issue with allowing scheduled articles here.

@Mikellorza Would you mind double checking this since you originally wrote the fix for LPS-188040? I want to make sure I'm not missing something and ensure that guest users cannot see content that they shouldn't be able to see.