### PR TITLE
LPD-19549 doAsUserId param is included in document URL when selected from Repository Browser (2nd try)

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -223,13 +223,6 @@ public class DLURLHelperImpl implements DLURLHelper {
 				appendVersion);
 		}
 
-		if ((themeDisplay != null) &&
-			Validator.isNotNull(themeDisplay.getDoAsUserId())) {
-
-			previewURL = _portal.addPreservedParameters(
-				themeDisplay, previewURL, false, true);
-		}
-
 		if ((themeDisplay != null) && themeDisplay.isAddSessionIdToURL()) {
 			return _portal.getURLWithSessionId(
 				previewURL, themeDisplay.getSessionId());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -83,9 +83,11 @@ public class DLURLHelperImpl implements DLURLHelper {
 		}
 
 		return HttpComponentsUtil.addParameter(
-			getPreviewURL(
-				fileEntry, fileVersion, themeDisplay, queryString,
-				appendVersion, absoluteURL),
+			_addDoAsUserIdParameter(
+				themeDisplay,
+				getPreviewURL(
+					fileEntry, fileVersion, themeDisplay, queryString,
+					appendVersion, absoluteURL)),
 			"download", true);
 	}
 
@@ -264,8 +266,10 @@ public class DLURLHelperImpl implements DLURLHelper {
 			}
 		}
 
-		return _getImageSrc(
-			fileEntry, fileVersion, themeDisplay, thumbnailQueryString);
+		return _addDoAsUserIdParameter(
+			themeDisplay,
+			_getImageSrc(
+				fileEntry, fileVersion, themeDisplay, thumbnailQueryString));
 	}
 
 	@Override
@@ -387,6 +391,20 @@ public class DLURLHelperImpl implements DLURLHelper {
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private String _addDoAsUserIdParameter(
+		ThemeDisplay themeDisplay, String url) {
+
+		if ((themeDisplay != null) &&
+			Validator.isNotNull(themeDisplay.getDoAsUserId()) &&
+			Validator.isNotNull(url)) {
+
+			return HttpComponentsUtil.setParameter(
+				url, "doAsUserId", themeDisplay.getDoAsUserId());
+		}
+
+		return url;
 	}
 
 	private String _getDLFileVersionURLProviderURL(


### PR DESCRIPTION
After first attempt #5227 and discussion with @robertoDiaz and @adolfopa this is the new PR, where:

* PR #4598 has been reverted to solve the LPD-19549 (coming from an LPP)
* The doAsUserId is added only when generating the Thumbnail and Download links. This solves the original problem in LPS-193614. 