### PR TITLE
[CLDR] LPD-18614 Fix Functional Test: LocalFile.KBArticle#CanViewEntryInfo with CLDR and JRE locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -1938,13 +1938,9 @@ definition {
 			locator1 = "KnowledgeBaseArticle#INFO_VERSION_TITLE",
 			value1 = ${entryVersion});
 
-		var modifiedDate = DateUtil.getFormattedCurrentDate("MMMM d, yyyy");
+		var modifiedDate = DateUtil.getFormattedCurrentDate("MMMM d");
 
-		AssertTextEquals.assertPartialText(
-			key_entryVersion = ${entryVersion},
-			locator1 = "KnowledgeBaseArticle#INFO_VERSION_SUBTITLE",
-			userName = ${userName},
-			value1 = "By ${userName}, on ${modifiedDate}");
+		AssertElementPresent(locator1 = "//li[contains(*,'${entryVersion}')]//div[@class='list-group-subtitle'][contains(text(),'By ${userName}, on ${modifiedDate}')]");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
Hello team,
This pull is for [LPD-18614](https://liferay.atlassian.net/browse/LPD-18614)

## Motivation
We are in preparation to change locale provider from JRE/COMPAT to CLDR. This made some slight differences in some display name of timezone, country, and formats. This made many functional tests fail as a result.

## Proposed Solution
In this pull, I made the macro test the subtitle and the title by an `AssertElementPresent` with a Xpath

## Steps to Reproduce
Set `bundle/tomcat-9.0.xx/bin/setenv.sh` `-Djava.locale.providers=JRE,COMPAT,CLDR` to `-Djava.locale.providers=CLDR`
run the test locally using: `ant -f build-test-local.xml -Dtest.class=KBArticleSchedule#CanViewEntryInfo run-poshi-tomcat`
See the failure for it:
`java.lang.Exception: Actual text "By Test Test. on February 15. 24 9:44 PM" does not match pattern "(?iu).*By Test Test. on February 15. 2024.*" at "//li[contains(..'Version 1')]//div[@class='list-group-subtitle']"`
Test should pass both cases.

I am testing it 2 ways here:

[with CLDR](https://github.com/regiCesar21/liferay-portal/pull/37)
[with JRE](https://github.com/regiCesar21/liferay-portal/pull/38)