### PR TITLE
LPD-21578 revert "LPS-188471 Use the new method to obtain the other values"

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
@@ -32,8 +32,6 @@ import com.liferay.journal.web.internal.info.item.JournalArticleInfoItemFields;
 import com.liferay.layout.page.template.info.item.provider.DisplayPageInfoItemFieldSetProvider;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletRequestModel;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -100,8 +98,6 @@ public class JournalArticleInfoItemFieldValuesProvider
 			).infoFieldValues(
 				_getDDMStructureInfoFieldValues(journalArticle)
 			).infoFieldValues(
-				_getDefaultDDMStructureInfoFieldValues(journalArticle)
-			).infoFieldValues(
 				_getDDMTemplateInfoFieldValues(journalArticle)
 			).infoFieldValues(
 				_templateInfoItemFieldSetProvider.getInfoFieldValues(
@@ -126,38 +122,8 @@ public class JournalArticleInfoItemFieldValuesProvider
 	private List<InfoFieldValue<Object>> _getDDMStructureInfoFieldValues(
 		JournalArticle article) {
 
-		DDMStructure ddmStructure = article.getDDMStructure();
-
-		JournalArticle ddmStructureArticle = null;
-
-		try {
-			ddmStructureArticle = _journalArticleLocalService.getArticle(
-				ddmStructure.getGroupId(), DDMStructure.class.getName(),
-				ddmStructure.getStructureId());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		if (ddmStructureArticle == null) {
-			return _ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
-				article, article.getDDMFormValues());
-		}
-
-		List<InfoFieldValue<Object>> journalArticleFieldValues =
-			new ArrayList<>();
-
-		journalArticleFieldValues.addAll(
-			_ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
-				article, article.getDDMFormValues(false)));
-
-		journalArticleFieldValues.addAll(
-			_ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
-				ddmStructureArticle, ddmStructureArticle.getDDMFormValues()));
-
-		return journalArticleFieldValues;
+		return _ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
+			article, article.getDDMFormValues());
 	}
 
 	private List<InfoFieldValue<Object>> _getDDMTemplateInfoFieldValues(
@@ -179,32 +145,6 @@ public class JournalArticleInfoItemFieldValuesProvider
 			});
 
 		return infoFieldValues;
-	}
-
-	private List<InfoFieldValue<Object>> _getDefaultDDMStructureInfoFieldValues(
-		JournalArticle article) {
-
-		DDMStructure ddmStructure = article.getDDMStructure();
-
-		JournalArticle ddmStructureArticle = null;
-
-		try {
-			ddmStructureArticle = _journalArticleLocalService.getArticle(
-				ddmStructure.getGroupId(), DDMStructure.class.getName(),
-				ddmStructure.getStructureId());
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
-
-		if (ddmStructureArticle != null) {
-			return _ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
-				ddmStructureArticle, ddmStructureArticle.getDDMFormValues());
-		}
-
-		return new ArrayList<>();
 	}
 
 	private String _getInfoItemFormVariationKey(JournalArticle journalArticle) {
@@ -434,9 +374,6 @@ public class JournalArticleInfoItemFieldValuesProvider
 
 		return null;
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		JournalArticleInfoItemFieldValuesProvider.class);
 
 	@Reference
 	private AssetEntryInfoItemFieldSetProvider


### PR DESCRIPTION
We do not want that an unsaved Web Content had the default value on a new field of her structure. So if the WC was not modified since the change on the structure, the WC will have a BLANK value on the new field, although the latter has or does not have a default value.


https://liferay.atlassian.net/browse/LPD-21578

Steps to reproduce:

1) Create a new Web Content Structure with a text field
2) Go to Edit Default Values for that structure and click in the button Save.
3) Create a Web Content based off of this structure
4) Go to the Translate View of this Web Content (3-dot button of the Web Content > Translate)

Result:

- The text field appears only one time.

 

additionally we should test:


1) Create a Web Content Structure with a text field “Text1”
2) Create a Web Content based off of that Web Content Structure
3) Add a new field “Text2” to the Web Content Structure
4) Edit the default values of the Web Content Structure and set Text2 field to “My Default Value”
5) Map it to Text2 field of the Web Content created in step 2

Actual result:

The Heading fragment displays the value “”