### PR TITLE
LPD-25575

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -531,7 +531,13 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		}
 
 		if (documentFolderId == null) {
-			documentFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+			if (document != null) {
+				documentFolderId = document.getDocumentFolderId();
+			}
+
+			if (documentFolderId == null) {
+				documentFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+			}
 		}
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -226,6 +226,32 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testPutSiteDocumentByExternalReferenceCode() throws Exception {
+		super.testPutSiteDocumentByExternalReferenceCode();
+
+		DLFolder dlFolder = _dlFolderLocalService.addFolder(
+			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
+			testGroup.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
+
+		Document randomDocument = randomDocument();
+
+		randomDocument.setDocumentFolderId(dlFolder.getFolderId());
+
+		Document putDocument =
+			documentResource.putSiteDocumentByExternalReferenceCode(
+				randomDocument.getSiteId(),
+				randomDocument.getExternalReferenceCode(), randomDocument,
+				getMultipartFiles());
+
+		Assert.assertEquals(
+			(Long)dlFolder.getFolderId(), putDocument.getDocumentFolderId());
+	}
+
+	@Override
 	protected void assertValid(
 			Document document, Map<String, File> multipartFiles)
 		throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-25575

When adding a document by external reference code through the headless API it does not have a _folderId_ field. However, this information can be passed along through the _document_ object. These changes allow for getting the folder from this object before defaulting to the root folder.