### PR TITLE
LPD-20679 BUG Asset Publisher > WebContent > Geo structure

### DIFF
--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
@@ -122,7 +122,7 @@ class MapBase extends EventEmitter {
 				MapBase.CONTROLS.TYPE,
 				MapBase.CONTROLS.ZOOM,
 			],
-			data,
+			data = '{}',
 			geolocation = false,
 			position = {location: {lat: 0, lng: 0}},
 			zoom = 11,
@@ -131,7 +131,7 @@ class MapBase extends EventEmitter {
 		this._STATE_ = {
 			boundingBox,
 			controls,
-			data,
+			data: JSON.parse(data),
 			geolocation,
 			position,
 			zoom,

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
@@ -122,7 +122,7 @@ class MapBase extends EventEmitter {
 				MapBase.CONTROLS.TYPE,
 				MapBase.CONTROLS.ZOOM,
 			],
-			data = '{}',
+			data = null,
 			geolocation = false,
 			position = {location: {lat: 0, lng: 0}},
 			zoom = 11,

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
@@ -50,7 +50,7 @@ class MapGoogleMaps extends MapBase {
 			Object.assign(mapConfig, controlsConfig)
 		);
 
-		if (this.data && this.data.features) {
+		if (this.data?.features?.length) {
 			const bounds = new google.maps.LatLngBounds();
 
 			this.data.features.forEach((feature) =>

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
@@ -70,7 +70,7 @@ class MapOpenStreetMap extends MapBase {
 			Object.assign(mapConfig, controlsConfig)
 		);
 
-		if (this.data && this.data.features) {
+		if (this.data?.features?.length) {
 			const bounds = new L.LatLngBounds();
 
 			this.data.features.forEach((feature) =>


### PR DESCRIPTION
# Issue: https://liferay.atlassian.net/browse/LPD-20679

> [!CAUTION]
> I don't have much context regarding Custom Web Content Structures with geo fields.
> We need to **check/test** this thoroughly.

I only added a parse in commit 1fbca2a0c61609721b76a4f08d88de8c1fc5c6ae, but it seems strange that it worked without parsing the data. I'm not sure if the data was parsed in the past; I spent some time searching the history, but I found nothing.
## Before PR
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/98cace38-e87f-4b16-8495-88e20b07c64b)

## After PR
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/0217b75f-e791-4f54-a29b-3758be3f0ff9)
