### PR TITLE
LPD-21030

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaConfiguration.path
@@ -33,7 +33,7 @@
 </tr>
 <tr>
 	<td>DISPLAY_SETTINGS_ROOT_FOLDER_FIELD</td>
-	<td>//input[contains(@id,'rootFolderName')]</td>
+	<td>//input[contains(@id,'resourceName')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-21030

The input name changed when we started using the resource selector tag, but the POSHI xpath expr. was not updated accordingly.

# How can you verify that it works?

The POSHI test `DMFileEntry#CanCopyBasicDocumentLinkViaActionsDropdown` should pass.