### PR TITLE
LPD-24606 We need to set WebKeys.CURRENT_URL to avoid errors in DisplayPageLayoutTypeController

### DIFF
--- a/modules/dxp/apps/analytics/analytics-reports-journal-test/src/testIntegration/java/com/liferay/analytics/reports/journal/internal/content/dashboard/item/action/provider/test/ViewInPanelJournalArticleContentDashboardItemActionProviderTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-journal-test/src/testIntegration/java/com/liferay/analytics/reports/journal/internal/content/dashboard/item/action/provider/test/ViewInPanelJournalArticleContentDashboardItemActionProviderTest.java
@@ -226,6 +226,12 @@ public class ViewInPanelJournalArticleContentDashboardItemActionProviderTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
+		ThemeDisplay themeDisplay = _getThemeDisplay(
+			mockHttpServletRequest, user);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, _portal.getPortalURL(_layout, themeDisplay));
+
 		AssetEntry assetEntry = _assetEntryLocalService.getEntry(
 			JournalArticle.class.getName(),
 			_journalArticle.getResourcePrimKey());
@@ -243,8 +249,7 @@ public class ViewInPanelJournalArticleContentDashboardItemActionProviderTest {
 					JournalArticle.class.getName(),
 					_journalArticle.getResourcePrimKey())));
 		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY,
-			_getThemeDisplay(mockHttpServletRequest, user));
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		_serviceContext.setRequest(mockHttpServletRequest);
 


### PR DESCRIPTION
Motivation
-----
Fix https://liferay.atlassian.net/browse/LPD-24606


Proposed Solution
-----
Includes **WebKeys.CURRENT_URL** parameter into the request since it is necessary for display pages url.