### PR TITLE
LPD-23607 Adaptive Media page opens slowly with large amount of images

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Adaptive Media Image API
 Bundle-SymbolicName: com.liferay.adaptive.media.image.api
-Bundle-Version: 13.1.1
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.adaptive.media.image.configuration,\
 	com.liferay.adaptive.media.image.counter,\

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
@@ -434,6 +434,11 @@ public interface AMImageEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getPercentage(long companyId, String configurationUuid);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getPercentage(
+		long companyId, String configurationUuid,
+		int expectedAMImageEntriesCount);
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceUtil.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceUtil.java
@@ -490,6 +490,14 @@ public class AMImageEntryLocalServiceUtil {
 		return getService().getPercentage(companyId, configurationUuid);
 	}
 
+	public static int getPercentage(
+		long companyId, String configurationUuid,
+		int expectedAMImageEntriesCount) {
+
+		return getService().getPercentage(
+			companyId, configurationUuid, expectedAMImageEntriesCount);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceWrapper.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalServiceWrapper.java
@@ -535,6 +535,15 @@ public class AMImageEntryLocalServiceWrapper
 			companyId, configurationUuid);
 	}
 
+	@Override
+	public int getPercentage(
+		long companyId, String configurationUuid,
+		int expectedAMImageEntriesCount) {
+
+		return _amImageEntryLocalService.getPercentage(
+			companyId, configurationUuid, expectedAMImageEntriesCount);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.9.0
+version 1.10.0

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
@@ -280,8 +280,15 @@ public class AMImageEntryLocalServiceImpl
 	 */
 	@Override
 	public int getPercentage(long companyId, String configurationUuid) {
-		int expectedAMImageEntriesCount = getExpectedAMImageEntriesCount(
-			companyId);
+		return getPercentage(
+			companyId, configurationUuid,
+			getExpectedAMImageEntriesCount(companyId));
+	}
+
+	@Override
+	public int getPercentage(
+		long companyId, String configurationUuid,
+		int expectedAMImageEntriesCount) {
 
 		if (expectedAMImageEntriesCount == 0) {
 			return 0;

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/constants/AMWebKeys.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/constants/AMWebKeys.java
@@ -21,4 +21,6 @@ public class AMWebKeys {
 	public static final String SELECTED_CONFIGURATION_ENTRIES =
 		"SELECTED_CONFIGURATION_ENTRIES";
 
+	public static final String TOTAL_IMAGES = "TOTAL_IMAGES";
+
 }

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/InfoPanelMVCResourceCommand.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/InfoPanelMVCResourceCommand.java
@@ -49,6 +49,9 @@ public class InfoPanelMVCResourceCommand extends BaseMVCResourceCommand {
 		resourceRequest.setAttribute(
 			AMWebKeys.SELECTED_CONFIGURATION_ENTRIES,
 			_getSelectedAMImageConfigurationEntries(resourceRequest));
+		resourceRequest.setAttribute(
+			AMWebKeys.TOTAL_IMAGES,
+			ParamUtil.getInteger(resourceRequest, AMWebKeys.TOTAL_IMAGES));
 
 		include(
 			resourceRequest, resourceResponse,

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -7,6 +7,7 @@ package com.liferay.adaptive.media.web.internal.portlet.action;
 
 import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
 import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
+import com.liferay.adaptive.media.image.service.AMImageEntryLocalService;
 import com.liferay.adaptive.media.web.internal.constants.AMPortletKeys;
 import com.liferay.adaptive.media.web.internal.constants.AMWebKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
@@ -40,21 +41,27 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
-			_getAMImageConfigurationEntries(renderRequest);
+			_getAMImageConfigurationEntries(renderRequest, themeDisplay);
 
 		renderRequest.setAttribute(
 			AMWebKeys.CONFIGURATION_ENTRIES_LIST,
 			new ArrayList<>(amImageConfigurationEntries));
 
+		renderRequest.setAttribute(
+			AMWebKeys.TOTAL_IMAGES,
+			_amImageEntryLocalService.getExpectedAMImageEntriesCount(
+				themeDisplay.getCompanyId()));
+
 		return "/adaptive_media/view.jsp";
 	}
 
 	private Collection<AMImageConfigurationEntry>
-		_getAMImageConfigurationEntries(RenderRequest renderRequest) {
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		_getAMImageConfigurationEntries(
+			RenderRequest renderRequest, ThemeDisplay themeDisplay) {
 
 		String entriesNavigation = ParamUtil.getString(
 			renderRequest, "entriesNavigation", "all");
@@ -81,5 +88,8 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private AMImageConfigurationHelper _amImageConfigurationHelper;
+
+	@Reference
+	private AMImageEntryLocalService _amImageEntryLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/image_configuration_entry_action.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/image_configuration_entry_action.jsp
@@ -38,6 +38,8 @@ if (optimizeImageSingleBackgroundTasks != null) {
 }
 
 String entryUuid = String.valueOf(amImageConfigurationEntry.getUUID());
+
+int totalImages = (int)request.getAttribute(AMWebKeys.TOTAL_IMAGES);
 %>
 
 <liferay-ui:icon-menu
@@ -101,7 +103,7 @@ String entryUuid = String.valueOf(amImageConfigurationEntry.getUUID());
 	<%
 	String onClick = liferayPortletResponse.getNamespace() + "adaptRemaining('" + entryUuid + "', '" + optimizeImagesURL.toString() + "');";
 
-	int percentage = AMImageEntryLocalServiceUtil.getPercentage(themeDisplay.getCompanyId(), entryUuid);
+	int percentage = AMImageEntryLocalServiceUtil.getPercentage(themeDisplay.getCompanyId(), entryUuid, totalImages);
 	%>
 
 	<liferay-ui:icon

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/info_panel.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/info_panel.jsp
@@ -19,6 +19,8 @@ if (ListUtil.isNotEmpty(selectedAMImageConfigurationEntries)) {
 
 	selectedConfigurationEntriesSize = selectedAMImageConfigurationEntries.size();
 }
+
+int totalImages = (int)request.getAttribute(AMWebKeys.TOTAL_IMAGES);
 %>
 
 <div class="sidebar-header">
@@ -92,8 +94,6 @@ if (ListUtil.isNotEmpty(selectedAMImageConfigurationEntries)) {
 
 							<%
 							int adaptedImages = AMImageEntryLocalServiceUtil.getAMImageEntriesCount(themeDisplay.getCompanyId(), amImageConfigurationEntry.getUUID());
-
-							int totalImages = AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(themeDisplay.getCompanyId());
 							%>
 
 							<%= Math.min(adaptedImages, totalImages) %>/<%= totalImages %>

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/view.jsp
@@ -13,6 +13,8 @@ SearchContainer<?> amSearchContainer = new SearchContainer<>(renderRequest, rend
 amSearchContainer.setId("imageConfigurationEntries");
 amSearchContainer.setResultsAndTotal((List)request.getAttribute(AMWebKeys.CONFIGURATION_ENTRIES_LIST));
 amSearchContainer.setRowChecker(new ImageConfigurationEntriesChecker(liferayPortletResponse));
+
+int totalImages = (int)request.getAttribute(AMWebKeys.TOTAL_IMAGES);
 %>
 
 <clay:management-toolbar
@@ -20,7 +22,9 @@ amSearchContainer.setRowChecker(new ImageConfigurationEntriesChecker(liferayPort
 />
 
 <div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
-	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/adaptive_media/info_panel" var="sidebarPanelURL" />
+	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/adaptive_media/info_panel" var="sidebarPanelURL">
+		<portlet:param name="<%= AMWebKeys.TOTAL_IMAGES %>" value="<%= String.valueOf(totalImages) %>" />
+	</liferay-portlet:resourceURL>
 
 	<liferay-frontend:sidebar-panel
 		resourceURL="<%= sidebarPanelURL %>"
@@ -111,8 +115,6 @@ amSearchContainer.setRowChecker(new ImageConfigurationEntriesChecker(liferayPort
 						String uuid = String.valueOf(amImageConfigurationEntry.getUUID());
 
 						int adaptedImages = AMImageEntryLocalServiceUtil.getAMImageEntriesCount(themeDisplay.getCompanyId(), amImageConfigurationEntry.getUUID());
-
-						int totalImages = AMImageEntryLocalServiceUtil.getExpectedAMImageEntriesCount(themeDisplay.getCompanyId());
 						%>
 
 						<div id="<portlet:namespace />AdaptRemainingContainer_<%= rowId %>">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23607

When accessing Control Panel - Adaptive Media it calculates the number of adapted images as well as the number of images still remaining. This query is very expensive so we need to limit the amount of times it is called.

Currently, the query was called a total of 8 times with the default resolution settings. It was called twice for every resolution and twice for each of the _*AMImageCounter_ implementations. As the number of resolutions or implementations increase the issue becomes even more pronounced.

The changes here calculate the total images only once per _*AMImageCounter_ implementation and then reuses the value among the JSPs instead of recalculating it. With the default settings it will now only be called 2 times instead of 8.

If there are any questions or concerns please let me know.