### PR TITLE
LPD-20705 create playwright tests - KB Article Locking

### DIFF
--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -64,6 +64,27 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async postSiteKnowledgeBaseArticle({
+		articleBody,
+		siteId,
+		title,
+	}: {
+		articleBody: string;
+		siteId: string;
+		title: string;
+	}): Promise<KnowledgeBaseArticle> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/knowledge-base-articles`,
+			{
+				data: {
+					articleBody,
+					title,
+				},
+				failOnStatusCode: true,
+			}
+		);
+	}
+
 	async postStructuredContent({
 		categoryIds,
 		contentStructureId,

--- a/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
@@ -6,7 +6,6 @@
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {KnowledgeBasePage} from './KnowledgeBasePage';
 
 export class KnowledgeBaseEditArticlePage {
@@ -61,11 +60,6 @@ export class KnowledgeBaseEditArticlePage {
 			target: this.publishMenuItem,
 			trigger: this.publishButton,
 		});
-
-		await waitForSuccessAlert(
-			this.page,
-			`Success:${title} was successfully published.`
-		);
 	}
 
 	async scheduleNewKnowledgeBaseArticle(

--- a/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
@@ -9,6 +9,7 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {KnowledgeBasePage} from './KnowledgeBasePage';
 
 export class KnowledgeBaseEditArticlePage {
+	readonly cancelButton: Locator;
 	readonly contentFrameLocator: FrameLocator;
 	readonly contentTextBox: Locator;
 	readonly page: Page;
@@ -22,6 +23,7 @@ export class KnowledgeBaseEditArticlePage {
 	knowledgeBasePage: KnowledgeBasePage;
 
 	constructor(page: Page) {
+		this.cancelButton = page.getByRole('link', {name: 'Cancel'});
 		this.contentFrameLocator = page.frameLocator('iframe');
 		this.contentTextBox = this.contentFrameLocator.getByRole('textbox');
 		this.knowledgeBasePage = new KnowledgeBasePage(page);
@@ -41,6 +43,10 @@ export class KnowledgeBaseEditArticlePage {
 		await this.knowledgeBasePage.goto(siteUrl);
 
 		await this.knowledgeBasePage.goToCreateNewArticle();
+	}
+
+	async cancel() {
+		await this.cancelButton.click();
 	}
 
 	async publishNewKnowledgeBaseArticle(content: string, title: string) {

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -11,6 +11,7 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {knowledgeBasePages} from '../../fixtures/knowledgeBasePagesTest';
 import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
 const testFeatureFlagsEnabled = mergeTests(
 	apiHelpersTest,
@@ -45,6 +46,11 @@ testFeatureFlagsDisabled(
 			content,
 			title
 		);
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was successfully published.`
+		);
 		await expect(kbArticle).toBeVisible();
 
 		await knowledgeBasePage.goto(site.friendlyUrlPath);
@@ -71,6 +77,11 @@ testFeatureFlagsEnabled(
 			content,
 			title
 		);
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was successfully published.`
+		);
 		await expect(kbArticle).toBeVisible();
 
 		await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
@@ -90,9 +101,16 @@ testFeatureFlagsDisabled(
 	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {
 		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
 
+		const title = getRandomString();
+
 		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
 			getRandomString(),
-			getRandomString()
+			title
+		);
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was successfully published.`
 		);
 
 		await knowledgeBasePage.goto(site.friendlyUrlPath);
@@ -108,9 +126,16 @@ testFeatureFlagsEnabled(
 	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {
 		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
 
+		const title = getRandomString();
+
 		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
 			getRandomString(),
-			getRandomString()
+			title
+		);
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was successfully published.`
 		);
 
 		await knowledgeBasePage.goto(site.friendlyUrlPath);
@@ -145,6 +170,11 @@ testFeatureFlagsEnabled(
 			getRandomString(),
 			`${new Date().getFullYear() + 1}-01-01 00:00`,
 			title
+		);
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} will be published on`
 		);
 		await expect(kbArticle).toBeVisible();
 

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -16,21 +16,21 @@ import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {KnowledgeBaseUrls} from './utils/knowledgeBaseUrls';
 
-const testFeatureFlagsEnabled = mergeTests(
+const testFeatureFlagsDisabled = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPD-11003': true,
-		'LPS-188058': true,
+		'LPD-11003': false,
+		'LPS-188058': false,
 	}),
 	isolatedSiteTest,
 	knowledgeBasePages,
 	loginTest()
 );
-
-const testFeatureFlagsDisabled = mergeTests(
+const testFeatureFlagsEnabled = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
-		'LPS-188058': false,
+		'LPD-11003': true,
+		'LPS-188058': true,
 	}),
 	isolatedSiteTest,
 	knowledgeBasePages,
@@ -49,12 +49,12 @@ testFeatureFlagsEnabled(
 				siteId: site.id,
 				title,
 			});
-
 		const knowledgeBaseUrls = new KnowledgeBaseUrls(site.friendlyUrlPath);
 
 		await page.goto(
 			knowledgeBaseUrls.getEditKBArticleUrl(knowledgeBaseArticle.id)
 		);
+
 		await expect(page.getByPlaceholder('Untitled Article')).toHaveValue(
 			title
 		);
@@ -66,6 +66,7 @@ testFeatureFlagsEnabled(
 				browserContext,
 				'demo.company.admin'
 			);
+
 			await otherUserPage.goto(
 				knowledgeBaseUrls.getEditKBArticleUrl(
 					knowledgeBaseArticle.id,
@@ -73,6 +74,7 @@ testFeatureFlagsEnabled(
 					knowledgeBaseUrls.home
 				)
 			);
+
 			await expect(
 				otherUserPage.getByPlaceholder('Untitled Article')
 			).toHaveValue(title);
@@ -81,12 +83,14 @@ testFeatureFlagsEnabled(
 				`${content} test`,
 				`${title} test`
 			);
+
 			await expect(
 				page.getByText('Your changes cannot be saved.')
 			).toBeVisible();
 
 			const otherUserKnowledgeBaseEditArticlePage =
 				new KnowledgeBaseEditArticlePage(otherUserPage);
+
 			await otherUserKnowledgeBaseEditArticlePage.cancel();
 		}
 		finally {
@@ -100,10 +104,10 @@ testFeatureFlagsDisabled(
 	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {
 		const content = getRandomString();
 		const title = getRandomString();
+
 		const kbArticle = page.getByRole('link', {name: title});
 
 		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-
 		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
 			content,
 			title
@@ -113,10 +117,12 @@ testFeatureFlagsDisabled(
 			page,
 			`Success:${title} was successfully published.`
 		);
+
 		await expect(kbArticle).toBeVisible();
 
 		await knowledgeBasePage.goto(site.friendlyUrlPath);
 		await knowledgeBasePage.deleteKnowledgeBaseArticle(title);
+
 		await expect(kbArticle).toBeHidden();
 	}
 );
@@ -131,10 +137,10 @@ testFeatureFlagsEnabled(
 	}) => {
 		const content = getRandomString();
 		const title = getRandomString();
+
 		const kbArticle = page.getByRole('link', {name: title});
 
 		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-
 		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
 			content,
 			title
@@ -144,6 +150,7 @@ testFeatureFlagsEnabled(
 			page,
 			`Success:${title} was successfully published.`
 		);
+
 		await expect(kbArticle).toBeVisible();
 
 		await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
@@ -177,6 +184,7 @@ testFeatureFlagsDisabled(
 
 		await knowledgeBasePage.goto(site.friendlyUrlPath);
 		await knowledgeBasePage.deleteAll(false);
+
 		await expect(
 			page.getByRole('heading', {name: 'Knowledge base is empty.'})
 		).toBeVisible();
@@ -208,7 +216,6 @@ testFeatureFlagsEnabled(
 				'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
 			)
 		).toBeVisible();
-
 		await expect(
 			page.getByRole('heading', {name: 'Knowledge base is empty.'})
 		).toBeVisible();
@@ -224,10 +231,10 @@ testFeatureFlagsEnabled(
 		site,
 	}) => {
 		const title = getRandomString();
+
 		const kbArticle = page.getByRole('link', {name: title});
 
 		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-
 		await knowledgeBaseEditArticlePage.scheduleNewKnowledgeBaseArticle(
 			getRandomString(),
 			`${new Date().getFullYear() + 1}-01-01 00:00`,
@@ -238,11 +245,12 @@ testFeatureFlagsEnabled(
 			page,
 			`Success:${title} will be published on`
 		);
+
 		await expect(kbArticle).toBeVisible();
 
 		await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
-
 		await knowledgeBaseViewArticlePage.deleteKnowledgeBaseArticle();
+
 		await expect(
 			page.locator(
 				'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -59,32 +59,39 @@ testFeatureFlagsEnabled(
 			title
 		);
 
-		const otherUserPage = await getLoggedInPage(
-			browser,
-			'demo.company.admin'
-		);
-		await otherUserPage.goto(
-			knowledgeBaseUrls.getEditKBArticleUrl(
-				knowledgeBaseArticle.id,
-				true,
-				knowledgeBaseUrls.home
-			)
-		);
-		await expect(
-			otherUserPage.getByPlaceholder('Untitled Article')
-		).toHaveValue(title);
+		const browserContext = await browser.newContext();
 
-		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
-			`${content} test`,
-			`${title} test`
-		);
-		await expect(
-			page.getByText('Your changes cannot be saved.')
-		).toBeVisible();
+		try {
+			const otherUserPage = await getLoggedInPage(
+				browserContext,
+				'demo.company.admin'
+			);
+			await otherUserPage.goto(
+				knowledgeBaseUrls.getEditKBArticleUrl(
+					knowledgeBaseArticle.id,
+					true,
+					knowledgeBaseUrls.home
+				)
+			);
+			await expect(
+				otherUserPage.getByPlaceholder('Untitled Article')
+			).toHaveValue(title);
 
-		const otherUserKnowledgeBaseEditArticlePage =
-			new KnowledgeBaseEditArticlePage(otherUserPage);
-		await otherUserKnowledgeBaseEditArticlePage.cancel();
+			await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
+				`${content} test`,
+				`${title} test`
+			);
+			await expect(
+				page.getByText('Your changes cannot be saved.')
+			).toBeVisible();
+
+			const otherUserKnowledgeBaseEditArticlePage =
+				new KnowledgeBaseEditArticlePage(otherUserPage);
+			await otherUserKnowledgeBaseEditArticlePage.cancel();
+		}
+		finally {
+			await browserContext.close();
+		}
 	}
 );
 

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -10,12 +10,16 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {knowledgeBasePages} from '../../fixtures/knowledgeBasePagesTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {KnowledgeBaseEditArticlePage} from '../../pages/knowledge-base-web/KnowledgeBaseEditArticlePage';
+import getLoggedInPage from '../../utils/getLoggedInPage';
 import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {KnowledgeBaseUrls} from './utils/knowledgeBaseUrls';
 
 const testFeatureFlagsEnabled = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-11003': true,
 		'LPS-188058': true,
 	}),
 	isolatedSiteTest,
@@ -31,6 +35,57 @@ const testFeatureFlagsDisabled = mergeTests(
 	isolatedSiteTest,
 	knowledgeBasePages,
 	loginTest()
+);
+
+testFeatureFlagsEnabled(
+	'LPD-23801 error message is shown when an admin user tries to publish an article that an admin is currently editing',
+	async ({apiHelpers, browser, knowledgeBaseEditArticlePage, page, site}) => {
+		const content = getRandomString();
+		const title = getRandomString();
+
+		const knowledgeBaseArticle =
+			await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+				articleBody: content,
+				siteId: site.id,
+				title,
+			});
+
+		const knowledgeBaseUrls = new KnowledgeBaseUrls(site.friendlyUrlPath);
+
+		await page.goto(
+			knowledgeBaseUrls.getEditKBArticleUrl(knowledgeBaseArticle.id)
+		);
+		await expect(page.getByPlaceholder('Untitled Article')).toHaveValue(
+			title
+		);
+
+		const otherUserPage = await getLoggedInPage(
+			browser,
+			'demo.company.admin'
+		);
+		await otherUserPage.goto(
+			knowledgeBaseUrls.getEditKBArticleUrl(
+				knowledgeBaseArticle.id,
+				true,
+				knowledgeBaseUrls.home
+			)
+		);
+		await expect(
+			otherUserPage.getByPlaceholder('Untitled Article')
+		).toHaveValue(title);
+
+		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
+			`${content} test`,
+			`${title} test`
+		);
+		await expect(
+			page.getByText('Your changes cannot be saved.')
+		).toBeVisible();
+
+		const otherUserKnowledgeBaseEditArticlePage =
+			new KnowledgeBaseEditArticlePage(otherUserPage);
+		await otherUserKnowledgeBaseEditArticlePage.cancel();
+	}
 );
 
 testFeatureFlagsDisabled(

--- a/modules/test/playwright/tests/knowledge-base-web/utils/knowledgeBaseUrls.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/utils/knowledgeBaseUrls.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+
+export class KnowledgeBaseUrls {
+	readonly home: string;
+	readonly parameterPrefix =
+		'_com_liferay_knowledge_base_web_portlet_AdminPortlet_';
+
+	constructor(siteUrl?: Site['friendlyUrlPath']) {
+		this.home = `/group${siteUrl || '/guest'}${PORTLET_URLS.knowledgeBase}`;
+	}
+
+	getEditKBArticleUrl(
+		id: string,
+		forceLock: boolean = false,
+		redirect?: string
+	) {
+		let array = [
+			this.getRenderCommandUrl('/knowledge_base/edit_kb_article'),
+			this.getParameter('resourcePrimKey', id),
+		];
+
+		if (forceLock) {
+			array = array.concat(this.getParameter('forceLock', '1'));
+		}
+
+		if (redirect !== undefined) {
+			array = array.concat(this.getParameter('redirect', redirect));
+		}
+
+		return array.join('&');
+	}
+
+	private getParameter(key: string, value: string) {
+		return `${this.parameterPrefix}${key}=${value}`;
+	}
+
+	private getRenderCommandUrl(commandName: string) {
+		return [
+			this.home,
+			this.getParameter('mvcRenderCommandName', commandName),
+		].join('&');
+	}
+}

--- a/modules/test/playwright/types/knowledge-base-article.d.ts
+++ b/modules/test/playwright/types/knowledge-base-article.d.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type KnowledgeBaseArticle = {
+	articleBody: string;
+	id: string;
+	title: string;
+};

--- a/modules/test/playwright/utils/getLoggedInPage.ts
+++ b/modules/test/playwright/utils/getLoggedInPage.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, Page} from '@playwright/test';
+
+import createTempFile, {
+	TempFileMissingError,
+	readTempFile,
+} from './createTempFile';
+import performLogin, {LoginScreenName} from './performLogin';
+
+/**
+ * Obtain a logged in page.
+ *
+ * The provided `loggedInPage` is guaranteed to be at the home page.
+ *
+ * @param browser a Browser instance
+ * @param screenName the screen name to use for performing the login
+ */
+export default async function getLoggedInPage(
+	browser: Browser,
+	screenName: LoginScreenName
+): Promise<Page> {
+	const browserContext = await browser.newContext();
+	const loggedInPage = await browserContext.newPage();
+	const tempFile = `loggedInPageTest-${screenName}.json`;
+
+	try {
+		const {cookies} = JSON.parse(readTempFile(tempFile));
+
+		browserContext.addCookies(cookies);
+
+		await loggedInPage.goto('/');
+	}
+	catch (error) {
+		if (!(error instanceof TempFileMissingError)) {
+			throw error;
+		}
+
+		const cookies = await performLogin(loggedInPage, screenName);
+
+		createTempFile(tempFile, JSON.stringify({cookies}));
+	}
+
+	return loggedInPage;
+}

--- a/modules/test/playwright/utils/getLoggedInPage.ts
+++ b/modules/test/playwright/utils/getLoggedInPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Browser, Page} from '@playwright/test';
+import {BrowserContext, Page} from '@playwright/test';
 
 import createTempFile, {
 	TempFileMissingError,
@@ -16,14 +16,13 @@ import performLogin, {LoginScreenName} from './performLogin';
  *
  * The provided `loggedInPage` is guaranteed to be at the home page.
  *
- * @param browser a Browser instance
+ * @param browserContext a BrowserContext instance
  * @param screenName the screen name to use for performing the login
  */
 export default async function getLoggedInPage(
-	browser: Browser,
+	browserContext: BrowserContext,
 	screenName: LoginScreenName
 ): Promise<Page> {
-	const browserContext = await browser.newContext();
 	const loggedInPage = await browserContext.newPage();
 	const tempFile = `loggedInPageTest-${screenName}.json`;
 


### PR DESCRIPTION
I've added the first Playwright tests for the [KB Article Lock epic](https://liferay.atlassian.net/browse/LPD-11003), so I had to work on:

* having 2 concurrent users
* adding a KB Article through API (to avoid manual navigation)
* providing direct URLs for KB pages (to avoid manual navigation)

I've just covered the test for this subtask: https://liferay.atlassian.net/browse/LPD-23801

:warning:  PLEASE NOTE - you need to run this command before running the tests, so we can login with other users: `npm run local:setup knowledge-base-web`

Put on hold until https://github.com/brianchandotcom/liferay-portal/pull/149899 is merged into master.