### PR TITLE
LPD-26464 Cannot use keyword filtering in API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dynamic/data/mapping/DDMStructureField.java
@@ -5,15 +5,23 @@
 
 package com.liferay.headless.delivery.dynamic.data.mapping;
 
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
+import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Javier de Arcos
@@ -67,12 +75,40 @@ public class DDMStructureField {
 	}
 
 	public String getDDMStructureNestedTypeSortableFieldName() {
-		return StringBundler.concat(
+		String ddmStructureNestedTypeSortableFieldName = StringBundler.concat(
 			DDMIndexer.DDM_FIELD_ARRAY, StringPool.PERIOD,
 			DDMIndexer.DDM_VALUE_FIELD_NAME_PREFIX,
 			StringUtil.upperCaseFirstLetter(_indexType), _getLocaleSuffix(),
 			StringPool.UNDERLINE, _type, StringPool.UNDERLINE,
 			Field.SORTABLE_FIELD_SUFFIX);
+
+		DDMStructure ddmStructure =
+			DDMStructureLocalServiceUtil.fetchDDMStructure(
+				GetterUtil.getLong(_ddmStructureId));
+
+		if (ddmStructure != null) {
+			try {
+				DDMFormField ddmFormField =
+					ddmStructure.getDDMFormFieldByFieldReference(
+						_fieldReference);
+
+				if ((ddmFormField != null) &&
+					Objects.equals(
+						ddmFormField.getDataType(), FieldConstants.STRING)) {
+
+					ddmStructureNestedTypeSortableFieldName =
+						ddmStructureNestedTypeSortableFieldName +
+							".keyword_lowercase";
+				}
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
+				}
+			}
+		}
+
+		return ddmStructureNestedTypeSortableFieldName;
 	}
 
 	public String getLocale() {
@@ -110,6 +146,9 @@ public class DDMStructureField {
 
 		return StringPool.UNDERLINE.concat(_locale);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMStructureField.class);
 
 	private final String _ddmStructureId;
 	private final String _fieldReference;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -326,6 +326,16 @@ public class StructuredContentResourceTest
 
 	@Override
 	@Test
+	public void testGetContentStructureStructuredContentsPage()
+		throws Exception {
+
+		super.testGetContentStructureStructuredContentsPage();
+
+		_testGetContentStructureStructuredContentsPageWithFilter();
+	}
+
+	@Override
+	@Test
 	public void testGetSiteStructuredContentsPage() throws Exception {
 		super.testGetSiteStructuredContentsPage();
 
@@ -718,6 +728,12 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected StructuredContent randomStructuredContent() throws Exception {
+		return randomStructuredContent(RandomTestUtil.randomString(10));
+	}
+
+	protected StructuredContent randomStructuredContent(String dataValue)
+		throws Exception {
+
 		StructuredContent structuredContent = super.randomStructuredContent();
 
 		structuredContent.setContentFields(
@@ -726,7 +742,7 @@ public class StructuredContentResourceTest
 					{
 						contentFieldValue = new ContentFieldValue() {
 							{
-								data = RandomTestUtil.randomString(10);
+								data = dataValue;
 							}
 						};
 						name = "Foo";
@@ -1454,6 +1470,60 @@ public class StructuredContentResourceTest
 			"dependencies/" + fileName);
 
 		return StringUtil.read(inputStream);
+	}
+
+	private void _testGetContentStructureStructuredContentsPageWithFilter()
+		throws Exception {
+
+		Long contentStructureId =
+			testGetContentStructureStructuredContentsPage_getContentStructureId();
+
+		StructuredContent structuredContent1 = randomStructuredContent(
+			"first second");
+		StructuredContent structuredContent2 = randomStructuredContent(
+			"second");
+
+		testGetContentStructureStructuredContentsPage_addStructuredContent(
+			contentStructureId, structuredContent1);
+		testGetContentStructureStructuredContentsPage_addStructuredContent(
+			contentStructureId, structuredContent2);
+
+		Page<StructuredContent> page =
+			structuredContentResource.getContentStructureStructuredContentsPage(
+				contentStructureId, null, null, "contentFields/Foo eq 'second'",
+				Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		List<StructuredContent> items =
+			(List<StructuredContent>)page.getItems();
+
+		assertEquals(structuredContent2, items.get(0));
+
+		page =
+			structuredContentResource.getContentStructureStructuredContentsPage(
+				contentStructureId, null, null,
+				"contains(contentFields/Foo,'first')", Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		items = (List<StructuredContent>)page.getItems();
+
+		assertEquals(structuredContent1, items.get(0));
+
+		page =
+			structuredContentResource.getContentStructureStructuredContentsPage(
+				contentStructureId, null, null,
+				"contains(contentFields/Foo,'second')", Pagination.of(1, 10),
+				null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		items = (List<StructuredContent>)page.getItems();
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(structuredContent1, structuredContent2), items);
 	}
 
 	private void _testGetSiteStructuredContentsPageByDefaultPriority()


### PR DESCRIPTION
Cannot use keyword filtering in API

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-26464)

Filtering by contains for DDMFields fails because it's not targeting the correct field. Now for Strings, we should target field + .keyword_lowercase

# How am I fixing it?

Identify if we are targeting a ddmField of type "string" and target the correct field

# How can you verify that it works?

* Follow the steps in the LPD
* Or run the provided integration tests

