### PR TITLE
LPD-20372 get group acenstor site and depot groupIds to allow all ava…

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -51,7 +51,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTAware;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -691,22 +690,6 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		return serviceContext;
 	}
 
-	private long[] _getAncestorSiteAndDepotGroupIds(long groupId) {
-		try {
-			if (_siteConnectedGroupGroupProvider == null) {
-				return _portal.getAncestorSiteGroupIds(groupId);
-			}
-
-			return _siteConnectedGroupGroupProvider.
-				getAncestorSiteAndDepotGroupIds(groupId, true);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-
-			return new long[0];
-		}
-	}
-
 	private long _getDDMStructureId(FileEntry fileEntry) throws Exception {
 		if (!(fileEntry.getModel() instanceof DLFileEntry)) {
 			return 0;
@@ -752,7 +735,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		try {
 			for (DLFileEntryType dlFileEntryType :
 					_dlFileEntryTypeLocalService.getFolderFileEntryTypes(
-						_getAncestorSiteAndDepotGroupIds(groupId),
+						_siteConnectedGroupGroupProvider.
+							getAncestorSiteAndDepotGroupIds(groupId, true),
 						documentFolderId, true)) {
 
 				if (name.equals(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.delivery.internal.resource.v1_0;
 
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
@@ -50,8 +51,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -689,6 +692,25 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		return serviceContext;
 	}
 
+	private long[] _getAncestorSiteAndDepotGroupIds(long groupId) {
+		try {
+			SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider =
+				_siteConnectedGroupGroupProviderSnapshot.get();
+
+			if (siteConnectedGroupGroupProvider == null) {
+				return _portal.getAncestorSiteGroupIds(groupId);
+			}
+
+			return siteConnectedGroupGroupProvider.
+				getAncestorSiteAndDepotGroupIds(groupId, true);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return new long[0];
+		}
+	}
+
 	private long _getDDMStructureId(FileEntry fileEntry) throws Exception {
 		if (!(fileEntry.getModel() instanceof DLFileEntry)) {
 			return 0;
@@ -734,7 +756,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		try {
 			for (DLFileEntryType dlFileEntryType :
 					_dlFileEntryTypeLocalService.getFolderFileEntryTypes(
-						new long[] {groupId}, documentFolderId, true)) {
+						_getAncestorSiteAndDepotGroupIds(groupId),
+						documentFolderId, true)) {
 
 				if (name.equals(
 						dlFileEntryType.getName(
@@ -990,6 +1013,11 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DocumentResourceImpl.class);
+
+	private static final Snapshot<SiteConnectedGroupGroupProvider>
+		_siteConnectedGroupGroupProviderSnapshot = new Snapshot<>(
+			DocumentResourceImpl.class, SiteConnectedGroupGroupProvider.class,
+			null, true);
 
 	@Reference
 	private Aggregations _aggregations;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -694,14 +693,11 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 	private long[] _getAncestorSiteAndDepotGroupIds(long groupId) {
 		try {
-			SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider =
-				_siteConnectedGroupGroupProviderSnapshot.get();
-
-			if (siteConnectedGroupGroupProvider == null) {
+			if (_siteConnectedGroupGroupProvider == null) {
 				return _portal.getAncestorSiteGroupIds(groupId);
 			}
 
-			return siteConnectedGroupGroupProvider.
+			return _siteConnectedGroupGroupProvider.
 				getAncestorSiteAndDepotGroupIds(groupId, true);
 		}
 		catch (PortalException portalException) {
@@ -1014,11 +1010,6 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 	private static final Log _log = LogFactoryUtil.getLog(
 		DocumentResourceImpl.class);
 
-	private static final Snapshot<SiteConnectedGroupGroupProvider>
-		_siteConnectedGroupGroupProviderSnapshot = new Snapshot<>(
-			DocumentResourceImpl.class, SiteConnectedGroupGroupProvider.class,
-			null, true);
-
 	@Reference
 	private Aggregations _aggregations;
 
@@ -1098,6 +1089,9 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 	@Reference
 	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Reference
+	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;
 
 	@Reference
 	private Sorts _sorts;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20372

When calling Headless API, document types were being gathered only from the group the folder belongs to, not all available ancestor sites and connected depots.