### PR TITLE
LPD-20037 Allow users without permission to view the blog's images to still view the blog entry

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/model/impl/BlogsEntryImpl.java
@@ -9,6 +9,8 @@ import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -31,8 +33,11 @@ public class BlogsEntryImpl extends BlogsEntryBaseImpl {
 			return null;
 		}
 
-		FileEntry fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
-			coverImageFileEntryId);
+		FileEntry fileEntry = _fetchFileEntry(coverImageFileEntryId);
+
+		if (fileEntry == null) {
+			return null;
+		}
 
 		return fileEntry.getTitle();
 	}
@@ -47,8 +52,11 @@ public class BlogsEntryImpl extends BlogsEntryBaseImpl {
 			return null;
 		}
 
-		FileEntry fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
-			coverImageFileEntryId);
+		FileEntry fileEntry = _fetchFileEntry(coverImageFileEntryId);
+
+		if (fileEntry == null) {
+			return null;
+		}
 
 		return DLURLHelperUtil.getPreviewURL(
 			fileEntry, fileEntry.getFileVersion(), themeDisplay,
@@ -64,8 +72,11 @@ public class BlogsEntryImpl extends BlogsEntryBaseImpl {
 		long smallImageFileEntryId = getSmallImageFileEntryId();
 
 		if (smallImageFileEntryId != 0) {
-			FileEntry fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
-				smallImageFileEntryId);
+			FileEntry fileEntry = _fetchFileEntry(smallImageFileEntryId);
+
+			if (fileEntry == null) {
+				return null;
+			}
 
 			return fileEntry.getTitle();
 		}
@@ -90,8 +101,11 @@ public class BlogsEntryImpl extends BlogsEntryBaseImpl {
 		long smallImageFileEntryId = getSmallImageFileEntryId();
 
 		if (smallImageFileEntryId != 0) {
-			FileEntry fileEntry = PortletFileRepositoryUtil.getPortletFileEntry(
-				smallImageFileEntryId);
+			FileEntry fileEntry = _fetchFileEntry(smallImageFileEntryId);
+
+			if (fileEntry == null) {
+				return null;
+			}
 
 			return DLURLHelperUtil.getPreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
@@ -125,6 +139,21 @@ public class BlogsEntryImpl extends BlogsEntryBaseImpl {
 	public void setSmallImageType(String smallImageType) {
 		_smallImageType = smallImageType;
 	}
+
+	private FileEntry _fetchFileEntry(long fileEntryId) {
+		try {
+			return PortletFileRepositoryUtil.getPortletFileEntry(fileEntryId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get file entry", portalException);
+			}
+
+			return null;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(BlogsEntryImpl.class);
 
 	private String _smallImageType;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20037

If a user does not have permission to view a blog's cover image then an exception is thrown and the user can only see the title of the blog. Instead of having an exception bubble up these changes make it so that `null` is returned instead.

If the correct solution is that the user should not be able to see the blogs entry at all then please let me know and I can work on making those changes. However, to me, this makes the most sense as they have permission to view the entry just not the image.