### PR TITLE
LPD-26752 TESTS Blogs friendlyURL categories

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -6,7 +6,7 @@
 import {ApiHelpers} from './ApiHelpers';
 
 interface createVocabularyProps {
-	assetTypes: AssetType[];
+	assetTypes?: AssetType[];
 	name: string;
 	siteId: string;
 }
@@ -35,7 +35,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 *
 	 * @param siteId the id of the site in which the vocabulary will be created
 	 * @param name the name of the vocabulary
-	 * @param assetTypes the asset types to which the vocabulary can be used
+	 * @param [assetTypes] the asset types to which the vocabulary can be used
 	 */
 
 	async createVocabulary({

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -27,16 +27,28 @@ export class DisplayPageTemplatesPage {
 		);
 	}
 
-	async publishNewTemplate(name: string) {
+	async publishNewTemplate({
+		contentSubtype,
+		contentType,
+		name,
+	}: {
+		contentSubtype?: 'Basic Web Content';
+		contentType: 'Web Content Article' | 'Blogs Entry';
+		name: string;
+	}) {
 		await this.newButton.click();
 		await this.page.getByRole('button', {name: 'Blank'}).click();
 		await this.page.getByLabel('Name').fill(name);
 		await this.page
 			.getByLabel('Content Type')
-			.selectOption({label: 'Web Content Article'});
-		await this.page
-			.getByLabel('Subtype')
-			.selectOption({label: 'Basic Web Content'});
+			.selectOption({label: contentType});
+
+		if (contentSubtype) {
+			await this.page
+				.getByLabel('Subtype')
+				.selectOption({label: contentSubtype});
+		}
+
 		await this.page.getByRole('button', {name: 'Save'}).click();
 		await this.publishButton.waitFor();
 		await this.publishButton.click();
@@ -46,7 +58,7 @@ export class DisplayPageTemplatesPage {
 		);
 	}
 
-	async clickMoreActions(name: string) {
+	private async clickMoreActions(name: string) {
 		await this.page
 			.locator(
 				'#_com_liferay_layout_page_template_admin_web_portlet_LayoutPageTemplatesPortlet_displayPagesSearchContainer .card-page-item'

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -38,7 +38,7 @@ export class DisplayPageTemplatesPage {
 	}) {
 		await this.newButton.click();
 		await this.page.getByRole('button', {name: 'Blank'}).click();
-		await this.page.getByLabel('Name').fill(name);
+		await this.page.getByLabel('Name', {exact: true}).fill(name);
 		await this.page
 			.getByLabel('Content Type')
 			.selectOption({label: contentType});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -5,12 +5,22 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
-const test = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
+const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	blogsPagesTest,
+	loginTest(),
+	featureFlagsTest({
+		'LPD-11147': true,
+	})
+);
 
 test('LPD-22497: Permission sets are differing depending on autosaving of a blog entry', async ({
 	blogsEditBlogEntryPage,
@@ -47,4 +57,42 @@ test('LPD-22497: Permission sets are differing depending on autosaving of a blog
 		],
 		title
 	);
+});
+
+test('LPD-26752 Select categories for the custom friendly URL', async ({
+	apiHelpers,
+	blogsEditBlogEntryPage,
+	page,
+	site,
+}) => {
+	const vocabularyName = getRandomString();
+	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
+
+	const {id: vocabularyId} =
+		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+			name: vocabularyName,
+			siteId: site.id,
+		});
+
+	for (const categoryName of friendlyUrlCategories) {
+		await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name: categoryName,
+			vocabularyId,
+		});
+	}
+
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {categories: friendlyUrlCategories},
+		publish: false,
+		title,
+	});
+
+	await expect(
+		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
+	).toBeVisible();
 });

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -10,12 +10,10 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
-import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
-import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
-import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
+import {friendlyURLCategoriesSetup} from './utils/friendlyURLCategoriesSetup';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -77,94 +75,15 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	const vocabularyName = getRandomString();
 	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
 
-	const {id: vocabularyId} =
-		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
-			name: vocabularyName,
-			siteId: site.id,
-		});
-
-	for (const categoryName of friendlyUrlCategories) {
-		await apiHelpers.headlessAdminTaxonomy.createCategory({
-			name: categoryName,
-			vocabularyId,
-		});
-	}
-
-	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
-
-	const displayPageTemplateName = getRandomString();
-
-	await displayPageTemplatesPage.publishNewTemplate({
-		contentType: 'Blogs Entry',
-		name: displayPageTemplateName,
-	});
-
-	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
-
-	const widgetId = getRandomString();
-
-	const widgetDefinition = getWidgetDefinition({
-		id: widgetId,
-		widgetName:
-			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
-	});
-
-	const layout = await apiHelpers.headlessDelivery.createSitePage({
-		pageDefinition: getPageDefinition([widgetDefinition]),
-		siteId: site.id,
-		title: getRandomString(),
-	});
-
-	await pageEditorPage.goto(layout, site.friendlyUrlPath);
-
-	const topper = await pageEditorPage.getTopper(widgetId);
-
-	await topper.hover();
-	await clickAndExpectToBeVisible({
-		autoClick: true,
-		target: page.getByRole('menuitem', {
-			exact: true,
-			name: 'Configuration',
-		}),
-		trigger: topper.locator('.portlet-options'),
-	});
-
-	const assetPublisherConfigurationIframe = await page.frameLocator(
-		'iframe[title="Asset Publisher\\a      - Configuration"]'
-	);
-
-	const assetPublisherConfigurationDynamicRadio =
-		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
-	await assetPublisherConfigurationDynamicRadio.waitFor();
-	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
-		await assetPublisherConfigurationIframe
-			.getByRole('link', {name: 'Asset Selection'})
-			.click();
-	}
-	await assetPublisherConfigurationDynamicRadio.click();
-
-	const assetPublisherConfigurationSourceAssetTypeSelect =
-		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
-	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
-		await assetPublisherConfigurationIframe
-			.getByRole('link', {name: 'Source'})
-			.click();
-	}
-	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
-		label: 'Blogs Entry',
-	});
-
-	await assetPublisherConfigurationIframe
-		.getByRole('button', {name: 'Save'})
-		.click();
-
-	await page.getByLabel('close', {exact: true}).click();
-	await page.getByLabel('Publish', {exact: true}).click();
-
-	await waitForSuccessAlert(
+	await friendlyURLCategoriesSetup({
+		apiHelpers,
+		displayPageTemplatesPage,
+		friendlyUrlCategories,
 		page,
-		'Success:The page was published successfully.'
-	);
+		pageEditorPage,
+		site,
+		vocabularyName,
+	});
 
 	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -9,16 +9,23 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
 const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	blogsPagesTest,
+	pageEditorPagesTest,
 	loginTest(),
 	featureFlagsTest({
 		'LPD-11147': true,
+		'LPS-178052': true,
 	})
 );
 
@@ -64,6 +71,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	blogsEditBlogEntryPage,
 	displayPageTemplatesPage,
 	page,
+	pageEditorPage,
 	site,
 }) => {
 	const vocabularyName = getRandomString();
@@ -92,6 +100,71 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	});
 
 	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+
+	const widgetId = getRandomString();
+
+	const widgetDefinition = getWidgetDefinition({
+		id: widgetId,
+		widgetName:
+			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+	});
+
+	const layout = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition([widgetDefinition]),
+		siteId: site.id,
+		title: getRandomString(),
+	});
+
+	await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+	const topper = await pageEditorPage.getTopper(widgetId);
+
+	await topper.hover();
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {
+			exact: true,
+			name: 'Configuration',
+		}),
+		trigger: topper.locator('.portlet-options'),
+	});
+
+	const assetPublisherConfigurationIframe = await page.frameLocator(
+		'iframe[title="Asset Publisher\\a      - Configuration"]'
+	);
+
+	const assetPublisherConfigurationDynamicRadio =
+		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
+	await assetPublisherConfigurationDynamicRadio.waitFor();
+	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Asset Selection'})
+			.click();
+	}
+	await assetPublisherConfigurationDynamicRadio.click();
+
+	const assetPublisherConfigurationSourceAssetTypeSelect =
+		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
+	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Source'})
+			.click();
+	}
+	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
+		label: 'Blogs Entry',
+	});
+
+	await assetPublisherConfigurationIframe
+		.getByRole('button', {name: 'Save'})
+		.click();
+
+	await page.getByLabel('close', {exact: true}).click();
+	await page.getByLabel('Publish', {exact: true}).click();
+
+	await waitForSuccessAlert(
+		page,
+		'Success:The page was published successfully.'
+	);
 
 	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -62,6 +62,7 @@ test('LPD-22497: Permission sets are differing depending on autosaving of a blog
 test('LPD-26752 Select categories for the custom friendly URL', async ({
 	apiHelpers,
 	blogsEditBlogEntryPage,
+	displayPageTemplatesPage,
 	page,
 	site,
 }) => {
@@ -80,6 +81,17 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 			vocabularyId,
 		});
 	}
+
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	const displayPageTemplateName = getRandomString();
+
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentType: 'Blogs Entry',
+		name: displayPageTemplateName,
+	});
+
+	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
 
 	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -87,7 +87,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories},
+		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
 		publish: false,
 		title,
 	});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -180,4 +180,15 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	await expect(
 		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
 	).toBeVisible();
+
+	await page.getByRole('button', {name: 'Publish'}).click();
+	await waitForSuccessAlert(page);
+
+	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
+
+	await expect(response.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
+			'/'
+		)}/${title}`
+	);
 });

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -11,7 +11,6 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 import {friendlyURLCategoriesSetup} from './utils/friendlyURLCategoriesSetup';
 
@@ -100,8 +99,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
 	).toBeVisible();
 
-	await page.getByRole('button', {name: 'Publish'}).click();
-	await waitForSuccessAlert(page);
+	await blogsEditBlogEntryPage.publishBlogEntry();
 
 	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -10,37 +10,41 @@ import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
-const baseTest = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
+const test = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
 
-const blogEntryAutoSaved = mergeTests(baseTest);
+test('LPD-22497: Permission sets are differing depending on autosaving of a blog entry', async ({
+	blogsEditBlogEntryPage,
+	blogsPage,
+	page,
+	site,
+}) => {
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 
-blogEntryAutoSaved(
-	'LPD-22497: Permission sets are differing depending on autosaving of a blog entry',
-	async ({blogsEditBlogEntryPage, blogsPage, page, site}) => {
-		await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+	const title = getRandomString();
 
-		const title = getRandomString();
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		publish: false,
+		title,
+	});
 
-		await blogsEditBlogEntryPage.editBlogEntry(getRandomString(), title);
+	await expect(
+		page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_saveStatus'
+		)
+	).toContainText('Draft Saved at', {
+		timeout: 40000,
+	});
 
-		await expect(
-			page.locator(
-				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_saveStatus'
-			)
-		).toContainText('Draft Saved at', {
-			timeout: 40000,
-		});
+	await blogsPage.goto(site.friendlyUrlPath);
 
-		await blogsPage.goto(site.friendlyUrlPath);
-
-		await blogsPage.assertBlogEntryPermissions(
-			[
-				{enabled: true, locator: '#guest_ACTION_ADD_DISCUSSION'},
-				{enabled: true, locator: '#guest_ACTION_VIEW'},
-				{enabled: true, locator: '#site-member_ACTION_ADD_DISCUSSION'},
-				{enabled: true, locator: '#site-member_ACTION_VIEW'},
-			],
-			title
-		);
-	}
-);
+	await blogsPage.assertBlogEntryPermissions(
+		[
+			{enabled: true, locator: '#guest_ACTION_ADD_DISCUSSION'},
+			{enabled: true, locator: '#guest_ACTION_VIEW'},
+			{enabled: true, locator: '#site-member_ACTION_ADD_DISCUSSION'},
+			{enabled: true, locator: '#site-member_ACTION_VIEW'},
+		],
+		title
+	);
+});

--- a/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
+++ b/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
@@ -5,18 +5,23 @@
 
 import {test} from '@playwright/test';
 
+import {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import {BlogsEditBlogEntryPage} from '../pages/BlogsEditBlogEntryPage';
 import {BlogsPage} from '../pages/BlogsPage';
 
 const blogsPagesTest = test.extend<{
 	blogsEditBlogEntryPage: BlogsEditBlogEntryPage;
 	blogsPage: BlogsPage;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
 }>({
 	blogsEditBlogEntryPage: async ({page}, use) => {
 		await use(new BlogsEditBlogEntryPage(page));
 	},
 	blogsPage: async ({page}, use) => {
 		await use(new BlogsPage(page));
+	},
+	displayPageTemplatesPage: async ({page}, use) => {
+		await use(new DisplayPageTemplatesPage(page));
 	},
 });
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -12,11 +12,15 @@ export class BlogsEditBlogEntryPage {
 
 	readonly blogsPage: BlogsPage;
 	readonly publishButton: Locator;
+	readonly contentEditor: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
 		this.blogsPage = new BlogsPage(page);
+		this.contentEditor = page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor.cke_editable'
+		);
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
 	}
 
@@ -25,26 +29,60 @@ export class BlogsEditBlogEntryPage {
 		await this.blogsPage.goToCreateBlogEntry();
 	}
 
+	private async editBlogEntryAddfriendlyUrl({
+		categories,
+	}: {
+		categories: string[];
+	}) {
+		const fieldset = await this.page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_friendly-url'
+		);
+
+		if (await fieldset.locator('.panel-body').isHidden()) {
+			await fieldset.getByRole('button', {name: 'Friendly URL'}).click();
+		}
+
+		await fieldset.getByText('Use a Customized URL').click();
+		await fieldset.getByRole('button', {name: 'Select'}).click();
+
+		const categoriesSelectorIframe = await this.page.frameLocator(
+			'iframe[title="Filter by Categories"]'
+		);
+
+		await categoriesSelectorIframe.getByText('Test').click();
+
+		for (const categoryName of categories) {
+			await categoriesSelectorIframe.getByText(categoryName).click();
+		}
+
+		await this.page
+			.getByLabel('Filter by Categories')
+			.getByRole('button', {name: 'Select'})
+			.click();
+	}
+
 	async editBlogEntry({
 		content,
+		friendlyUrl,
 		publish = true,
 		title,
 	}: {
 		content: string;
+		friendlyUrl?: {categories: string[]};
 		publish?: boolean;
 		title: string;
 	}) {
-		await this.page.getByPlaceholder('Title *').waitFor();
-
 		await this.page.getByPlaceholder('Title *').fill(title);
 
-		await this.page.getByRole('paragraph').click();
+		await this.contentEditor.fill(content);
 
-		await this.page
-			.locator(
-				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
-			)
-			.fill(content);
+		const {categories} = friendlyUrl;
+
+		if (categories?.length) {
+			await this.editBlogEntryAddfriendlyUrl({
+				categories,
+			});
+		}
 
 		if (publish) {
 			await this.publishButton.click();

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -11,19 +11,13 @@ export class BlogsEditBlogEntryPage {
 	readonly page: Page;
 
 	readonly blogsPage: BlogsPage;
-	readonly propertiesTab: Locator;
 	readonly publishButton: Locator;
-	readonly titlePlaceholder: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
 		this.blogsPage = new BlogsPage(page);
-		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
-		this.titlePlaceholder = page.getByPlaceholder(
-			'Untitled Basic Web Content'
-		);
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -40,7 +34,7 @@ export class BlogsEditBlogEntryPage {
 
 		await this.page
 			.locator(
-				'[id="_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor"]'
+				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
 			)
 			.fill(content);
 	}

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -7,6 +7,11 @@ import {Locator, Page} from '@playwright/test';
 
 import {BlogsPage} from './BlogsPage';
 
+type editBlogEntryAddfriendlyUrlType = {
+	categories: string[];
+	vocabularyName: string;
+};
+
 export class BlogsEditBlogEntryPage {
 	readonly page: Page;
 
@@ -31,9 +36,8 @@ export class BlogsEditBlogEntryPage {
 
 	private async editBlogEntryAddfriendlyUrl({
 		categories,
-	}: {
-		categories: string[];
-	}) {
+		vocabularyName,
+	}: editBlogEntryAddfriendlyUrlType) {
 		const fieldset = await this.page.locator(
 			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_friendly-url'
 		);
@@ -49,7 +53,7 @@ export class BlogsEditBlogEntryPage {
 			'iframe[title="Filter by Categories"]'
 		);
 
-		await categoriesSelectorIframe.getByText('Test').click();
+		await categoriesSelectorIframe.getByText(vocabularyName).click();
 
 		for (const categoryName of categories) {
 			await categoriesSelectorIframe.getByText(categoryName).click();
@@ -68,7 +72,7 @@ export class BlogsEditBlogEntryPage {
 		title,
 	}: {
 		content: string;
-		friendlyUrl?: {categories: string[]};
+		friendlyUrl?: editBlogEntryAddfriendlyUrlType;
 		publish?: boolean;
 		title: string;
 	}) {
@@ -76,11 +80,12 @@ export class BlogsEditBlogEntryPage {
 
 		await this.contentEditor.fill(content);
 
-		const {categories} = friendlyUrl;
+		if (friendlyUrl) {
+			const {categories, vocabularyName} = friendlyUrl;
 
-		if (categories?.length) {
 			await this.editBlogEntryAddfriendlyUrl({
 				categories,
+				vocabularyName,
 			});
 		}
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import {BlogsPage} from './BlogsPage';
 
 type editBlogEntryAddfriendlyUrlType = {
@@ -90,7 +91,12 @@ export class BlogsEditBlogEntryPage {
 		}
 
 		if (publish) {
-			await this.publishButton.click();
+			await this.publishBlogEntry();
 		}
+	}
+
+	async publishBlogEntry() {
+		await this.publishButton.click();
+		await waitForSuccessAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -25,7 +25,15 @@ export class BlogsEditBlogEntryPage {
 		await this.blogsPage.goToCreateBlogEntry();
 	}
 
-	async editBlogEntry(content: string, title: string) {
+	async editBlogEntry({
+		content,
+		publish = true,
+		title,
+	}: {
+		content: string;
+		publish?: boolean;
+		title: string;
+	}) {
 		await this.page.getByPlaceholder('Title *').waitFor();
 
 		await this.page.getByPlaceholder('Title *').fill(title);
@@ -37,5 +45,9 @@ export class BlogsEditBlogEntryPage {
 				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
 			)
 			.fill(content);
+
+		if (publish) {
+			await this.publishButton.click();
+		}
 	}
 }

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import getPageDefinition from '../../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getWidgetDefinition';
+
+import type {ApiHelpers} from '../../../helpers/ApiHelpers';
+import type {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
+
+export async function createAssetPublisherAndConfigure({
+	apiHelpers,
+	page,
+	pageEditorPage,
+	site,
+}: {
+	apiHelpers: ApiHelpers;
+	page: Page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+}) {
+	const widgetId = getRandomString();
+
+	const widgetDefinition = getWidgetDefinition({
+		id: widgetId,
+		widgetName:
+			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+	});
+
+	const layout = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition([widgetDefinition]),
+		siteId: site.id,
+		title: getRandomString(),
+	});
+
+	await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+	const topper = pageEditorPage.getTopper(widgetId);
+
+	await topper.hover();
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {
+			exact: true,
+			name: 'Configuration',
+		}),
+		trigger: topper.locator('.portlet-options'),
+	});
+
+	const assetPublisherConfigurationIframe = await page.frameLocator(
+		'iframe[title="Asset Publisher\\a      - Configuration"]'
+	);
+
+	const assetPublisherConfigurationDynamicRadio =
+		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
+	await assetPublisherConfigurationDynamicRadio.waitFor();
+	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Asset Selection'})
+			.click();
+	}
+	await assetPublisherConfigurationDynamicRadio.click();
+
+	const assetPublisherConfigurationSourceAssetTypeSelect =
+		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
+	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Source'})
+			.click();
+	}
+	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
+		label: 'Blogs Entry',
+	});
+
+	await assetPublisherConfigurationIframe
+		.getByRole('button', {name: 'Save'})
+		.click();
+
+	await page.getByLabel('close', {exact: true}).click();
+	await page.getByLabel('Publish', {exact: true}).click();
+
+	await waitForSuccessAlert(
+		page,
+		'Success:The page was published successfully.'
+	);
+}

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -42,7 +42,6 @@ export async function createAssetPublisherAndConfigure({
 	await pageEditorPage.goto(layout, site.friendlyUrlPath);
 
 	const topper = pageEditorPage.getTopper(widgetId);
-
 	await topper.hover();
 	await clickAndExpectToBeVisible({
 		autoClick: true,
@@ -53,40 +52,38 @@ export async function createAssetPublisherAndConfigure({
 		trigger: topper.locator('.portlet-options'),
 	});
 
-	const assetPublisherConfigurationIframe = await page.frameLocator(
-		'iframe[title="Asset Publisher\\a      - Configuration"]'
-	);
+	const configurationModal = await page.frameLocator('#modalIframe');
+	await configurationModal.locator('.portlet-body').waitFor();
 
-	const assetPublisherConfigurationDynamicRadio =
-		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
-	await assetPublisherConfigurationDynamicRadio.waitFor();
-	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
-		await assetPublisherConfigurationIframe
+	const configurationDynamicLabel = await configurationModal.getByText(
+		'Dynamic'
+	);
+	if (await configurationDynamicLabel.isHidden()) {
+		await configurationModal
 			.getByRole('link', {name: 'Asset Selection'})
 			.click();
 	}
-	await assetPublisherConfigurationDynamicRadio.click();
+	await configurationDynamicLabel.click();
+	await waitForSuccessAlert(
+		configurationModal,
+		'Success:You have successfully updated the setup.'
+	);
 
-	const assetPublisherConfigurationSourceAssetTypeSelect =
-		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
-	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
-		await assetPublisherConfigurationIframe
-			.getByRole('link', {name: 'Source'})
-			.click();
+	const configurationSourceAssetTypeSelect =
+		await configurationModal.getByLabel('Asset Type');
+	if (await configurationSourceAssetTypeSelect.isHidden()) {
+		await configurationModal.getByRole('link', {name: 'Source'}).click();
 	}
-	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
+	await configurationSourceAssetTypeSelect.selectOption({
 		label: 'Blogs Entry',
 	});
 
-	await assetPublisherConfigurationIframe
-		.getByRole('button', {name: 'Save'})
-		.click();
-
-	await page.getByLabel('close', {exact: true}).click();
-	await page.getByLabel('Publish', {exact: true}).click();
-
+	await configurationModal.getByRole('button', {name: 'Save'}).click();
 	await waitForSuccessAlert(
-		page,
-		'Success:The page was published successfully.'
+		configurationModal,
+		'Success:You have successfully updated the setup.'
 	);
+	await page.getByLabel('close', {exact: true}).click();
+
+	await pageEditorPage.publishPage();
 }

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -52,7 +52,9 @@ export async function createAssetPublisherAndConfigure({
 		trigger: topper.locator('.portlet-options'),
 	});
 
-	const configurationModal = await page.frameLocator('#modalIframe');
+	const configurationModal = await page.frameLocator(
+		'iframe[title*="Asset Publisher"][title*="Configuration"]'
+	);
 	await configurationModal.locator('.portlet-body').waitFor();
 
 	const configurationDynamicLabel = await configurationModal.getByText(

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -58,7 +58,8 @@ export async function createAssetPublisherAndConfigure({
 	await configurationModal.locator('.portlet-body').waitFor();
 
 	const configurationDynamicLabel = await configurationModal.getByText(
-		'Dynamic'
+		'Dynamic',
+		{exact: true}
 	);
 	if (await configurationDynamicLabel.isHidden()) {
 		await configurationModal

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type {ApiHelpers} from '../../../helpers/ApiHelpers';
+
+export async function createCategories({
+	apiHelpers,
+	friendlyUrlCategories,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	friendlyUrlCategories: string[];
+	site: Site;
+	vocabularyName: string;
+}) {
+	const {id: vocabularyId} =
+		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+			name: vocabularyName,
+			siteId: site.id,
+		});
+
+	for (const categoryName of friendlyUrlCategories) {
+		await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name: categoryName,
+			vocabularyId,
+		});
+	}
+}

--- a/modules/test/playwright/tests/blogs-web/utils/createDPTandMarkAsDefault.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createDPTandMarkAsDefault.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getRandomString from '../../../utils/getRandomString';
+
+import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+
+export async function createDPTandMarkAsDefault({
+	displayPageTemplatesPage,
+	site,
+}: {
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	site: Site;
+}) {
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	const displayPageTemplateName = getRandomString();
+
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentType: 'Blogs Entry',
+		name: displayPageTemplateName,
+	});
+
+	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+}

--- a/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {createAssetPublisherAndConfigure} from './createAssetPublisherAndConfigure';
+import {createCategories} from './createCategories';
+import {createDPTandMarkAsDefault} from './createDPTandMarkAsDefault';
+
+import type {ApiHelpers} from '../../../helpers/ApiHelpers';
+import type {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
+import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+
+export async function friendlyURLCategoriesSetup({
+	apiHelpers,
+	displayPageTemplatesPage,
+	friendlyUrlCategories,
+	page,
+	pageEditorPage,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	friendlyUrlCategories: string[];
+	page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+	vocabularyName: string;
+}) {
+	await createCategories({
+		apiHelpers,
+		friendlyUrlCategories,
+		site,
+		vocabularyName,
+	});
+	await createDPTandMarkAsDefault({displayPageTemplatesPage, site});
+	await createAssetPublisherAndConfigure({
+		apiHelpers,
+		page,
+		pageEditorPage,
+		site,
+	});
+}

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -343,9 +343,11 @@ prefixUrlTest(
 
 		const displayPageTemplateName = getRandomString();
 
-		await displayPageTemplatesPage.publishNewTemplate(
-			displayPageTemplateName
-		);
+		await displayPageTemplatesPage.publishNewTemplate({
+			contentSubtype: 'Basic Web Content',
+			contentType: 'Web Content Article',
+			name: displayPageTemplateName,
+		});
 
 		await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
 

--- a/modules/test/playwright/tests/layout-page-template-admin-web/displayPageTemplates.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/displayPageTemplates.spec.ts
@@ -25,7 +25,11 @@ test('checks that the card checkbox has the correct aria label', async ({
 
 	const displayPageTemplateName = getRandomString();
 
-	await displayPageTemplatesPage.publishNewTemplate(displayPageTemplateName);
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentSubtype: 'Basic Web Content',
+		contentType: 'Web Content Article',
+		name: displayPageTemplateName,
+	});
 
 	await expect(
 		page.getByLabel(`Select ${displayPageTemplateName}`)


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26752

We are adding tests to Epic https://liferay.atlassian.net/browse/LPD-11147 use cases.

# How am I testing?

We are trying to test if a user adds categories to a blog entry via UI, 

- ✅ The addon URL preview is the expected.
- ✅ The redirect with the categories is created


# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run test -- -g "LPD-26752|LPD-6813"` to only run the new test and affected test

<img width="906" alt="image" src="https://github.com/liferay-content-management/liferay-portal/assets/67901/135eb282-c437-464a-93a4-6badbc7a422a">

# Avoid flakiness repeating 10 times

```sh
npm run test -- -g "LPD-26752" --reporter list --repeat-each 10
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/c8cf3ebc-2933-4f2e-a5da-42a54d944899)

# Screenrecord tests execution

<details open>
  <summary>New test</summary>

[video.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/3358ba44-752d-4854-9bcc-525d7a3e0f37)


</details>

<details>
  <summary>Affected test</summary>
  
[video.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/15f2130e-a2b4-466f-8cbb-0de73ea1abb0)


</details>