### PR TITLE
LPD-22374 use a synchronizedList to ensure adding elements is done in…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,7 +70,8 @@ public class JournalArticleAssetEntryClassTypeIdUpgradeProcess
 							classTypeId, key -> new ConcurrentHashMap<>());
 
 					List<Long> entryIds = entryIdsMap.computeIfAbsent(
-						ddmStructureId, key -> new ArrayList<>());
+						ddmStructureId,
+						key -> Collections.synchronizedList(new ArrayList<>()));
 
 					entryIds.add(entryId);
 				},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22374

A swarm request was opened for a customer who had an upgrade failure in JournalArticleAssetEntryClassTypeIdUpgradeProcess. In that conversation, it was determined that upgrade process is using a list that is not thread-safe in a multi threaded processes. This lead the customer to have a failed upgrade process.

I was unable to reproduce this on my end, however I agree with [Michael Bowerman's analysis](https://liferay.slack.com/archives/C04UDLG44G3/p1710781943480159?thread_ts=1710775582.932039&cid=C04UDLG44G3) that we should use a thread-safe list [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java#L71-L74).

I was able to ensure the changes ran by manually manipulating the database, but I still could not reproduce the error the customer saw.