### PR TITLE
LPD-21190 Correct individual scope to check TranslationPortlet permissio

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/service/TranslationEntryResourcePermissionLocalServiceWrapper.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/service/TranslationEntryResourcePermissionLocalServiceWrapper.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.translation.constants.TranslationActionKeys;
 import com.liferay.translation.constants.TranslationConstants;
+import com.liferay.translation.constants.TranslationPortletKeys;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
 
@@ -40,7 +41,9 @@ public class TranslationEntryResourcePermissionLocalServiceWrapper
 		}
 
 		if (scope != ResourceConstants.SCOPE_INDIVIDUAL) {
-			return false;
+			return super.hasResourcePermission(
+				companyId, TranslationPortletKeys.TRANSLATION, scope, primKey,
+				roleId, actionId);
 		}
 
 		TranslationEntry translationEntry =
@@ -81,7 +84,9 @@ public class TranslationEntryResourcePermissionLocalServiceWrapper
 		}
 
 		if (scope != ResourceConstants.SCOPE_INDIVIDUAL) {
-			return false;
+			return super.hasResourcePermission(
+				companyId, TranslationPortletKeys.TRANSLATION, scope, primKey,
+				roleIds, actionId);
 		}
 
 		TranslationEntry translationEntry =


### PR DESCRIPTION
Hi Team,

May I ask if you could review my PR?

Issue https://liferay.atlassian.net/browse/LPD-21190, that even if I set view permission for translation, I could not see the translations in Content & Data -> Translation Processes. 

Root cause,  this is always false: [TranslationEntryResourcePermissionLocalServiceWrapper.java](https://github.com/liferay/liferay-portal/blame/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/service/TranslationEntryResourcePermissionLocalServiceWrapper.java#L83) as we never check with individual scope.

solution: If I remove the if (scope != ResourceConstants.SCOPE_INDIVIDUAL), it does not work as this is not an entry check, so after it can not fetch translation entry, and can not check hasResourcePermission() as we dont have permission saved in the database as TranslationEntry. The solution is to check permission neme="TranslationPortlet", because it is saved with that name in the table.

It was tested locally.

Thank you in advance!