### PR TITLE
LPD-19196 Show scheduled document on search on management toolbar

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelIndexerWriterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelIndexerWriterContributor.java
@@ -79,7 +79,7 @@ public class DLFileEntryModelIndexerWriterContributor
 		}
 
 		if (!dlFileEntry.isInTrash() && !dlFileVersion.isApproved() &&
-			!dlFileVersion.isExpired()) {
+			!dlFileVersion.isExpired() && !dlFileVersion.isScheduled()) {
 
 			return IndexerWriterMode.SKIP;
 		}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
@@ -61,6 +61,125 @@ public class DLFileEntrySearchByStatusTest {
 	}
 
 	@Test
+	public void testSearchFileAnyStatus() throws Exception {
+		String titlePrefix = "Document ";
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
+		searchContext.setKeywords(titlePrefix);
+
+		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
+			DLFileEntry.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(
+			searchContext.getAttribute("queryString") + "->" + hits, 2,
+			hits.getLength());
+	}
+
+	@Test
+	public void testSearchFileApprovedStatus() throws Exception {
+		String titlePrefix = "Document ";
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setAttribute("status", WorkflowConstants.STATUS_APPROVED);
+		searchContext.setKeywords(titlePrefix);
+
+		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
+			DLFileEntry.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(
+			searchContext.getAttribute("queryString") + "->" + hits, 1,
+			hits.getLength());
+	}
+
+	@Test
+	public void testSearchFileNoStatusOnlyApproved() throws Exception {
+		String titlePrefix = "Document ";
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
+			displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setKeywords(titlePrefix);
+
+		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
+			DLFileEntry.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(
+			searchContext.getAttribute("queryString") + "->" + hits, 1,
+			hits.getLength());
+	}
+
+	@Test
 	public void testSearchScheduledFile() throws Exception {
 		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@FeatureFlags("LPD-10701")
+@RunWith(Arquillian.class)
+@Sync
+public class DLFileEntrySearchByStatusTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testSearchScheduledFile() throws Exception {
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		String title = "Document";
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			title, StringPool.BLANK, StringUtil.randomString(),
+			StringUtil.randomString(), new byte[0], displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
+		searchContext.setKeywords(title);
+
+		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
+			DLFileEntry.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(
+			searchContext.getAttribute("queryString") + "->" + hits, 1,
+			hits.getLength());
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private IndexerRegistry _indexerRegistry;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
@@ -71,20 +71,7 @@ public class DLFileEntrySearchByStatusTest {
 		_addFileEntry(
 			displayDate, titlePrefix + " " + StringUtil.randomString());
 
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
-			_group.getGroupId());
-
-		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
-		searchContext.setKeywords(titlePrefix);
-
-		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
-			DLFileEntry.class);
-
-		Hits hits = indexer.search(searchContext);
-
-		Assert.assertEquals(
-			searchContext.getAttribute("queryString") + "->" + hits, 2,
-			hits.getLength());
+		_assertHits(2, titlePrefix, true, WorkflowConstants.STATUS_ANY);
 	}
 
 	@Test
@@ -98,20 +85,7 @@ public class DLFileEntrySearchByStatusTest {
 		_addFileEntry(
 			displayDate, titlePrefix + " " + StringUtil.randomString());
 
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
-			_group.getGroupId());
-
-		searchContext.setAttribute("status", WorkflowConstants.STATUS_APPROVED);
-		searchContext.setKeywords(titlePrefix);
-
-		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
-			DLFileEntry.class);
-
-		Hits hits = indexer.search(searchContext);
-
-		Assert.assertEquals(
-			searchContext.getAttribute("queryString") + "->" + hits, 1,
-			hits.getLength());
+		_assertHits(1, titlePrefix, true, WorkflowConstants.STATUS_APPROVED);
 	}
 
 	@Test
@@ -124,19 +98,7 @@ public class DLFileEntrySearchByStatusTest {
 
 		_addFileEntry(displayDate, titlePrefix + StringUtil.randomString());
 
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
-			_group.getGroupId());
-
-		searchContext.setKeywords(titlePrefix);
-
-		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
-			DLFileEntry.class);
-
-		Hits hits = indexer.search(searchContext);
-
-		Assert.assertEquals(
-			searchContext.getAttribute("queryString") + "->" + hits, 1,
-			hits.getLength());
+		_assertHits(1, titlePrefix, false, WorkflowConstants.STATUS_ANY);
 	}
 
 	@Test
@@ -147,20 +109,7 @@ public class DLFileEntrySearchByStatusTest {
 			new Date(System.currentTimeMillis() + Time.DAY),
 			title + " " + StringUtil.randomString());
 
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
-			_group.getGroupId());
-
-		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
-		searchContext.setKeywords(title);
-
-		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
-			DLFileEntry.class);
-
-		Hits hits = indexer.search(searchContext);
-
-		Assert.assertEquals(
-			searchContext.getAttribute("queryString") + "->" + hits, 1,
-			hits.getLength());
+		_assertHits(1, title, true, WorkflowConstants.STATUS_ANY);
 	}
 
 	private void _addFileEntry(Date displayDate, String title)
@@ -173,6 +122,29 @@ public class DLFileEntrySearchByStatusTest {
 			title, StringPool.BLANK, StringUtil.randomString(),
 			StringUtil.randomString(), new byte[0], displayDate, null, null,
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private void _assertHits(
+			int expectedCount, String keywords, boolean setStatus, int status)
+		throws Exception {
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		if (setStatus) {
+			searchContext.setAttribute("status", status);
+		}
+
+		searchContext.setKeywords(keywords);
+
+		Indexer<DLFileEntry> indexer = _indexerRegistry.getIndexer(
+			DLFileEntry.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(
+			searchContext.getAttribute("queryString") + "->" + hits,
+			expectedCount, hits.getLength());
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchByStatusTest.java
@@ -62,27 +62,14 @@ public class DLFileEntrySearchByStatusTest {
 
 	@Test
 	public void testSearchFileAnyStatus() throws Exception {
-		String titlePrefix = "Document ";
+		String titlePrefix = "Document";
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			null, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(null, titlePrefix + StringUtil.randomString());
 
 		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			displayDate, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(
+			displayDate, titlePrefix + " " + StringUtil.randomString());
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
 			_group.getGroupId());
@@ -102,27 +89,14 @@ public class DLFileEntrySearchByStatusTest {
 
 	@Test
 	public void testSearchFileApprovedStatus() throws Exception {
-		String titlePrefix = "Document ";
+		String titlePrefix = "Document";
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			null, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(null, titlePrefix + StringUtil.randomString());
 
 		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			displayDate, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(
+			displayDate, titlePrefix + " " + StringUtil.randomString());
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
 			_group.getGroupId());
@@ -142,27 +116,13 @@ public class DLFileEntrySearchByStatusTest {
 
 	@Test
 	public void testSearchFileNoStatusOnlyApproved() throws Exception {
-		String titlePrefix = "Document ";
+		String titlePrefix = "Document";
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			null, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(null, titlePrefix + " " + StringUtil.randomString());
 
 		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			titlePrefix + StringUtil.randomString(), StringPool.BLANK,
-			StringUtil.randomString(), StringUtil.randomString(), new byte[0],
-			displayDate, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(displayDate, titlePrefix + StringUtil.randomString());
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
 			_group.getGroupId());
@@ -181,17 +141,11 @@ public class DLFileEntrySearchByStatusTest {
 
 	@Test
 	public void testSearchScheduledFile() throws Exception {
-		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
-
 		String title = "Document";
 
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			title, StringPool.BLANK, StringUtil.randomString(),
-			StringUtil.randomString(), new byte[0], displayDate, null, null,
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_addFileEntry(
+			new Date(System.currentTimeMillis() + Time.DAY),
+			title + " " + StringUtil.randomString());
 
 		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
 			_group.getGroupId());
@@ -207,6 +161,18 @@ public class DLFileEntrySearchByStatusTest {
 		Assert.assertEquals(
 			searchContext.getAttribute("queryString") + "->" + hits, 1,
 			hits.getLength());
+	}
+
+	private void _addFileEntry(Date displayDate, String title)
+		throws Exception {
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			title, StringPool.BLANK, StringUtil.randomString(),
+			StringUtil.randomString(), new byte[0], displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -58,10 +58,8 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
-import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -70,7 +68,6 @@ import java.io.File;
 import java.io.InputStream;
 
 import java.util.Collections;
-import java.util.Date;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -210,28 +207,6 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchByDDMStructureField() throws Exception {
-	}
-
-	@FeatureFlags("LPD-10701")
-	@Test
-	public void testSearchScheduledFile() throws Exception {
-		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
-
-		_dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
-			"Document", StringPool.BLANK, StringUtil.randomString(),
-			StringUtil.randomString(), new byte[0], displayDate, null, null,
-			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
-
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
-			group.getGroupId());
-
-		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
-		searchContext.setKeywords("Document");
-
-		assertBaseModelsCount(1, "Document", searchContext);
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -13,11 +13,11 @@ import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
-import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLTrashServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.document.library.kernel.service.DLTrashService;
 import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.dynamic.data.mapping.configuration.DDMIndexerConfiguration;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormFieldValue;
@@ -27,12 +27,12 @@ import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.search.TestOrderHelper;
-import com.liferay.dynamic.data.mapping.util.DDMBeanTranslatorUtil;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.dynamic.data.mapping.util.DDMBeanTranslator;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
-import com.liferay.dynamic.data.mapping.util.DDMUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -55,9 +55,10 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
 import com.liferay.portal.test.rule.Inject;
@@ -68,6 +69,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import java.util.Collections;
+import java.util.Date;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -235,7 +237,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 			file = FileUtil.createTempFile(inputStream);
 
-			DLAppLocalServiceUtil.addFileEntry(
+			_dlAppLocalService.addFileEntry(
 				null, serviceContext.getUserId(),
 				serviceContext.getScopeGroupId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName, mimeType,
@@ -252,7 +254,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@Test
 	public void testSearchTreePath() throws Exception {
-		DLAppLocalServiceUtil.addFileEntry(
+		_dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
@@ -260,13 +262,13 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			StringUtil.randomString(), new byte[0], null, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		Folder folder = DLAppLocalServiceUtil.addFolder(
+		Folder folder = _dlAppLocalService.addFolder(
 			null, TestPropsValues.getUserId(), group.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), StringUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
-		DLAppLocalServiceUtil.addFileEntry(
+		_dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), group.getGroupId(),
 			folder.getFolderId(), StringUtil.randomString(),
 			ContentTypes.APPLICATION_OCTET_STREAM, "Document", StringPool.BLANK,
@@ -301,11 +303,11 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		_ddmStructure = ddmStructure;
 
 		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.fetchDataDefinitionFileEntryType(
+			_dlFileEntryTypeLocalService.fetchDataDefinitionFileEntryType(
 				ddmStructure.getGroupId(), ddmStructure.getStructureId());
 
 		if (dlFileEntryType == null) {
-			dlFileEntryType = DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+			dlFileEntryType = _dlFileEntryTypeLocalService.addFileEntryType(
 				TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 				ddmStructure.getStructureId(), null,
 				Collections.singletonMap(
@@ -315,7 +317,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
 				serviceContext);
 
-			DLFileEntryTypeLocalServiceUtil.addDDMStructureLinks(
+			_dlFileEntryTypeLocalService.addDDMStructureLinks(
 				dlFileEntryType.getFileEntryTypeId(),
 				SetUtil.fromArray(ddmStructure.getStructureId()));
 		}
@@ -323,7 +325,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		String content = "Content: Enterprise. Open Source. For Life.";
 
 		DDMFormValues ddmFormValues = createDDMFormValues(
-			DDMBeanTranslatorUtil.translate(ddmStructure.getDDMForm()));
+			_ddmBeanTranslator.translate(ddmStructure.getDDMForm()));
 
 		for (String keyword : keywords) {
 			ddmFormValues.addDDMFormFieldValue(
@@ -339,7 +341,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 				ddmStructure.getStructureId(),
 			ddmFormValues);
 
-		FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
@@ -415,7 +417,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void deleteBaseModel(long primaryKey) throws Exception {
-		DLFileEntryLocalServiceUtil.deleteFileEntry(primaryKey);
+		_dlFileEntryLocalService.deleteFileEntry(primaryKey);
 	}
 
 	@Override
@@ -427,10 +429,10 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		DLFileEntry dlFileEntry = (DLFileEntry)baseModel;
 
 		if (expireAllVersions) {
-			DLAppServiceUtil.deleteFileEntry(dlFileEntry.getFileEntryId());
+			_dlAppService.deleteFileEntry(dlFileEntry.getFileEntryId());
 		}
 		else {
-			DLAppServiceUtil.deleteFileVersion(
+			_dlAppService.deleteFileVersion(
 				dlFileEntry.getFileEntryId(), dlFileEntry.getVersion());
 		}
 	}
@@ -452,7 +454,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			BaseModel<?> parentBaseModel, ServiceContext serviceContext)
 		throws Exception {
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, serviceContext.getScopeGroupId(),
 			(Long)parentBaseModel.getPrimaryKeyObj(),
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
@@ -466,7 +468,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			Group group, ServiceContext serviceContext)
 		throws Exception {
 
-		Folder folder = DLAppServiceUtil.addFolder(
+		Folder folder = _dlAppService.addFolder(
 			null, serviceContext.getScopeGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(_FOLDER_NAME_MAX_LENGTH),
@@ -492,21 +494,21 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void moveBaseModelToTrash(long primaryKey) throws Exception {
-		DLTrashServiceUtil.moveFileEntryToTrash(primaryKey);
+		_dlTrashService.moveFileEntryToTrash(primaryKey);
 	}
 
 	@Override
 	protected void moveParentBaseModelToTrash(long primaryKey)
 		throws Exception {
 
-		DLTrashServiceUtil.moveFolderToTrash(primaryKey);
+		_dlTrashService.moveFolderToTrash(primaryKey);
 	}
 
 	@Override
 	protected Hits searchGroupEntries(long groupId, long creatorUserId)
 		throws Exception {
 
-		return DLAppServiceUtil.search(
+		return _dlAppService.search(
 			groupId, creatorUserId, WorkflowConstants.STATUS_APPROVED,
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 	}
@@ -519,7 +521,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 		DLFileEntry dlFileEntry = (DLFileEntry)baseModel;
 
-		FileEntry fileEntry = DLAppServiceUtil.updateFileEntry(
+		FileEntry fileEntry = _dlAppService.updateFileEntry(
 			dlFileEntry.getFileEntryId(), null, dlFileEntry.getMimeType(),
 			keywords, StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			DLVersionNumberIncrease.MAJOR, (byte[])null,
@@ -535,9 +537,9 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 		DDMForm ddmForm = DDMStructureTestUtil.getSampleDDMForm("title");
 
-		DDMFormLayout ddmFormLayout = DDMUtil.getDefaultDDMFormLayout(ddmForm);
+		DDMFormLayout ddmFormLayout = _ddm.getDefaultDDMFormLayout(ddmForm);
 
-		DDMStructureLocalServiceUtil.updateStructure(
+		_ddmStructureLocalService.updateStructure(
 			_ddmStructure.getUserId(), _ddmStructure.getStructureId(),
 			_ddmStructure.getParentStructureId(), _ddmStructure.getNameMap(),
 			_ddmStructure.getDescriptionMap(), ddmForm, ddmFormLayout,
@@ -582,7 +584,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 		@Override
 		protected long getClassNameId() {
-			return PortalUtil.getClassNameId(DLFileEntryMetadata.class);
+			return _portal.getClassNameId(DLFileEntryMetadata.class);
 		}
 
 		@Override
@@ -610,6 +612,33 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Inject
 	private static DDMIndexer _ddmIndexer;
 
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMBeanTranslator _ddmBeanTranslator;
+
 	private DDMStructure _ddmStructure;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLAppService _dlAppService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
+
+	@Inject
+	private DLTrashService _dlTrashService;
+
+	@Inject
+	private Portal _portal;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -209,6 +210,28 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchByDDMStructureField() throws Exception {
+	}
+
+	@FeatureFlags("LPD-10701")
+	@Test
+	public void testSearchScheduledFile() throws Exception {
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		_dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.APPLICATION_OCTET_STREAM,
+			"Document", StringPool.BLANK, StringUtil.randomString(),
+			StringUtil.randomString(), new byte[0], displayDate, null, null,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			group.getGroupId());
+
+		searchContext.setAttribute("status", WorkflowConstants.STATUS_ANY);
+		searchContext.setKeywords("Document");
+
+		assertBaseModelsCount(1, "Document", searchContext);
 	}
 
 	@Test

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
@@ -367,6 +367,12 @@ public class DLFileVersionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByF_SArrayable() throws Exception {
+		_persistence.countByF_S(
+			RandomTestUtil.nextLong(), new int[] {RandomTestUtil.nextInt(), 0});
+	}
+
+	@Test
 	public void testCountByLtD_S() throws Exception {
 		_persistence.countByLtD_S(
 			RandomTestUtil.nextDate(), RandomTestUtil.nextInt());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -347,7 +347,7 @@
 		</finder>
 		<finder name="F_S" return-type="Collection">
 			<finder-column name="fileEntryId" />
-			<finder-column name="status" />
+			<finder-column arrayable-operator="OR" name="status" />
 		</finder>
 		<finder name="LtD_S" return-type="Collection">
 			<finder-column comparator="&lt;" name="displayDate" />

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -469,7 +469,7 @@ public class DLAppHelperLocalServiceImpl
 				visible = true;
 			}
 			else {
-				addDraftAssetEntry = _addDraftAssetEntry(dlFileVersion);
+				addDraftAssetEntry = _isAddDraftAssetEntry(dlFileVersion);
 			}
 		}
 		else {
@@ -880,7 +880,7 @@ public class DLAppHelperLocalServiceImpl
 		}
 	}
 
-	private boolean _addDraftAssetEntry(DLFileVersion dlFileVersion) {
+	private boolean _isAddDraftAssetEntry(DLFileVersion dlFileVersion) {
 		String version = dlFileVersion.getVersion();
 
 		if (version.equals(DLFileEntryConstants.VERSION_DEFAULT)) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -880,6 +880,23 @@ public class DLAppHelperLocalServiceImpl
 		}
 	}
 
+	private void _deleteFileEntry(long fileEntryId) throws PortalException {
+
+		// File shortcuts
+
+		_dlFileShortcutLocalService.deleteFileShortcuts(fileEntryId);
+
+		// Asset
+
+		_assetEntryLocalService.deleteEntry(
+			DLFileEntryConstants.getClassName(), fileEntryId);
+
+		// Ratings
+
+		_ratingsStatsLocalService.deleteStats(
+			DLFileEntryConstants.getClassName(), fileEntryId);
+	}
+
 	private boolean _isAddDraftAssetEntry(DLFileVersion dlFileVersion) {
 		String version = dlFileVersion.getVersion();
 
@@ -903,23 +920,6 @@ public class DLAppHelperLocalServiceImpl
 		}
 
 		return true;
-	}
-
-	private void _deleteFileEntry(long fileEntryId) throws PortalException {
-
-		// File shortcuts
-
-		_dlFileShortcutLocalService.deleteFileShortcuts(fileEntryId);
-
-		// Asset
-
-		_assetEntryLocalService.deleteEntry(
-			DLFileEntryConstants.getClassName(), fileEntryId);
-
-		// Ratings
-
-		_ratingsStatsLocalService.deleteStats(
-			DLFileEntryConstants.getClassName(), fileEntryId);
 	}
 
 	private static final int[] _ASSET_ENTRY_CREATION_STATUSES = {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -677,7 +677,8 @@ public class DLAppHelperLocalServiceImpl
 			return;
 		}
 
-		if (newStatus == WorkflowConstants.STATUS_APPROVED) {
+		if ((newStatus == WorkflowConstants.STATUS_APPROVED) ||
+			(newStatus == WorkflowConstants.STATUS_SCHEDULED)) {
 
 			// Asset
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -469,11 +469,7 @@ public class DLAppHelperLocalServiceImpl
 				visible = true;
 			}
 			else {
-				String version = dlFileVersion.getVersion();
-
-				if (!version.equals(DLFileEntryConstants.VERSION_DEFAULT)) {
-					addDraftAssetEntry = true;
-				}
+				addDraftAssetEntry = _addDraftAssetEntry(dlFileVersion);
 			}
 		}
 		else {
@@ -883,6 +879,31 @@ public class DLAppHelperLocalServiceImpl
 		}
 	}
 
+	private boolean _addDraftAssetEntry(DLFileVersion dlFileVersion) {
+		String version = dlFileVersion.getVersion();
+
+		if (version.equals(DLFileEntryConstants.VERSION_DEFAULT)) {
+			return false;
+		}
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			DLFileEntryConstants.getClassName(),
+			dlFileVersion.getFileEntryId());
+
+		if (assetEntry == null) {
+			return false;
+		}
+
+		int approvedFileVersions = _dlFileVersionPersistence.countByF_S(
+			dlFileVersion.getFileEntryId(), _ASSET_ENTRY_CREATION_STATUSES);
+
+		if (approvedFileVersions == 0) {
+			return false;
+		}
+
+		return true;
+	}
+
 	private void _deleteFileEntry(long fileEntryId) throws PortalException {
 
 		// File shortcuts
@@ -899,6 +920,11 @@ public class DLAppHelperLocalServiceImpl
 		_ratingsStatsLocalService.deleteStats(
 			DLFileEntryConstants.getClassName(), fileEntryId);
 	}
+
+	private static final int[] _ASSET_ENTRY_CREATION_STATUSES = {
+		WorkflowConstants.STATUS_APPROVED, WorkflowConstants.STATUS_EXPIRED,
+		WorkflowConstants.STATUS_SCHEDULED
+	};
 
 	@BeanReference(type = AssetCategoryLocalService.class)
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2017,11 +2017,13 @@ public class DLFileEntryLocalServiceImpl
 
 		// File entry
 
-		if (status == WorkflowConstants.STATUS_APPROVED) {
+		if ((status == WorkflowConstants.STATUS_APPROVED) ||
+			(status == WorkflowConstants.STATUS_SCHEDULED)) {
+
 			int compare = DLUtil.compareVersions(
 				dlFileEntry.getVersion(), dlFileVersion.getVersion());
 
-			if (compare <= 0) {
+			if ((compare <= 0) || (oldStatus != status)) {
 				dlFileEntry.setModifiedDate(dlFileVersion.getModifiedDate());
 				dlFileEntry.setFileName(dlFileVersion.getFileName());
 				dlFileEntry.setExtension(dlFileVersion.getExtension());

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileVersionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileVersionPersistenceImpl.java
@@ -30,12 +30,14 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelperUtil;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portlet.documentlibrary.model.impl.DLFileVersionImpl;
@@ -4448,6 +4450,7 @@ public class DLFileVersionPersistenceImpl
 	private FinderPath _finderPathWithPaginationFindByF_S;
 	private FinderPath _finderPathWithoutPaginationFindByF_S;
 	private FinderPath _finderPathCountByF_S;
+	private FinderPath _finderPathWithPaginationCountByF_S;
 
 	/**
 	 * Returns all the document library file versions where fileEntryId = &#63; and status = &#63;.
@@ -4914,6 +4917,208 @@ public class DLFileVersionPersistenceImpl
 	}
 
 	/**
+	 * Returns all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the matching document library file versions
+	 */
+	@Override
+	public List<DLFileVersion> findByF_S(long fileEntryId, int[] statuses) {
+		return findByF_S(
+			fileEntryId, statuses, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @return the range of matching document library file versions
+	 */
+	@Override
+	public List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end) {
+
+		return findByF_S(fileEntryId, statuses, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file versions
+	 */
+	@Override
+	public List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		OrderByComparator<DLFileVersion> orderByComparator) {
+
+		return findByF_S(
+			fileEntryId, statuses, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file versions
+	 */
+	@Override
+	public List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		OrderByComparator<DLFileVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		if (statuses == null) {
+			statuses = new int[0];
+		}
+		else if (statuses.length > 1) {
+			statuses = ArrayUtil.sortedUnique(statuses);
+		}
+
+		if (statuses.length == 1) {
+			return findByF_S(
+				fileEntryId, statuses[0], start, end, orderByComparator);
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					DLFileVersion.class)) {
+
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderArgs = new Object[] {
+						fileEntryId, StringUtil.merge(statuses)
+					};
+				}
+			}
+			else if (useFinderCache) {
+				finderArgs = new Object[] {
+					fileEntryId, StringUtil.merge(statuses), start, end,
+					orderByComparator
+				};
+			}
+
+			List<DLFileVersion> list = null;
+
+			if (useFinderCache) {
+				list = (List<DLFileVersion>)FinderCacheUtil.getResult(
+					_finderPathWithPaginationFindByF_S, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (DLFileVersion dlFileVersion : list) {
+						if ((fileEntryId != dlFileVersion.getFileEntryId()) ||
+							!ArrayUtil.contains(
+								statuses, dlFileVersion.getStatus())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = new StringBundler();
+
+				sb.append(_SQL_SELECT_DLFILEVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_F_S_FILEENTRYID_2);
+
+				if (statuses.length > 0) {
+					sb.append("(");
+
+					sb.append(_FINDER_COLUMN_F_S_STATUS_7);
+
+					sb.append(StringUtil.merge(statuses));
+
+					sb.append(")");
+
+					sb.append(")");
+				}
+
+				sb.setStringAt(
+					removeConjunction(sb.stringAt(sb.index() - 1)),
+					sb.index() - 1);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(DLFileVersionModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(fileEntryId);
+
+					list = (List<DLFileVersion>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						FinderCacheUtil.putResult(
+							_finderPathWithPaginationFindByF_S, finderArgs,
+							list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
 	 * Removes all the document library file versions where fileEntryId = &#63; and status = &#63; from the database.
 	 *
 	 * @param fileEntryId the file entry ID
@@ -4990,11 +5195,94 @@ public class DLFileVersionPersistenceImpl
 		}
 	}
 
+	/**
+	 * Returns the number of document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the number of matching document library file versions
+	 */
+	@Override
+	public int countByF_S(long fileEntryId, int[] statuses) {
+		if (statuses == null) {
+			statuses = new int[0];
+		}
+		else if (statuses.length > 1) {
+			statuses = ArrayUtil.sortedUnique(statuses);
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					DLFileVersion.class)) {
+
+			Object[] finderArgs = new Object[] {
+				fileEntryId, StringUtil.merge(statuses)
+			};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				_finderPathWithPaginationCountByF_S, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler();
+
+				sb.append(_SQL_COUNT_DLFILEVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_F_S_FILEENTRYID_2);
+
+				if (statuses.length > 0) {
+					sb.append("(");
+
+					sb.append(_FINDER_COLUMN_F_S_STATUS_7);
+
+					sb.append(StringUtil.merge(statuses));
+
+					sb.append(")");
+
+					sb.append(")");
+				}
+
+				sb.setStringAt(
+					removeConjunction(sb.stringAt(sb.index() - 1)),
+					sb.index() - 1);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(fileEntryId);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(
+						_finderPathWithPaginationCountByF_S, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
 	private static final String _FINDER_COLUMN_F_S_FILEENTRYID_2 =
 		"dlFileVersion.fileEntryId = ? AND ";
 
 	private static final String _FINDER_COLUMN_F_S_STATUS_2 =
 		"dlFileVersion.status = ?";
+
+	private static final String _FINDER_COLUMN_F_S_STATUS_7 =
+		"dlFileVersion.status IN (";
 
 	private FinderPath _finderPathWithPaginationFindByLtD_S;
 	private FinderPath _finderPathWithPaginationCountByLtD_S;
@@ -7928,6 +8216,11 @@ public class DLFileVersionPersistenceImpl
 
 		_finderPathCountByF_S = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByF_S",
+			new String[] {Long.class.getName(), Integer.class.getName()},
+			new String[] {"fileEntryId", "status"}, false);
+
+		_finderPathWithPaginationCountByF_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByF_S",
 			new String[] {Long.class.getName(), Integer.class.getName()},
 			new String[] {"fileEntryId", "status"}, false);
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileVersionPersistence.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileVersionPersistence.java
@@ -1311,6 +1311,76 @@ public interface DLFileVersionPersistence
 		throws NoSuchFileVersionException;
 
 	/**
+	 * Returns all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the matching document library file versions
+	 */
+	public java.util.List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses);
+
+	/**
+	 * Returns a range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @return the range of matching document library file versions
+	 */
+	public java.util.List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file versions
+	 */
+	public java.util.List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileVersion>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file versions
+	 */
+	public java.util.List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileVersion>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
 	 * Removes all the document library file versions where fileEntryId = &#63; and status = &#63; from the database.
 	 *
 	 * @param fileEntryId the file entry ID
@@ -1326,6 +1396,15 @@ public interface DLFileVersionPersistence
 	 * @return the number of matching document library file versions
 	 */
 	public int countByF_S(long fileEntryId, int status);
+
+	/**
+	 * Returns the number of document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the number of matching document library file versions
+	 */
+	public int countByF_S(long fileEntryId, int[] statuses);
 
 	/**
 	 * Returns all the document library file versions where displayDate &lt; &#63; and status = &#63;.

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileVersionUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileVersionUtil.java
@@ -1660,6 +1660,89 @@ public class DLFileVersionUtil {
 	}
 
 	/**
+	 * Returns all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the matching document library file versions
+	 */
+	public static List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses) {
+
+		return getPersistence().findByF_S(fileEntryId, statuses);
+	}
+
+	/**
+	 * Returns a range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @return the range of matching document library file versions
+	 */
+	public static List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end) {
+
+		return getPersistence().findByF_S(fileEntryId, statuses, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file versions
+	 */
+	public static List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		OrderByComparator<DLFileVersion> orderByComparator) {
+
+		return getPersistence().findByF_S(
+			fileEntryId, statuses, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file versions where fileEntryId = &#63; and status = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @param start the lower bound of the range of document library file versions
+	 * @param end the upper bound of the range of document library file versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file versions
+	 */
+	public static List<DLFileVersion> findByF_S(
+		long fileEntryId, int[] statuses, int start, int end,
+		OrderByComparator<DLFileVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByF_S(
+			fileEntryId, statuses, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
 	 * Removes all the document library file versions where fileEntryId = &#63; and status = &#63; from the database.
 	 *
 	 * @param fileEntryId the file entry ID
@@ -1678,6 +1761,17 @@ public class DLFileVersionUtil {
 	 */
 	public static int countByF_S(long fileEntryId, int status) {
 		return getPersistence().countByF_S(fileEntryId, status);
+	}
+
+	/**
+	 * Returns the number of document library file versions where fileEntryId = &#63; and status = any &#63;.
+	 *
+	 * @param fileEntryId the file entry ID
+	 * @param statuses the statuses
+	 * @return the number of matching document library file versions
+	 */
+	public static int countByF_S(long fileEntryId, int[] statuses) {
+		return getPersistence().countByF_S(fileEntryId, statuses);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0


### PR DESCRIPTION
changes asked on https://github.com/brianchandotcom/liferay-portal/pull/149599#issuecomment-2080579115

When searching on the management toolbar of the DM page if we search the document scheduled should be returned

1. FF LPD-10701 should be active
2. Create a document with title "test"
3. Create a scheduled document with title "test 2"
4. go to DM page
5. search by "test"

Expected:
The 2 documents should appear
[
 Compartir.pantalla.-.2024-04-22.12_42_10.mp4 ](https://github.com/liferay-content-management/liferay-portal/assets/47524751/1d577912-8529-4687-9973-f4c47893b77b)

- **LPD-19196 use injection instead of utils**
- **LPD-19196 add test to check that a recently created scheduled file is indexed and showing on the search**
- **LPD-19196 move test to another file to check more cases**
- **LPD-19196 add more tests to check behavior**
- **LPD-19196 reindex if scheduled too**
- **LPD-19196 find fileEntries by several statuses**
- **LPD-19196 buildService**
- **LPD-19196 do not create a draft assetEntry if there is an existing one**
- **LPD-19196 update the fileEntry on the case that is scheduled and the status has changed**
- **LPD-19196 update the asset if the new status is scheduled too and delete the draft if exists**
- **LPD-19196 rename**
- **LPD-19196 autoSF**
