### PR TITLE
LPD-22564 Click add option when there is more than one option

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DataEngine.macro
@@ -242,6 +242,10 @@ definition {
 				value1 = ${fieldFieldLabel});
 		}
 
+		if (${index} != 1) {
+			FormFields.clickAddOptionButton();
+		}
+
 		if (isSet(optionFieldLabel)) {
 			Type(
 				index = ${index},


### PR DESCRIPTION
Click add option when there is more than one option

# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-22564)

Fix POSHI test WebContentStructures#EditFieldReferenceOfFieldOption

# How am I fixing it?

Click in add option field when we have more than one option

# How can you verify that it works?

Execute poshi test