### PR TITLE
LPD-22233  Wrong instanceId for fieldsets causing duplicate entry error for  IX_B27A301F index

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -164,7 +164,7 @@ public class JournalConverterImpl implements JournalConverter {
 
 				_updateFieldsDisplay(
 					ddmFields, ddmFormField.getName(),
-					String.valueOf(ddmStructure.getStructureId()));
+					StringUtil.randomString());
 			}
 
 			_addNestedDDMFields(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
@@ -249,7 +249,7 @@ public class JournalConverterUtilTest {
 		Fields actualFields = _journalConverter.getDDMFields(
 			_ddmStructure, content);
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	@Test
@@ -280,7 +280,7 @@ public class JournalConverterUtilTest {
 		Fields actualFields = _journalConverter.getDDMFields(
 			_ddmStructure, content);
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	@Test
@@ -292,7 +292,7 @@ public class JournalConverterUtilTest {
 		Fields actualFields = _journalConverter.getDDMFields(
 			_ddmStructure, content);
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	@Test
@@ -359,7 +359,7 @@ public class JournalConverterUtilTest {
 		Fields actualFields = _journalConverter.getDDMFields(
 			childDDMStructure, content);
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	@Test
@@ -392,7 +392,7 @@ public class JournalConverterUtilTest {
 		Fields actualFields = _journalConverter.getDDMFields(
 			_ddmStructure, content);
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	@Test
@@ -411,7 +411,7 @@ public class JournalConverterUtilTest {
 			ddmStructure,
 			read("test-journal-content-removed-nested-field.xml"));
 
-		Assert.assertEquals(expectedFields, actualFields);
+		_assertFields(expectedFields, actualFields);
 	}
 
 	protected void assertEquals(
@@ -782,6 +782,53 @@ public class JournalConverterUtilTest {
 		}
 
 		fields.put(field);
+	}
+
+	private void _assertFields(Fields expectedFields, Fields actualFields) {
+		Assert.assertEquals(
+			expectedFields.getNames(
+			).size(),
+			actualFields.getNames(
+			).size());
+
+		for (String name : expectedFields.getNames()) {
+			Assert.assertEquals(
+				expectedFields.getDDMStructureId(),
+				actualFields.getDDMStructureId());
+
+			if (!name.equals(DDM.FIELDS_DISPLAY_NAME)) {
+				Assert.assertEquals(
+					expectedFields.get(name), actualFields.get(name));
+			}
+			else {
+				Field actualFieldsDisplayField = actualFields.get(name);
+
+				String actualFieldsDisplayValues =
+					(String)actualFieldsDisplayField.getValue();
+
+				Field expectedFieldsDisplayField = expectedFields.get(name);
+
+				String[] expectedFieldsDisplayValues = StringUtil.split(
+					(String)expectedFieldsDisplayField.getValue());
+
+				for (String expectedFieldsDisplayValue :
+						expectedFieldsDisplayValues) {
+
+					if (!expectedFieldsDisplayValue.contains("FieldSet")) {
+						Assert.assertTrue(
+							actualFieldsDisplayValues.contains(
+								expectedFieldsDisplayValue));
+					}
+					else {
+						Assert.assertTrue(
+							actualFieldsDisplayValues.contains(
+								StringUtil.extractFirst(
+									expectedFieldsDisplayValue,
+									DDM.INSTANCE_SEPARATOR)));
+					}
+				}
+			}
+		}
 	}
 
 	private Fields _getRemovedNestedFields(long ddmStructureId) {


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-22233

Description
-----------
We are adding a wrong instanceId to identify field-set fields of the content when we are adding it to the structure. Field-set field is the only field that we are adding to the content when we are updating an structure(see the reason in the first commit). When we are in this scenario we add a field-set to the content using as the instance-id the ddmStructureId and this causes an unique index issue when we have some field-set fields to add to the content.