### PR TITLE
LPD-24664 Blogs friendlyURL default url categories

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetCategoriesFriendlyUrlSelector.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetCategoriesFriendlyUrlSelector.js
@@ -92,13 +92,16 @@ function AssetVocabulariesCategoriesFriendlyUrlSelector({
 		if (inputAddonNodeRef.current) {
 			inputAddonNodeRef.current.innerText =
 				inputAddon +
-				selectedItems
-					.map(
-						(category) => `${normalizeFriendlyURL(category.label)}/`
-					)
-					.join('');
+				(disabled
+					? ''
+					: selectedItems
+							.map(
+								(category) =>
+									`${normalizeFriendlyURL(category.label)}/`
+							)
+							.join(''));
 		}
-	}, [inputAddon, inputAddonNodeRef, selectedItems]);
+	}, [inputAddon, inputAddonNodeRef, selectedItems, disabled]);
 
 	useEffect(() => {
 		const input = friendlyURLinputRef.current;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetCategoriesFriendlyUrlSelector.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetCategoriesFriendlyUrlSelector.js
@@ -143,7 +143,7 @@ function AssetVocabulariesCategoriesFriendlyUrlSelector({
 						inputName={
 							portletNamespace + 'friendlyURLAssetCategoryIds'
 						}
-						items={selectedItems}
+						items={disabled ? [] : selectedItems}
 						onItemsChange={handleItemsChange}
 					/>
 				</ClayInput.GroupItem>


### PR DESCRIPTION
# Issue https://liferay.atlassian.net/browse/LPD-24664 

## Before PR

When selecting **Use the Default URL** the categories are still there but disabled

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/d94e8409-4f3c-4e0a-852b-aee90cada32a)


## After PR

When selecting **Use the Default URL** the categories are cleared but maintained in memory before publish

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/219d9d9d-f635-4c0c-a430-8a38be3ce2b4)

Click on **Use the Default URL**
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/0b067b47-4e7b-4304-940a-56d6181d94c0)

Click on **Use a Customized URL**
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/219d9d9d-f635-4c0c-a430-8a38be3ce2b4)
