### PR TITLE
LPD-25416 / LPD-25399 Take into account publications and use batched stmt

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
@@ -42,25 +42,27 @@ public class JournalArticleAssetEntryClassTypeIdUpgradeProcess
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				StringBundler.concat(
 					"select distinct AssetEntry.entryId, ",
-					"AssetEntry.classTypeId, JournalArticle.DDMStructureId ",
-					"from AssetEntry, JournalArticle where ",
-					"AssetEntry.classNameId = ", classNameId,
+					"AssetEntry.classTypeId, JournalArticle.DDMStructureId, ",
+					"AssetEntry.ctCollectionId from AssetEntry, ",
+					"JournalArticle where AssetEntry.classNameId = ",
+					classNameId,
 					" and (AssetEntry.classPK = JournalArticle.id_ or ",
 					"AssetEntry.classPK = JournalArticle.resourcePrimKey) and ",
 					"AssetEntry.classTypeId != JournalArticle.DDMStructureId"));
 			PreparedStatement preparedStatement2 = connection.prepareStatement(
-				"update AssetEntry set classTypeId = ? where entryId = ?");
+				"update AssetEntry set classTypeId = ? where entryId = ? and " +
+					"ctCollectionId = ?");
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			while (resultSet.next()) {
 				long entryId = resultSet.getLong(1);
 				long classTypeId = resultSet.getLong(2);
-
 				long ddmStructureId = resultSet.getLong(3);
+				long ctCollectionId = resultSet.getLong(4);
 
 				preparedStatement2.setLong(1, ddmStructureId);
-
 				preparedStatement2.setLong(2, entryId);
+				preparedStatement2.setLong(3, ctCollectionId);
 
 				preparedStatement2.addBatch();
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v5_1_1/JournalArticleAssetEntryClassTypeIdUpgradeProcess.java
@@ -7,6 +7,7 @@ package com.liferay.journal.internal.upgrade.v5_1_1;
 
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -49,9 +50,11 @@ public class JournalArticleAssetEntryClassTypeIdUpgradeProcess
 					" and (AssetEntry.classPK = JournalArticle.id_ or ",
 					"AssetEntry.classPK = JournalArticle.resourcePrimKey) and ",
 					"AssetEntry.classTypeId != JournalArticle.DDMStructureId"));
-			PreparedStatement preparedStatement2 = connection.prepareStatement(
-				"update AssetEntry set classTypeId = ? where entryId = ? and " +
-					"ctCollectionId = ?");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update AssetEntry set classTypeId = ? where entryId = ? " +
+						"and ctCollectionId = ?");
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			while (resultSet.next()) {


### PR DESCRIPTION
# What is this trying to solve?

This fixes two different issues:
- https://liferay.atlassian.net/browse/LPD-25416 Upgrade process query isn't taking publications into account.
- https://liferay.atlassian.net/browse/LPD-25399 Test failure under HSQL.

# How am I fixing it?

The first issue is fixed simply by adding the `ctCollectionId` to both queries, making sure we update only the entries belonging to the same collection.

In the second case, the upgrade was trying to do the update in batches, but it wasn't creating a batched prepared statement.

# How can you verify that it works?

Run the `com.liferay.journal.internal.upgrade.v5_1_1.test.JournalArticleAssetEntryClassTypeIdUpgradeProcessTest` integration test.