### PR TITLE
LPD-22497 Permission sets are differing depending on autosaving of a blog entry

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/blogs.js
@@ -434,6 +434,22 @@ export default class Blogs {
 
 				const body = new URLSearchParams(bodyData);
 
+				const groupPermissions = document.querySelectorAll(
+					`input[name=${namespace}groupPermissions]:checked`
+				);
+
+				groupPermissions.forEach((item) => {
+					body.append(`${namespace}groupPermissions`, item.value);
+				});
+
+				const guestPermissions = document.querySelectorAll(
+					`input[name=${namespace}guestPermissions]:checked`
+				);
+
+				guestPermissions.forEach((item) => {
+					body.append(`${namespace}guestPermissions`, item.value);
+				});
+
 				fetch(this._config.editEntryURL, {
 					body,
 					method: 'POST',


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-22497

Description
-----------
Add permissions to the autosave call. Add selected permissions directly to the URLSearchParams because there are some parameters with same name and I can not use  body object to keep them.