### PR TITLE
LPD-26964 Adds an integration test for LPS-158221 use case

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
 
 import org.junit.Assert;
@@ -60,7 +61,9 @@ public class JournalArticleAssetRendererTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -55,6 +56,7 @@ import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
 
 import javax.portlet.PortletPreferences;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -84,6 +86,13 @@ public class JournalArticleAssetRendererTest {
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group.getGroupId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -94,13 +94,6 @@ public class JournalArticleAssetRendererTest {
 				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0,
 				0, 0, WorkflowConstants.STATUS_APPROVED, _serviceContext);
 
-		AssetRendererFactory<JournalArticle> assetRendererFactory =
-			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
-				JournalArticle.class);
-
-		AssetRenderer<JournalArticle> assetRenderer =
-			assetRendererFactory.getAssetRenderer(article, 0);
-
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
 			_layoutDisplayPageProviderRegistry.
 				getLayoutDisplayPageProviderByClassName(
@@ -112,20 +105,10 @@ public class JournalArticleAssetRendererTest {
 			_company, _group,
 			_layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid()));
 
-		String viewInContextURL = assetRenderer.getURLViewInContext(
-			_getLiferayPortletRequest(themeDisplay), null, null);
+		String viewInContextURL = _getURLViewInContext(
+			article.getResourcePrimKey(), themeDisplay);
 
-		Assert.assertNotNull(viewInContextURL);
-
-		int index = viewInContextURL.indexOf(urlSeparator);
-
-		Assert.assertTrue(index >= 0);
-
-		String friendlyURL = viewInContextURL.substring(
-			index + urlSeparator.length());
-
-		Assert.assertEquals(
-			article.getUrlTitle(), HttpComponentsUtil.getPath(friendlyURL));
+		_assertURL(viewInContextURL, urlSeparator, article.getUrlTitle());
 
 		String version = HttpComponentsUtil.getParameter(
 			viewInContextURL, "version");
@@ -137,25 +120,27 @@ public class JournalArticleAssetRendererTest {
 
 		article = JournalTestUtil.updateArticleWithWorkflow(article, true);
 
-		assetRenderer = assetRendererFactory.getAssetRenderer(article, 0);
+		viewInContextURL = _getURLViewInContext(
+			article.getResourcePrimKey(), themeDisplay);
 
-		viewInContextURL = assetRenderer.getURLViewInContext(
-			_getLiferayPortletRequest(themeDisplay), null, null);
-
-		Assert.assertNotNull(viewInContextURL);
-
-		index = viewInContextURL.indexOf(urlSeparator);
-
-		Assert.assertTrue(index >= 0);
-
-		friendlyURL = viewInContextURL.substring(index + urlSeparator.length());
-
-		Assert.assertEquals(
-			article.getUrlTitle(), HttpComponentsUtil.getPath(friendlyURL));
+		_assertURL(viewInContextURL, urlSeparator, article.getUrlTitle());
 
 		Assert.assertEquals(
 			StringPool.BLANK,
 			HttpComponentsUtil.getParameter(viewInContextURL, "version"));
+	}
+
+	private void _assertURL(String url, String urlSeparator, String urlTitle) {
+		Assert.assertNotNull(url);
+
+		int index = url.indexOf(urlSeparator);
+
+		Assert.assertTrue(index >= 0);
+
+		Assert.assertEquals(
+			urlTitle,
+			HttpComponentsUtil.getPath(
+				url.substring(index + urlSeparator.length())));
 	}
 
 	private LiferayPortletRequest _getLiferayPortletRequest(
@@ -166,6 +151,21 @@ public class JournalArticleAssetRendererTest {
 		renderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		return _portal.getLiferayPortletRequest(renderRequest);
+	}
+
+	private String _getURLViewInContext(
+			long resourcePrimKey, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		AssetRendererFactory<JournalArticle> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+				JournalArticle.class);
+
+		AssetRenderer<JournalArticle> assetRenderer =
+			assetRendererFactory.getAssetRenderer(resourcePrimKey);
+
+		return assetRenderer.getURLViewInContext(
+			_getLiferayPortletRequest(themeDisplay), null, null);
 	}
 
 	private Company _company;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -9,9 +9,12 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderRegistry;
@@ -19,11 +22,15 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
-import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -38,12 +45,15 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
+
+import javax.portlet.PortletPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -130,6 +140,89 @@ public class JournalArticleAssetRendererTest {
 			HttpComponentsUtil.getParameter(viewInContextURL, "version"));
 	}
 
+	@Test
+	public void testGetURLViewInContextWithLayoutUuid() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticleWithWorkflow(
+			_group.getGroupId(), true);
+
+		ThemeDisplay themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group,
+			_getDynamicSelectionAssetPublisherPortletLayout());
+
+		Assert.assertNull(
+			_getURLViewInContext(
+				journalArticle.getResourcePrimKey(), themeDisplay));
+
+		Layout layout = _addDefaultAssetPublisherLayout();
+
+		journalArticle = _journalArticleLocalService.updateArticle(
+			TestPropsValues.getUserId(), journalArticle.getGroupId(),
+			journalArticle.getFolderId(), journalArticle.getArticleId(),
+			journalArticle.getVersion(), journalArticle.getTitleMap(),
+			journalArticle.getDescriptionMap(), journalArticle.getContent(),
+			layout.getUuid(), _serviceContext);
+
+		String viewInContextURL = _getURLViewInContext(
+			journalArticle.getResourcePrimKey(), themeDisplay);
+
+		_assertURL(
+			viewInContextURL, JournalArticleConstants.CANONICAL_URL_SEPARATOR,
+			journalArticle.getUrlTitle());
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		Assert.assertEquals(
+			viewInContextURL,
+			_getURLViewInContext(
+				journalArticle.getResourcePrimKey(), themeDisplay));
+	}
+
+	private String _addAssetPublisherPortletToLayout(Layout layout)
+		throws Exception {
+
+		JSONObject processAddPortletJSONObject =
+			ContentLayoutTestUtil.addPortletToLayout(
+				layout, AssetPublisherPortletKeys.ASSET_PUBLISHER);
+
+		JSONObject fragmentEntryLinkJSONObject =
+			processAddPortletJSONObject.getJSONObject("fragmentEntryLink");
+
+		JSONObject editableValuesJSONObject =
+			fragmentEntryLinkJSONObject.getJSONObject("editableValues");
+
+		return PortletIdCodec.encode(
+			editableValuesJSONObject.getString("portletId"),
+			editableValuesJSONObject.getString("instanceId"));
+	}
+
+	private Layout _addDefaultAssetPublisherLayout() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		Assert.assertNotNull(draftLayout);
+
+		ContentLayoutTestUtil.publishLayout(
+			_addDefaultAssetPublisherPortletToLayout(draftLayout), layout);
+
+		return _layoutLocalService.getLayout(layout.getPlid());
+	}
+
+	private Layout _addDefaultAssetPublisherPortletToLayout(Layout layout)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			layout.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			LayoutTypePortletConstants.DEFAULT_ASSET_PUBLISHER_PORTLET_ID,
+			_addAssetPublisherPortletToLayout(layout));
+
+		return _layoutLocalService.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
+			typeSettingsUnicodeProperties.toString());
+	}
+
 	private void _assertURL(String url, String urlSeparator, String urlTitle) {
 		Assert.assertNotNull(url);
 
@@ -141,6 +234,28 @@ public class JournalArticleAssetRendererTest {
 			urlTitle,
 			HttpComponentsUtil.getPath(
 				url.substring(index + urlSeparator.length())));
+	}
+
+	private Layout _getDynamicSelectionAssetPublisherPortletLayout()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		Assert.assertNotNull(draftLayout);
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(
+				draftLayout, _addAssetPublisherPortletToLayout(draftLayout));
+
+		portletPreferences.setValue("selectionStyle", "dynamic");
+
+		portletPreferences.store();
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		return _layoutLocalService.getLayout(layout.getPlid());
 	}
 
 	private LiferayPortletRequest _getLiferayPortletRequest(
@@ -178,6 +293,9 @@ public class JournalArticleAssetRendererTest {
 
 	@Inject
 	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Inject
 	private LayoutDisplayPageProviderRegistry

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -18,6 +18,7 @@ import com.liferay.layout.display.page.LayoutDisplayPageProviderRegistry;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -63,6 +64,9 @@ public class JournalArticleAssetRendererTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_company = _companyLocalService.fetchCompany(
+			TestPropsValues.getCompanyId());
+
 		_group = GroupTestUtil.addGroup();
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
@@ -101,8 +105,9 @@ public class JournalArticleAssetRendererTest {
 
 		String urlSeparator = layoutDisplayPageProvider.getURLSeparator();
 
-		ThemeDisplay themeDisplay = _getThemeDisplay(
-			layoutPageTemplateEntry.getPlid());
+		ThemeDisplay themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group,
+			_layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid()));
 
 		String viewInContextURL = assetRenderer.getURLViewInContext(
 			_getLiferayPortletRequest(themeDisplay), null, null);
@@ -160,24 +165,7 @@ public class JournalArticleAssetRendererTest {
 		return _portal.getLiferayPortletRequest(renderRequest);
 	}
 
-	private ThemeDisplay _getThemeDisplay(long plid) throws Exception {
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setCompany(
-			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
-
-		Layout layout = _layoutLocalService.getLayout(plid);
-
-		themeDisplay.setLayout(layout);
-		themeDisplay.setLayoutSet(layout.getLayoutSet());
-
-		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-		themeDisplay.setScopeGroupId(_group.getGroupId());
-		themeDisplay.setSiteGroupId(_group.getGroupId());
-
-		return themeDisplay;
-	}
+	private Company _company;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
[LPD-26964](https://liferay.atlassian.net/browse/LPD-26964) Add a test for Whole page content is not visible while clicking on search result

# What is this trying to solve?

Adds an integration test for the use case: the WebContent in search results links to the Asset Publisher instead of WC. Ref: LPP-46545: Whole page content is not visible while clicking on search result

# How am I fixing it?
Adds the integration test JournalArticleAssetRendererTest.testGetURLViewInContextWithLayoutUuid

# How can you verify that it works?
Execute the test JournalArticleAssetRendererTest.testGetURLViewInContextWithLayoutUuid