### PR TITLE
LPD-23847 Update the locator to avoid double selection

### DIFF
--- a/modules/test/playwright/pages/knowledge-base-web/KnowledgeBasePage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KnowledgeBasePage.ts
@@ -20,7 +20,9 @@ export class KnowledgeBasePage {
 			name: 'Basic Article',
 		});
 		this.foldersAndArticlesButton = page.getByLabel('Folders and Articles');
-		this.newButton = page.getByLabel('New', {exact: true});
+		this.newButton = page
+			.locator('.management-bar')
+			.getByText('New', {exact: true});
 		this.page = page;
 		this.selectAllCheckBox = page.getByLabel(
 			'Select All Items on the Page'


### PR DESCRIPTION
# Issue: https://liferay.atlassian.net/browse/LPD-23847

One locator resolves two elements instead of one, we fine-tune the locator to get one element only.

It looks like some HTML update in the management toolbar, but I can't locate the change 😕 

## Before the PR

### Local
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/7c65ac20-e5c8-4f01-84d5-3cde1f707b1d)

### CI - https://github.com/boton/liferay-portal/pull/234#issuecomment-2064680553
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/069d362a-bb49-4f55-a29f-9b1551e6b378)



## After the PR

### Local
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/bc3f6941-27e2-4e83-88f8-4cee7a8af024)

### CI
We'll see in this PR  👀 
