### PR TITLE
LPD-22611 Changing jmatio version to 1.5

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -2946,6 +2946,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>com.liferay.portal.search.rest.api.jar!jackson-dataformat-xml.jar</file-name>
+				<version>2.9.8</version>
+				<project-name>Jackson-dataformat-XML</project-name>
+				<project-url>http://wiki.fasterxml.com/JacksonExtensionXmlDataBinding</project-url>
+				<licenses>
+					<license>
+						<license-name>The Apache Software License, Version 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>com.liferay.portal.search.rest.impl.jar!jackson-dataformat-xml.jar</file-name>
 				<version>2.9.8</version>
 				<project-name>Jackson-dataformat-XML</project-name>
@@ -3819,7 +3831,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.tika.jar!jmatio.jar</file-name>
-				<version>1.2</version>
+				<version>1.5</version>
 				<project-name>JMatIO</project-name>
 				<project-url>https://github.com/tballison/jmatio</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -992,7 +992,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1550,6 +1550,12 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">com.liferay.portal.search.rest.api.jar!jackson-dataformat-xml.jar</td><td nowrap="nowrap">2.9.8</td><td nowrap="nowrap"><a href="http://wiki.fasterxml.com/JacksonExtensionXmlDataBinding">Jackson-dataformat-XML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">com.liferay.portal.search.rest.impl.jar!jackson-dataformat-xml.jar</td><td nowrap="nowrap">2.9.8</td><td nowrap="nowrap"><a href="http://wiki.fasterxml.com/JacksonExtensionXmlDataBinding">Jackson-dataformat-XML</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
@@ -1682,7 +1688,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1712,7 +1718,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1994,7 +2000,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.tika.jar!jmatio.jar</td><td nowrap="nowrap">1.2</td><td nowrap="nowrap"><a href="https://github.com/tballison/jmatio">JMatIO</a></td><td nowrap><a href="http://www.linfo.org/bsdlicense.html">BSD</a>
+<td nowrap="nowrap">com.liferay.portal.tika.jar!jmatio.jar</td><td nowrap="nowrap">1.5</td><td nowrap="nowrap"><a href="https://github.com/tballison/jmatio">JMatIO</a></td><td nowrap><a href="http://www.linfo.org/bsdlicense.html">BSD</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/portal/portal-tika/build.gradle
+++ b/modules/apps/portal/portal-tika/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	compileInclude group: "org.apache.tika", name: "tika-parsers", version: "1.28.5"
 	compileInclude group: "org.ccil.cowan.tagsoup", name: "tagsoup", version: "1.2.1"
 	compileInclude group: "org.gagravarr", name: "vorbis-java-core", version: "0.8"
-	compileInclude group: "org.tallison", name: "jmatio", version: "1.2"
+	compileInclude group: "org.tallison", name: "jmatio", version: "1.5"
 
 	compileOnly group: "com.adobe.xmp", name: "xmpcore", version: "6.1.11"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"


### PR DESCRIPTION
Hi,

I would like to kindly ask to review my PR:

Issue:
[https://liferay.atlassian.net/browse/LPD-22611](LPD-22611) when uploading a matlab file it throws: java.lang.NoClassDefFoundError: sun/misc/Cleaner


root cause: 

This class (sun.misc.Cleaner) has been moved to another pckg in JDK9 (https://bugs.openjdk.org/browse/JDK-8148117), see https://hg.openjdk.org/jdk9/jdk9/jdk/rev/07dcdd5d9401. Tika should be updated as it uses outdated dependency (JMatIO) which has this issue when parsing MatLab files: https://github.com/diffplug/JMatIO/issues/4

Solution is to update jmatio to 1.5. 

Thank you in advance!