### PR TITLE
LPD-19285 Update KBArticleServiceTest integration tests (2nd try)

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.knowledge.base.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.knowledge.base.service.KBArticleService;
 import com.liferay.knowledge.base.util.comparator.KBArticlePriorityComparator;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -62,12 +64,12 @@ public class KBArticleServiceTest {
 
 		_originalName = PrincipalThreadLocal.getName();
 
-		User user = TestPropsValues.getUser();
+		_user = TestPropsValues.getUser();
 
-		PrincipalThreadLocal.setName(user.getUserId());
+		PrincipalThreadLocal.setName(_user.getUserId());
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
-			_group, user.getUserId());
+			_group, _user.getUserId());
 
 		_testPortletId = "TEST_PORTLET_" + RandomTestUtil.randomString();
 	}
@@ -75,6 +77,40 @@ public class KBArticleServiceTest {
 	@After
 	public void tearDown() {
 		PrincipalThreadLocal.setName(_originalName);
+	}
+
+	@FeatureFlags("LPD-11003")
+	@Test
+	public void testForceLockKBArticle() throws Exception {
+		KBArticle kbArticle = _addKbArticle(new Date());
+		User otherUser = UserTestUtil.addUser(_group.getGroupId());
+
+		try {
+			_kbArticleLocalService.lockKBArticle(
+				otherUser.getUserId(), kbArticle.getResourcePrimKey());
+
+			Assert.assertTrue(
+				_kbArticleLocalService.hasKBArticleLock(
+					otherUser.getUserId(), kbArticle.getResourcePrimKey()));
+
+			Assert.assertFalse(
+				_kbArticleLocalService.hasKBArticleLock(
+					_user.getUserId(), kbArticle.getResourcePrimKey()));
+
+			_kbArticleService.forceLockKBArticle(
+				_group.getGroupId(), kbArticle.getResourcePrimKey());
+
+			Assert.assertFalse(
+				_kbArticleLocalService.hasKBArticleLock(
+					otherUser.getUserId(), kbArticle.getResourcePrimKey()));
+
+			Assert.assertTrue(
+				_kbArticleLocalService.hasKBArticleLock(
+					_user.getUserId(), kbArticle.getResourcePrimKey()));
+		}
+		finally {
+			_kbArticleService.deleteKBArticle(kbArticle.getResourcePrimKey());
+		}
 	}
 
 	@FeatureFlags("LPS-188058")
@@ -125,11 +161,15 @@ public class KBArticleServiceTest {
 	private Group _group;
 
 	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+	@Inject
 	private KBArticleService _kbArticleService;
 
 	private long _kbFolderClassNameId;
 	private String _originalName;
 	private ServiceContext _serviceContext;
 	private String _testPortletId;
+	private User _user;
 
 }


### PR DESCRIPTION
After sending the PR #5229 I realized about errors appearing in the system console. The problems came from the final cleanup process, not from the test itself.