### PR TITLE
LPD-24943 Use version of the file as file name, as fallback when obtaining the file inputStream when copying the file 

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -12,12 +12,18 @@ import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.store.DLStoreRequest;
+import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -27,12 +33,15 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
+import java.io.InputStream;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -175,6 +184,52 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		AssertUtils.assertEqualsSorted(assetTagNames, assetEntry.getTagNames());
+	}
+
+	@Test
+	public void testFileEntryCanUpdateOldVersionStoreFileTitle()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(),
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), null, null, null,
+			new UnsyncByteArrayInputStream(CONTENT.getBytes()),
+			CONTENT.length(), null, null, null, serviceContext);
+
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		DLStoreUtil.updateFile(
+			DLStoreRequest.builder(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName()
+			).versionLabel(
+				dlFileVersion.getVersion()
+			).build(),
+			new UnsyncByteArrayInputStream(CONTENT.getBytes()));
+		DLStoreUtil.deleteFile(
+			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+
+		String title = RandomTestUtil.randomString();
+
+		InputStream inputStream = new UnsyncByteArrayInputStream(
+			CONTENT.getBytes());
+
+		fileEntry = dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), StringUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM, title, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
+			FileUtil.createTempFile(inputStream), null, null, null,
+			serviceContext);
+
+		Assert.assertEquals(title, fileEntry.getTitle());
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
@@ -419,22 +419,7 @@ public class DLCheckInCheckOutTest {
 
 	@Test
 	public void testCheckOutOldStoreFile() throws Exception {
-		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
-			_fileEntry.getFileEntryId());
-
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
-
-		DLStoreUtil.updateFile(
-			DLStoreRequest.builder(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName()
-			).versionLabel(
-				dlFileVersion.getVersion()
-			).build(),
-			new UnsyncByteArrayInputStream(_TEST_CONTENT.getBytes()));
-		DLStoreUtil.deleteFile(
-			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+		_renameDLStoreFile();
 
 		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
 
@@ -505,22 +490,7 @@ public class DLCheckInCheckOutTest {
 
 	@Test
 	public void testUpdateFileEntryOldStoreFile() throws Exception {
-		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
-			_fileEntry.getFileEntryId());
-
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
-
-		DLStoreUtil.updateFile(
-			DLStoreRequest.builder(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName()
-			).versionLabel(
-				dlFileVersion.getVersion()
-			).build(),
-			new UnsyncByteArrayInputStream(_TEST_CONTENT.getBytes()));
-		DLStoreUtil.deleteFile(
-			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+		_renameDLStoreFile();
 
 		DLAppServiceUtil.checkOutFileEntry(
 			_fileEntry.getFileEntryId(), _serviceContext);
@@ -661,6 +631,25 @@ public class DLCheckInCheckOutTest {
 			fileEntryId, fileName, ContentTypes.TEXT_PLAIN, fileName, null,
 			null, null, DLVersionNumberIncrease.MINOR, inputStream,
 			content.length(), null, null, null, _serviceContext);
+	}
+
+	private void _renameDLStoreFile() throws Exception {
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+			_fileEntry.getFileEntryId());
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		DLStoreUtil.updateFile(
+			DLStoreRequest.builder(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName()
+			).versionLabel(
+				dlFileVersion.getVersion()
+			).build(),
+			new UnsyncByteArrayInputStream(_TEST_CONTENT.getBytes()));
+		DLStoreUtil.deleteFile(
+			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
 	}
 
 	private static final String _FILE_NAME = "test1.txt";

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
@@ -9,10 +9,15 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.FileEntryLockException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.store.DLStoreRequest;
+import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.model.Group;
@@ -413,6 +418,43 @@ public class DLCheckInCheckOutTest {
 	}
 
 	@Test
+	public void testCheckOutOldStoreFile() throws Exception {
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+			_fileEntry.getFileEntryId());
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		DLStoreUtil.updateFile(
+			DLStoreRequest.builder(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName()
+			).versionLabel(
+				dlFileVersion.getVersion()
+			).build(),
+			new UnsyncByteArrayInputStream(_TEST_CONTENT.getBytes()));
+		DLStoreUtil.deleteFile(
+			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
+		DLAppServiceUtil.checkOutFileEntry(
+			_fileEntry.getFileEntryId(), _serviceContext);
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		DateTestUtil.assertEquals(lastPostDate, folder.getLastPostDate());
+
+		FileVersion fileVersion = _fileEntry.getLatestFileVersion();
+
+		Assert.assertEquals("PWC", fileVersion.getVersion());
+
+		getAssetEntry(fileVersion.getFileVersionId(), true);
+	}
+
+	@Test
 	public void testUpdateFileEntry() throws Exception {
 		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
 
@@ -431,6 +473,55 @@ public class DLCheckInCheckOutTest {
 
 	@Test
 	public void testUpdateFileEntry2() throws Exception {
+		DLAppServiceUtil.checkOutFileEntry(
+			_fileEntry.getFileEntryId(), _serviceContext);
+
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
+		FileEntry fileEntry = updateFileEntry(_fileEntry.getFileEntryId());
+
+		Assert.assertEquals("1.0", fileEntry.getVersion());
+
+		FileVersion fileVersion = fileEntry.getLatestFileVersion();
+
+		Assert.assertEquals("PWC", fileVersion.getVersion());
+
+		DLAppServiceUtil.checkInFileEntry(
+			_fileEntry.getFileEntryId(), DLVersionNumberIncrease.MINOR,
+			StringPool.BLANK, _serviceContext);
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertFalse(lastPostDate.after(folder.getLastPostDate()));
+
+		fileEntry = DLAppServiceUtil.getFileEntry(_fileEntry.getFileEntryId());
+
+		Assert.assertEquals("1.1", fileEntry.getVersion());
+
+		getAssetEntry(fileVersion.getFileVersionId(), false);
+	}
+
+	@Test
+	public void testUpdateFileEntryOldStoreFile() throws Exception {
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+			_fileEntry.getFileEntryId());
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		DLStoreUtil.updateFile(
+			DLStoreRequest.builder(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName()
+			).versionLabel(
+				dlFileVersion.getVersion()
+			).build(),
+			new UnsyncByteArrayInputStream(_TEST_CONTENT.getBytes()));
+		DLStoreUtil.deleteFile(
+			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+
 		DLAppServiceUtil.checkOutFileEntry(
 			_fileEntry.getFileEntryId(), _serviceContext);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -441,6 +441,7 @@ public class DLFileEntryLocalServiceImpl
 		// File version
 
 		String oldStoreFileName = latestDLFileVersion.getStoreFileName();
+		String oldVersion = latestDLFileVersion.getVersion();
 
 		latestDLFileVersion = _dlFileVersionPersistence.fetchByPrimaryKey(
 			latestDLFileVersion.getFileVersionId());
@@ -465,12 +466,29 @@ public class DLFileEntryLocalServiceImpl
 
 		// File
 
-		DLStoreUtil.copyFileVersion(
-			user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), oldStoreFileName,
-			latestDLFileVersion.getStoreFileName());
+		try {
+			DLStoreUtil.copyFileVersion(
+				user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), oldStoreFileName,
+				latestDLFileVersion.getStoreFileName());
 
-		_registerPWCDeletionCallback(dlFileEntry, oldStoreFileName);
+			_registerPWCDeletionCallback(dlFileEntry, oldStoreFileName);
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Using version of the file as file name for file version " +
+						latestDLFileVersion,
+					noSuchFileException);
+			}
+
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), oldVersion,
+				latestDLFileVersion.getStoreFileName());
+
+			_registerPWCDeletionCallback(dlFileEntry, oldVersion);
+		}
 
 		unlockFileEntry(fileEntryId);
 	}
@@ -522,10 +540,25 @@ public class DLFileEntryLocalServiceImpl
 		DLFileVersion latestDLFileVersion = dlFileEntry.getLatestFileVersion(
 			true);
 
-		DLStoreUtil.copyFileVersion(
-			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName(),
-			latestDLFileVersion.getStoreFileName());
+		try {
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), dlFileVersion.getStoreFileName(),
+				latestDLFileVersion.getStoreFileName());
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Using version of the file as file name for file version " +
+						dlFileVersion,
+					noSuchFileException);
+			}
+
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), dlFileVersion.getVersion(),
+				latestDLFileVersion.getStoreFileName());
+		}
 
 		return dlFileEntry;
 	}
@@ -2897,7 +2930,7 @@ public class DLFileEntryLocalServiceImpl
 		catch (NoSuchFileException noSuchFileException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
-					"Using version label as file name for file version " +
+					"Using version of the file as file name for file version " +
 						dlFileVersion,
 					noSuchFileException);
 			}
@@ -3480,10 +3513,25 @@ public class DLFileEntryLocalServiceImpl
 			user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName(), previousDLFileVersion.getStoreFileName());
 
-		DLStoreUtil.copyFileVersion(
-			user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-			dlFileEntry.getName(), latestDLFileVersion.getStoreFileName(),
-			lastDLFileVersion.getStoreFileName());
+		try {
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), latestDLFileVersion.getStoreFileName(),
+				lastDLFileVersion.getStoreFileName());
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Using version of the file as file name for file version " +
+						latestDLFileVersion,
+					noSuchFileException);
+			}
+
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), latestDLFileVersion.getVersion(),
+				lastDLFileVersion.getStoreFileName());
+		}
 
 		// Latest file version
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -540,25 +540,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileVersion latestDLFileVersion = dlFileEntry.getLatestFileVersion(
 			true);
 
-		try {
-			DLStoreUtil.copyFileVersion(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), dlFileVersion.getStoreFileName(),
-				latestDLFileVersion.getStoreFileName());
-		}
-		catch (NoSuchFileException noSuchFileException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Using version of the file as file name for file version " +
-						dlFileVersion,
-					noSuchFileException);
-			}
-
-			DLStoreUtil.copyFileVersion(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), dlFileVersion.getVersion(),
-				latestDLFileVersion.getStoreFileName());
-		}
+		_copyFileVersion(dlFileEntry, dlFileVersion, latestDLFileVersion);
 
 		return dlFileEntry;
 	}
@@ -2727,6 +2709,32 @@ public class DLFileEntryLocalServiceImpl
 		}
 	}
 
+	private void _copyFileVersion(
+			DLFileEntry dlFileEntry, DLFileVersion fromDLFileVersion,
+			DLFileVersion toDLFileVersion)
+		throws PortalException {
+
+		try {
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), fromDLFileVersion.getStoreFileName(),
+				toDLFileVersion.getStoreFileName());
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Using version of the file as file name for file version " +
+						fromDLFileVersion,
+					noSuchFileException);
+			}
+
+			DLStoreUtil.copyFileVersion(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), fromDLFileVersion.getVersion(),
+				toDLFileVersion.getStoreFileName());
+		}
+	}
+
 	private void _deleteFile(
 			long companyId, long repositoryId, String name,
 			String storeFileName)
@@ -3513,25 +3521,7 @@ public class DLFileEntryLocalServiceImpl
 			user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName(), previousDLFileVersion.getStoreFileName());
 
-		try {
-			DLStoreUtil.copyFileVersion(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), latestDLFileVersion.getStoreFileName(),
-				lastDLFileVersion.getStoreFileName());
-		}
-		catch (NoSuchFileException noSuchFileException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Using version of the file as file name for file version " +
-						latestDLFileVersion,
-					noSuchFileException);
-			}
-
-			DLStoreUtil.copyFileVersion(
-				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), latestDLFileVersion.getVersion(),
-				lastDLFileVersion.getStoreFileName());
-		}
+		_copyFileVersion(dlFileEntry, latestDLFileVersion, lastDLFileVersion);
 
 		// Latest file version
 


### PR DESCRIPTION
To reproduce follow steps on https://liferay.atlassian.net/browse/LPD-24943

Resend liferay-content-management#5413 to change message on the debug message to be more clear brianchandotcom#150068 (comment)


Commits:
LPD-24943 Use version of the file as file name, as fallback when obtaining the file inputStream when copying the file because the version label on old versions is the file version, not the store file name
LPD-24943 extract method
LPD-24943 add test to check the update of an old fashion store data that does not have the storeUUID on the file
LPD-24943 extract common code