### PR TITLE
LPD-23065 Structure Boolean Field defaults to Null

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -95,10 +95,23 @@ public class ContentFieldUtil {
 
 						Value value = ddmFormFieldValue.getValue();
 
+						Locale defaultLocale = value.getDefaultLocale();
+
 						Map<Locale, String> values = value.getValues();
 
 						if (values == null) {
 							values = Collections.emptyMap();
+						}
+
+						if (!values.containsKey(defaultLocale)) {
+							map.put(
+								LocaleUtil.toBCP47LanguageId(defaultLocale),
+								_getContentFieldValue(
+									ddmFormField, dlAppService, dlURLHelper,
+									dtoConverterContext, journalArticleService,
+									layoutLocalService, defaultLocale,
+									String.valueOf(
+										value.getString(defaultLocale))));
 						}
 
 						for (Map.Entry<Locale, String> entry :

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -152,8 +152,25 @@ public class ContentFieldUtil {
 		try {
 			UriInfo uriInfo = dtoConverterContext.getUriInfo();
 
-			if (Objects.equals(DDMFormFieldType.DATE, ddmFormField.getType()) ||
-				Objects.equals(ddmFormField.getType(), "date")) {
+			if (Objects.equals(
+					DDMFormFieldType.CHECKBOX, ddmFormField.getType())) {
+
+				return new ContentFieldValue() {
+					{
+						setData(
+							() -> {
+								if (Validator.isNull(valueString)) {
+									return Boolean.FALSE.toString();
+								}
+
+								return valueString;
+							});
+					}
+				};
+			}
+			else if (Objects.equals(
+						DDMFormFieldType.DATE, ddmFormField.getType()) ||
+					 Objects.equals(ddmFormField.getType(), "date")) {
 
 				return new ContentFieldValue() {
 					{

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
@@ -522,7 +522,22 @@ public class FreeMarkerManager extends BaseTemplateManager {
 
 		_configuration = new Configuration(Configuration.VERSION_2_3_32);
 
+		_configuration.setAttemptExceptionReporter(
+			(templateException, environment) -> {
+			});
+		_configuration.setDefaultEncoding(StringPool.UTF8);
+		_configuration.setLocalizedLookup(
+			_freeMarkerEngineConfiguration.localizedLookup());
+		_configuration.setNewBuiltinClassResolver(_templateClassResolver);
+
 		try {
+			_configuration.setLogTemplateExceptions(
+				_freeMarkerEngineConfiguration.logTemplateExceptions());
+			_configuration.setSetting("auto_import", _getMacroLibrary());
+			_configuration.setSetting(
+				"template_exception_handler",
+				_freeMarkerEngineConfiguration.templateExceptionHandler());
+
 			Field field = ReflectionUtil.getDeclaredField(
 				Configuration.class, "cache");
 
@@ -540,28 +555,6 @@ public class FreeMarkerManager extends BaseTemplateManager {
 				"loop-count-threshold",
 				new SimpleNumber(
 					_freeMarkerEngineConfiguration.loopCountThreshold()));
-		}
-		catch (Exception exception) {
-			throw new TemplateException(
-				"Unable to Initialize FreeMarker manager", exception);
-		}
-
-		_configuration.setAttemptExceptionReporter(
-			(templateException, environment) -> {
-			});
-
-		_configuration.setDefaultEncoding(StringPool.UTF8);
-		_configuration.setLocalizedLookup(
-			_freeMarkerEngineConfiguration.localizedLookup());
-		_configuration.setNewBuiltinClassResolver(_templateClassResolver);
-
-		try {
-			_configuration.setLogTemplateExceptions(
-				_freeMarkerEngineConfiguration.logTemplateExceptions());
-			_configuration.setSetting("auto_import", _getMacroLibrary());
-			_configuration.setSetting(
-				"template_exception_handler",
-				_freeMarkerEngineConfiguration.templateExceptionHandler());
 		}
 		catch (Exception exception) {
 			throw new TemplateException(

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerManager.java
@@ -546,6 +546,10 @@ public class FreeMarkerManager extends BaseTemplateManager {
 				"Unable to Initialize FreeMarker manager", exception);
 		}
 
+		_configuration.setAttemptExceptionReporter(
+			(templateException, environment) -> {
+			});
+
 		_configuration.setDefaultEncoding(StringPool.UTF8);
 		_configuration.setLocalizedLookup(
 			_freeMarkerEngineConfiguration.localizedLookup());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23065

Controls the case of checkbox field with no interaction in the interface.

## Change summary:

* Takes into account the checkbox field when retrieving the structured content fields though a headless call

## Test Scenario No 1

* Create a new Structure: Content & Data > Web Content > Structures > New
* Drag and Drop the Boolean Field
* Name it “test-struct” and click Save
* Publish a new Web Content called “test-wc” using “test-struct” and leave the Boolean field unchecked.
* From API explorer, go to the getStructuredContent endpoint(/v1.0/structured-contents/{structuredContentId})
* Enter the structuredContentId for “test-wc“ and click Execute
* See that contentFieldValue for the checkbox contains the correct boolean value

## Test Scenario No 2

* After following the first scenario, set the X-Accept-All-Languages to true to the request and click Execute
* See that contentFieldValue_i18n for the checkbox contains the correct boolean value
