### PR TITLE
LPD-24145 if is a shortcut, use the shortcut data instead of the file

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -441,6 +441,14 @@ public class UIItemsBuilder {
 						(ItemSelector)_httpServletRequest.getAttribute(
 							ItemSelector.class.getName()));
 
+				if (_fileShortcut != null) {
+					return folderItemSelectorURLProvider.
+						getSelectMoveToFolderURL(
+							_fileShortcut.getRepositoryId(),
+							_fileShortcut.getFolderId(),
+							DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+				}
+
 				return folderItemSelectorURLProvider.getSelectMoveToFolderURL(
 					_fileEntry.getRepositoryId(), _fileEntry.getFolderId(),
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/document-libary/JSONDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/document-libary/JSONDocument.macro
@@ -288,7 +288,6 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 		var targetRepositoryId = JSONGroupAPI._getSiteIdByGroupKey(groupName = ${targetGroupName});
-		var sourceRepositoryId = JSONGroupAPI._getSiteIdByGroupKey(groupName = ${sourceGroupName});
 
 		if (isSet(sourceFolderName)) {
 			Variables.assertDefined(parameterList = ${sourceFolderName});
@@ -339,12 +338,15 @@ definition {
 		}
 
 		var userLoginInfo = JSONUtil2.formatJSONUser();
+		var targetGroupId = JSONGroupAPI._getGroupIdByName(
+			groupName = ${targetGroupName},
+			site = "true");
 
 		var curl = '''
 			${portalURL}/api/jsonws/dlfileshortcut/add-file-shortcut  \
 				-u ${userLoginInfo} \
-				-d groupId=${targetRepositoryId} \
-				-d repositoryId=${sourceRepositoryId} \
+				-d groupId=${targetGroupId} \
+				-d repositoryId=${targetRepositoryId} \
 				-d folderId=${targetFolderId} \
 				-d toFileEntryId=${fileEntryId}
 		''';

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileShortcut.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileShortcut.testcase
@@ -250,7 +250,6 @@ definition {
 	}
 
 	@description = "This validates LPS-68795. It ensures that a shortcut can be moved into a folder."
-	@ignore = "true"
 	@priority = 4
 	test CanMoveShortcutIntoFolder {
 		property custom.properties = "dl.actions.visible=true";


### PR DESCRIPTION

Steps to reproduce: 

1) On current site (Liferay) go to Content and Data > Documents and Media 
2) Create a file entry DM Document Title
3) Create a new site Site Name
4) On the new site, go to Content and Data > Documents and Media 
5) Create a shortcut to the DM Document Title that is on site Liferay (select from breadcrumb)
6) Once created, click on Move action and check the breadcrumb

**Expected result:** 
It opens where the shortcut is (Site and Libraries > Site Name)


Other Steps to reproduce:

1) Create new File
2) Create shortcut to this file Navigate to media.
3) Create a Folder
4) Move File to the folder
5) Move Shortcut to the folder

**Expected result:** 
you can move to the folder




- **LPD-24145 if is a shortcut, use the shortcut data instead of the file**
- **LPD-24145 remove the ignore on the poshi test**
