### PR TITLE
LPD-21627 Add integration testing to Triplicate fields when translating Web Contents with Default Values for their structure

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -81,7 +82,7 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 
 		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
 			_group.getGroupId(), ddmStructure.getStructureId(),
-			PortalUtil.getClassNameId(JournalArticle.class));
+			_portal.getClassNameId(JournalArticle.class));
 
 		Calendar displayDateCalendar = new GregorianCalendar();
 
@@ -164,7 +165,7 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 
 			DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
 				_group.getGroupId(), ddmStructure.getStructureId(),
-				PortalUtil.getClassNameId(JournalArticle.class));
+				_portal.getClassNameId(JournalArticle.class));
 
 			Calendar displayDateCalendar = new GregorianCalendar();
 
@@ -269,5 +270,8 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 
 	@Inject
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
@@ -6,8 +6,12 @@
 package com.liferay.journal.web.internal.info.item.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.info.field.InfoField;
@@ -20,10 +24,13 @@ import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -32,8 +39,10 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -43,8 +52,11 @@ import com.liferay.portlet.display.template.PortletDisplayTemplate;
 import java.io.File;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -148,6 +160,44 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 	}
 
 	@Test
+	public void testGetInfoItemFieldValuesWithDefaultValuesReturnedOnlyOneTime()
+		throws Exception {
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent();
+
+		String ddmStructureSuffix = RandomTestUtil.randomString();
+
+		Tuple tuple = _createJournalArticleWithPredefinedValues(
+			ddmStructureSuffix);
+
+		DDMStructure ddmStructure = (DDMStructure)tuple.getObject(0);
+		DDMTemplate ddmTemplate = (DDMTemplate)tuple.getObject(1);
+
+		JournalArticle journalArticle = _journalArticleLocalService.addArticle(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0, StringPool.BLANK,
+			true, JournalArticleConstants.VERSION_DEFAULT,
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), content,
+			ddmStructure.getStructureId(), ddmTemplate.getTemplateKey(), null,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true, true, true,
+			0, 0, null, null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		InfoItemFieldValues infoItemFieldValues =
+			_infoItemFieldValuesProvider.getInfoItemFieldValues(journalArticle);
+
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			infoItemFieldValues.getInfoFieldValues(
+				"DDMStructure_" + ddmStructureSuffix);
+
+		Assert.assertEquals(
+			infoFieldValues.toString(), 1, infoFieldValues.size());
+	}
+
+	@Test
 	public void testGetInfoItemFieldValuesWithSmallImage() throws Exception {
 		ServiceContext originalServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
@@ -212,6 +262,62 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 		}
 	}
 
+	private Tuple _createJournalArticleWithPredefinedValues(String ddmName)
+		throws Exception {
+
+		Set<Locale> availableLocales = DDMFormTestUtil.createAvailableLocales(
+			LocaleUtil.SPAIN, LocaleUtil.US);
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			availableLocales, LocaleUtil.US);
+
+		DDMFormField ddmFormField =
+			DDMFormTestUtil.createLocalizableTextDDMFormField(ddmName);
+
+		LocalizedValue label = new LocalizedValue(LocaleUtil.US);
+
+		label.addString(LocaleUtil.SPAIN, "etiqueta");
+		label.addString(LocaleUtil.US, "label");
+
+		ddmFormField.setLabel(label);
+
+		ddmForm.addDDMFormField(ddmFormField);
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(), ddmForm);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class),
+			TemplateConstants.LANG_TYPE_FTL,
+			JournalTestUtil.getSampleTemplateFTL(), LocaleUtil.US);
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent(
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Valor Predefinido"
+			).put(
+				LocaleUtil.US, "Predefined Value"
+			).build(),
+			LocaleUtil.US.toString());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		_journalArticleLocalService.addArticleDefaultValues(
+			serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+			_classNameLocalService.getClassNameId(DDMStructure.class),
+			ddmStructure.getStructureId(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			null, content, ddmStructure.getStructureId(),
+			ddmTemplate.getTemplateKey(), null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
+			serviceContext);
+
+		return new Tuple(ddmStructure, ddmTemplate);
+	}
+
 	private File _getFile() throws Exception {
 		Class<?> clazz = getClass();
 
@@ -259,6 +365,9 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 
 		return themeDisplay;
 	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
Original ticket :
https://liferay.atlassian.net/browse/LPD-21578

- **LPD-21627 use injection instead util**
- **LPD-21627 test that if the ddmStructure has default value does not appear more than 1 time**
