### PR TITLE
LPD-26178 Refactor Content Dashboard Filters

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
+++ b/modules/apps/content-dashboard/content-dashboard-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Content Dashboard API
 Bundle-SymbolicName: com.liferay.content.dashboard.api
-Bundle-Version: 9.1.2
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.content.dashboard.info.item,\
 	com.liferay.content.dashboard.item,\

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/filter/ContentDashboardItemFilter.java
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/java/com/liferay/content/dashboard/item/filter/ContentDashboardItemFilter.java
@@ -6,6 +6,7 @@
 package com.liferay.content.dashboard.item.filter;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
 
 import java.util.List;
 import java.util.Locale;
@@ -28,6 +29,10 @@ public interface ContentDashboardItemFilter {
 	public String getParameterName();
 
 	public List<String> getParameterValues();
+
+	public default TermsFilter getTermsFilter() {
+		return null;
+	}
 
 	public Type getType();
 

--- a/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/filter/packageinfo
+++ b/modules/apps/content-dashboard/content-dashboard-api/src/main/resources/com/liferay/content/dashboard/item/filter/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/package.json
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/package.json
@@ -3,7 +3,7 @@
 		"@liferay/content-dashboard-web": "*",
 		"react": "16.12.0"
 	},
-	"main": "js/components/SelectFileExtensionWrapper.js",
+	"main": "js/index.js",
 	"name": "@liferay/content-dashboard-document-library-impl",
 	"private": true,
 	"scripts": {

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/filter/FileExtensionContentDashboardItemFilter.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/filter/FileExtensionContentDashboardItemFilter.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -102,6 +103,23 @@ public class FileExtensionContentDashboardItemFilter
 	@Override
 	public List<String> getParameterValues() {
 		return _getFileExtensions(_httpServletRequest);
+	}
+
+	@Override
+	public TermsFilter getTermsFilter() {
+		List<String> fileExtensions = getParameterValues();
+
+		if (ListUtil.isEmpty(fileExtensions)) {
+			return null;
+		}
+
+		TermsFilter termsFilter = new TermsFilter(getParameterName());
+
+		for (String fileExtension : fileExtensions) {
+			termsFilter.addValue(fileExtension);
+		}
+
+		return termsFilter;
 	}
 
 	@Override

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/js/components/SelectFileExtensionWrapper.js
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/js/components/SelectFileExtensionWrapper.js
@@ -6,6 +6,6 @@
 import {SelectFileExtension} from '@liferay/content-dashboard-web';
 import React from 'react';
 
-export function SelectFileExtensionWrapper(props) {
+export default function SelectFileExtensionWrapper(props) {
 	return <SelectFileExtension {...props} />;
 }

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/js/index.js
@@ -3,8 +3,4 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-module.exports = {
-	build: {
-		main: 'src/main/resources/META-INF/resources/js/index.js',
-	},
-};
+export {default as SelectFileExtensionWrapper} from './components/SelectFileExtensionWrapper';

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/dao/search/ContentDashboardItemSearchContainerFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/dao/search/ContentDashboardItemSearchContainerFactory.java
@@ -11,6 +11,7 @@ import com.liferay.content.dashboard.item.ContentDashboardItem;
 import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.web.internal.constants.ContentDashboardPortletKeys;
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
+import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
 import com.liferay.content.dashboard.web.internal.search.request.ContentDashboardSearchContextBuilder;
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
@@ -48,6 +49,8 @@ public class ContentDashboardItemSearchContainerFactory {
 		AssetCategoryLocalService assetCategoryLocalService,
 		AssetVocabularyLocalService assetVocabularyLocalService,
 		ContentDashboardItemFactoryRegistry contentDashboardItemFactoryRegistry,
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry,
 		ContentDashboardSearchRequestBuilderFactory
 			contentDashboardSearchRequestBuilderFactory,
 		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
@@ -57,6 +60,7 @@ public class ContentDashboardItemSearchContainerFactory {
 		return new ContentDashboardItemSearchContainerFactory(
 			assetCategoryLocalService, assetVocabularyLocalService,
 			contentDashboardItemFactoryRegistry,
+			contentDashboardItemFilterProviderRegistry,
 			contentDashboardSearchRequestBuilderFactory,
 			infoSearchClassMapperRegistry, portal, portletRequest,
 			portletResponse, searcher);
@@ -77,6 +81,8 @@ public class ContentDashboardItemSearchContainerFactory {
 		AssetCategoryLocalService assetCategoryLocalService,
 		AssetVocabularyLocalService assetVocabularyLocalService,
 		ContentDashboardItemFactoryRegistry contentDashboardItemFactoryRegistry,
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry,
 		ContentDashboardSearchRequestBuilderFactory
 			contentDashboardSearchRequestBuilderFactory,
 		InfoSearchClassMapperRegistry infoSearchClassMapperRegistry,
@@ -87,6 +93,8 @@ public class ContentDashboardItemSearchContainerFactory {
 		_assetVocabularyLocalService = assetVocabularyLocalService;
 		_contentDashboardItemFactoryRegistry =
 			contentDashboardItemFactoryRegistry;
+		_contentDashboardItemFilterProviderRegistry =
+			contentDashboardItemFilterProviderRegistry;
 		_contentDashboardSearchRequestBuilderFactory =
 			contentDashboardSearchRequestBuilderFactory;
 		_infoSearchClassMapperRegistry = infoSearchClassMapperRegistry;
@@ -172,7 +180,8 @@ public class ContentDashboardItemSearchContainerFactory {
 			_contentDashboardSearchRequestBuilderFactory.builder(
 				new ContentDashboardSearchContextBuilder(
 					_portal.getHttpServletRequest(_portletRequest),
-					_assetCategoryLocalService, _assetVocabularyLocalService
+					_assetCategoryLocalService, _assetVocabularyLocalService,
+					_contentDashboardItemFilterProviderRegistry
 				).withEnd(
 					end
 				).withSort(
@@ -243,6 +252,8 @@ public class ContentDashboardItemSearchContainerFactory {
 	private final AssetVocabularyLocalService _assetVocabularyLocalService;
 	private final ContentDashboardItemFactoryRegistry
 		_contentDashboardItemFactoryRegistry;
+	private final ContentDashboardItemFilterProviderRegistry
+		_contentDashboardItemFilterProviderRegistry;
 	private final ContentDashboardSearchRequestBuilderFactory
 		_contentDashboardSearchRequestBuilderFactory;
 	private final InfoSearchClassMapperRegistry _infoSearchClassMapperRegistry;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/ContentDashboardAdminPortlet.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/ContentDashboardAdminPortlet.java
@@ -96,7 +96,8 @@ public class ContentDashboardAdminPortlet extends MVCPortlet {
 				_aggregations,
 				new ContentDashboardSearchContextBuilder(
 					_portal.getHttpServletRequest(renderRequest),
-					_assetCategoryLocalService, _assetVocabularyLocalService),
+					_assetCategoryLocalService, _assetVocabularyLocalService,
+					_contentDashboardItemFilterProviderRegistry),
 				_contentDashboardSearchRequestBuilderFactory,
 				_portal.getLocale(renderRequest), _queries, resourceBundle,
 				_searcher);
@@ -111,6 +112,7 @@ public class ContentDashboardAdminPortlet extends MVCPortlet {
 				ContentDashboardItemSearchContainerFactory.getInstance(
 					_assetCategoryLocalService, _assetVocabularyLocalService,
 					_contentDashboardItemFactoryRegistry,
+					_contentDashboardItemFilterProviderRegistry,
 					_contentDashboardSearchRequestBuilderFactory,
 					_infoSearchClassMapperRegistry, _portal, renderRequest,
 					renderResponse, _searcher);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/portlet/action/GetContentDashboardItemsXlsMVCResourceCommand.java
@@ -14,6 +14,7 @@ import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.web.internal.constants.ContentDashboardPortletKeys;
 import com.liferay.content.dashboard.web.internal.item.ContentDashboardItemFactoryRegistry;
+import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
 import com.liferay.content.dashboard.web.internal.search.request.ContentDashboardSearchContextBuilder;
 import com.liferay.content.dashboard.web.internal.searcher.ContentDashboardSearchRequestBuilderFactory;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
@@ -293,7 +294,8 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 			_contentDashboardSearchRequestBuilderFactory.builder(
 				new ContentDashboardSearchContextBuilder(
 					_portal.getHttpServletRequest(resourceRequest),
-					_assetCategoryLocalService, _assetVocabularyLocalService
+					_assetCategoryLocalService, _assetVocabularyLocalService,
+					_contentDashboardItemFilterProviderRegistry
 				).withEnd(
 					end
 				).withSort(
@@ -381,6 +383,10 @@ public class GetContentDashboardItemsXlsMVCResourceCommand
 	@Reference
 	private ContentDashboardItemFactoryRegistry
 		_contentDashboardItemFactoryRegistry;
+
+	@Reference
+	private ContentDashboardItemFilterProviderRegistry
+		_contentDashboardItemFilterProviderRegistry;
 
 	@Reference
 	private ContentDashboardSearchRequestBuilderFactory

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -53,11 +54,15 @@ public class ContentDashboardSearchContextBuilder {
 	public ContentDashboardSearchContextBuilder(
 		HttpServletRequest httpServletRequest,
 		AssetCategoryLocalService assetCategoryLocalService,
-		AssetVocabularyLocalService assetVocabularyLocalService) {
+		AssetVocabularyLocalService assetVocabularyLocalService,
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry) {
 
 		_httpServletRequest = httpServletRequest;
 		_assetCategoryLocalService = assetCategoryLocalService;
 		_assetVocabularyLocalService = assetVocabularyLocalService;
+		_contentDashboardItemFilterProviderRegistry =
+			contentDashboardItemFilterProviderRegistry;
 	}
 
 	public SearchContext build() {
@@ -359,6 +364,8 @@ public class ContentDashboardSearchContextBuilder {
 
 	private final AssetCategoryLocalService _assetCategoryLocalService;
 	private final AssetVocabularyLocalService _assetVocabularyLocalService;
+	private final ContentDashboardItemFilterProviderRegistry
+		_contentDashboardItemFilterProviderRegistry;
 	private Integer _end;
 	private final HttpServletRequest _httpServletRequest;
 	private Sort[] _sort;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
@@ -10,6 +10,9 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.content.dashboard.item.action.exception.ContentDashboardItemActionException;
+import com.liferay.content.dashboard.item.filter.ContentDashboardItemFilter;
+import com.liferay.content.dashboard.item.filter.provider.ContentDashboardItemFilterProvider;
 import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
@@ -281,6 +284,38 @@ public class ContentDashboardSearchContextBuilder {
 
 			if (filter != null) {
 				booleanFilter.add(filter, BooleanClauseOccur.MUST);
+			}
+		}
+
+		for (ContentDashboardItemFilterProvider
+				contentDashboardItemFilterProvider :
+					_contentDashboardItemFilterProviderRegistry.
+						getContentDashboardItemFilterProviders()) {
+
+			if (!contentDashboardItemFilterProvider.isShow(
+					_httpServletRequest)) {
+
+				continue;
+			}
+
+			try {
+				ContentDashboardItemFilter contentDashboardItemFilter =
+					contentDashboardItemFilterProvider.
+						getContentDashboardItemFilter(_httpServletRequest);
+
+				TermsFilter termsFilter =
+					contentDashboardItemFilter.getTermsFilter();
+
+				if (termsFilter != null) {
+					booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+				}
+			}
+			catch (ContentDashboardItemActionException
+						contentDashboardItemActionException) {
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(contentDashboardItemActionException);
+				}
 			}
 		}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
@@ -92,7 +92,6 @@ public class ContentDashboardSearchContextBuilder {
 				ParamUtil.getStringValues(_httpServletRequest, "assetTagId"),
 				ParamUtil.getLongValues(_httpServletRequest, "authorIds"),
 				PortalUtil.getCompanyId(_httpServletRequest),
-				ParamUtil.getStringValues(_httpServletRequest, "fileExtension"),
 				ParamUtil.getString(_httpServletRequest, "reviewDate")));
 
 		String[] contentDashboardItemSubtypePayloads =
@@ -266,8 +265,7 @@ public class ContentDashboardSearchContextBuilder {
 
 	private BooleanClause[] _getBooleanClauses(
 		AssetCategoryIds assetCategoryIds, String[] assetTagNames,
-		long[] authorIds, long companyId, String[] fileExtensions,
-		String reviewDate) {
+		long[] authorIds, long companyId, String reviewDate) {
 
 		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
 
@@ -278,7 +276,6 @@ public class ContentDashboardSearchContextBuilder {
 					_getAssetCategoryIdsFilter(assetCategoryIds),
 					_getAssetTagNamesFilter(assetTagNames),
 					_getAuthorIdsFilter(authorIds),
-					_getFileExtensionsFilter(fileExtensions),
 					_getGoogleDriveShortcutFilter(companyId),
 					_getReviewDateFilter(reviewDate))) {
 
@@ -325,20 +322,6 @@ public class ContentDashboardSearchContextBuilder {
 			BooleanClauseFactoryUtil.create(
 				booleanQueryImpl, BooleanClauseOccur.MUST.getName())
 		};
-	}
-
-	private Filter _getFileExtensionsFilter(String[] fileExtensions) {
-		if (ArrayUtil.isEmpty(fileExtensions)) {
-			return null;
-		}
-
-		TermsFilter termsFilter = new TermsFilter("fileExtension");
-
-		for (String fileExtension : fileExtensions) {
-			termsFilter.addValue(fileExtension);
-		}
-
-		return termsFilter;
 	}
 
 	private Filter _getGoogleDriveShortcutFilter(long companyId) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilderTest.java
@@ -1,0 +1,324 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.dashboard.web.internal.search.request;
+
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.content.dashboard.item.action.exception.ContentDashboardItemActionException;
+import com.liferay.content.dashboard.item.filter.ContentDashboardItemFilter;
+import com.liferay.content.dashboard.item.filter.provider.ContentDashboardItemFilterProvider;
+import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.context.SearchContextFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ContentDashboardSearchContextBuilderTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpCompanyLocalServiceUtil();
+		_setUpDLFileEntryTypeLocalServiceUtil();
+		_setUpPortal();
+		_setUpSearchContextFactory();
+	}
+
+	@Test
+	public void testBuildWithAvailableContentDashboardItemFilterProvider()
+		throws ContentDashboardItemActionException {
+
+		String parameterName = RandomTestUtil.randomString();
+		String[] parameterValues = {RandomTestUtil.randomString()};
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			parameterName, parameterValues);
+
+		AssetCategoryLocalService assetCategoryLocalService = Mockito.mock(
+			AssetCategoryLocalService.class);
+		AssetVocabularyLocalService assetVocabularyLocalService = Mockito.mock(
+			AssetVocabularyLocalService.class);
+
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry =
+				_getContentDashboardItemFilterProviderRegistry(
+					_getContentDashboardItemFilterProvider(
+						_getContentDashboardItemFilter(
+							parameterName, parameterValues),
+						httpServletRequest, true));
+
+		ContentDashboardSearchContextBuilder
+			contentDashboardSearchContextBuilder =
+				new ContentDashboardSearchContextBuilder(
+					httpServletRequest, assetCategoryLocalService,
+					assetVocabularyLocalService,
+					contentDashboardItemFilterProviderRegistry);
+
+		Assert.assertNotNull(contentDashboardSearchContextBuilder);
+
+		SearchContext searchContext =
+			contentDashboardSearchContextBuilder.build();
+
+		List<BooleanClause<Filter>> mustBooleanClauses = _getBooleanClauses(
+			searchContext);
+
+		Assert.assertEquals(
+			mustBooleanClauses.toString(), 1, mustBooleanClauses.size());
+
+		BooleanClause<Filter> filterBooleanClause = mustBooleanClauses.get(0);
+
+		TermsFilter termsFilter = (TermsFilter)filterBooleanClause.getClause();
+
+		Assert.assertEquals(parameterName, termsFilter.getField());
+		Assert.assertEquals(parameterValues, termsFilter.getValues());
+	}
+
+	@Test
+	public void testBuildWithUnavailableContentDashboardItemFilterProvider()
+		throws ContentDashboardItemActionException {
+
+		String parameterName = RandomTestUtil.randomString();
+		String[] parameterValues = {RandomTestUtil.randomString()};
+
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(
+			parameterName, parameterValues);
+
+		AssetCategoryLocalService assetCategoryLocalService = Mockito.mock(
+			AssetCategoryLocalService.class);
+		AssetVocabularyLocalService assetVocabularyLocalService = Mockito.mock(
+			AssetVocabularyLocalService.class);
+
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry =
+				_getContentDashboardItemFilterProviderRegistry(
+					_getContentDashboardItemFilterProvider(
+						_getContentDashboardItemFilter(
+							parameterName, parameterValues),
+						httpServletRequest, false));
+
+		ContentDashboardSearchContextBuilder
+			contentDashboardSearchContextBuilder =
+				new ContentDashboardSearchContextBuilder(
+					httpServletRequest, assetCategoryLocalService,
+					assetVocabularyLocalService,
+					contentDashboardItemFilterProviderRegistry);
+
+		Assert.assertNotNull(contentDashboardSearchContextBuilder);
+
+		SearchContext searchContext =
+			contentDashboardSearchContextBuilder.build();
+
+		List<BooleanClause<Filter>> mustBooleanClauses = _getBooleanClauses(
+			searchContext);
+
+		Assert.assertEquals(
+			mustBooleanClauses.toString(), 0, mustBooleanClauses.size());
+	}
+
+	private List<BooleanClause<Filter>> _getBooleanClauses(
+		SearchContext searchContext) {
+
+		BooleanClause<Query>[] booleanClauses =
+			searchContext.getBooleanClauses();
+
+		Assert.assertNotNull(booleanClauses);
+
+		Assert.assertEquals(
+			booleanClauses.toString(), 1, booleanClauses.length);
+
+		BooleanClause<Query> booleanClause = booleanClauses[0];
+
+		BooleanQuery booleanQuery = (BooleanQuery)booleanClause.getClause();
+
+		BooleanFilter preBooleanFilter = booleanQuery.getPreBooleanFilter();
+
+		return preBooleanFilter.getMustBooleanClauses();
+	}
+
+	private ContentDashboardItemFilter _getContentDashboardItemFilter(
+		String parameterName, String... parameterValues) {
+
+		ContentDashboardItemFilter contentDashboardItemFilter = Mockito.mock(
+			ContentDashboardItemFilter.class);
+
+		TermsFilter termsFilter = new TermsFilter(parameterName);
+
+		for (String parameterValue : parameterValues) {
+			termsFilter.addValue(parameterValue);
+		}
+
+		Mockito.when(
+			contentDashboardItemFilter.getTermsFilter()
+		).thenReturn(
+			termsFilter
+		);
+
+		return contentDashboardItemFilter;
+	}
+
+	private ContentDashboardItemFilterProvider
+			_getContentDashboardItemFilterProvider(
+				ContentDashboardItemFilter contentDashboardItemFilter,
+				HttpServletRequest httpServletRequest, boolean show)
+		throws ContentDashboardItemActionException {
+
+		ContentDashboardItemFilterProvider contentDashboardItemFilterProvider =
+			Mockito.mock(ContentDashboardItemFilterProvider.class);
+
+		Mockito.when(
+			contentDashboardItemFilterProvider.getContentDashboardItemFilter(
+				httpServletRequest)
+		).thenReturn(
+			contentDashboardItemFilter
+		);
+
+		Mockito.when(
+			contentDashboardItemFilterProvider.isShow(httpServletRequest)
+		).thenReturn(
+			show
+		);
+
+		return contentDashboardItemFilterProvider;
+	}
+
+	private ContentDashboardItemFilterProviderRegistry
+		_getContentDashboardItemFilterProviderRegistry(
+			ContentDashboardItemFilterProvider
+				contentDashboardItemFilterProvider) {
+
+		ContentDashboardItemFilterProviderRegistry
+			contentDashboardItemFilterProviderRegistry = Mockito.mock(
+				ContentDashboardItemFilterProviderRegistry.class);
+
+		Mockito.when(
+			contentDashboardItemFilterProviderRegistry.
+				getContentDashboardItemFilterProviders()
+		).thenReturn(
+			Arrays.asList(contentDashboardItemFilterProvider)
+		);
+
+		return contentDashboardItemFilterProviderRegistry;
+	}
+
+	private HttpServletRequest _getHttpServletRequest(
+		String parameterName, String... parameterValues) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Mockito.when(
+			httpServletRequest.getParameterValues(parameterName)
+		).thenReturn(
+			parameterValues
+		);
+
+		return httpServletRequest;
+	}
+
+	private void _setUpCompanyLocalServiceUtil() throws Exception {
+		CompanyLocalServiceUtil companyLocalServiceUtil =
+			new CompanyLocalServiceUtil();
+
+		Company company = Mockito.mock(Company.class);
+
+		Mockito.when(
+			_companyLocalService.getCompany(Mockito.anyLong())
+		).thenReturn(
+			company
+		);
+
+		companyLocalServiceUtil.setService(_companyLocalService);
+	}
+
+	private void _setUpDLFileEntryTypeLocalServiceUtil() {
+		DLFileEntryTypeLocalServiceUtil dlFileEntryTypeLocalServiceUtil =
+			new DLFileEntryTypeLocalServiceUtil();
+
+		Mockito.when(
+			_dlFileEntryTypeLocalService.fetchFileEntryType(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			null
+		);
+
+		dlFileEntryTypeLocalServiceUtil.setService(
+			_dlFileEntryTypeLocalService);
+	}
+
+	private void _setUpPortal() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		Mockito.when(
+			_portal.getCompanyId(Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		portalUtil.setPortal(_portal);
+	}
+
+	private void _setUpSearchContextFactory() {
+		Mockito.doReturn(
+			new SearchContext()
+		).when(
+			_searchContextFactory
+		).getSearchContext(
+			Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any(),
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong(),
+			Mockito.any(), Mockito.anyLong()
+		);
+	}
+
+	private final CompanyLocalService _companyLocalService = Mockito.mock(
+		CompanyLocalService.class);
+	private final DLFileEntryTypeLocalService _dlFileEntryTypeLocalService =
+		Mockito.mock(DLFileEntryTypeLocalService.class);
+	private final Portal _portal = Mockito.mock(Portal.class);
+	private final SearchContextFactory _searchContextFactory = Mockito.mock(
+		SearchContextFactory.class);
+
+}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPD-26178)

At the moment, filters that are contributed are not taken into account when building the boolean clauses while building the search context in Content Dashboard. This PR tries to address this. The idea is to add a new method that retrieves the terms and add them to the boolean clauses. This is applied to extensions.

Note that basically everything should work as it is working now.

## Change summary:

* Change main entrypoint for js components in content dashboard document library impl
* Take into account the terms filters in a content dashboard filter when building the search context
* Adds unit test


## Test Scenario

* Deploy the current PR
* Start the portal
* Go to Applications Menu -> Content Dashboard
* Click on Filters -> Extensions
* Select one extension 
* The results are filtered by the extension that was selected

![Content Dashboard](https://github.com/liferay-content-management/liferay-portal/assets/4267448/8eee526f-b842-4313-8b3d-17cb9ca550e2)
