### PR TITLE
LPD-22775 When attributes has the same name that the some words we need to rename it to add the proper data

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -89,6 +89,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 			put(_RANDOM_ID + "OptionsMap", getOptionsMap());
 		}
 
+		if (Objects.equals(templateNode.getName(), "type")) {
+			put(_RANDOM_ID + "Type", getType());
+		}
+
 		put(templateNode.getName(), templateNode);
 	}
 
@@ -263,6 +267,12 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	public String getType() {
+		if (super.containsKey(_RANDOM_ID + "Type") ||
+			Validator.isNotNull((String)get(_RANDOM_ID + "Type"))) {
+
+			return (String)get(_RANDOM_ID + "Type");
+		}
+
 		Object type = get("type");
 
 		if ((type == null) || (type instanceof String)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -67,6 +67,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	public void appendChild(TemplateNode templateNode) {
 		_childTemplateNodes.put(templateNode.getName(), templateNode);
 
+		if (Objects.equals(templateNode.getName(), "data")) {
+			put(_RANDOM_ID + "Data", _getData());
+		}
+
 		if (Objects.equals(templateNode.getName(), "name")) {
 			put(_RANDOM_ID + "Name", getName());
 		}
@@ -178,7 +182,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 			return _getGeolocationData();
 		}
 
-		return (String)get("data");
+		return _getData();
 	}
 
 	public String getFriendlyUrl() {
@@ -239,7 +243,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 			return StringPool.BLANK;
 		}
 
-		String data = (String)get("data");
+		String data = _getData();
 
 		if (!JSONUtil.isJSONObject(data)) {
 			return StringPool.BLANK;
@@ -269,7 +273,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	private String _getColorData() {
-		String data = (String)get("data");
+		String data = _getData();
 
 		if (data.startsWith(StringPool.POUND)) {
 			return data;
@@ -278,12 +282,22 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		return StringPool.POUND + data;
 	}
 
+	private String _getData() {
+		if (super.containsKey(_RANDOM_ID + "Data") ||
+			Validator.isNotNull((String)get(_RANDOM_ID + "Data"))) {
+
+			return (String)get(_RANDOM_ID + "Data");
+		}
+
+		return (String)get("data");
+	}
+
 	private String _getDDMJournalArticleFriendlyURL() {
 		if (_themeDisplay == null) {
 			return StringPool.BLANK;
 		}
 
-		String data = (String)get("data");
+		String data = _getData();
 
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(data);
@@ -330,7 +344,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	private String _getFileEntryData() {
-		String data = (String)get("data");
+		String data = _getData();
 
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(data);
@@ -360,7 +374,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	private String _getGeolocationData() {
-		String data = (String)get("data");
+		String data = _getData();
 
 		if (Validator.isNull(data)) {
 			return StringPool.BLANK;
@@ -395,7 +409,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	private String _getLatestArticleData() {
-		String data = (String)get("data");
+		String data = _getData();
 
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(data);
@@ -459,11 +473,11 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 			}
 		}
 
-		return (String)get("data");
+		return _getData();
 	}
 
 	private String _getNumericData() {
-		String data = (String)get("data");
+		String data = _getData();
 
 		DecimalFormat decimalFormat = (DecimalFormat)DecimalFormat.getInstance(
 			LocaleUtil.getMostRelevantLocale());

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -78,6 +79,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 
 		if (Objects.equals(templateNode.getName(), "name")) {
 			put(_RANDOM_ID + "Name", getName());
+		}
+
+		if (Objects.equals(templateNode.getName(), "options")) {
+			put(_RANDOM_ID + "Options", getOptions());
 		}
 
 		put(templateNode.getName(), templateNode);
@@ -229,6 +234,12 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	public List<String> getOptions() {
+		if (super.containsKey(_RANDOM_ID + "Options") ||
+			ListUtil.isNotEmpty((List<String>)get(_RANDOM_ID + "Options"))) {
+
+			return (List<String>)get(_RANDOM_ID + "Options");
+		}
+
 		return (List<String>)get("options");
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -66,6 +67,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 
 	public void appendChild(TemplateNode templateNode) {
 		_childTemplateNodes.put(templateNode.getName(), templateNode);
+
+		if (Objects.equals(templateNode.getName(), "attributes")) {
+			put(_RANDOM_ID + "Attributes", getAttributes());
+		}
 
 		if (Objects.equals(templateNode.getName(), "data")) {
 			put(_RANDOM_ID + "Data", _getData());
@@ -148,6 +153,13 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	public Map<String, String> getAttributes() {
+		if (super.containsKey(_RANDOM_ID + "Attributes") ||
+			MapUtil.isNotEmpty(
+				(Map<String, String>)get(_RANDOM_ID + "Attributes"))) {
+
+			return (Map<String, String>)get(_RANDOM_ID + "Attributes");
+		}
+
 		return (Map<String, String>)get("attributes");
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -85,6 +85,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 			put(_RANDOM_ID + "Options", getOptions());
 		}
 
+		if (Objects.equals(templateNode.getName(), "optionsMap")) {
+			put(_RANDOM_ID + "OptionsMap", getOptionsMap());
+		}
+
 		put(templateNode.getName(), templateNode);
 	}
 
@@ -244,6 +248,13 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	public Map<String, String> getOptionsMap() {
+		if (super.containsKey(_RANDOM_ID + "OptionsMap") ||
+			MapUtil.isNotEmpty(
+				(Map<String, String>)get(_RANDOM_ID + "OptionsMap"))) {
+
+			return (Map<String, String>)get(_RANDOM_ID + "OptionsMap");
+		}
+
 		return (Map<String, String>)get("optionsMap");
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22775

Steps to reproduce:

1) Create an structure Structure_one with a 5 text field
2) In this field advanced tap, change the field reference to "attributes" and save.
3) In second field advanced tap, change the field reference to "data" and save.
4) In 3rd field advanced tap, change the field reference to "options" and save.
5) In 4th field advanced tap, change the field reference to "optionsMap" and save.
6) In 5th field advanced tap, change the field reference to "type" and save.
7) Create another structure Structure_two
8) Add a fieldset Structure_one and save it
9) Create a web content with the Structure_two and add values to all the fields
10) Display this web content on a page, for instance, through a web content viewer.


- **LPD-22775 Rename the "data" attribute because if we have a child node with "data" as name the (String)get("data") will not return the proper data. We need to add an internal method to get the data looking if the name property had changed or not**
- **LPD-22775 Rename the "attributes" attribute because if we have a child node with "attributes" as name the getAttributes will not return the proper data.**
- **LPD-22775 Rename the "options" attribute because if we have a child node with "options" as name the getOptions will not return the proper data.**
- **LPD-22775 Rename the "optionsMap" attribute because if we have a child node with "optionsMap" as name the getOptionsMap will not return the proper data.**
- **LPD-22775 Rename the "type" attribute because if we have a child node with "type" as name the getType will not return the proper data.**
