### PR TITLE
LPD-20538 set expiration date values and validation for properly expire documents

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -352,7 +353,8 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
 			"Site", TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "fileName.pdf",
-			"application/pdf", new byte[0], new Date(150000), new Date(150000),
+			"application/pdf", new byte[0], new Date(150000),
+			new Date(System.currentTimeMillis() + Time.MINUTE),
 			new Date(150000), _serviceContext);
 
 		return _contentDashboardFileItemFactory.create(

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemsXlsMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemsXlsMVCResourceCommandTest.java
@@ -87,7 +87,7 @@ public class GetContentDashboardItemsXlsMVCResourceCommandTest {
 		FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
 			"Site", TestPropsValues.getUserId(), _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "fileName.pdf",
-			"application/pdf", new byte[0], createDate, createDate, createDate,
+			"application/pdf", new byte[0], createDate, null, createDate,
 			serviceContext);
 
 		List<String> expectedWorkbookHeaders = ListUtil.fromArray(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.security.permission.DoAsUserThread;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -156,7 +157,8 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testFileEntryShouldSaveExpirationDate() throws Exception {
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 
 		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -213,7 +214,8 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertNull(fileEntry.getExpirationDate());
 		Assert.assertNull(fileEntry.getReviewDate());
 
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), RandomTestUtil.randomString(), null,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -259,7 +259,8 @@ public class DLFileEntryLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Date displayDate = new Date();
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 		Date reviewDate = new Date();
 
 		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
@@ -399,7 +400,8 @@ public class DLFileEntryLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Date displayDate = new Date();
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 		Date reviewDate = new Date();
 
 		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
@@ -441,7 +443,8 @@ public class DLFileEntryLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		Date reviewDate = new Date();
-		Date expitationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 
 		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
@@ -449,11 +452,11 @@ public class DLFileEntryLocalServiceTest {
 			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringPool.BLANK, StringPool.BLANK, -1, new HashMap<>(), null,
-			new ByteArrayInputStream(new byte[0]), 0, null, expitationDate,
+			new ByteArrayInputStream(new byte[0]), 0, null, expirationDate,
 			reviewDate, serviceContext);
 
 		Assert.assertNull(dlFileEntry.getDisplayDate());
-		Assert.assertEquals(expitationDate, dlFileEntry.getExpirationDate());
+		Assert.assertEquals(expirationDate, dlFileEntry.getExpirationDate());
 		Assert.assertEquals(reviewDate, dlFileEntry.getReviewDate());
 	}
 
@@ -485,7 +488,8 @@ public class DLFileEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());
 
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 
 		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
@@ -1218,7 +1222,8 @@ public class DLFileEntryLocalServiceTest {
 		Assert.assertNull(dlFileVersion.getReviewDate());
 
 		Date displayDate = new Date();
-		Date expirationDate = new Date();
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
 		Date reviewDate = new Date();
 
 		dlFileEntry = DLFileEntryLocalServiceUtil.updateFileEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryExternalReferenceCodeException;
 import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
+import com.liferay.document.library.kernel.exception.FileEntryExpirationDateException;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.InvalidFileVersionException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
@@ -82,6 +83,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -121,6 +123,45 @@ public class DLFileEntryLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test(expected = FileEntryExpirationDateException.class)
+	public void testAddFileEntryShouldFailIfExpirationDateIsBeforeDisplayDate()
+		throws Exception {
+
+		String content = StringUtil.randomString();
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.HOUR);
+
+		DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			"file.txt", ContentTypes.TEXT_PLAIN, "file.txt",
+			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK, -1,
+			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
+			0, displayDate, expirationDate, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Test(expected = FileEntryExpirationDateException.class)
+	public void testAddFileEntryShouldFailIfExpirationDateIsBeforeNow()
+		throws Exception {
+
+		String content = StringUtil.randomString();
+
+		Date expirationDate = new Date(System.currentTimeMillis() - Time.DAY);
+
+		DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			"file.txt", ContentTypes.TEXT_PLAIN, "file.txt",
+			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK, -1,
+			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
+			0, null, expirationDate, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
 	@Test(expected = FileExtensionException.class)
@@ -1239,6 +1280,69 @@ public class DLFileEntryLocalServiceTest {
 
 		Assert.assertNotNull(dlFileVersion.getStoreUUID());
 		Assert.assertNotEquals(storeUUID, dlFileVersion.getStoreUUID());
+	}
+
+	@Test(expected = FileEntryExpirationDateException.class)
+	public void testUpdateFileEntryShouldFailIfExpirationDateIsBeforeDisplayDate()
+		throws Exception {
+
+		String content = StringUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			"file.txt", ContentTypes.TEXT_PLAIN, "file.txt",
+			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK, -1,
+			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
+			0, null, null, null, serviceContext);
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.HOUR);
+
+		DLFileEntryLocalServiceUtil.updateFileEntry(
+			dlFileEntry.getUserId(), dlFileEntry.getFileEntryId(),
+			dlFileEntry.getFileName(), dlFileEntry.getMimeType(),
+			dlFileEntry.getTitle(), StringUtil.randomString(),
+			dlFileEntry.getTitle(), StringPool.BLANK,
+			DLVersionNumberIncrease.fromMajorVersion(false),
+			dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
+			new ByteArrayInputStream(content.getBytes()), 0, displayDate,
+			expirationDate, null, serviceContext);
+	}
+
+	@Test(expected = FileEntryExpirationDateException.class)
+	public void testUpdateFileEntryShouldFailIfExpirationDateIsBeforeNow()
+		throws Exception {
+
+		String content = StringUtil.randomString();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			"file.txt", ContentTypes.TEXT_PLAIN, "file.txt",
+			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK, -1,
+			new HashMap<>(), null, new ByteArrayInputStream(content.getBytes()),
+			0, null, null, null, serviceContext);
+
+		Date expirationDate = new Date(System.currentTimeMillis() - Time.DAY);
+
+		DLFileEntryLocalServiceUtil.updateFileEntry(
+			dlFileEntry.getUserId(), dlFileEntry.getFileEntryId(),
+			dlFileEntry.getFileName(), dlFileEntry.getMimeType(),
+			dlFileEntry.getTitle(), StringUtil.randomString(),
+			dlFileEntry.getTitle(), StringPool.BLANK,
+			DLVersionNumberIncrease.fromMajorVersion(false),
+			dlFileEntry.getFileEntryTypeId(), new HashMap<>(), null,
+			new ByteArrayInputStream(content.getBytes()), 0, null,
+			expirationDate, null, serviceContext);
 	}
 
 	@Test(expected = FileExtensionException.class)

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -245,7 +246,8 @@ public class DLFileVersionTest {
 			_fileVersion.getMimeType(), _fileVersion.getTitle(),
 			StringPool.BLANK, _fileVersion.getDescription(),
 			_fileVersion.getChangeLog(), DLVersionNumberIncrease.MINOR,
-			_DATA_VERSION_1, _fileVersion.getDisplayDate(), new Date(),
+			_DATA_VERSION_1, _fileVersion.getDisplayDate(),
+			new Date(System.currentTimeMillis() + Time.MINUTE),
 			_fileVersion.getReviewDate(), _serviceContext);
 
 		Assert.assertNotEquals(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionUpdateTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Date;
@@ -82,11 +83,14 @@ public class DLFileVersionUpdateTest extends BaseDLAppTestCase {
 			addMimeType, addFileName, null, description, changeLog, addBytes,
 			null, null, null, serviceContext);
 
+		Date expirationDate = new Date(
+			System.currentTimeMillis() + Time.MINUTE);
+
 		fileEntry = dlAppService.updateFileEntry(
 			fileEntry.getFileEntryId(), updateFileName, updateMimeType,
 			updateFileName, null, description, changeLog,
-			DLVersionNumberIncrease.MINOR, updateBytes, new Date(), new Date(),
-			new Date(), serviceContext);
+			DLVersionNumberIncrease.MINOR, updateBytes, new Date(),
+			expirationDate, new Date(), serviceContext);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
@@ -63,22 +63,32 @@ public class CheckFileEntrySchedulerJobConfigurationTest {
 
 	@Test
 	public void testExpireFileEntry() throws Exception {
-		Date expirationDate = new Date(System.currentTimeMillis() - Time.DAY);
-
 		FileEntry fileEntry = _dlAppService.addFileEntry(
 			null, _group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM,
 			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), (byte[])null, null, expirationDate,
-			null,
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
-		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 1);
-
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Date expirationDate = new Date(
+			System.currentTimeMillis() - Time.MINUTE);
+
+		dlFileEntry.setExpirationDate(expirationDate);
+
+		dlFileEntry = _dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileEntry.getStatus());
+
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 2);
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
 			fileEntry.getFileEntryId());
 
 		Assert.assertEquals(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryExternalReferenceCodeException;
 import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
+import com.liferay.document.library.kernel.exception.FileEntryExpirationDateException;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.exception.FileNameException;
 import com.liferay.document.library.kernel.exception.InvalidFileEntryTypeException;
@@ -246,7 +247,8 @@ public class DLFileEntryLocalServiceImpl
 			fileEntryTypeId);
 
 		_validateFile(
-			groupId, folderId, 0, fileEntryTypeId, fileName, extension, title);
+			groupId, folderId, 0, fileEntryTypeId, fileName, extension, title,
+			displayDate, expirationDate);
 
 		long fileEntryId = counterLocalService.increment();
 
@@ -3672,7 +3674,7 @@ public class DLFileEntryLocalServiceImpl
 			_validateFile(
 				dlFileEntry.getGroupId(), dlFileEntry.getFolderId(),
 				dlFileEntry.getFileEntryId(), fileEntryTypeId, fileName,
-				extension, title);
+				extension, title, displayDate, expirationDate);
 
 			// File version
 
@@ -3834,7 +3836,8 @@ public class DLFileEntryLocalServiceImpl
 
 	private void _validateFile(
 			long groupId, long folderId, long fileEntryId, long fileEntryTypeId,
-			String fileName, String extension, String title)
+			String fileName, String extension, String title, Date displayDate,
+			Date expirationDate)
 		throws PortalException {
 
 		DLValidatorUtil.validateFileName(fileName);
@@ -3850,6 +3853,20 @@ public class DLFileEntryLocalServiceImpl
 		}
 
 		validateFile(groupId, folderId, fileEntryId, fileName, title);
+
+		if ((expirationDate != null) && expirationDate.before(new Date())) {
+			throw new FileEntryExpirationDateException(
+				"Expiration date " + expirationDate + " is in the past");
+		}
+
+		if ((displayDate != null) && (expirationDate != null) &&
+			displayDate.after(expirationDate)) {
+
+			throw new FileEntryExpirationDateException(
+				StringBundler.concat(
+					"Expiration date ", expirationDate,
+					" is prior to display date ", displayDate));
+		}
 	}
 
 	private void _validateFileEntryTypeId(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2063,14 +2063,21 @@ public class DLFileEntryLocalServiceImpl
 
 				dlFileEntry.setVersion(newVersion);
 				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
+				dlFileEntry.setExpirationDate(
+					dlFileVersion.getExpirationDate());
 
 				dlFileEntry = dlFileEntryPersistence.update(dlFileEntry);
 			}
 			else if (!Objects.equals(
 						dlFileEntry.getDisplayDate(),
-						dlFileVersion.getDisplayDate())) {
+						dlFileVersion.getDisplayDate()) ||
+					 !Objects.equals(
+						 dlFileEntry.getExpirationDate(),
+						 dlFileVersion.getExpirationDate())) {
 
 				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
+				dlFileEntry.setExpirationDate(
+					dlFileVersion.getExpirationDate());
 
 				dlFileEntry = dlFileEntryPersistence.update(dlFileEntry);
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -3854,7 +3854,9 @@ public class DLFileEntryLocalServiceImpl
 
 		validateFile(groupId, folderId, fileEntryId, fileName, title);
 
-		if ((expirationDate != null) && expirationDate.before(new Date())) {
+		if (!ExportImportThreadLocal.isImportInProcess() &&
+			(expirationDate != null) && expirationDate.before(new Date())) {
+
 			throw new FileEntryExpirationDateException(
 				"Expiration date " + expirationDate + " is in the past");
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2836,6 +2836,9 @@ public class DLFileEntryLocalServiceImpl
 				DLFileEntryTable.INSTANCE.companyId.eq(
 					companyId
 				).and(
+					DLFileEntryTable.INSTANCE.expirationDate.gte(
+						_dates.get(companyId))
+				).and(
 					DLFileEntryTable.INSTANCE.expirationDate.lte(expirationDate)
 				)
 			));


### PR DESCRIPTION
LPD-17556 is needed (waiting for master, thats why it's on hold)


How to check it

1) modify documents and media service putting the check interval to 1
2) create a document and put the expiration date on 3 min on the future
3) let it expire
4) edit and put it 3 mins on the future
5) assert that the file is approved and only when 3 mins passes it expires

- **LPD-20538 expire only between the date and the date minus the check interval**
- **LPD-20538 set expiration date to the fileEntry to allow searching on the check interval**
- **LPD-20538 add validation for expiration date and the relation of expiration - display date**
- **LPD-20538 add test to check the validation**
