### PR TITLE
LPD-26759 Select Basic Web Content Pagination breaks when using Everywhere filter

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -328,6 +328,8 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			getPortletURL()
 		).setParameter(
 			"folderId", _getFolderId()
+		).setParameter(
+			"scope", _getScopeFilter()
 		).buildPortletURL();
 
 		SearchContainer<Object> articleAndFolderSearchContainer =
@@ -630,6 +632,14 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return _orderByType;
 	}
 
+	private String _getScopeFilter() {
+		if (Validator.isNull(_scope)) {
+			_scope = ParamUtil.getString(_httpServletRequest, "scope");
+		}
+
+		return _scope;
+	}
+
 	private long _getStagingAwareGroupId() {
 		if (_groupId != null) {
 			return _groupId;
@@ -783,6 +793,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private final ResourcePermissionLocalService
 		_resourcePermissionLocalService;
 	private final RoleLocalService _roleLocalService;
+	private String _scope;
 	private final boolean _search;
 	private Boolean _searchEverywhere;
 	private final StagingGroupHelper _stagingGroupHelper;


### PR DESCRIPTION
Select Basic Web Content Pagination breaks when using Everywhere filter

# What is this trying to solve?
[Link to ticket](https://issues.liferay.com/browse/LPD-26759)

The filter selected was removed when the pagination was changed. 

# How am I fixing it?
The PR adds the scope value to the search container. 

# How can you verify that it works?

1. Create 3 Basic Web Content Articles on Global site
2. Create 3 Basic Web Content Articles on the non-Global site (Liferay)
3. Add an Asset Publisher Widget to the Home page, then go to the Asset Publisher's Configuration menu
4. At the Asset Selection, choose the Manual radio button
5. In Asset Entries, choose Basic Web Content
6. In the Pop Up window you should see the 3 Non-Global Web Content Articles
7. In Filter -> Filter by Location select Everywhere, you should see 3 of the Global Web Content Articles (total 6 web contents)
8. Scroll down to the Pagination section, change pagination to 4 Entries, and click on the > (Next page) button.

This PR is missing tests, that is why it is a DRAFT. 