### PR TITLE
PD-26431 addAMImageEntry must always be executed in a new transaction, otherwise with large amounts of entries process never updates progress.

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/service/AMImageEntryLocalService.java
@@ -79,6 +79,7 @@ public interface AMImageEntryLocalService
 	 * @throws PortalException if an adaptive media image already exists for the
 	 file version and configuration
 	 */
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public AMImageEntry addAMImageEntry(
 			AMImageConfigurationEntry amImageConfigurationEntry,
 			FileVersion fileVersion, int height, int width,

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/resources/com/liferay/adaptive/media/image/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.0.1

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/service/impl/AMImageEntryLocalServiceImpl.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.Transactional;
 
 import java.io.InputStream;
 
@@ -76,6 +78,7 @@ public class AMImageEntryLocalServiceImpl
 	 *         file version and configuration
 	 */
 	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public AMImageEntry addAMImageEntry(
 			AMImageConfigurationEntry amImageConfigurationEntry,
 			FileVersion fileVersion, int height, int width,


### PR DESCRIPTION
# What is this trying to solve?

- https://liferay.atlassian.net/browse/LPD-26431 addAMImageEntry must always be executed in a new transaction, otherwise with large amounts of entries process never updates progress.

# How am I fixing it?

Modifying the adittion of addAMImageEntry making it write each transaction individually into the database.

# How can you verify that it works?

1. Upload a huge amount of image files. I start observing the behavior starting at 10 000 images.
2. Go to Control Panel/Adaptive Media, create a new resolution and start the Adapt Remaining operation for it.
3. The task never updates it’s progress until the full process is over.

# Why does this pull not include tests?

This cannot be observed reliably from a test. We'd need to check that a progress bar increases over time, which may lead to flakiness if the bar progresses too slowly or too fast.
