### PR TITLE
LPD-25183 Fix journal playwright tests

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -515,7 +515,7 @@ translationTest(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('option', {
-				name: 'Catalan Language: Translating 3/4',
+				name: 'Catalan Language: Translating 1/2',
 			}),
 			trigger: translationButton,
 		});

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -369,11 +369,11 @@ translationTest(
 
 		await markAsTranslatedButton.click();
 
-		const confirmMarkAsTranslatedButton = page
-			.getByLabel('Mark ca_ES as Translated')
-			.getByRole('button', {name: 'Mark as Translated'});
+		await expect(
+			page.getByRole('heading', {name: 'Mark "ca_ES" as Translated'})
+		).toBeVisible();
 
-		await confirmMarkAsTranslatedButton.click();
+		await page.getByRole('button', {name: 'Mark as Translated'}).click();
 
 		await translationButton.click();
 


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPD-25183 (duplicated by https://liferay.atlassian.net/browse/LPD-23910). 

Failed tests: 
- LPD-19627: Translate several fields in a Basic Web Content and check how many fields have been translated, 
- LPD-23278: This is a test for mark as translated button in web content, 
- LPD-19627: Translate all fields of a Web Content based on a custom structure with repeatable fields

Before: 
![Screenshot 2024-05-07 at 13 06 16](https://github.com/liferay-content-management/liferay-portal/assets/8373764/91266849-5860-4e6b-9b9e-9f99802a6668)

After the fixes: 

![Screenshot 2024-05-07 at 15 13 26](https://github.com/liferay-content-management/liferay-portal/assets/8373764/eaf12785-2e8e-4d16-bfc2-3b54375dfcff)

@DiegoHu97 please review if the last two test fixes are correct (it reflects the current behaviour) or if instead those are bugs in master. --> This test "LPD-19627: Translate all fields of a Web Content based on a custom structure with repeatable fields"  is a bug, fix is not included in this pull 