### PR TITLE
[CLDR] LPD-18615 Make LocalFile.KBArticleSchedule#CanEditScheduled work with both CLDR and JRE locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -787,11 +787,7 @@ definition {
 	@summary = "Default summary"
 	macro editScheduledDate(increaseMinutes = null, tooltipMessageDate = null, kbArticleTitle = null) {
 		if (isSet(tooltipMessageDate)) {
-			MouseOver.javaScriptFocus(locator1 = "Icon#TOOLTIP");
-
-			AssertTextEquals.assertPartialText(
-				locator1 = "Message#TOOLTIP",
-				value1 = ${tooltipMessageDate});
+			AssertElementPresent(locator1 = "//span[*[name()='svg'][contains(@class,'icon-question')]]/../span[contains(text(),'${tooltipMessageDate}')]");
 		}
 
 		Click(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -100,7 +100,7 @@ definition {
 			kbArticleContent = "Knowledge Base Article Content",
 			kbArticleTitle = "Knowledge Base Article Title");
 
-		var tooltipMessageDate = DateUtil.getDateOffsetByMinutes(5, "MMMM d, yyyy h:mm a");
+		var tooltipMessageDate = DateUtil.getDateOffsetByMinutes(5, "MMMM d");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 


### PR DESCRIPTION
Hello team,
This pull is for [LPD-18615](https://liferay.atlassian.net/browse/LPD-18615)

## Motivation
We are in preparation to change locale provider from JRE/COMPAT to CLDR. This made some slight differences in some display name of timezone, country, and formats. This made many functional tests fail as a result.

## Proposed Solution
In this pull, I made the macro test the `tooltipMessageDate` by an `AssertElementPresent` with a Xpath

## Steps to Reproduce
Set `bundle/tomcat-9.0.xx/bin/setenv.sh` `-Djava.locale.providers=JRE,COMPAT,CLDR`   to -`Djava.locale.providers=CLDR`
run the test locally using:  `ant -f build-test-local.xml -Dtest.class=KBArticleSchedule#CanEditScheduledArticle run-poshi-tomcat`
See the failure for it: 
`Actual text "March 11, 24 3:51 PM" does not match pattern "(?iu).March 11, 2024 2:51 PM." at "//div[contains(@class,'tooltip') and contains(@class,'show')]"`
Test should pass both cases.

I am testing it 2 ways here:
1. [With JRE](https://github.com/regiCesar21/liferay-portal/pull/35)
2. [With CLDR](https://github.com/regiCesar21/liferay-portal/pull/36)