### PR TITLE
LPD-21632 & LPD-21634 Ellipsis menu appear on default language

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
@@ -94,62 +94,70 @@ export default function TranslationOptions({
 
 	return (
 		<>
-			<ClayDropDown
-				active={dropdownActive}
-				onActiveChange={(active: boolean) => {
-					if (active) {
-						updateTranslations();
+			{selectedLanguageId !== defaultLanguageId && (
+				<ClayDropDown
+					active={dropdownActive}
+					onActiveChange={(active: boolean) => {
+						if (active) {
+							updateTranslations();
+						}
+
+						setDropdownActive(active);
+					}}
+					trigger={
+						<ClayButton
+							aria-label={Liferay.Language.get(
+								'translation-options'
+							)}
+							className="px-2"
+							displayType="secondary"
+							size="sm"
+							title={Liferay.Language.get('translation-options')}
+							type="button"
+						>
+							<ClayIcon symbol="ellipsis-v" />
+						</ClayButton>
 					}
+				>
+					<ClayDropDown.ItemList>
+						<ClayDropDown.Item>
+							<ClayButton
+								className="font-weight-normal text-secondary"
+								disabled={!!disabledResetButton}
+								displayType="unstyled"
+								onClick={() =>
+									onOpenChangeResetTranslation(true)
+								}
+								size="sm"
+							>
+								<ClayIcon symbol="trash" />
 
-					setDropdownActive(active);
-				}}
-				trigger={
-					<ClayButton
-						aria-label={Liferay.Language.get('translation-options')}
-						className="px-2"
-						displayType="secondary"
-						size="sm"
-						title={Liferay.Language.get('translation-options')}
-						type="button"
-					>
-						<ClayIcon symbol="ellipsis-v" />
-					</ClayButton>
-				}
-			>
-				<ClayDropDown.ItemList>
-					<ClayDropDown.Item>
-						<ClayButton
-							className="font-weight-normal text-secondary"
-							disabled={!!disabledResetButton}
-							displayType="unstyled"
-							onClick={() => onOpenChangeResetTranslation(true)}
-							size="sm"
-						>
-							<ClayIcon symbol="trash" />
+								<span className="c-ml-3">
+									{Liferay.Language.get('reset-translation')}
+								</span>
+							</ClayButton>
+						</ClayDropDown.Item>
 
-							<span className="c-ml-3">
-								{Liferay.Language.get('reset-translation')}
-							</span>
-						</ClayButton>
-					</ClayDropDown.Item>
+						<ClayDropDown.Item>
+							<ClayButton
+								className="font-weight-normal text-secondary"
+								disabled={!!disabledMarkTranslatedButton}
+								displayType="unstyled"
+								onClick={() =>
+									onOpenChangeMarkAsTranslated(true)
+								}
+								size="sm"
+							>
+								<ClayIcon symbol="question-circle-full" />
 
-					<ClayDropDown.Item>
-						<ClayButton
-							className="font-weight-normal text-secondary"
-							disabled={!!disabledMarkTranslatedButton}
-							displayType="unstyled"
-							onClick={() => onOpenChangeMarkAsTranslated(true)}
-							size="sm"
-						>
-							<ClayIcon symbol="question-circle-full" />
-
-							<span className="c-ml-3">
-								{Liferay.Language.get('mark-as-translated')}
-							</span>
-						</ClayButton>
-					</ClayDropDown.Item>
-				</ClayDropDown.ItemList>
-			</ClayDropDown>
+								<span className="c-ml-3">
+									{Liferay.Language.get('mark-as-translated')}
+								</span>
+							</ClayButton>
+						</ClayDropDown.Item>
+					</ClayDropDown.ItemList>
+				</ClayDropDown>
+			)}
 
 			{openResetTranslation && (
 				<ClayModal observer={resetTranslationObserver} status="danger">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
@@ -80,17 +80,15 @@ export default function TranslationOptions({
 	};
 
 	const disabledResetButton =
-		selectedLanguageId === defaultLanguageId ||
 		(translationProgress &&
 			!translationProgress.translatedItems[selectedLanguageId]) ||
 		(translationProgress &&
 			translationProgress.translatedItems[selectedLanguageId] === 0);
 
 	const disabledMarkTranslatedButton =
-		selectedLanguageId === defaultLanguageId ||
-		(translationProgress &&
-			translationProgress.translatedItems[selectedLanguageId] ===
-				translationProgress.totalItems);
+		translationProgress &&
+		translationProgress.translatedItems[selectedLanguageId] ===
+			translationProgress.totalItems;
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationOptions.tsx
@@ -80,15 +80,12 @@ export default function TranslationOptions({
 	};
 
 	const disabledResetButton =
-		(translationProgress &&
-			!translationProgress.translatedItems[selectedLanguageId]) ||
-		(translationProgress &&
-			translationProgress.translatedItems[selectedLanguageId] === 0);
+		!translationProgress?.translatedItems[selectedLanguageId] ||
+		translationProgress?.translatedItems[selectedLanguageId] === 0;
 
 	const disabledMarkTranslatedButton =
-		translationProgress &&
-		translationProgress.translatedItems[selectedLanguageId] ===
-			translationProgress.totalItems;
+		translationProgress?.translatedItems[selectedLanguageId] ===
+		translationProgress?.totalItems;
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
@@ -62,9 +62,24 @@ const renderTranslatedComponent = () =>
 describe('TranslationOptions', () => {
 	Liferay.FeatureFlags['LPD-11253'] = true;
 
+	it('translations options ellipsis not rendered when default language is selected', () => {
+		renderDefaultComponent();
+
+		const resetTranslationsButton = screen.queryByTitle(
+			'translation-options'
+		);
+
+		expect(resetTranslationsButton).not.toBeInTheDocument();
+	});
+
 	describe('Reset Translations Button', () => {
-		it('reset translations button is disabled with default language', () => {
-			renderDefaultComponent();
+		it('reset translations button is disabled when default language is selected', () => {
+			render(
+				<TranslationOptions
+					{...DEFAULT_PROPS}
+					selectedLanguageId="ca_ES"
+				/>
+			);
 
 			const resetTranslationsButton = screen.getByText(
 				'reset-translation'

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
@@ -42,23 +42,8 @@ const DEFAULT_PROPS = {
 	selectedLanguageId: 'en_US',
 };
 
-const TRANSLATED_PROPS = {
-	...DEFAULT_PROPS,
-	selectedLanguageId: 'ar_SA',
-	translationProgress: {
-		totalItems: 4,
-		translatedItems: {
-			ar_SA: 1,
-		},
-	},
-};
-
 const renderDefaultComponent = () =>
 	render(<TranslationOptions {...DEFAULT_PROPS} />);
-
-const renderTranslatedComponent = () =>
-	render(<TranslationOptions {...TRANSLATED_PROPS} />);
-
 describe('TranslationOptions', () => {
 	Liferay.FeatureFlags['LPD-11253'] = true;
 
@@ -86,16 +71,6 @@ describe('TranslationOptions', () => {
 			);
 
 			expect(resetTranslationsButton).toBeDisabled();
-		});
-
-		it('reset translations button is enabled when there is a translation in progress', () => {
-			renderTranslatedComponent();
-
-			const resetTranslationsButton = screen.getByText(
-				'reset-translation'
-			);
-
-			expect(resetTranslationsButton).not.toBeDisabled();
 		});
 	});
 });

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx
@@ -59,22 +59,28 @@ const renderDefaultComponent = () =>
 const renderTranslatedComponent = () =>
 	render(<TranslationOptions {...TRANSLATED_PROPS} />);
 
-describe('ResetTranslationsButton', () => {
+describe('TranslationOptions', () => {
 	Liferay.FeatureFlags['LPD-11253'] = true;
 
-	it('reset translations button is disabled with default language', () => {
-		renderDefaultComponent();
+	describe('Reset Translations Button', () => {
+		it('reset translations button is disabled with default language', () => {
+			renderDefaultComponent();
 
-		const resetTranslationsButton = screen.getByText('reset-translation');
+			const resetTranslationsButton = screen.getByText(
+				'reset-translation'
+			);
 
-		expect(resetTranslationsButton).toBeDisabled();
-	});
+			expect(resetTranslationsButton).toBeDisabled();
+		});
 
-	it('reset translations button is enabled when there is a translation in progress', () => {
-		renderTranslatedComponent();
+		it('reset translations button is enabled when there is a translation in progress', () => {
+			renderTranslatedComponent();
 
-		const resetTranslationsButton = screen.getByText('reset-translation');
+			const resetTranslationsButton = screen.getByText(
+				'reset-translation'
+			);
 
-		expect(resetTranslationsButton).not.toBeDisabled();
+			expect(resetTranslationsButton).not.toBeDisabled();
+		});
 	});
 });

--- a/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
@@ -36,7 +36,9 @@ test('LPD-18809 search suggestions should filter by product visibility with the 
 
 	// setup
 
-	const site = await apiHelpers.headlessSite.createSite(getRandomString());
+	const site = await apiHelpers.headlessSite.createSite({
+		name: getRandomString(),
+	});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -316,6 +316,8 @@ translationTest(
 			name: 'Reset Translation',
 		});
 
+		await expect(resetTranslationButton).toBeEnabled();
+
 		await resetTranslationButton.click();
 
 		const deleteButton = page.getByRole('button', {name: 'Delete'});


### PR DESCRIPTION
[Link to ticket 1](https://liferay.atlassian.net/browse/LPD-21632)  
[Link to ticket 2](https://liferay.atlassian.net/browse/LPD-21634)

## Steps

*   Activate FFs 'LPD-11253' and 'LPS-114700' 
*   **Case 1**
    *   Go to Content & Data > Create a Web Content
    *   Asset Translations options ellipsis is not present

![](https://github.com/liferay-content-management/liferay-portal/assets/91208451/e1ac1ef5-7a55-4d89-94d5-d596cda564e0)

*   **Case 2**
    *   Go to Content & Data > Create a Web Content
    *   Change the language to a different one from the default
    *   Click on the Translations Options ellipsis
    *   See Reset Translations button is disabled

![](https://github.com/liferay-content-management/liferay-portal/assets/91208451/fab39dec-d82d-4aa5-86ca-5ce624910af3)