### PR TITLE
LPD-24848 [ee-ts] Media Gallery close button 

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -277,7 +277,7 @@ PortletURL embeddedPlayerURL = PortletURLBuilder.createRenderURL(
 
 	imageViewer.TPL_CLOSE = imageViewer.TPL_CLOSE.replace(
 		/<\s*span[^>]*>(.*?)<\s*\/\s*span>/,
-		Liferay.Util.getLexiconIconTpl('times', 'icon-monospaced')
+		Liferay.Util.getLexiconIconTpl('times', 'icon-monospaced text-white')
 	);
 
 	var TPL_PLAYER_PAUSE =


### PR DESCRIPTION
### What is the problem
Issue https://liferay.atlassian.net/browse/LPD-24848 from https://liferay.atlassian.net/browse/LPP-53860 **Issue with close button in media gallery widget**

Close button is almost the same color as the banner on top, making it bearly visible.

### How to solve this
Force white color to avoid conflict between Clay and AUI ImageViewer styles


**Before:** 

<img width="819" alt="Media gallery before " src="https://github.com/liferay-content-management/liferay-portal/assets/8373764/6b7a1341-6a59-415f-9c48-b98c50baaf29">


**After:** 
<img width="817" alt="Media Gallery after " src="https://github.com/liferay-content-management/liferay-portal/assets/8373764/3bbe8776-b994-4b33-824b-7bfecdac6fae">



