### PR TITLE
LPD-27461 Fix BlogsEntry#ExternalVideoEmbeddedInBlogContentFieldCanBePlayed

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -1728,7 +1728,11 @@ definition {
 	@description = "This checks that an external video embedded in a blog content can be played correctly."
 	@priority = 3
 	test ExternalVideoEmbeddedInBlogContentFieldCanBePlayed {
-		property portal.release = "quarantine";
+		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+
+		SystemSettings.configureSystemSetting(
+			enableSetting = "false",
+			settingFieldName = "Enabled");
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27461

The POSHI test was marked with `quaratine` because it was not working.

# How am I fixing it?

Disabling th IFrame Sanitizer was needed.

# How can you verify that it works?

Run the POSHI test locally