### PR TITLE
LPD-26190 update amazon awssdk libs to newer version

### DIFF
--- a/modules/apps/translation/translation-translator-aws/bnd.bnd
+++ b/modules/apps/translation/translation-translator-aws/bnd.bnd
@@ -14,6 +14,8 @@ Import-Package:\
 	\
 	!com.oracle.svm.core.annotate.*,\
 	\
+	!io.netty.internal.tcnative.*,\
+	\
 	!lzma.sdk.*,\
 	\
 	!net.jpountz.lz4.*,\
@@ -23,10 +25,13 @@ Import-Package:\
 	!org.apache.log.*,\
 	!org.apache.log4j.*,\
 	\
+	!org.bouncycastle.asn1.pkcs.*,\
 	!org.bouncycastle.asn1.x500.*,\
 	!org.bouncycastle.cert.*,\
 	!org.bouncycastle.jce.provider.*,\
+	!org.bouncycastle.openssl.*,\
 	!org.bouncycastle.operator.*,\
+	!org.bouncycastle.pkcs.*,\
 	\
 	!org.conscrypt.*,\
 	\
@@ -38,6 +43,8 @@ Import-Package:\
 	!org.slf4j.impl.*,\
 	\
 	!reactor.blockhound.*,\
+	\
+	!software.amazon.awssdk.crt.*,\
 	\
 	!sun.security.x509.*,\
 	\

--- a/modules/apps/translation/translation-translator-aws/build.gradle
+++ b/modules/apps/translation/translation-translator-aws/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 dependencies {
 	compileIncludePlatform group: "software.amazon.awssdk", name: "translate"
-	compileIncludePlatform platform("software.amazon.awssdk:bom:2.17.112")
+	compileIncludePlatform platform("software.amazon.awssdk:bom:2.25.53")
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"

--- a/modules/third-party/org-opensearch-java-client/build.gradle
+++ b/modules/third-party/org-opensearch-java-client/build.gradle
@@ -39,11 +39,11 @@ dependencies {
 	api group: "org.apache.logging.log4j", name: "log4j-core", version: "2.17.2"
 	api group: "org.eclipse", name: "yasson", version: "2.0.2"
 	api group: "org.eclipse.parsson", name: "parsson", version: "1.1.4"
-	api group: "software.amazon.awssdk", name: "apache-client", version: "2.21.27"
-	api group: "software.amazon.awssdk", name: "auth", version: "2.21.27"
-	api group: "software.amazon.awssdk", name: "aws-crt-client", version: "2.21.27"
-	api group: "software.amazon.awssdk", name: "sdk-core", version: "2.21.27"
-	api group: "software.amazon.awssdk", name: "sts", version: "2.21.27"
+	api group: "software.amazon.awssdk", name: "apache-client", version: "2.25.53"
+	api group: "software.amazon.awssdk", name: "auth", version: "2.25.53"
+	api group: "software.amazon.awssdk", name: "aws-crt-client", version: "2.25.53"
+	api group: "software.amazon.awssdk", name: "sdk-core", version: "2.25.53"
+	api group: "software.amazon.awssdk", name: "sts", version: "2.25.53"
 
 	compileOnly group: "org.opensearch.client", name: "opensearch-java", transitive: false, version: "2.8.0"
 }


### PR DESCRIPTION
Updating `software.amazon.awssdk` to `2.25.53`

The new version uses `netty-nio-client:2.25.53` that includes `netty-codec-http:4.1.108`

**This is a library upgrade, so no additional tests necessary. Existing regression suite should catch any outstanding issues.**


