### PR TITLE
LPD-26912 Expiration and Review date are not saved in WC

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -249,7 +249,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			uploadPortletRequest, "expirationDateAmPm");
 
 		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire", displayDateYear == 0);
+			uploadPortletRequest, "neverExpire", expirationDateYear == 0);
 
 		if (!PropsValues.SCHEDULER_ENABLED) {
 			neverExpire = true;
@@ -273,7 +273,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			uploadPortletRequest, "reviewDateAmPm");
 
 		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview", displayDateYear == 0);
+			uploadPortletRequest, "neverReview", reviewDateYear == 0);
 
 		if (!PropsValues.SCHEDULER_ENABLED) {
 			neverReview = true;

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -69,7 +69,6 @@ const expect = baseExpect.extend({
 const autoSaveAsDraftTest = mergeTests(
 	baseTest,
 	featureFlagsTest({
-		'LPD-11228': true,
 		'LPD-15596': true,
 		'LPS-141392': true,
 	})

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -972,16 +972,24 @@ scheduleTest(
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
 		const articleTitle = getRandomString();
-		const scheduleDate = '9987-11-26 13:00';
+		const expirationDate = '01/01/9999';
+		const publishDate = '9987-11-26 13:00';
+		const reviewDate = '01/01/9999';
 
 		await journalEditArticlePage.scheduleArticle(
 			articleTitle,
-			scheduleDate
+			publishDate,
+			undefined,
+			expirationDate,
+			reviewDate
 		);
 
 		await journalEditArticlePage.assertScheduleDate(
 			articleTitle,
-			scheduleDate
+			publishDate,
+			undefined,
+			expirationDate,
+			reviewDate
 		);
 	}
 );

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -984,7 +984,7 @@ scheduleTest(
 			reviewDate
 		);
 
-		await journalEditArticlePage.assertScheduleDate(
+		await journalEditArticlePage.assertScheduledArticleDates(
 			articleTitle,
 			publishDate,
 			undefined,
@@ -1029,7 +1029,7 @@ scheduleTest(
 
 		await journalPage.goto(site.friendlyUrlPath);
 
-		await journalEditArticlePage.assertScheduleDate(
+		await journalEditArticlePage.assertScheduledArticleDates(
 			articleTitle,
 			articleDate,
 			{workflow: true}

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -135,10 +135,28 @@ export class JournalEditArticlePage {
 
 	async scheduleArticle(
 		title: string,
-		date: string,
-		{workflow} = {workflow: false}
+		publishDate: string,
+		{workflow} = {workflow: false},
+		expirationDate?: string,
+		reviewDate?: string
 	) {
 		await this.fillTitle(title);
+
+		if (!(await this.page.getByText('Never Expire').isVisible())) {
+			await this.page.getByRole('link', {name: 'Schedule'}).click();
+		}
+
+		if (expirationDate) {
+			await this.page.getByText('Never Expire').click();
+
+			await this.page.getByText('Expiration Date').fill(expirationDate);
+		}
+
+		if (reviewDate) {
+			await this.page.getByText('Never Review').click();
+
+			await this.page.getByText('Review Date').fill(reviewDate);
+		}
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
@@ -158,7 +176,7 @@ export class JournalEditArticlePage {
 			),
 		});
 
-		await this.page.getByPlaceholder('YYYY-MM-DD HH:mm').fill(date);
+		await this.page.getByPlaceholder('YYYY-MM-DD HH:mm').fill(publishDate);
 
 		await this.page
 			.locator('.modal-footer')
@@ -205,8 +223,10 @@ export class JournalEditArticlePage {
 
 	async assertScheduleDate(
 		title: string,
-		date: string,
-		{workflow} = {workflow: false}
+		publishDate: string,
+		{workflow} = {workflow: false},
+		expirationDate?: string,
+		reviewDate?: string
 	) {
 		await this.editArticle(title);
 
@@ -228,8 +248,20 @@ export class JournalEditArticlePage {
 			),
 		});
 
+		if (expirationDate) {
+			await expect(this.page.getByText('Expiration Date')).toHaveValue(
+				expirationDate
+			);
+		}
+
 		await expect(
 			this.page.getByPlaceholder('YYYY-MM-DD HH:mm')
-		).toHaveValue(date);
+		).toHaveValue(publishDate);
+
+		if (reviewDate) {
+			await expect(this.page.getByText('Review Date')).toHaveValue(
+				reviewDate
+			);
+		}
 	}
 }

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -221,7 +221,7 @@ export class JournalEditArticlePage {
 		await row.locator('span.label').filter({hasText: 'Pending'}).waitFor();
 	}
 
-	async assertScheduleDate(
+	async assertScheduledArticleDates(
 		title: string,
 		publishDate: string,
 		{workflow} = {workflow: false},


### PR DESCRIPTION
Expiration and Review date are not saved in WC

# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-26912)

Save the expiration and review date when saving Web Content with FF LPD-15596 enabled

# How am I fixing it?

Set the default expiration/review date when here is no expiration/review date instead of taking into account the displayDate

# How can you verify that it works?

Follow the steps in the ticket

**CC: @jkappler**