### PR TITLE
LPD-27402 OOTB Image - Adaptive Media doesn't render if map a PDF Preview Image

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-content-transformer-api/src/main/java/com/liferay/adaptive/media/content/transformer/BaseRegexStringContentTransformer.java
+++ b/modules/apps/adaptive-media/adaptive-media-content-transformer-api/src/main/java/com/liferay/adaptive/media/content/transformer/BaseRegexStringContentTransformer.java
@@ -37,11 +37,11 @@ public abstract class BaseRegexStringContentTransformer
 
 			FileEntry fileEntry = getFileEntry(matcher);
 
-			if (!isSupported(fileEntry)) {
-				return content;
-			}
+			String replacement = matcher.group(0);
 
-			String replacement = getReplacement(matcher.group(0), fileEntry);
+			if (isSupported(fileEntry)) {
+				replacement = getReplacement(replacement, fileEntry);
+			}
 
 			matcher.appendReplacement(
 				sb, Matcher.quoteReplacement(replacement));

--- a/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/test/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/test/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImplTest.java
@@ -38,6 +38,7 @@ public class HtmlContentTransformerImplTest {
 	@Before
 	public void setUp() throws Exception {
 		_setUpHtmlContentTransformerImplStub();
+		_setUpPdfFileEntry();
 		_setUpPngFileEntry();
 	}
 
@@ -127,6 +128,26 @@ public class HtmlContentTransformerImplTest {
 	}
 
 	@Test
+	public void testReplacesTwoConsecutiveImageTagsWithUnsupportedMimeType()
+		throws Exception {
+
+		Mockito.when(
+			_amImageHTMLTagFactory.create(
+				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
+				_pngFileEntry)
+		).thenReturn(
+			"<whatever></whatever>"
+		);
+
+		Assert.assertEquals(
+			"<whatever></whatever><img data-fileentryid=\"1999\" " +
+				"src=\"adaptable\"/>",
+			_htmlContentTransformerImpl.transform(
+				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>" +
+					"<img data-fileentryid=\"1999\" src=\"adaptable\"/>"));
+	}
+
+	@Test
 	public void testReturnsNullForNullContent() throws Exception {
 		Assert.assertNull(_htmlContentTransformerImpl.transform(null));
 	}
@@ -199,6 +220,13 @@ public class HtmlContentTransformerImplTest {
 			AMImageMimeTypeProvider.class);
 
 		Mockito.when(
+			amImageMimeTypeProvider.isMimeTypeSupported(
+				ContentTypes.APPLICATION_PDF)
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
 			amImageMimeTypeProvider.isMimeTypeSupported(ContentTypes.IMAGE_PNG)
 		).thenReturn(
 			true
@@ -207,6 +235,20 @@ public class HtmlContentTransformerImplTest {
 		_htmlContentTransformerImpl = new HtmlContentTransformerImplStub(
 			_amImageHTMLTagFactory, amImageMimeTypeProvider,
 			_dlAppLocalService);
+	}
+
+	private void _setUpPdfFileEntry() throws Exception {
+		Mockito.when(
+			_dlAppLocalService.getFileEntry(1999L)
+		).thenReturn(
+			_pdfFileEntry
+		);
+
+		Mockito.when(
+			_pdfFileEntry.getMimeType()
+		).thenReturn(
+			ContentTypes.APPLICATION_PDF
+		);
 	}
 
 	private void _setUpPngFileEntry() throws Exception {
@@ -228,6 +270,7 @@ public class HtmlContentTransformerImplTest {
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
 	private HtmlContentTransformerImplStub _htmlContentTransformerImpl;
+	private final FileEntry _pdfFileEntry = Mockito.mock(FileEntry.class);
 	private final FileEntry _pngFileEntry = Mockito.mock(FileEntry.class);
 
 	private class HtmlContentTransformerImplStub

--- a/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/test/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/test/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImplTest.java
@@ -11,8 +11,8 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -36,12 +36,9 @@ public class HtmlContentTransformerImplTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() throws PortalException {
-		Mockito.when(
-			_dlAppLocalService.getFileEntry(1989L)
-		).thenReturn(
-			_fileEntry
-		);
+	public void setUp() throws Exception {
+		_setUpHtmlContentTransformerImplStub();
+		_setUpPngFileEntry();
 	}
 
 	@Test
@@ -51,7 +48,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -82,7 +79,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -101,7 +98,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -117,7 +114,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -157,7 +154,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" \nsrc=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -175,7 +172,7 @@ public class HtmlContentTransformerImplTest {
 		Mockito.when(
 			_amImageHTMLTagFactory.create(
 				"<img data-fileentryid=\"1989\" src=\"adaptable\"/>",
-				_fileEntry)
+				_pngFileEntry)
 		).thenReturn(
 			"<whatever></whatever>"
 		);
@@ -197,17 +194,41 @@ public class HtmlContentTransformerImplTest {
 		return text + StringPool.NEW_LINE + text;
 	}
 
+	private void _setUpHtmlContentTransformerImplStub() {
+		AMImageMimeTypeProvider amImageMimeTypeProvider = Mockito.mock(
+			AMImageMimeTypeProvider.class);
+
+		Mockito.when(
+			amImageMimeTypeProvider.isMimeTypeSupported(ContentTypes.IMAGE_PNG)
+		).thenReturn(
+			true
+		);
+
+		_htmlContentTransformerImpl = new HtmlContentTransformerImplStub(
+			_amImageHTMLTagFactory, amImageMimeTypeProvider,
+			_dlAppLocalService);
+	}
+
+	private void _setUpPngFileEntry() throws Exception {
+		Mockito.when(
+			_dlAppLocalService.getFileEntry(1989L)
+		).thenReturn(
+			_pngFileEntry
+		);
+
+		Mockito.when(
+			_pngFileEntry.getMimeType()
+		).thenReturn(
+			ContentTypes.IMAGE_PNG
+		);
+	}
+
 	private final AMImageHTMLTagFactory _amImageHTMLTagFactory = Mockito.mock(
 		AMImageHTMLTagFactory.class);
-	private final AMImageMimeTypeProvider _amImageMimeTypeProvider =
-		Mockito.mock(AMImageMimeTypeProvider.class);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
-	private final FileEntry _fileEntry = Mockito.mock(FileEntry.class);
-	private final HtmlContentTransformerImplStub _htmlContentTransformerImpl =
-		new HtmlContentTransformerImplStub(
-			_amImageHTMLTagFactory, _amImageMimeTypeProvider,
-			_dlAppLocalService);
+	private HtmlContentTransformerImplStub _htmlContentTransformerImpl;
+	private final FileEntry _pngFileEntry = Mockito.mock(FileEntry.class);
 
 	private class HtmlContentTransformerImplStub
 		extends HtmlContentTransformerImpl {
@@ -220,11 +241,6 @@ public class HtmlContentTransformerImplTest {
 			super(
 				amImageHTMLTagFactory, amImageMimeTypeProvider,
 				dlAppLocalService);
-		}
-
-		@Override
-		protected boolean isSupported(FileEntry fileEntry) {
-			return true;
 		}
 
 	}


### PR DESCRIPTION
OOTB Image - Adaptive Media doesn't render if map a PDF Preview Image

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-27402)

When the content that arrives to BaseRegexStringContentTransformer contains a file entry that is not supported, the content is returned without replacing the values of the file entries that are supported.

# How am I fixing it?

Don't return the unprocessed content when an invalid file entry is found, just avoid processing it and treat this as the matcher

# How can you verify that it works?

Follow the steps provided in the ticket, or run the provided unit test
