### PR TITLE
LPD-19549 doAsUserId param is included in document URL when selected from Repository Browser (3rd try)

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLURLHelperImpl.java
@@ -223,13 +223,6 @@ public class DLURLHelperImpl implements DLURLHelper {
 				appendVersion);
 		}
 
-		if ((themeDisplay != null) &&
-			Validator.isNotNull(themeDisplay.getDoAsUserId())) {
-
-			previewURL = _portal.addPreservedParameters(
-				themeDisplay, previewURL, false, true);
-		}
-
 		if ((themeDisplay != null) && themeDisplay.isAddSessionIdToURL()) {
 			return _portal.getURLWithSessionId(
 				previewURL, themeDisplay.getSessionId());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.servlet.BrowserSnifferUtil;
@@ -270,8 +271,9 @@ public class DLViewEntriesDisplayContext {
 	}
 
 	public String getThumbnailSrc(FileVersion fileVersion) throws Exception {
-		return DLURLHelperUtil.getThumbnailSrc(
-			fileVersion.getFileEntry(), fileVersion, _themeDisplay);
+		return _addDoAsUserIdParameter(
+			DLURLHelperUtil.getThumbnailSrc(
+				fileVersion.getFileEntry(), fileVersion, _themeDisplay));
 	}
 
 	public String getViewFileEntryURL(FileEntry fileEntry) {
@@ -364,6 +366,17 @@ public class DLViewEntriesDisplayContext {
 
 	public boolean isVersioningStrategyOverridable() {
 		return _dlAdminDisplayContext.isVersioningStrategyOverridable();
+	}
+
+	private String _addDoAsUserIdParameter(String url) {
+		if (Validator.isNotNull(_themeDisplay.getDoAsUserId()) &&
+			Validator.isNotNull(url)) {
+
+			return HttpComponentsUtil.setParameter(
+				url, "doAsUserId", _themeDisplay.getDoAsUserId());
+		}
+
+		return url;
 	}
 
 	private long _getRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -346,9 +347,10 @@ public class UIItemsBuilder {
 				"senna-off", "true"
 			).build()
 		).setHref(
-			_dlURLHelper.getDownloadURL(
-				_fileEntry, _fileVersion, _themeDisplay, StringPool.BLANK,
-				appendVersion, true)
+			_addDoAsUserIdParameter(
+				_dlURLHelper.getDownloadURL(
+					_fileEntry, _fileVersion, _themeDisplay, StringPool.BLANK,
+					appendVersion, true))
 		).setIcon(
 			"download"
 		).setKey(
@@ -835,6 +837,17 @@ public class UIItemsBuilder {
 				"Unable to build UIItemsBuilder for " + fileVersion,
 				portalException);
 		}
+	}
+
+	private String _addDoAsUserIdParameter(String url) {
+		if (Validator.isNotNull(_themeDisplay.getDoAsUserId()) &&
+			Validator.isNotNull(url)) {
+
+			return HttpComponentsUtil.setParameter(
+				url, "doAsUserId", _themeDisplay.getDoAsUserId());
+		}
+
+		return url;
 	}
 
 	private PortletURL _getActionURL(String mvcActionCommandName) {


### PR DESCRIPTION
After first attempt PR #5227 (and second PR #5245 ) and discussion with @robertoDiaz and @adolfopa this is the new PR, where:

* PR #4598  has been reverted to solve the [LPD-19549](https://liferay.atlassian.net/browse/LPD-19549) (coming from an LPP)
* The `doAsUserId` is added only when generating the Thumbnail and Download links. This solves the original problem in [LPS-193614](https://liferay.atlassian.net/browse/LPS-193614). 