### PR TITLE
LPD-23376 Fix failing KB tests

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-markdown-converter-impl/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-markdown-converter-impl/build.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"
 
 dependencies {
 	compileInclude group: "com.liferay", name: "org.parboiled", version: "1.1.6.LIFERAY-PATCHED-1"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-23376

As part of https://liferay.atlassian.net/browse/LPD-15162, the JDK versions were bumped. This broke KB, as the ASM version required by the markdown parser doesn't support newer versions.  This is a release blocker, so I'm (partially) reverting those changes until we can replace the parser (or deprecate the feature).

# How am I fixing it?

By partially reverting e8d45abc5320a7e4f155e5ba793848c00d191eb2.

# How can you verify that it works?

All integration tests in `knowledge-base-test` pass.