### PR TITLE
LPD-26759 Select Basic Web Content Pagination breaks when using Everywhere filter 

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -328,6 +328,8 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			getPortletURL()
 		).setParameter(
 			"folderId", _getFolderId()
+		).setParameter(
+			"scope", _getScopeFilter()
 		).buildPortletURL();
 
 		SearchContainer<Object> articleAndFolderSearchContainer =
@@ -630,6 +632,16 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return _orderByType;
 	}
 
+	private String _getScopeFilter() {
+		if (_scope != null) {
+			return _scope;
+		}
+
+		_scope = ParamUtil.getString(_httpServletRequest, "scope");
+
+		return _scope;
+	}
+
 	private long _getStagingAwareGroupId() {
 		if (_groupId != null) {
 			return _groupId;
@@ -783,6 +795,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private final ResourcePermissionLocalService
 		_resourcePermissionLocalService;
 	private final RoleLocalService _roleLocalService;
+	private String _scope;
 	private final boolean _search;
 	private Boolean _searchEverywhere;
 	private final StagingGroupHelper _stagingGroupHelper;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -65,7 +65,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -99,7 +99,8 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
 		String itemSelectedEventName,
 		JournalArticleItemSelectorView journalArticleItemSelectorView,
-		JournalWebConfiguration journalWebConfiguration, PortletURL portletURL,
+		JournalWebConfiguration journalWebConfiguration, Portal portal,
+		PortletURL portletURL,
 		ResourcePermissionLocalService resourcePermissionLocalService,
 		RoleLocalService roleLocalService, boolean search,
 		StagingGroupHelper stagingGroupHelper) {
@@ -109,6 +110,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		_itemSelectedEventName = itemSelectedEventName;
 		_journalArticleItemSelectorView = journalArticleItemSelectorView;
 		_journalWebConfiguration = journalWebConfiguration;
+		_portal = portal;
 		_portletURL = portletURL;
 		_resourcePermissionLocalService = resourcePermissionLocalService;
 		_roleLocalService = roleLocalService;
@@ -307,7 +309,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(
 				_portletURL,
-				PortalUtil.getLiferayPortletResponse(_portletResponse))
+				_portal.getLiferayPortletResponse(_portletResponse))
 		).setParameter(
 			"displayStyle", getDisplayStyle()
 		).setParameter(
@@ -592,7 +594,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			return _journalArticleClassNameId;
 		}
 
-		_journalArticleClassNameId = PortalUtil.getClassNameId(
+		_journalArticleClassNameId = _portal.getClassNameId(
 			JournalArticle.class.getName());
 
 		return _journalArticleClassNameId;
@@ -789,6 +791,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private String _keywords;
 	private String _orderByCol;
 	private String _orderByType;
+	private final Portal _portal;
 	private final PortletRequest _portletRequest;
 	private final PortletResponse _portletResponse;
 	private final PortletURL _portletURL;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/item/selector/JournalArticleItemSelectorView.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/item/selector/JournalArticleItemSelectorView.java
@@ -21,6 +21,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.staging.StagingGroupHelper;
 
 import java.io.IOException;
@@ -106,7 +107,7 @@ public class JournalArticleItemSelectorView
 				new JournalArticleItemSelectorViewDisplayContext(
 					(HttpServletRequest)servletRequest,
 					infoItemItemSelectorCriterion, itemSelectedEventName, this,
-					_journalWebConfiguration, portletURL,
+					_journalWebConfiguration, _portal, portletURL,
 					_resourcePermissionLocalService, _roleLocalService, search,
 					_stagingGroupHelper);
 
@@ -136,6 +137,9 @@ public class JournalArticleItemSelectorView
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
@@ -1,0 +1,294 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.display.context;
+
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.service.JournalFolderLocalServiceUtil;
+import com.liferay.journal.service.JournalFolderServiceUtil;
+import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
+import com.liferay.journal.web.internal.item.selector.JournalArticleItemSelectorView;
+import com.liferay.portal.kernel.bean.BeanProperties;
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
+import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.staging.StagingGroupHelper;
+
+import java.util.Collections;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletResponse;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class JournalArticleItemSelectorViewDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws PortletException {
+		_setUpBeanProperties();
+		_setUpHttpServletRequest();
+		_setUpJournalFolderLocalServiceUtil();
+		_setUpJournalFolderServiceUtil();
+		_setUpLanguage();
+		_setUpPortal();
+		_setUpPortletURLBuilder();
+		_setUpPortletURLUtil();
+		_setUpSearchDisplayStyleUtil();
+		_setUpSearchOrderByUtil();
+	}
+
+	@After
+	public void tearDown() {
+		_journalFolderLocalServiceUtilMockedStatic.close();
+		_journalFolderServiceUtilMockedStatic.close();
+		_portletURLBuilderMockedStatic.close();
+		_portletURLUtilMockedStatic.close();
+		_searchDisplayStyleUtilMockedStatic.close();
+		_searchOrderByUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testSearchContainerWithScope() throws Exception {
+		_testSearchContainerWithScope("false");
+		_testSearchContainerWithScope("true");
+	}
+
+	private void _setUpBeanProperties() {
+		BeanPropertiesUtil beanPropertiesUtil = new BeanPropertiesUtil();
+
+		beanPropertiesUtil.setBeanProperties(_beanProperties);
+	}
+
+	private void _setUpHttpServletRequest() {
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
+		RenderRequest renderRequest = new MockLiferayPortletRenderRequest();
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST)
+		).thenReturn(
+			renderRequest
+		);
+
+		RenderResponse renderResponse = new MockLiferayPortletRenderResponse();
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE)
+		).thenReturn(
+			renderResponse
+		);
+	}
+
+	private void _setUpJournalFolderLocalServiceUtil() {
+		JournalFolder journalFolder = Mockito.mock(JournalFolder.class);
+		_journalFolderLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			JournalFolderLocalServiceUtil.class);
+
+		Mockito.when(
+			JournalFolderLocalServiceUtil.fetchFolder(Mockito.anyLong())
+		).thenReturn(
+			journalFolder
+		);
+	}
+
+	private void _setUpJournalFolderServiceUtil() {
+		_journalFolderServiceUtilMockedStatic = Mockito.mockStatic(
+			JournalFolderServiceUtil.class);
+
+		Mockito.when(
+			JournalFolderServiceUtil.getFoldersAndArticles(
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyInt(), Mockito.any(),
+				Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.any(OrderByComparator.class))
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			JournalFolderServiceUtil.getFoldersAndArticlesCount(
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.anyLong(), Mockito.anyInt())
+		).thenReturn(
+			0
+		);
+	}
+
+	private void _setUpLanguage() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(_language);
+	}
+
+	private void _setUpPortal() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		LiferayPortletResponse mockLiferayPortletResponse = Mockito.mock(
+			LiferayPortletResponse.class);
+
+		Mockito.when(
+			_portal.getCompanyId(Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_portal.getLiferayPortletResponse(
+				Mockito.any(PortletResponse.class))
+		).thenReturn(
+			mockLiferayPortletResponse
+		);
+
+		portalUtil.setPortal(_portal);
+	}
+
+	private void _setUpPortletURLBuilder() {
+		_portletURLBuilderMockedStatic = Mockito.mockStatic(
+			PortletURLBuilder.class);
+
+		Mockito.when(
+			PortletURLBuilder.create(Mockito.any())
+		).thenReturn(
+			new PortletURLBuilder.PortletURLStep(new MockLiferayPortletURL())
+		);
+	}
+
+	private void _setUpPortletURLUtil() throws PortletException {
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+
+		Mockito.when(
+			PortletURLUtil.clone(
+				Mockito.any(LiferayPortletURL.class), Mockito.anyString(),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+	}
+
+	private void _setUpSearchDisplayStyleUtil() {
+		_searchDisplayStyleUtilMockedStatic = Mockito.mockStatic(
+			SearchDisplayStyleUtil.class);
+
+		Mockito.when(
+			SearchDisplayStyleUtil.getDisplayStyle(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+	}
+
+	private void _setUpSearchOrderByUtil() {
+		_searchOrderByUtilMockedStatic = Mockito.mockStatic(
+			SearchOrderByUtil.class);
+
+		Mockito.when(
+			SearchOrderByUtil.getOrderByCol(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+	}
+
+	private void _testSearchContainerWithScope(String scope) throws Exception {
+		Mockito.when(
+			_httpServletRequest.getParameter("scope")
+		).thenReturn(
+			scope
+		);
+
+		JournalArticleItemSelectorViewDisplayContext
+			journalArticleItemSelectorView =
+				new JournalArticleItemSelectorViewDisplayContext(
+					_httpServletRequest,
+					Mockito.mock(InfoItemItemSelectorCriterion.class),
+					RandomTestUtil.randomString(),
+					Mockito.mock(JournalArticleItemSelectorView.class),
+					Mockito.mock(JournalWebConfiguration.class), _portal,
+					new MockLiferayPortletURL(),
+					Mockito.mock(ResourcePermissionLocalService.class),
+					Mockito.mock(RoleLocalService.class), false,
+					Mockito.mock(StagingGroupHelper.class));
+
+		SearchContainer<?> searchContainer =
+			journalArticleItemSelectorView.getSearchContainer();
+
+		Assert.assertNotNull(searchContainer);
+
+		MockLiferayPortletURL iteratorURL =
+			(MockLiferayPortletURL)searchContainer.getIteratorURL();
+
+		Assert.assertEquals(scope, iteratorURL.getParameter("scope"));
+	}
+
+	private static MockedStatic<JournalFolderLocalServiceUtil>
+		_journalFolderLocalServiceUtilMockedStatic;
+	private static MockedStatic<JournalFolderServiceUtil>
+		_journalFolderServiceUtilMockedStatic;
+	private static MockedStatic<PortletURLBuilder>
+		_portletURLBuilderMockedStatic;
+	private static MockedStatic<PortletURLUtil> _portletURLUtilMockedStatic;
+	private static MockedStatic<SearchDisplayStyleUtil>
+		_searchDisplayStyleUtilMockedStatic;
+	private static MockedStatic<SearchOrderByUtil>
+		_searchOrderByUtilMockedStatic;
+
+	private final BeanProperties _beanProperties = Mockito.mock(
+		BeanProperties.class);
+	private final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private final Language _language = Mockito.mock(Language.class);
+	private final Portal _portal = Mockito.mock(Portal.class);
+	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+}


### PR DESCRIPTION
Select Basic Web Content Pagination breaks when using Everywhere filter

# What is this trying to solve?
[Link to ticket](https://issues.liferay.com/browse/LPD-26759)

The filter selected was removed when the pagination was changed. 

# How am I fixing it?
The PR adds the scope value to the search container. 

# How can you verify that it works?

1. Create 3 Basic Web Content Articles on Global site
2. Create 3 Basic Web Content Articles on the non-Global site (Liferay)
3. Add an Asset Publisher Widget to the Home page, then go to the Asset Publisher's Configuration menu
4. At the Asset Selection, choose the Manual radio button
5. In Asset Entries, choose Basic Web Content
6. In the Pop Up window you should see the 3 Non-Global Web Content Articles
7. In Filter -> Filter by Location select Everywhere, you should see 3 of the Global Web Content Articles (total 6 web contents)
8. Scroll down to the Pagination section, change pagination to 4 Entries, and click on the > (Next page) button.

You can also run the provided unit test

@ambrinchaudhary 