### PR TITLE
LPD-22663 Reassign Web Content and Questions to Content Management team

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -11543,6 +11543,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Blogs,\
         Bookmarks,\
         Bulk Editing,\
+        Categories,\
         Comment,\
         Connected Apps,\
         Content Management Headless,\
@@ -11562,6 +11563,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         My Subscriptions,\
         Notifications,\
         Online Editing,\
+        Questions,\
         Ratings,\
         Redirect,\
         Saved Content,\
@@ -11573,6 +11575,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Translations Management,\
         Twitter,\
         Upgrades Content Management,\
+        Web Content Administration,\
+        Web Content Display,\
+        Web Content Search,\
         Wiki
 
     testray.team.commerce.component.names=\
@@ -11754,7 +11759,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         OSB Site Initializer Customer Portal,\
         OSB Site Initializer EVP,\
         OSB Site Initializer Partner Portal,\
-        Questions,\
         Site Initializer Extender,\
         Site Initializer Liferay Marketplace,\
         Site Initializer Raylife AP,\
@@ -11793,7 +11797,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         AI-Creator,\
         Asset Publisher,\
         Breadcrumb,\
-        Categories,\
         Collections,\
         Content Dashboard,\
         Content Page Templates,\
@@ -11834,9 +11837,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Upgrades WEM,\
         Utility Pages,\
         Weather,\
-        Web Content Administration,\
-        Web Content Display,\
-        Web Content Search,\
         Widget Page Templates,\
         Widget Pages,\
         XSL,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22663

Hi team,

To avoid reporting test failures to the wrong team, this PR reassigns Web Content, Categories, and Questions to the Content Management team. The reference for the changes is from feedback on Slack during release analysis. If this is incorrect, please DM me on Slack with the components that are affected by the restructure. 

Thanks

cc @john-co, @joshitagaki @kyle-miho @mariamuriel @lr-ruben @natocesarrego