### PR TITLE
LPD-19337 Create TranslationFilter Component

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
@@ -42,9 +42,12 @@ const FieldRepeatableDND = ({children, field, index, nestedFieldIndex}) => {
 
 	return (
 		<div
-			className={classNames('lfr-forms__form-view-field-repeatable-dnd', {
-				'lfr-forms__form-view-field-repeatable-dnd--dragging': isDragging,
-			})}
+			className={
+				(field.hidden ? 'hide ' : '') +
+				classNames('lfr-forms__form-view-field-repeatable-dnd', {
+					'lfr-forms__form-view-field-repeatable-dnd--dragging': isDragging,
+				})
+			}
 			ref={(element) => {
 				dragRef(element);
 				ref.current = element;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
@@ -16,19 +16,13 @@ import {EVENT_TYPES} from '../actions/eventTypes.es';
 export function createRepeatedField(sourceField, repeatedIndex) {
 	const instanceId = generateInstanceId();
 	const {locale, name, nestedFields, predefinedValue} = sourceField;
-	let localizedValue;
+	const localizedValue = {};
+	const localizedValueEdited = {};
 
 	if (sourceField.localizedValue) {
-		localizedValue = Object.keys(sourceField.localizedValue).reduce(
-			(localizedValues, key) => {
-				localizedValues[key] = '';
-
-				return localizedValues;
-			},
-			{}
-		);
-
-		localizedValue[locale] = predefinedValue ?? localizedValue[locale];
+		localizedValue[locale] =
+			predefinedValue || localizedValue[locale] || '';
+		localizedValueEdited[locale] = true;
 	}
 
 	return {
@@ -36,6 +30,7 @@ export function createRepeatedField(sourceField, repeatedIndex) {
 		confirmationValue: '',
 		instanceId,
 		localizedValue,
+		localizedValueEdited,
 		name: generateName(name, {instanceId, repeatedIndex}),
 		nestedFields: nestedFields?.map((nestedField) =>
 			createRepeatedField(nestedField)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -259,7 +259,9 @@ export default function FieldBase({
 				<input
 					data-field-name={`${fieldName}${instanceId}`}
 					data-languageid={locale}
-					data-translated={!!localizedValueEdited[editingLanguageId]}
+					data-translated={
+						!!localizedValueEdited?.[editingLanguageId]
+					}
 					key={locale}
 					name={name.replace(editingLanguageId, locale)}
 					type="hidden"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -202,6 +202,7 @@ export default function FieldBase({
 	itemPath,
 	label,
 	localizedValue = {},
+	localizedValueEdited,
 	name,
 	nestedFields,
 	onClick,
@@ -258,6 +259,7 @@ export default function FieldBase({
 				<input
 					data-field-name={`${fieldName}${instanceId}`}
 					data-languageid={locale}
+					data-translated={!!localizedValueEdited[editingLanguageId]}
 					key={locale}
 					name={name.replace(editingLanguageId, locale)}
 					type="hidden"
@@ -265,7 +267,15 @@ export default function FieldBase({
 				/>
 			);
 		});
-	}, [localizedValue, editingLanguageId, fieldName, instanceId, name, type]);
+	}, [
+		localizedValue,
+		localizedValueEdited,
+		editingLanguageId,
+		fieldName,
+		instanceId,
+		name,
+		type,
+	]);
 
 	const renderLabel =
 		(label && showLabel) || hideField || repeatable || required || tooltip;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -370,6 +370,111 @@ export default function FieldBase({
 		}, 1000);
 	};
 
+	const translationFilterChange = useCallback(
+		(event) => {
+			const pagesVisitor = new PagesVisitor(pages);
+			switch (event.option) {
+				case 'translated':
+					dispatch({
+						payload: pagesVisitor.mapFields(
+							(field) => {
+								if (!field.localizable) {
+									return {
+										...field,
+										disabled: true,
+										hidden: true,
+										visible: false,
+									};
+								}
+								if (
+									field.localizedValueEdited?.[
+										editingLanguageId
+									]
+								) {
+									return {
+										...field,
+										disabled: false,
+										hidden: false,
+										visible: true,
+									};
+								}
+								else {
+									return {
+										...field,
+										disabled: true,
+										hidden: true,
+										visible: false,
+									};
+								}
+							},
+							false,
+							true
+						),
+						type: CORE_EVENT_TYPES.PAGE.UPDATE,
+					});
+
+					break;
+				case 'untranslated':
+					dispatch({
+						payload: pagesVisitor.mapFields(
+							(field) => {
+								if (!field.localizable) {
+									return {
+										...field,
+										disabled: true,
+										hidden: true,
+										visible: false,
+									};
+								}
+								if (
+									field.localizedValueEdited?.[
+										editingLanguageId
+									]
+								) {
+									return {
+										...field,
+										disabled: true,
+										hidden: true,
+										visible: false,
+									};
+								}
+								else {
+									return {
+										...field,
+										disabled: false,
+										hidden: false,
+										visible: true,
+									};
+								}
+							},
+							false,
+							true
+						),
+						type: CORE_EVENT_TYPES.PAGE.UPDATE,
+					});
+					break;
+				default:
+					dispatch({
+						payload: pagesVisitor.mapFields(
+							(field) => {
+								return {
+									...field,
+									disabled: false,
+									hidden: false,
+									visible: true,
+								};
+							},
+							false,
+							true
+						),
+						type: CORE_EVENT_TYPES.PAGE.UPDATE,
+					});
+					break;
+			}
+		},
+		[dispatch, editingLanguageId, pages]
+	);
+
 	useEffect(() => {
 		Liferay.on('disableRepeatableButton', disableRepeatableButton);
 
@@ -442,6 +547,10 @@ export default function FieldBase({
 	useEffect(() => {
 		Liferay.on('inputLocalized:resetTranslations', resetTranslations);
 		Liferay.on('inputLocalized:markAsTranslated', markAsTranslated);
+		Liferay.on(
+			'inputLocalized:translationFilterChange',
+			translationFilterChange
+		);
 
 		return () => {
 			Liferay.detach(
@@ -449,8 +558,9 @@ export default function FieldBase({
 				resetTranslations
 			);
 			Liferay.detach('inputLocalized:markAsTranslated', markAsTranslated);
+			Liferay.on('translationFilterChange', translationFilterChange);
 		};
-	}, [resetTranslations, markAsTranslated]);
+	}, [resetTranslations, markAsTranslated, translationFilterChange]);
 
 	return (
 		<ClayForm.Group

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -205,25 +205,6 @@ public class JournalConverterImpl implements JournalConverter {
 		}
 	}
 
-	private void _addMissingFieldValues(
-		Field ddmField, String defaultLanguageId,
-		Set<String> missingLanguageIds) {
-
-		if (missingLanguageIds.isEmpty()) {
-			return;
-		}
-
-		Locale defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
-
-		Serializable fieldValue = ddmField.getValue(defaultLocale);
-
-		for (String missingLanguageId : missingLanguageIds) {
-			Locale missingLocale = LocaleUtil.fromLanguageId(missingLanguageId);
-
-			ddmField.setValue(missingLocale, fieldValue);
-		}
-	}
-
 	private void _addNestedDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
@@ -429,8 +410,6 @@ public class JournalConverterImpl implements JournalConverter {
 
 			ddmField.addValue(locale, serializable);
 		}
-
-		_addMissingFieldValues(ddmField, defaultLanguageId, missingLanguageIds);
 
 		return ddmField;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -249,7 +249,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	@Override
 	public DDMFormValues getDDMFormValues() {
 		if (_ddmFormValues == null) {
-			_ddmFormValues = getDDMFormValues(true);
+			_ddmFormValues = getDDMFormValues(false);
 		}
 
 		return _ddmFormValues;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -114,26 +114,26 @@ journalEditArticleDisplayContext.setViewAttributes();
 											%>'
 										/>
 									</div>
-								</c:if>
 
-								<div class="autofit-col c-ml-2">
-									<react:component
-										module="{TranslationFilter} from journal-web"
-										props='<%=
-											HashMapBuilder.<String, Object>put(
-												"defaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
-											).put(
-												"fields", journalEditArticleDisplayContext.getFieldMap()
-											).put(
-												"locales", journalEditArticleDisplayContext.getLocales()
-											).put(
-												"namespace", liferayPortletResponse.getNamespace()
-											).put(
-												"selectedLanguageId", journalEditArticleDisplayContext.getSelectedLanguageId()
-											).build()
-										%>'
-									/>
-								</div>
+									<div class="autofit-col c-ml-2">
+										<react:component
+											module="{TranslationFilter} from journal-web"
+											props='<%=
+												HashMapBuilder.<String, Object>put(
+													"defaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
+												).put(
+													"fields", journalEditArticleDisplayContext.getFieldMap()
+												).put(
+													"locales", journalEditArticleDisplayContext.getLocales()
+												).put(
+													"namespace", liferayPortletResponse.getNamespace()
+												).put(
+													"selectedLanguageId", journalEditArticleDisplayContext.getSelectedLanguageId()
+												).build()
+											%>'
+										/>
+									</div>
+								</c:if>
 							</div>
 						</c:when>
 						<c:otherwise>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -116,8 +116,23 @@ journalEditArticleDisplayContext.setViewAttributes();
 									</div>
 								</c:if>
 
-								<div class="autofit-col autofit-col-expand c-ml-3">
-									<aui:input cssClass="form-control-inline form-control-sm" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" languagesDropdownDirection="down" languagesDropdownVisible="<%= false %>" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
+								<div class="autofit-col c-ml-2">
+									<react:component
+										module="{TranslationFilter} from journal-web"
+										props='<%=
+											HashMapBuilder.<String, Object>put(
+												"defaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
+											).put(
+												"fields", journalEditArticleDisplayContext.getFieldMap()
+											).put(
+												"locales", journalEditArticleDisplayContext.getLocales()
+											).put(
+												"namespace", liferayPortletResponse.getNamespace()
+											).put(
+												"selectedLanguageId", journalEditArticleDisplayContext.getSelectedLanguageId()
+											).build()
+										%>'
+									/>
 								</div>
 							</div>
 						</c:when>
@@ -278,81 +293,97 @@ journalEditArticleDisplayContext.setViewAttributes();
 
 				<c:choose>
 					<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPS-114700") %>'>
-						<clay:panel
-							displayTitle='<%= LanguageUtil.get(request, "metadata") %>'
-							displayType="block"
-							expanded="<%= true %>"
-						>
-							<div class="c-gap-4 d-flex flex-column panel-body">
-								<div>
-									<label for="<portlet:namespace />descriptionMapAsXML" id="<portlet:namespace />Aria"><liferay-ui:message key="description" /></label>
+						<div id="<portlet:namespace />metadata">
+							<clay:panel
+								displayTitle='<%= LanguageUtil.get(request, "metadata") %>'
+								displayType="block"
+								expanded="<%= true %>"
+							>
+								<div class="c-gap-4 d-flex flex-column panel-body">
+									<div id="<portlet:namespace />titleMapAsXMLWrapper">
+										<label for="<portlet:namespace />titleMapAsXML" id="<portlet:namespace />Aria"><liferay-ui:message key="title" /></label>
 
-									<liferay-ui:input-localized
-										availableLocales="<%= journalEditArticleDisplayContext.getAvailableLocales() %>"
-										defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
-										editorName="ckeditor"
-										formName="fm"
-										ignoreRequestValue="<%= journalEditArticleDisplayContext.isChangeStructure() %>"
-										languagesDropdownVisible="<%= false %>"
-										name="descriptionMapAsXML"
-										selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>"
-										type="editor"
-										xml="<%= (article != null) ? article.getDescriptionMapAsXML() : StringPool.BLANK %>"
-									/>
-								</div>
+										<aui:input cssClass="form-control-inline form-control-sm" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" languagesDropdownDirection="down" languagesDropdownVisible="<%= false %>" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
+									</div>
 
-								<c:if test="<%= !JournalUtil.isEditDefaultValues(article) %>">
-									<div>
-										<c:if test="<%= Validator.isNotNull(journalEditArticleDisplayContext.getFriendlyURLDuplicatedWarningMessage()) %>">
-											<clay:alert
-												dismissible="<%= true %>"
-												displayType="warning"
-												message="<%= journalEditArticleDisplayContext.getFriendlyURLDuplicatedWarningMessage() %>"
-											/>
-										</c:if>
+									<div id="<portlet:namespace />descriptionMapAsXMLWrapper">
+										<label for="<portlet:namespace />descriptionMapAsXML" id="<portlet:namespace />Aria"><liferay-ui:message key="description" /></label>
 
-										<label for="<portlet:namespace />friendlyURL">
-											<liferay-ui:message key="friendly-url" />
-
-											<%
-											StringBundler sb = new StringBundler(3);
-
-											sb.append(LanguageUtil.get(request, "changing-the-friendly-url-will-affect-all-web-content-article-versions-even-when-saving-it-as-a-draft"));
-											sb.append(StringPool.SPACE);
-											sb.append(LanguageUtil.get(request, "the-friendly-url-may-be-modified-to-ensure-uniqueness"));
-											%>
-
-										</label>
-
-										<span class="d-inline-block lfr-portal-tooltip text-4 text-secondary" tabindex="0" title="<%= sb.toString() %>">
-											<clay:icon
-												symbol="question-circle-full"
-											/>
-										</span>
-
-										<liferay-friendly-url:input
-											className="<%= JournalArticle.class.getName() %>"
-											classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
-											inputAddon="<%= journalEditArticleDisplayContext.getFriendlyURLBase() %>"
+										<liferay-ui:input-localized
+											availableLocales="<%= journalEditArticleDisplayContext.getAvailableLocales() %>"
+											defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
+											editorName="ckeditor"
+											formName="fm"
+											ignoreRequestValue="<%= journalEditArticleDisplayContext.isChangeStructure() %>"
 											languagesDropdownVisible="<%= false %>"
-											name="friendlyURL"
-											showHistory="<%= false %>"
-											showLabel="<%= false %>"
+											name="descriptionMapAsXML"
+											selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>"
+											type="editor"
+											xml="<%= (article != null) ? article.getDescriptionMapAsXML() : StringPool.BLANK %>"
 										/>
 									</div>
-								</c:if>
-							</div>
-						</clay:panel>
 
-						<clay:panel
-							displayTitle='<%= LanguageUtil.get(request, "fields") %>'
-							displayType="block"
-							expanded="<%= true %>"
-						>
-							<div class="c-px-2 panel-body">
-								<%@ include file="/article_content.jspf" %>
-							</div>
-						</clay:panel>
+									<c:if test="<%= !JournalUtil.isEditDefaultValues(article) %>">
+										<div id="<portlet:namespace />friendlyURLWrapper">
+											<c:if test="<%= Validator.isNotNull(journalEditArticleDisplayContext.getFriendlyURLDuplicatedWarningMessage()) %>">
+												<clay:alert
+													dismissible="<%= true %>"
+													displayType="warning"
+													message="<%= journalEditArticleDisplayContext.getFriendlyURLDuplicatedWarningMessage() %>"
+												/>
+											</c:if>
+
+											<label for="<portlet:namespace />friendlyURL">
+												<liferay-ui:message key="friendly-url" />
+
+												<%
+												StringBundler sb = new StringBundler(3);
+
+												sb.append(LanguageUtil.get(request, "changing-the-friendly-url-will-affect-all-web-content-article-versions-even-when-saving-it-as-a-draft"));
+												sb.append(StringPool.SPACE);
+												sb.append(LanguageUtil.get(request, "the-friendly-url-may-be-modified-to-ensure-uniqueness"));
+												%>
+
+											</label>
+
+											<span class="d-inline-block lfr-portal-tooltip text-4 text-secondary" tabindex="0" title="<%= sb.toString() %>">
+												<clay:icon
+													symbol="question-circle-full"
+												/>
+											</span>
+
+											<liferay-friendly-url:input
+												className="<%= JournalArticle.class.getName() %>"
+												classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
+												inputAddon="<%= journalEditArticleDisplayContext.getFriendlyURLBase() %>"
+												languagesDropdownVisible="<%= false %>"
+												name="friendlyURL"
+												showHistory="<%= false %>"
+												showLabel="<%= false %>"
+											/>
+										</div>
+									</c:if>
+								</div>
+							</clay:panel>
+						</div>
+
+						<div id="<portlet:namespace />content">
+							<clay:panel
+								displayTitle='<%= LanguageUtil.get(request, "fields") %>'
+								displayType="block"
+								expanded="<%= true %>"
+							>
+								<div class="c-px-2 panel-body">
+									<%@ include file="/article_content.jspf" %>
+								</div>
+							</clay:panel>
+						</div>
+
+						<div>
+							<react:component
+								module="{EmptyStatePlaceholder} from journal-web"
+							/>
+						</div>
 					</c:when>
 					<c:otherwise>
 						<%@ include file="/article_content.jspf" %>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/index.js
@@ -6,6 +6,8 @@
 export {default as BasicInfoPanel} from './data_engine/panels/index.es';
 export {default as DataEngineLayoutRendererLanguageProxy} from './DataEngineLayoutRendererLanguageProxy.es';
 export {default as HighlightedDDMStructuresConfiguration} from './configuration_browse/HighlightedDDMStructuresConfiguration';
+export {default as EmptyStatePlaceholder} from './translation_manager/EmptyStatePlaceholder';
+export {default as TranslationFilter} from './translation_manager/TranslationFilter';
 export {default as TranslationManager} from './translation_manager/TranslationManager';
 export {default as TranslationOptions} from './translation_manager/TranslationOptions';
 export {default as SaveButtons} from './SaveButtons';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/EmptyStatePlaceholder.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/EmptyStatePlaceholder.js
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayEmptyState from '@clayui/empty-state';
+import React from 'react';
+
+export default function EmptyStatePlaceholder() {
+	return (
+		<ClayEmptyState
+			description={Liferay.Language.get('no-results-were-found')}
+			hidden={true}
+			id="emptyPlaceHolder"
+			imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
+			small
+			title={Liferay.Language.get('no-results-found')}
+		/>
+	);
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
@@ -129,33 +129,34 @@ export default function TranslationFilter({
 
 	return (
 		<>
-			<Picker
-				active={active}
-				as={Trigger}
-				disabled={defaultLanguageId === selectedLanguageId}
-				id="picker"
-				onActiveChange={(active: boolean) => {
-					if (active) {
-						updateTranslations();
-					}
+			{selectedLanguageId !== defaultLanguageId && (
+				<Picker
+					active={active}
+					as={Trigger}
+					id="picker"
+					onActiveChange={(active: boolean) => {
+						if (active) {
+							updateTranslations();
+						}
 
-					setActive(active);
-				}}
-				onSelectionChange={handleSelection}
-				selectedKey={selectedKey}
-			>
-				<Option key="all-fields">
-					{Liferay.Language.get('all-fields')}
-				</Option>
+						setActive(active);
+					}}
+					onSelectionChange={handleSelection}
+					selectedKey={selectedKey}
+				>
+					<Option key="all-fields">
+						{Liferay.Language.get('all-fields')}
+					</Option>
 
-				<Option key="translated">
-					{Liferay.Language.get('translated')}
-				</Option>
+					<Option key="translated">
+						{Liferay.Language.get('translated')}
+					</Option>
 
-				<Option key="untranslated">
-					{Liferay.Language.get('untranslated')}
-				</Option>
-			</Picker>
+					<Option key="untranslated">
+						{Liferay.Language.get('untranslated')}
+					</Option>
+				</Picker>
+			)}
 		</>
 	);
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
@@ -35,6 +35,8 @@ export default function TranslationFilter({
 	const {
 		defaultLanguageId,
 		selectedLanguageId,
+		translationProgress,
+		translations,
 		updateTranslations,
 	} = useTranslationProgress({
 		defaultLanguageId: initialDefaultLanguageId,
@@ -45,9 +47,80 @@ export default function TranslationFilter({
 	});
 
 	const handleSelection = (option: React.Key) => {
-		Liferay.fire('inputLocalized:translationFilterChange', {option})
-		setSelectedKey(option as string)
-	}
+		Liferay.fire('inputLocalized:translationFilterChange', {option});
+
+		const metadataWrapper = document.getElementById(namespace + 'metadata');
+		const contentWrapper = document.getElementById(namespace + 'content');
+		const emptyPlaceholder = document.getElementById('emptyPlaceHolder');
+
+		translations.map((field) => {
+			if (Object.keys(initialFields).includes(field.fieldName)) {
+				const fieldNode = document.getElementById(
+					namespace + field.fieldName + 'Wrapper'
+				);
+				if (
+					fieldNode &&
+					metadataWrapper &&
+					contentWrapper &&
+					emptyPlaceholder
+				) {
+					switch (option) {
+						case 'translated':
+							if (!field.languages.includes(selectedLanguageId)) {
+								fieldNode.hidden = true;
+							}
+							else {
+								fieldNode.hidden = false;
+							}
+							if (
+								!translationProgress?.translatedItems[
+									selectedLanguageId
+								]
+							) {
+								metadataWrapper.hidden = true;
+								contentWrapper.hidden = true;
+								emptyPlaceholder.hidden = false;
+							}
+							else {
+								metadataWrapper.hidden = false;
+								contentWrapper.hidden = false;
+								emptyPlaceholder.hidden = true;
+							}
+							break;
+						case 'untranslated':
+							if (field.languages.includes(selectedLanguageId)) {
+								fieldNode.hidden = true;
+							}
+							else {
+								fieldNode.hidden = false;
+							}
+							if (
+								translationProgress?.totalItems ===
+								translationProgress?.translatedItems[
+									selectedLanguageId
+								]
+							) {
+								metadataWrapper.hidden = true;
+								contentWrapper.hidden = true;
+								emptyPlaceholder.hidden = false;
+							}
+							else {
+								metadataWrapper.hidden = false;
+								contentWrapper.hidden = false;
+								emptyPlaceholder.hidden = true;
+							}
+							break;
+						default:
+							fieldNode.hidden = false;
+							metadataWrapper.hidden = false;
+							contentWrapper.hidden = false;
+							emptyPlaceholder.hidden = true;
+					}
+				}
+			}
+		});
+		setSelectedKey(option as string);
+	};
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Option, Picker} from '@clayui/core';
+import React, {LegacyRef, useState} from 'react';
+
+import {TranslationManagerProps} from './Types';
+import useTranslationProgress from './useTranslationProgress';
+
+const Trigger = React.forwardRef(
+	({children, ...otherProps}, ref: LegacyRef<HTMLButtonElement>) => (
+		<button
+			{...otherProps}
+			className="btn btn-block btn-secondary btn-sm form-control-select"
+			ref={ref}
+			tabIndex={0}
+		>
+			{children}
+		</button>
+	)
+);
+
+export default function TranslationFilter({
+	defaultLanguageId: initialDefaultLanguageId,
+	fields: initialFields,
+	locales,
+	namespace,
+	selectedLanguageId: initialSelectedLanguageId,
+}: TranslationManagerProps) {
+	const [active, setActive] = useState(false);
+	const [selectedKey, setSelectedKey] = useState(() => 'all-fields');
+
+	const {
+		defaultLanguageId,
+		selectedLanguageId,
+		updateTranslations,
+	} = useTranslationProgress({
+		defaultLanguageId: initialDefaultLanguageId,
+		fields: initialFields,
+		locales,
+		namespace,
+		selectedLanguageId: initialSelectedLanguageId,
+	});
+
+	const handleSelection = (option: React.Key) => {
+		Liferay.fire('inputLocalized:translationFilterChange', {option})
+		setSelectedKey(option as string)
+	}
+
+	return (
+		<>
+			<Picker
+				active={active}
+				as={Trigger}
+				disabled={defaultLanguageId === selectedLanguageId}
+				id="picker"
+				onActiveChange={(active: boolean) => {
+					if (active) {
+						updateTranslations();
+					}
+
+					setActive(active);
+				}}
+				onSelectionChange={handleSelection}
+				selectedKey={selectedKey}
+			>
+				<Option key="all-fields">
+					{Liferay.Language.get('all-fields')}
+				</Option>
+
+				<Option key="translated">
+					{Liferay.Language.get('translated')}
+				</Option>
+
+				<Option key="untranslated">
+					{Liferay.Language.get('untranslated')}
+				</Option>
+			</Picker>
+		</>
+	);
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.tsx
@@ -4,7 +4,7 @@
  */
 
 import {Option, Picker} from '@clayui/core';
-import React, {LegacyRef, useState} from 'react';
+import React, {LegacyRef, useEffect, useState} from 'react';
 
 import {TranslationManagerProps} from './Types';
 import useTranslationProgress from './useTranslationProgress';
@@ -121,6 +121,11 @@ export default function TranslationFilter({
 		});
 		setSelectedKey(option as string);
 	};
+
+	useEffect(() => {
+		handleSelection('all-fields');
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [selectedLanguageId]);
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -150,6 +150,7 @@ export default function useTranslationProgress({
 		defaultLanguageId,
 		selectedLanguageId,
 		translationProgress,
+		translations,
 		updateTranslations,
 	};
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -43,7 +43,7 @@ export default function useTranslationProgress({
 						`[type="hidden"][data-field-name="${fieldName}"]`
 					)
 				)
-					.filter((input) => input.value)
+					.filter((input) => input.value || input.getAttribute('data-translated'))
 					.map(
 						(input) =>
 							input.dataset.languageid as Liferay.Language.Locale

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -43,7 +43,10 @@ export default function useTranslationProgress({
 						`[type="hidden"][data-field-name="${fieldName}"]`
 					)
 				)
-					.filter((input) => input.value || input.getAttribute('data-translated'))
+					.filter(
+						(input) =>
+							input.value || input.getAttribute('data-translated')
+					)
 					.map(
 						(input) =>
 							input.dataset.languageid as Liferay.Language.Locale

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -146,13 +146,22 @@ export default function useTranslationProgress({
 		};
 	}, [defaultLocaleChangeHandler, localeChangeHandler]);
 
-	return {
-		defaultLanguageId,
-		selectedLanguageId,
-		translationProgress,
-		translations,
-		updateTranslations,
-	};
+	return useMemo(
+		() => ({
+			defaultLanguageId,
+			selectedLanguageId,
+			translationProgress,
+			translations,
+			updateTranslations,
+		}),
+		[
+			defaultLanguageId,
+			selectedLanguageId,
+			translationProgress,
+			translations,
+			updateTranslations,
+		]
+	);
 }
 
 export function fieldToTranslations(fields: Record<string, Field>) {

--- a/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.d.ts
+++ b/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/TranslationFilter.d.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+import {TranslationManagerProps} from './Types';
+export default function TranslationFilter({
+	defaultLanguageId: initialDefaultLanguageId,
+	fields: initialFields,
+	locales,
+	namespace,
+	selectedLanguageId: initialSelectedLanguageId,
+}: TranslationManagerProps): JSX.Element;

--- a/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.d.ts
+++ b/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.d.ts
@@ -31,6 +31,10 @@ export default function useTranslationProgress({
 		| 'zh_TW';
 	selectedLanguageId: Liferay.Language.Locale;
 	translationProgress: TranslationProgress | null | undefined;
+	translations: {
+		fieldName: string;
+		languages: Liferay.Language.Locale[];
+	}[];
 	updateTranslations: () => void;
 };
 export declare function fieldToTranslations(


### PR DESCRIPTION
Epic: [LPD-11253](https://liferay.atlassian.net/browse/LPD-11253)
Story: [LPD-6603](https://liferay.atlassian.net/browse/LPD-6603)

Missing requirement:
- If Translated or Untranslated option are selected and there is module: Metadata or Fields, that has no fields meeting the criteria, the whole module should not appear.
In order to implement this, We have to update the useTranslationProgress hook to track the translations separately for MetaFields and DDMFields. I opened another technical task for it: [LPD-22957](https://liferay.atlassian.net/browse/LPD-22957)

Impedibug discovered:
There is a bug with the rich text field, when we change locale the rich-text field already considered translated. This can be reproduced consistently when changing locale the first time and when we change locale from a fully translated locale. This needs to be investigated, but it is connected to the useTranslationProgress hook and DDM not to this story

needs:
feature.flag.LPS-114700=true
feature.flag.LPD-11253=true
