### PR TITLE
LPD-21860 Error when adding friendly URL of category to rich text field in web content

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -11,7 +11,6 @@ import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.exception.ExportImportContentProcessorException;
 import com.liferay.exportimport.kernel.exception.ExportImportContentValidationException;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -30,9 +29,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
-import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
-import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -56,12 +53,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import org.osgi.service.component.annotations.Activate;
@@ -947,7 +940,8 @@ public class LayoutReferencesExportImportContentProcessor
 
 			url = content.substring(beginPos + offset, endPos);
 
-			endPos = StringUtil.indexOfAny(url, _getFriendlyURLSeparators());
+			endPos = StringUtil.indexOfAny(
+				url, FriendlyURLResolverRegistryUtil.getURLSeparators());
 
 			if (endPos != -1) {
 				url = url.substring(0, endPos);
@@ -1173,39 +1167,6 @@ public class LayoutReferencesExportImportContentProcessor
 				throw exportImportContentValidationException;
 			}
 		}
-	}
-
-	private String[] _getFriendlyURLSeparators() {
-		List<String> friendlyURLSeparators = new ArrayList<>();
-
-		friendlyURLSeparators.add(Portal.FRIENDLY_URL_SEPARATOR);
-
-		for (String defaultFriendlyURLSeparator :
-				Arrays.asList(
-					FriendlyURLResolverConstants.URL_SEPARATOR_BLOGS_ENTRY,
-					FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
-					FriendlyURLResolverConstants.
-						URL_SEPARATOR_JOURNAL_ARTICLE)) {
-
-			friendlyURLSeparators.add(defaultFriendlyURLSeparator);
-
-			FriendlyURLResolver friendlyURLResolver =
-				FriendlyURLResolverRegistryUtil.
-					getFriendlyURLResolverByDefaultURLSeparator(
-						defaultFriendlyURLSeparator);
-
-			if ((friendlyURLResolver != null) &&
-				!Objects.equals(
-					defaultFriendlyURLSeparator,
-					friendlyURLResolver.getURLSeparator())) {
-
-				friendlyURLSeparators.add(
-					friendlyURLResolver.getDefaultURLSeparator());
-			}
-		}
-
-		return TransformUtil.transformToArray(
-			friendlyURLSeparators, s -> s, String.class);
 	}
 
 	private String _getPortalURL(String url, String portalURL)


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-21860

When validating URLs, the validation logic only takes into account some specific cases hardcoded in the staging classes. This makes it not possible to create content containing URLs pointing to arbitrary display pages.

# How am I fixing it?

Get the actual set of display page prefixes from the registry instead of using hardcoded values.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-21860.