### PR TITLE
LPD-21854 Title translated in collection display mapped field

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -76,6 +76,7 @@ else {
 						).buildString()
 					%>'
 					label="<%= article.getTitle(locale) %>"
+					translated="<%= false %>"
 				/>
 			</liferay-util:buffer>
 


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-21854

Description
-------------

1. I sent a PR to echo: https://github.com/liferay-echo/liferay-portal/pull/15435
We are translating values of the InfoLocalizedValue and this does not make sense for some fields like journal article title or description. So, I added a translate method to the builder in order to decide if we want to translate the value or not. I selected default translated value as true because I think that we can not assume that we can not stop translate the value for all use cases, let me know if I am wrong. 

2. In the other hand with the solution sent to echo, I modified some article values like title , description and ddm fields, maybe for the last one I should send a PR to DDM team but I do not know if it is worth it.