### PR TITLE
LPD-17556 publish document when reach display date

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
@@ -8,10 +8,13 @@ package com.liferay.document.library.web.internal.scheduler.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
@@ -24,6 +27,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -79,6 +83,51 @@ public class CheckFileEntrySchedulerJobConfigurationTest {
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_EXPIRED, dlFileEntry.getStatus());
+	}
+
+	@FeatureFlags("LPD-10701")
+	@Test
+	public void testPublishFileEntry() throws Exception {
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		FileEntry fileEntry = _dlAppService.addFileEntry(
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, displayDate, null,
+			null, serviceContext);
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, dlFileEntry.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() + 10);
+
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), StringPool.BLANK,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileEntry.getTitle(),
+			"urltitle", StringPool.BLANK, StringPool.BLANK,
+			DLVersionNumberIncrease.MINOR, (byte[])null, displayDate, null,
+			null, serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, dlFileEntry.getStatus());
+
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 1);
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileEntry.getStatus());
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2334,8 +2334,9 @@ public class DLFileEntryLocalServiceImpl
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				StringBundler.concat(
-					"Publishing file entries with display date less than ",
-					displayDate, " for company ", companyId));
+					"Publishing file entries with display date between ",
+					_dates.get(companyId), " and ", displayDate,
+					" for company ", companyId));
 		}
 
 		_publishFileEntriesByCompanyId(
@@ -3504,6 +3505,11 @@ public class DLFileEntryLocalServiceImpl
 			).where(
 				DLFileEntryTable.INSTANCE.companyId.eq(
 					companyId
+				).and(
+					DLFileEntryTable.INSTANCE.displayDate.isNotNull()
+				).and(
+					DLFileEntryTable.INSTANCE.displayDate.gte(
+						_dates.get(companyId))
 				).and(
 					DLFileEntryTable.INSTANCE.displayDate.lte(displayDate)
 				)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2060,6 +2060,15 @@ public class DLFileEntryLocalServiceImpl
 				}
 
 				dlFileEntry.setVersion(newVersion);
+				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
+
+				dlFileEntry = dlFileEntryPersistence.update(dlFileEntry);
+			}
+			else if (!Objects.equals(
+						dlFileEntry.getDisplayDate(),
+						dlFileVersion.getDisplayDate())) {
+
+				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
 
 				dlFileEntry = dlFileEntryPersistence.update(dlFileEntry);
 			}


### PR DESCRIPTION
Steps to test:

1) Change on System Settings > Documents and Media > Service > Check Interval : to 1 min
2) create a document with a schedule date now + 3 mins and publish
3) ensure the document has the schedule label
4) wait 3 mins
5) ensure the document is published (approved)

-- plus

6) modify the document with a schedule date now + 1 year and change the title, then publish 
7) ensure the document has the schedule label AND the approved on



Commits
- LPD-17556 update always the display date 
- LPD-17556 search between the previous date and that is not null 
- LPD-17556 add integration test 
