### PR TITLE
LPD-25437 Fix failing test WebContentUpgradeWithWithSecondComplexStructure#CanAddDefaultValueToWebContentStructure (3rd try)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
@@ -139,9 +139,11 @@ definition {
 
 		NavItem.gotoStructures();
 
-		LexiconEntry.gotoEntryMenuItem(
-			menuItem = "Edit Default Values",
-			rowEntry = "WC Structure Name");
+		WebContentStructures.editStructureDefaultValuesCP(structureName = "WC Structure Name");
+
+		AssertVisible(locator1 = "WCEditWebContent#SIDEBAR");
+
+		AssertVisible(locator1 = "Sidebar#FORM_BUILDER");
 
 		Type(
 			key_fieldFieldLabel = "Label UF Comunicado",
@@ -159,9 +161,11 @@ definition {
 
 		NavItem.gotoStructures();
 
-		LexiconEntry.gotoEntryMenuItem(
-			menuItem = "Edit Default Values",
-			rowEntry = "WC Structure Name");
+		WebContentStructures.editStructureDefaultValuesCP(structureName = "WC Structure Name");
+
+		AssertVisible(locator1 = "WCEditWebContent#SIDEBAR");
+
+		AssertVisible(locator1 = "Sidebar#FORM_BUILDER");
 
 		AssertTextEquals.assertValue(
 			key_fieldFieldLabel = "Label UF Comunicado",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
@@ -143,14 +143,10 @@ definition {
 			menuItem = "Edit Default Values",
 			rowEntry = "WC Structure Name");
 
-		takeScreenshot();
-
 		Type(
 			key_fieldFieldLabel = "Label UF Comunicado",
 			locator1 = "WCEditWebContent#TEXT_INPUT",
 			value1 = "Edited LabelUFComunicado Field");
-
-		takeScreenshot();
 
 		Type(
 			key_fieldFieldLabel = "Lista UF Comunicado",


### PR DESCRIPTION
* Removing TakeScreenshot, used for debug purposes
* Using an existing function to edit Structures default values

https://liferay.atlassian.net/browse/LPD-25437