### PR TITLE
LPD-17795 Skip test until bug is fixed

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileShortcut.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileShortcut.testcase
@@ -250,6 +250,7 @@ definition {
 	}
 
 	@description = "This validates LPS-68795. It ensures that a shortcut can be moved into a folder."
+	@ignore = "true"
 	@priority = 4
 	test CanMoveShortcutIntoFolder {
 		property custom.properties = "dl.actions.visible=true";


### PR DESCRIPTION
Ignore test `DMFileShortcut#CanMoveShortcutIntoFolder` until related bug is fixed. 