### PR TITLE
LPD-20723 Clay link is translating asset titles/names by default in vertical card

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -238,6 +238,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 														<clay:link
 															href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
 															label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
+															translated="<%= false %>"
 														/>
 
 														<c:if test="<%= fileEntry.hasLock() || fileEntry.isCheckedOut() %>">
@@ -481,6 +482,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 																).buildString()
 															%>'
 															label="<%= HtmlUtil.unescape(curFolder.getName()) %>"
+															translated="<%= false %>"
 														/>
 													</div>
 												</div>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
@@ -216,6 +216,11 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 		return _article.getTitle(defaultLanguage);
 	}
 
+	@Override
+	public boolean isTranslated() {
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleVerticalCard.class);
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalFolderHorizontalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalFolderHorizontalCard.java
@@ -100,6 +100,11 @@ public class JournalFolderHorizontalCard extends BaseHorizontalCard {
 		return _folder.getName();
 	}
 
+	@Override
+	public boolean isTranslated() {
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalFolderHorizontalCard.class);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -102,6 +102,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 											href="<%= editURL %>"
 											label="<%= title %>"
 											title="<%= HtmlUtil.escape(title) %>"
+											translated="<%= false %>"
 										/>
 									</c:when>
 									<c:otherwise>
@@ -226,6 +227,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 										<clay:link
 											href="<%= editURL %>"
 											label="<%= title %>"
+											translated="<%= false %>"
 										/>
 
 										<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-10626") && !journalDisplayContext.hasGuestViewPermission(curArticle) %>'>
@@ -387,6 +389,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 											href="<%= rowURL.toString() %>"
 											label="<%= HtmlUtil.escape(curFolder.getName()) %>"
 											title="<%= HtmlUtil.escape(curFolder.getName()) %>"
+											translated="<%= false %>"
 										/>
 									</c:when>
 									<c:otherwise>
@@ -468,6 +471,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 										<clay:link
 											href="<%= rowURL.toString() %>"
 											label="<%= HtmlUtil.escape(curFolder.getName()) %>"
+											translated="<%= false %>"
 										/>
 									</div>
 								</div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_table.jsp
@@ -69,6 +69,7 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 								aria-label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
 								href="<%= rowURL.toString() %>"
 								label="<%= HtmlUtil.escape(kbFolder.getName()) %>"
+								translated="<%= false %>"
 							/>
 						</clay:content-col>
 					</clay:content-row>
@@ -169,6 +170,7 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 								aria-label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
 								href="<%= viewURL.toString() %>"
 								label="<%= HtmlUtil.escape(kbArticle.getTitle()) %>"
+								translated="<%= false %>"
 							/>
 						</clay:content-col>
 					</clay:content-row>


### PR DESCRIPTION
Pending to core infra PR: https://github.com/liferay-core-infra/liferay-portal/pull/6780

bug: https://liferay.atlassian.net/browse/LPD-20723

Description
------
I have observed that we have some assets what we are translating the link to the details because the clay link is developed with this behavior by default. So, this PR contains the modifications to not translate the following assets:

1. Journal article and journal folders for all display views.
2. DL file and DL folder in table view.
3. KB article and KB folder in table view.