### PR TITLE
LPD-21203 Fix DLFileEntryModelDocumentContributor to check for a read-only store

### DIFF
--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-auto-tagger-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:bulk:bulk-selection-api")
+	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:change-tracking:change-tracking-store-api")
 	compileOnly project(":apps:changeset:changeset-api")

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -5,6 +5,8 @@
 
 package com.liferay.document.library.internal.search.spi.model.index.contributor;
 
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.document.library.internal.configuration.DLIndexerConfiguration;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
@@ -23,6 +25,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -42,6 +45,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextExtractor;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.portal.util.PropsValues;
@@ -291,7 +295,7 @@ public class DLFileEntryModelDocumentContributor
 			inputStream, PropsValues.DL_FILE_INDEXING_MAX_SIZE);
 
 		if (_dlIndexerConfiguration.cacheTextExtraction() &&
-			Validator.isNotNull(text)) {
+			Validator.isNotNull(text) && !_isReadOnlyCtCollection()) {
 
 			_dlStore.addFile(
 				DLStoreRequest.builder(
@@ -348,8 +352,28 @@ public class DLFileEntryModelDocumentContributor
 		return true;
 	}
 
+	private boolean _isReadOnlyCtCollection() throws PortalException {
+		if (CTCollectionThreadLocal.isProductionMode()) {
+			return false;
+		}
+
+		CTCollection ctCollection = _ctCollectionLocalService.getCTCollection(
+			CTCollectionThreadLocal.getCTCollectionId());
+
+		if ((ctCollection.getStatus() != WorkflowConstants.STATUS_DRAFT) &&
+			(ctCollection.getStatus() != WorkflowConstants.STATUS_PENDING)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFileEntryModelDocumentContributor.class);
+
+	@Reference
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@Reference
 	private DDMIndexer _ddmIndexer;


### PR DESCRIPTION
Solution: We avoid writing an index file if the Publication (CtCollection) is read only, this is, the Publication is marked as "Out of date" (status=Expired).

See the issue for the steps to reproduce the problem: https://liferay.atlassian.net/browse/LPD-21203

Notes:

* It would be nice to have the _isReadOnly_ method into the interface `CTCollectionLocalService`. The read only condition is used multiple times in the implementation class and also in the failing class `CTEntryLocalServiceImpl`.
* Another approach would be to avoid indexing files from a read only Publication. During indexation [here](https://github.com/liferay/liferay-portal/blob/6c2dd6f49a6cebdbd0c69351fa76387a06a64eb0/portal-kernel/src/com/liferay/portal/kernel/dao/orm/IndexableActionableDynamicQuery.java#L135) in the core we check for the current CtCollection, which could be a good place to discard read only publications. However I don't know if it can have side effects. Maybe another place could be [this](https://github.com/liferay/liferay-portal/blob/7ee67f43058a064d2413a2316ce3aae57389c255/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelIndexerWriterContributor.java#L45) on the Document Library module.