### PR TITLE
LPD-19549 doAsUserId param is included in document URL when selected from Repository Browser

### DIFF
--- a/modules/apps/document-library/document-library-api/bnd.bnd
+++ b/modules/apps/document-library/document-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library API
 Bundle-SymbolicName: com.liferay.document.library.api
-Bundle-Version: 24.3.1
+Bundle-Version: 25.0.0
 Export-Package:\
 	com.liferay.document.library.asset,\
 	com.liferay.document.library.asset.model,\

--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/util/DLURLHelper.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/util/DLURLHelper.java
@@ -57,6 +57,11 @@ public interface DLURLHelper {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString, boolean appendVersion, boolean absoluteURL);
 
+	public String getPreviewURL(
+		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
+		String queryString, boolean appendVersion, boolean absoluteURL,
+		boolean doAsUser);
+
 	public String getThumbnailSrc(
 			FileEntry fileEntry, FileVersion fileVersion,
 			ThemeDisplay themeDisplay)

--- a/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/util/packageinfo
+++ b/modules/apps/document-library/document-library-api/src/main/resources/com/liferay/document/library/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/FileEntryURLItemSelectorReturnTypeResolver.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/FileEntryURLItemSelectorReturnTypeResolver.java
@@ -49,7 +49,7 @@ public class FileEntryURLItemSelectorReturnTypeResolver
 
 			return _dlURLHelper.getPreviewURL(
 				fileEntry, fileEntry.getFileVersion(), themeDisplay,
-				StringPool.BLANK, false, false);
+				StringPool.BLANK, false, false, false);
 		}
 
 		return PortletFileRepositoryUtil.getPortletFileEntryURL(

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -211,6 +211,17 @@ public class DLURLHelperImpl implements DLURLHelper {
 		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
 		String queryString, boolean appendVersion, boolean absoluteURL) {
 
+		return getPreviewURL(
+			fileEntry, fileVersion, themeDisplay, queryString, true, true,
+			true);
+	}
+
+	@Override
+	public String getPreviewURL(
+		FileEntry fileEntry, FileVersion fileVersion, ThemeDisplay themeDisplay,
+		String queryString, boolean appendVersion, boolean absoluteURL,
+		boolean doAsUser) {
+
 		String previewURLPrefix = _getPreviewURLPrefix(
 			themeDisplay, absoluteURL);
 
@@ -223,7 +234,7 @@ public class DLURLHelperImpl implements DLURLHelper {
 				appendVersion);
 		}
 
-		if ((themeDisplay != null) &&
+		if (doAsUser && (themeDisplay != null) &&
 			Validator.isNotNull(themeDisplay.getDoAsUserId())) {
 
 			previewURL = _portal.addPreservedParameters(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-19549

Upon impersonation, when using an Item Selector to retrieve the URL of a DM file, the parameter `doAsUserId` is also returned. I could not analyze all places where an Item Selector is used, but it seems to be incorrect in most cases.

This problem started after the fix done back in [August, 2023](https://liferay.atlassian.net/browse/LPS-193614) where the `doAsUserId` parameter was added to all DM links, see PR #4598 . After some discussion about its correctness I believe it is correct in most cases. For cases where the `doAsUserId` parameter is not needed, like the current problem with the Item Selector, I've created a new method with an additional parameter.
