### PR TITLE
LPD-22860 Add timing logging to ImageMagick convert function

### DIFF
--- a/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/ImageMagickImpl.java
+++ b/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/ImageMagickImpl.java
@@ -225,9 +225,18 @@ public class ImageMagickImpl implements ImageMagick {
 			arguments.add(StringBundler.concat(width, "x", height, ">"));
 			arguments.add(scaledImageFile.getAbsolutePath());
 
+			long start = System.currentTimeMillis();
+
 			Future<?> future = convert(arguments);
 
 			ProcessEvent processEvent = (ProcessEvent)future.get();
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Converted image with ImageMagick in ",
+						System.currentTimeMillis() - start, "ms"));
+			}
 
 			if (_log.isDebugEnabled() &&
 				(processEvent.getException() != null)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22860

This is for an internal request to have more logging to help track down potential OOM issues.

They asked for logging to be added to the [convert function|https://github.com/liferay/liferay-portal/blob/master/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/ImageMagickImpl.java#L49]. However, the `convert` method only creates the `future` and then the caller executes it. That is why I've added the logging to the `scale` function instead.

The only other place this method is called is from [CMYKImageToolImpl.convertCMYKtoRGB|https://github.com/liferay/liferay-portal/blob/master/modules/apps/image/image-impl/src/main/java/com/liferay/image/internal/CMYKImageToolImpl.java#L71], but this too only returns the future. It is never called anywhere so there wasn't an appropriate place to add the logging.

If there are any questions or concerns please let me know.