### PR TITLE
LPD-24189 Validations when setting display date in D&M

### DIFF
--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -42,13 +44,14 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
 import com.liferay.portletmvc4spring.test.mock.web.portlet.MockPortletSession;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -98,14 +101,24 @@ public class EditFileEntryMVCActionCommandTest {
 			_editFileEntryMVCActionCommand, "_addMultipleFileEntries",
 			new Class<?>[] {
 				PortletConfig.class, ActionRequest.class, String.class,
-				List.class, List.class, Date.class, Date.class, Date.class,
-				ServiceContext.class
+				List.class, List.class, Boolean.class, User.class,
+				UploadPortletRequest.class, ServiceContext.class
 			},
 			_getLiferayPortletConfig(),
 			_getMockLiferayPortletActionRequest(
 				_getParameters(tempFileEntry, Constants.ADD_MULTIPLE)),
 			tempFileEntry.getFileName(), new ArrayList<>(), new ArrayList<>(),
-			null, null, null, ServiceContextTestUtil.getServiceContext());
+			true, TestPropsValues.getUser(),
+			UploadTestUtil.createUploadPortletRequest(
+				UploadTestUtil.createUploadServletRequest(
+					new MockHttpServletRequest(), null,
+					HashMapBuilder.put(
+						"groupId",
+						Collections.singletonList(
+							String.valueOf(_group.getGroupId()))
+					).build()),
+				null, RandomTestUtil.randomString()),
+			ServiceContextTestUtil.getServiceContext());
 
 		FileEntry fileName = _dlAppLocalService.getFileEntryByFileName(
 			_group.getGroupId(), tempFileEntry.getFolderId(), "image.jpg");
@@ -141,18 +154,30 @@ public class EditFileEntryMVCActionCommandTest {
 		Map<String, String[]> parameters = _getParameters(
 			tempFileEntry, Constants.ADD_MULTIPLE);
 
+		UploadPortletRequest uploadPortletRequest =
+			UploadTestUtil.createUploadPortletRequest(
+				UploadTestUtil.createUploadServletRequest(
+					new MockHttpServletRequest(), null,
+					HashMapBuilder.put(
+						"groupId",
+						Collections.singletonList(
+							String.valueOf(_group.getGroupId()))
+					).build()),
+				null, RandomTestUtil.randomString());
+
 		for (String selectedFileName : selectedFileNames) {
 			ReflectionTestUtil.invoke(
 				_editFileEntryMVCActionCommand, "_addMultipleFileEntries",
 				new Class<?>[] {
 					PortletConfig.class, ActionRequest.class, String.class,
-					List.class, List.class, Date.class, Date.class, Date.class,
-					ServiceContext.class
+					List.class, List.class, Boolean.class, User.class,
+					UploadPortletRequest.class, ServiceContext.class
 				},
 				_getLiferayPortletConfig(),
 				_getMockLiferayPortletActionRequest(parameters),
-				selectedFileName, new ArrayList<>(), new ArrayList<>(), null,
-				null, null, ServiceContextTestUtil.getServiceContext());
+				selectedFileName, new ArrayList<>(), new ArrayList<>(), true,
+				TestPropsValues.getUser(), uploadPortletRequest,
+				ServiceContextTestUtil.getServiceContext());
 		}
 
 		long folderId = tempFileEntry.getFolderId();
@@ -197,18 +222,30 @@ public class EditFileEntryMVCActionCommandTest {
 		Map<String, String[]> parameters = _getParameters(
 			tempFileEntry, Constants.ADD_MULTIPLE);
 
+		UploadPortletRequest uploadPortletRequest =
+			UploadTestUtil.createUploadPortletRequest(
+				UploadTestUtil.createUploadServletRequest(
+					new MockHttpServletRequest(), null,
+					HashMapBuilder.put(
+						"groupId",
+						Collections.singletonList(
+							String.valueOf(_group.getGroupId()))
+					).build()),
+				null, RandomTestUtil.randomString());
+
 		for (String selectedFileName : selectedFileNames) {
 			ReflectionTestUtil.invoke(
 				_editFileEntryMVCActionCommand, "_addMultipleFileEntries",
 				new Class<?>[] {
 					PortletConfig.class, ActionRequest.class, String.class,
-					List.class, List.class, Date.class, Date.class, Date.class,
-					ServiceContext.class
+					List.class, List.class, Boolean.class, User.class,
+					UploadPortletRequest.class, ServiceContext.class
 				},
 				_getLiferayPortletConfig(),
 				_getMockLiferayPortletActionRequest(parameters),
-				selectedFileName, new ArrayList<>(), new ArrayList<>(), null,
-				null, null, ServiceContextTestUtil.getServiceContext());
+				selectedFileName, new ArrayList<>(), new ArrayList<>(), true,
+				TestPropsValues.getUser(), uploadPortletRequest,
+				ServiceContextTestUtil.getServiceContext());
 		}
 
 		long folderId = tempFileEntry.getFolderId();
@@ -253,18 +290,30 @@ public class EditFileEntryMVCActionCommandTest {
 		Map<String, String[]> parameters = _getParameters(
 			tempFileEntry, Constants.ADD_MULTIPLE);
 
+		UploadPortletRequest uploadPortletRequest =
+			UploadTestUtil.createUploadPortletRequest(
+				UploadTestUtil.createUploadServletRequest(
+					new MockHttpServletRequest(), null,
+					HashMapBuilder.put(
+						"groupId",
+						Collections.singletonList(
+							String.valueOf(_group.getGroupId()))
+					).build()),
+				null, RandomTestUtil.randomString());
+
 		for (String selectedFileName : selectedFileNames) {
 			ReflectionTestUtil.invoke(
 				_editFileEntryMVCActionCommand, "_addMultipleFileEntries",
 				new Class<?>[] {
 					PortletConfig.class, ActionRequest.class, String.class,
-					List.class, List.class, Date.class, Date.class, Date.class,
-					ServiceContext.class
+					List.class, List.class, Boolean.class, User.class,
+					UploadPortletRequest.class, ServiceContext.class
 				},
 				_getLiferayPortletConfig(),
 				_getMockLiferayPortletActionRequest(parameters),
-				selectedFileName, new ArrayList<>(), new ArrayList<>(), null,
-				null, null, ServiceContextTestUtil.getServiceContext());
+				selectedFileName, new ArrayList<>(), new ArrayList<>(), true,
+				TestPropsValues.getUser(), uploadPortletRequest,
+				ServiceContextTestUtil.getServiceContext());
 		}
 
 		long folderId = tempFileEntry.getFolderId();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -399,21 +399,11 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		User user = _userLocalService.getUser(themeDisplay.getUserId());
 
-		Date displayDate = _getDisplayDate(
-			uploadPortletRequest, neverExpireDefaultValue, user.getTimeZone());
-
-		Date expirationDate = _getExpirationDate(
-			uploadPortletRequest, displayDate, neverExpireDefaultValue,
-			user.getTimeZone());
-
-		Date reviewDate = _getReviewDate(
-			uploadPortletRequest, neverExpireDefaultValue, user.getTimeZone());
-
 		for (String selectedFileName : selectedFileNames) {
 			_addMultipleFileEntries(
 				portletConfig, actionRequest, selectedFileName,
-				validFileNameKVPs, invalidFileNameKVPs, displayDate,
-				expirationDate, reviewDate, serviceContext);
+				validFileNameKVPs, invalidFileNameKVPs, neverExpireDefaultValue,
+				user, uploadPortletRequest, serviceContext);
 		}
 
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
@@ -452,8 +442,10 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 	private void _addMultipleFileEntries(
 			PortletConfig portletConfig, ActionRequest actionRequest,
 			String selectedFileName, List<KeyValuePair> validFileNameKVPs,
-			List<KeyValuePair> invalidFileNameKVPs, Date displayDate,
-			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
+			List<KeyValuePair> invalidFileNameKVPs,
+			boolean neverExpireDefaultValue, User user,
+			UploadPortletRequest uploadPortletRequest,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
@@ -467,6 +459,18 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		FileEntry tempFileEntry = null;
 
 		try {
+			Date displayDate = _getDisplayDate(
+				uploadPortletRequest, neverExpireDefaultValue,
+				user.getTimeZone());
+
+			Date expirationDate = _getExpirationDate(
+				uploadPortletRequest, displayDate, neverExpireDefaultValue,
+				user.getTimeZone());
+
+			Date reviewDate = _getReviewDate(
+				uploadPortletRequest, neverExpireDefaultValue,
+				user.getTimeZone());
+
 			tempFileEntry = TempFileEntryUtil.getTempFileEntry(
 				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 				TEMP_FOLDER_NAME, selectedFileName);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -443,7 +443,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 			PortletConfig portletConfig, ActionRequest actionRequest,
 			String selectedFileName, List<KeyValuePair> validFileNameKVPs,
 			List<KeyValuePair> invalidFileNameKVPs,
-			boolean neverExpireDefaultValue, User user,
+			Boolean neverExpireDefaultValue, User user,
 			UploadPortletRequest uploadPortletRequest,
 			ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -889,6 +889,21 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 				"the-folder-you-selected-already-has-an-entry-with-this-" +
 					"name.-please-select-a-different-folder");
 		}
+		else if (exception instanceof FileEntryDisplayDateException) {
+			errorMessage = _language.get(
+				_portal.getHttpServletRequest(actionRequest),
+				"please-enter-a-valid-publish-date");
+		}
+		else if (exception instanceof FileEntryExpirationDateException) {
+			errorMessage = _language.get(
+				_portal.getHttpServletRequest(actionRequest),
+				"please-enter-a-valid-expiration-date");
+		}
+		else if (exception instanceof FileEntryReviewDateException) {
+			errorMessage = _language.get(
+				_portal.getHttpServletRequest(actionRequest),
+				"please-enter-a-valid-review-date");
+		}
 		else if (exception instanceof FileExtensionException) {
 			errorMessage = _language.format(
 				themeDisplay.getLocale(),

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -50,7 +50,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -520,7 +520,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		ActionRequest actionRequest, FileVersion fileVersion,
 		ThemeDisplay themeDisplay) {
 
-		if (!_featureFlagManager.isEnabled("LPD-10701") ||
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-10701") ||
 			!fileVersion.isScheduled()) {
 
 			String portletResource = ParamUtil.getString(
@@ -999,7 +999,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		throws PortalException {
 
 		if (addDynamic || !PropsValues.SCHEDULER_ENABLED ||
-			!_featureFlagManager.isEnabled("LPD-10701")) {
+			!FeatureFlagManagerUtil.isEnabled("LPD-10701")) {
 
 			return null;
 		}
@@ -1550,9 +1550,6 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLTrashService _dlTrashService;
-
-	@Reference
-	private FeatureFlagManager _featureFlagManager;
 
 	@Reference
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;


### PR DESCRIPTION

https://liferay.atlassian.net/browse/LPD-24189


How to test it

1) enable FF 
2) Go to D&M > New > Multiple Files Upload > select or drag file(s)
3) set a display date AFTER a expiration date

- there is an error on each file
- 
![image](https://github.com/liferay-content-management/liferay-portal/assets/47524751/e35d124f-04cf-4165-9743-d864fcf85917)




- **LPD-24189 the error message must be shown on each file so we must include all the possible causes inside of the try catch of the message creation**
- **LPD-24189 put the relevant message for each relevant exception**
