### PR TITLE
LPD-20274 restore the creation of the JournalGroupServiceConfiguration to the init.jsp to prevent NPE the creation of the JournalDisplayContext should be needed on JournalConfigurationAction because now is on the request as attribute, but if we create there we will overload the calls for a class that can be done on the init.

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -22,7 +22,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemListBuilder;
 import com.liferay.item.selector.ItemSelector;
-import com.liferay.journal.configuration.JournalGroupServiceConfiguration;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalConstants;
@@ -45,7 +44,6 @@ import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.constants.JournalWebConstants;
 import com.liferay.journal.web.internal.dao.search.JournalRecentArticlesResultRowSplitter;
 import com.liferay.journal.web.internal.dao.search.JournalResultRowSplitter;
-import com.liferay.journal.web.internal.display.context.helper.JournalWebRequestHelper;
 import com.liferay.journal.web.internal.portlet.action.ActionUtil;
 import com.liferay.journal.web.internal.search.EntriesChecker;
 import com.liferay.journal.web.internal.search.EntriesMover;
@@ -778,22 +776,6 @@ public class JournalDisplayContext {
 			tabsItem -> tabsItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "versions"))
 		).build();
-	}
-
-	public JournalGroupServiceConfiguration
-		getJournalGroupServiceConfiguration() {
-
-		if (_journalGroupServiceConfiguration != null) {
-			return _journalGroupServiceConfiguration;
-		}
-
-		JournalWebRequestHelper journalWebRequestHelper =
-			new JournalWebRequestHelper(_httpServletRequest);
-
-		_journalGroupServiceConfiguration =
-			journalWebRequestHelper.getJournalGroupServiceConfiguration();
-
-		return _journalGroupServiceConfiguration;
 	}
 
 	public String getKeywords() {
@@ -2429,7 +2411,6 @@ public class JournalDisplayContext {
 	private Long _highlightedDDMStructureId;
 	private final HttpServletRequest _httpServletRequest;
 	private final ItemSelector _itemSelector;
-	private JournalGroupServiceConfiguration _journalGroupServiceConfiguration;
 	private final JournalHelper _journalHelper;
 	private final JournalWebConfiguration _journalWebConfiguration;
 	private String _keywords;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -127,6 +127,7 @@ page import="com.liferay.journal.web.internal.display.context.JournalPreviewArti
 page import="com.liferay.journal.web.internal.display.context.JournalVersionTabDisplayContext" %><%@
 page import="com.liferay.journal.web.internal.display.context.JournalViewMoreMenuItemsDisplayContext" %><%@
 page import="com.liferay.journal.web.internal.display.context.JournalViewMoreMenuItemsManagementToolbarDisplayContext" %><%@
+page import="com.liferay.journal.web.internal.display.context.helper.JournalWebRequestHelper" %><%@
 page import="com.liferay.journal.web.internal.exception.DDMStructureValidationModelListenerException" %><%@
 page import="com.liferay.journal.web.internal.frontend.taglib.clay.servlet.taglib.JournalArticleCommentsVerticalCard" %><%@
 page import="com.liferay.journal.web.internal.frontend.taglib.clay.servlet.taglib.JournalArticleHistoryVerticalCard" %><%@
@@ -227,7 +228,9 @@ JournalWebConfiguration journalWebConfiguration = (JournalWebConfiguration)reque
 
 JournalDisplayContext journalDisplayContext = (JournalDisplayContext)request.getAttribute(JournalDisplayContext.class.getName());
 
-JournalGroupServiceConfiguration journalGroupServiceConfiguration = journalDisplayContext.getJournalGroupServiceConfiguration();
+JournalWebRequestHelper journalWebRequestHelper = new JournalWebRequestHelper(request);
+
+JournalGroupServiceConfiguration journalGroupServiceConfiguration = journalWebRequestHelper.getJournalGroupServiceConfiguration();
 
 Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 %>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20274

Steps to Reproduce 

1) Go to Web content
2) Go to kebab menu (three dots)
3) Click on Configure