### PR TITLE
LPD-22600 Add DEFAULT_LANGUAGE_ID to indexing

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -94,6 +94,9 @@ public class DLFileEntryModelDocumentContributor
 
 			document.addKeyword(
 				Field.CLASS_TYPE_ID, dlFileEntry.getFileEntryTypeId());
+			document.addText(
+				Field.DEFAULT_LANGUAGE_ID,
+				LocaleUtil.toLanguageId(defaultLocale));
 			document.addText(Field.DESCRIPTION, dlFileEntry.getDescription());
 			document.addText(
 				Field.getLocalizedName(defaultLocale, Field.DESCRIPTION),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryIndexerIndexedFieldsTest.java
@@ -228,6 +228,9 @@ public class DLFileEntryIndexerIndexedFieldsTest extends BaseDLIndexerTestCase {
 		map.put(Field.CLASS_NAME_ID, "0");
 		map.put(Field.CLASS_PK, "0");
 		map.put(Field.COMPANY_ID, String.valueOf(fileEntry.getCompanyId()));
+		map.put(
+			Field.DEFAULT_LANGUAGE_ID,
+			LocaleUtil.toLanguageId(LocaleUtil.JAPAN));
 		map.put(Field.ENTRY_CLASS_NAME, DLFileEntry.class.getName());
 		map.put(
 			Field.ENTRY_CLASS_PK, String.valueOf(fileEntry.getFileEntryId()));


### PR DESCRIPTION
Issue is https://liferay.atlassian.net/browse/LPD-22600. If I upload a document, after I change the site dafult language, the search does not display the document's title and content.

Root cause: DLFileEntryModelSummaryContributor.java the getSummary() method cannot get content and title from the document, because the document doesn't have Field.DEFAULT_LANGUAGE_ID and it uses the portal default, and not the document one.

Solution. add to the document indexing the default language id in DLFileEntryModelDocumentContributor.java, so after re-indexing it, it changes the default language together with the localized title and content.

tested it locally and solves the issue