### PR TITLE
LPD-25484 Repeated data engine field keep their parent translated status

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
@@ -13,16 +13,19 @@ import {
 import {PagesVisitor} from '../../utils/visitors.es';
 import {EVENT_TYPES} from '../actions/eventTypes.es';
 
-export function createRepeatedField(sourceField, repeatedIndex) {
+export function createRepeatedField(
+	defaultLanguageId,
+	sourceField,
+	repeatedIndex
+) {
 	const instanceId = generateInstanceId();
-	const {locale, name, nestedFields, predefinedValue} = sourceField;
+	const {name, nestedFields, predefinedValue} = sourceField;
 	const localizedValue = {};
 	const localizedValueEdited = {};
 
 	if (sourceField.localizedValue) {
-		localizedValue[locale] =
-			predefinedValue || localizedValue[locale] || '';
-		localizedValueEdited[locale] = true;
+		localizedValue[defaultLanguageId] = predefinedValue || '';
+		localizedValueEdited[defaultLanguageId] = true;
 	}
 
 	return {
@@ -214,6 +217,7 @@ export default function fieldReducer(state, action) {
 						if (sourceFieldIndex > -1) {
 							const newFieldIndex = sourceFieldIndex + 1;
 							const newField = createRepeatedField(
+								state.defaultLanguageId,
 								fields[sourceFieldIndex],
 								newFieldIndex
 							);

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
@@ -44,11 +44,11 @@ const getDataRecordValues = ({
 	return dataRecordValues;
 };
 
-const getFieldProperties = (fieldName, pages) => {
+const getFieldProperties = (instanceId, pages) => {
 	const visitor = new PagesVisitor(pages);
 
 	const {itemSelectorURL, localizedValueEdited} = visitor.findField(
-		(field) => field.fieldName === fieldName
+		(field) => field.instanceId === instanceId
 	);
 
 	return {itemSelectorURL, localizedValueEdited};
@@ -112,7 +112,7 @@ export default function pageLanguageUpdate({
 
 						return {
 							...field,
-							...getFieldProperties(field.fieldName, pages),
+							...getFieldProperties(field.instanceId, pages),
 							editingLanguageId: nextEditingLanguageId,
 						};
 					},


### PR DESCRIPTION
[LPD-25484](https://liferay.atlassian.net/browse/LPD-25484)
In order two fix this issue I implemented two changes:

1. When we repeat a field, we only set the localizedValue for the defaultLanguageId
2. When we update the language, data-enginge iterates over the fields and retrieve their `localizedValueEdited` object, however the repeated fields share the same fieldName, so I changed the logic to use instanceId for filtering


Please review my changes