### PR TITLE
LPD-20509 Fix PingbackMethodImplTest test failures

### DIFF
--- a/modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
+++ b/modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
@@ -22,9 +22,11 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -42,8 +44,10 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,6 +68,17 @@ public class PingbackMethodImplTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
+	@BeforeClass
+	public static void setUpClass() {
+		_inetAddressUtilMockedStatic = Mockito.mockStatic(
+			InetAddressUtil.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_inetAddressUtilMockedStatic.close();
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_setUpBlogsEntryLocalService();
@@ -77,6 +92,15 @@ public class PingbackMethodImplTest {
 		_setUpPropsTestUtil();
 		_setUpUserLocalService();
 		_setUpXmlRpcUtil();
+
+		_inetAddressUtilMockedStatic.when(
+			() -> InetAddressUtil.isLocalInetAddress(
+				Mockito.argThat(
+					inetAddress -> ArrayUtil.contains(
+						_localAddresses, inetAddress)))
+		).thenReturn(
+			true
+		);
 	}
 
 	@After
@@ -720,6 +744,7 @@ public class PingbackMethodImplTest {
 
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
+	private static MockedStatic<InetAddressUtil> _inetAddressUtilMockedStatic;
 	private static MockedStatic<XmlRpcUtil> _xmlRpcUtilMockedStatic;
 
 	private final BlogsEntry _blogsEntry = Mockito.mock(BlogsEntry.class);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-20509

PingbackMethodImplTest has been failing for a while.

# How am I fixing it?

By mocking some static methods. The issue is that InetAddressUtil initializes some state that depends on a running portal. Mocking the methods allow we to run this in a unit test.