### PR TITLE
LPD-19515 Use getElementById instead of querySelector

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
@@ -65,9 +65,9 @@ export default function ResourceSelector({
 						showWarning: false,
 					});
 
-					const repositoryIdElement = document.querySelector<
-						HTMLInputElement
-					>(`${portletNamespace}selectedRepositoryId`);
+					const repositoryIdElement = document.getElementById(
+						`${portletNamespace}selectedRepositoryId`
+					) as HTMLInputElement;
 
 					if (repositoryIdElement) {
 						repositoryIdElement.value = selectedItem.repositoryid;


### PR DESCRIPTION
This fixes the followiing failing tests: https://liferay.atlassian.net/browse/LPD-19515

## Steps

- Go to Control Menu > Applications > Asset Libraries 
- Create one > in the left > Go to Sites section and link it to a site
- Go to Content and Data > Documents and Media > upload a file
- Go to Site Builder > Pages > Create a Content Page
- Add a Documents and Media widget > Go to its configuration
- In Folders Listing > click on select button 
- Go to Sites and Libraries section > Asset Library 
- Click on the Asset Library created and click on Select This Folder 

CC: @NemethNorbert 