### PR TITLE
LPD-21476 postStructuredContentFolderStructuredContent does not work with changed select option field reference

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -594,6 +594,12 @@ public class DDMValueUtil {
 		Map<String, LocalizedValue> options = ddmFormFieldOptions.getOptions();
 
 		for (String value : values) {
+			if (options.containsKey(value)) {
+				keys.add(value);
+
+				continue;
+			}
+
 			String key = StringPool.BLANK;
 
 			for (Map.Entry<String, LocalizedValue> entry : options.entrySet()) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -118,12 +118,12 @@ public class DDMValueUtil {
 				localizedContentFieldValues, preferredLocale);
 		}
 		else if (Objects.equals(
-					DDMFormFieldTypeConstants.RADIO, ddmFormField.getType()) ||
+					DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
+					ddmFormField.getType()) ||
+				 Objects.equals(
+					 DDMFormFieldTypeConstants.RADIO, ddmFormField.getType()) ||
 				 Objects.equals(
 					 DDMFormFieldTypeConstants.SELECT,
-					 ddmFormField.getType()) ||
-				 Objects.equals(
-					 DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
 					 ddmFormField.getType())) {
 
 			return _toSelectValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -193,8 +193,7 @@ public class DDMValueUtil {
 	}
 
 	private static String _getOptionValues(
-		DDMFormField ddmFormField, Locale locale, String optionValues,
-		boolean transformValuesToKeys) {
+		DDMFormField ddmFormField, Locale locale, String optionValues) {
 
 		try {
 			List<String> values = new ArrayList<>();
@@ -212,9 +211,7 @@ public class DDMValueUtil {
 						JSONFactoryUtil.createJSONArray(optionValues)));
 			}
 
-			if (transformValuesToKeys) {
-				values = _transformValuesToKeys(ddmFormField, locale, values);
-			}
+			values = _transformValuesToKeys(ddmFormField, locale, values);
 
 			if ((values.size() == 1) &&
 				DDMFormFieldType.RADIO.equals(ddmFormField.getType())) {
@@ -561,26 +558,20 @@ public class DDMValueUtil {
 				contentFieldValue, localizedContentFieldValues,
 				(localizedContentFieldValue, locale) -> {
 					String optionValues = localizedContentFieldValue.getData();
-					boolean transformValuesToKeys = true;
-
 					String value = localizedContentFieldValue.getValue();
 
 					if (Validator.isNotNull(value)) {
 						optionValues = value;
-						transformValuesToKeys = false;
 					}
 
-					return _getOptionValues(
-						ddmFormField, locale, optionValues,
-						transformValuesToKeys);
+					return _getOptionValues(ddmFormField, locale, optionValues);
 				},
 				preferredLocale);
 		}
 
 		return new UnlocalizedValue(
 			_getOptionValues(
-				ddmFormField, preferredLocale, contentFieldValue.getValue(),
-				false));
+				ddmFormField, preferredLocale, contentFieldValue.getValue()));
 	}
 
 	private static List<String> _transformValuesToKeys(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -584,6 +584,9 @@ public class DDMValueUtil {
 
 		Map<String, LocalizedValue> options = ddmFormFieldOptions.getOptions();
 
+		Map<String, String> optionsReferences =
+			ddmFormFieldOptions.getOptionsReferences();
+
 		for (String value : values) {
 			if (options.containsKey(value)) {
 				keys.add(value);
@@ -600,6 +603,18 @@ public class DDMValueUtil {
 					key = entry.getKey();
 
 					break;
+				}
+			}
+
+			if (Validator.isNull(key)) {
+				for (Map.Entry<String, String> entry :
+						optionsReferences.entrySet()) {
+
+					if (Objects.equals(entry.getValue(), value)) {
+						key = entry.getKey();
+
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-21476

Description
--------
Fix a bug to work with option values : value, reference and label when the user is creating a content from headless api using postStructuredContentFolderStructuredContent.