### PR TITLE
LPD-22490 Fix WebContentUpgrade test inconsistently failing because the structure builder is not available

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -191,6 +191,8 @@ definition {
 	macro gotoSidebarTab(tabName = null) {
 		var key_tabName = ${tabName};
 
+		WaitForVisible(locator1 = "Sidebar#TAB");
+
 		if (IsElementNotPresent(locator1 = "Sidebar#ACTIVE_TAB")) {
 			Click(locator1 = "Sidebar#TAB");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
@@ -32,10 +32,6 @@ definition {
 
 			WebContentNavigator.gotoEditStructure(structureName = "WC Structure Name");
 
-			// Pausing 10 seconds to ensure Structures Builder sidebar is loaded. See LPD-22490
-
-			Pause(value1 = 10000);
-
 			PortletEntry.changeLocale(locale = "en-US");
 
 			DataEngine.editFieldLabel(


### PR DESCRIPTION
Waiting for the sidebar to be visible and removing unuseful POSHI `pause` instruction

https://liferay.atlassian.net/browse/LPD-22490