### PR TITLE
LPD-25641 Submit for Workflow an Document with Expire date

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/workflow/test/DLFileEntryWorkflowHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/workflow/test/DLFileEntryWorkflowHandlerTest.java
@@ -61,32 +61,25 @@ public class DLFileEntryWorkflowHandlerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
+
+		_folder = _getSingleApproverFolder(_serviceContext);
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
 	}
 
 	@Test
 	public void testWorkflowApprovesFileEntry() throws PortalException {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
-		Folder folder = _getSingleApproverFolder(serviceContext);
-
-		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
-
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, _group.getGroupId(), folder.getFolderId(),
-			RandomTestUtil.randomString(), "text",
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), StringPool.BLANK,
-			StringPool.SPACE.getBytes(), null, null, null, serviceContext);
+		FileEntry fileEntry = _addFileEntry(null, null);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_PENDING, fileVersion.getStatus());
 
-		_updateStatus(
-			fileVersion, WorkflowConstants.STATUS_APPROVED, serviceContext);
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_APPROVED);
 
 		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
 
@@ -101,30 +94,15 @@ public class DLFileEntryWorkflowHandlerTest {
 	public void testWorkflowApprovesFileEntryScheduledFutureDate()
 		throws PortalException {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
-		Folder folder = _getSingleApproverFolder(serviceContext);
-
-		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
-
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, _group.getGroupId(), folder.getFolderId(),
-			RandomTestUtil.randomString(), "text",
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), StringPool.BLANK,
-			StringPool.SPACE.getBytes(),
-			new Date(System.currentTimeMillis() + Time.DAY), null, null,
-			serviceContext);
+		FileEntry fileEntry = _addFileEntry(
+			new Date(System.currentTimeMillis() + Time.DAY), null);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_PENDING, fileVersion.getStatus());
 
-		_updateStatus(
-			fileVersion, WorkflowConstants.STATUS_APPROVED, serviceContext);
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_APPROVED);
 
 		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
 
@@ -139,20 +117,7 @@ public class DLFileEntryWorkflowHandlerTest {
 	public void testWorkflowApprovesFileEntryScheduledPastDate()
 		throws PortalException {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
-		Folder folder = _getSingleApproverFolder(serviceContext);
-
-		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
-
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, _group.getGroupId(), folder.getFolderId(),
-			RandomTestUtil.randomString(), "text",
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), StringPool.BLANK,
-			StringPool.SPACE.getBytes(), null, null, null, serviceContext);
+		FileEntry fileEntry = _addFileEntry(null, null);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
@@ -167,8 +132,7 @@ public class DLFileEntryWorkflowHandlerTest {
 
 		_dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
 
-		_updateStatus(
-			fileVersion, WorkflowConstants.STATUS_APPROVED, serviceContext);
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_APPROVED);
 
 		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
 
@@ -180,28 +144,14 @@ public class DLFileEntryWorkflowHandlerTest {
 
 	@Test
 	public void testWorkflowRejectsFileEntry() throws PortalException {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
-
-		Folder folder = _getSingleApproverFolder(serviceContext);
-
-		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
-
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, _group.getGroupId(), folder.getFolderId(),
-			RandomTestUtil.randomString(), "text",
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), StringPool.BLANK,
-			StringPool.SPACE.getBytes(), null, null, null, serviceContext);
+		FileEntry fileEntry = _addFileEntry(null, null);
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_PENDING, fileVersion.getStatus());
 
-		_updateStatus(
-			fileVersion, WorkflowConstants.STATUS_DENIED, serviceContext);
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_DENIED);
 
 		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
 
@@ -211,8 +161,20 @@ public class DLFileEntryWorkflowHandlerTest {
 			WorkflowConstants.STATUS_DENIED, fileVersion.getStatus());
 	}
 
-	private Folder _getSingleApproverFolder(ServiceContext serviceContext)
+	private FileEntry _addFileEntry(Date displayDate, Date expirationDate)
 		throws PortalException {
+
+		return _dlAppService.addFileEntry(
+			null, _group.getGroupId(), _folder.getFolderId(),
+			RandomTestUtil.randomString(), "text",
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), StringPool.BLANK,
+			StringPool.SPACE.getBytes(), displayDate, expirationDate, null,
+			_serviceContext);
+	}
+
+	private Folder _getSingleApproverFolder(ServiceContext serviceContext)
+		throws Exception {
 
 		Folder folder = _dlAppService.addFolder(
 			null, _group.getGroupId(),
@@ -232,8 +194,7 @@ public class DLFileEntryWorkflowHandlerTest {
 			serviceContext);
 	}
 
-	private void _updateStatus(
-			FileVersion fileVersion, int status, ServiceContext serviceContext)
+	private void _updateStatus(FileVersion fileVersion, int status)
 		throws PortalException {
 
 		WorkflowHandler<DLFileEntry> workflowHandler =
@@ -249,7 +210,7 @@ public class DLFileEntryWorkflowHandlerTest {
 				WorkflowConstants.CONTEXT_USER_ID,
 				String.valueOf(TestPropsValues.getUserId())
 			).put(
-				"serviceContext", serviceContext
+				"serviceContext", _serviceContext
 			).build());
 	}
 
@@ -259,7 +220,11 @@ public class DLFileEntryWorkflowHandlerTest {
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 
+	private Folder _folder;
+
 	@DeleteAfterTestRun
 	private Group _group;
+
+	private ServiceContext _serviceContext;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/workflow/test/DLFileEntryWorkflowHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/workflow/test/DLFileEntryWorkflowHandlerTest.java
@@ -89,6 +89,62 @@ public class DLFileEntryWorkflowHandlerTest {
 			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
 	}
 
+	@Test
+	public void testWorkflowApprovesFileEntryExpireFutureDate()
+		throws PortalException {
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		FileEntry fileEntry = _addFileEntry(null, expirationDate);
+
+		FileVersion fileVersion = fileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_PENDING, fileVersion.getStatus());
+
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_APPROVED);
+
+		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
+
+		fileVersion = fileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
+		Assert.assertEquals(expirationDate, fileVersion.getExpirationDate());
+	}
+
+	@Test
+	public void testWorkflowApprovesFileEntryExpirePastDate()
+		throws PortalException {
+
+		FileEntry fileEntry = _addFileEntry(null, null);
+
+		FileVersion fileVersion = fileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_PENDING, fileVersion.getStatus());
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		dlFileEntry.setExpirationDate(
+			new Date(System.currentTimeMillis() - Time.DAY));
+
+		_dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+
+		_updateStatus(fileVersion, WorkflowConstants.STATUS_APPROVED);
+
+		fileEntry = _dlAppService.getFileEntry(fileEntry.getFileEntryId());
+
+		fileVersion = fileEntry.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, fileVersion.getStatus());
+		Assert.assertNull(fileVersion.getExpirationDate());
+	}
+
 	@FeatureFlags("LPD-10701")
 	@Test
 	public void testWorkflowApprovesFileEntryScheduledFutureDate()

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2020,9 +2020,19 @@ public class DLFileEntryLocalServiceImpl
 
 		// File version
 
-		int oldStatus = dlFileVersion.getStatus();
+		Date date = new Date();
 
-		status = _getStatus(dlFileVersion, status);
+		status = _getStatus(date, dlFileVersion, status);
+
+		Date expirationDate = dlFileVersion.getExpirationDate();
+
+		if ((status == WorkflowConstants.STATUS_APPROVED) &&
+			(expirationDate != null) && expirationDate.before(date)) {
+
+			dlFileVersion.setExpirationDate(null);
+		}
+
+		int oldStatus = dlFileVersion.getStatus();
 
 		dlFileVersion = _updateFileVersionStatus(dlFileVersion, status, userId);
 
@@ -2998,14 +3008,12 @@ public class DLFileEntryLocalServiceImpl
 		return versionParts[0] + StringPool.PERIOD + versionParts[1];
 	}
 
-	private int _getStatus(DLFileVersion dlFileVersion, int status) {
+	private int _getStatus(Date date, DLFileVersion dlFileVersion, int status) {
 		if (!FeatureFlagManagerUtil.isEnabled(
 				dlFileVersion.getCompanyId(), "LPD-10701")) {
 
 			return status;
 		}
-
-		Date date = new Date();
 
 		if ((status == WorkflowConstants.STATUS_APPROVED) &&
 			(dlFileVersion.getDisplayDate() != null) &&


### PR DESCRIPTION
I'm working over `LPD-25788` and `LPD-25640` so 'on-hold' till the PRs are merged and maybe a rebase is needed.




Steps to Test

1. modify : System Settings > Documents and Media > SYSTEM SCOPE > service : check interval to 1 (to test purposes)
2. Crate a Folder
3. Edit the folder to put single approver as workflow option
4. Create File with name “one” without expiration date on the "folder" with expiration date “now + 2 min”
5. Wait 5 minutes
6. Go to workflow assignments and approve it.


> When the document has an expiration date set previous to the date when the reviewer approves the document, the document will be set to [Approved] directly and the expiration date will be removed, checking the Never expire checkbox




Other :

1. modify : System Settings > Documents and Media > SYSTEM SCOPE > service : check interval to 1 (to test purposes)
2. Crate a Folder
3. Edit the folder to put single approver as workflow option
4. Create File with name “one” without expiration date on the "folder" with expiration date “now + 1 year”
5. Wait 5 minutes
6. Go to workflow assignments and approve it.

> When the document has an expiration date set after the date when the reviewer approves the document, the document will be set to [Approved] and the expiration date will remain, being the document set to [Expired] once the expiration date is reached.



### commits to check on this PR
- **LPD-25641 refactor code**
- **LPD-25641 add test to check the behavior when we approve a document with an expiration date**
- **LPD-25641 When the document has an expiration date set previous to the date when the reviewer approves the document, the document will be set to Approved directly and the expiration date will be removed**
