### PR TITLE
LPD-22308 Fix flacky test - missing iframe for BlogsEntry tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -260,6 +260,8 @@ definition {
 				navTab = ${navTab});
 		}
 		else {
+			WaitForVisible(locator1 = "ItemSelector#ITEM_SELECTOR_IFRAME");
+
 			ItemSelector.uploadFile(
 				invalidFileValidation = ${invalidFileValidation},
 				navTab = ${navTab},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
@@ -190,10 +190,6 @@ definition {
 		AssertClick(
 			locator1 = "BlogsEntry#ENTRY_COVER_IMAGE_SELECT_FILE",
 			value1 = "Select File");
-
-		// Pausing 2 seconds to ensure the upload iframe is loaded. See LPD-22308
-
-		Pause(value1 = 2000);
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -586,6 +586,8 @@ definition {
 		var key_navTab = ${navTab};
 		var key_uploadFileName = ${uploadFileName};
 
+		AssertVisible(locator1 = "ItemSelector#ITEM_SELECTOR_IFRAME");
+
 		SelectFrame(locator1 = "ItemSelector#ITEM_SELECTOR_IFRAME");
 
 		if (IsElementPresent(locator1 = "ItemSelector#NAVIGATION_SPECIFIC_TAB")) {


### PR DESCRIPTION
Trying to fix these POSHI tests, again. This time without the `pause` instruction.
https://liferay.atlassian.net/browse/LPD-22308