### PR TITLE
LPD-27271 Add a DM Folder in French language

### DIFF
--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {loginTest} from '../../fixtures/loginTest';
+import {PORTLET_URLS} from '../../utils/portletUrls';
+
+export const test = mergeTests(loginTest(), documentLibraryPagesTest);
+
+test('LPD-27271 Can create DM folder in French language', async ({page}) => {
+	const folderTitle = 'DM Folder FR';
+
+	await page.goto(`/fr/group/guest${PORTLET_URLS.documentLibrary}`);
+	await page.getByRole('button', {name: 'Nouveau'}).click();
+
+	await page
+		.getByRole('menuitem', {
+			name: 'Répertoire',
+		})
+		.click();
+
+	await page.getByRole('textbox').first().fill(folderTitle);
+	await page.getByRole('button', {name: 'Enregistrer'}).click();
+
+	await expect(page.getByRole('link', {name: folderTitle})).toBeVisible();
+
+	await page
+		.getByRole('checkbox', {name: `${folderTitle} More actions`})
+		.check();
+	await page.getByRole('button', {name: 'Effacer'}).nth(1).click();
+});

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -172,7 +172,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 				var inputPermissionsOptionsButton = document.getElementById('<%= uniqueNamespace %>inputPermissionsOptionsButton');
 
 				if (inputPermissionsOptionsButton) {
-					inputPermissionsOptionsButton.innerText = force ? '<%= LanguageUtil.get(request, "hide-options") %>' :'<%= LanguageUtil.get(request, "more-options") %>' ;
+					inputPermissionsOptionsButton.innerText = force ? '<%= HtmlUtil.escapeJS(LanguageUtil.get(request, "hide-options")) %>' : '<%= HtmlUtil.escapeJS(LanguageUtil.get(request, "more-options")) %>' ;
 					inputPermissionsOptionsButton.ariaExpanded = force;
 					inputPermissionsOptionsButton.classList = force ? "btn btn-secondary btn-sm mb-1 mt-3" : "btn btn-secondary btn-sm mb-5 mt-3";
 				}


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-27271)

DM Folders cannot be created in french language. Console errors appear. 

# How am I fixing it?

There was a conflict in single quotes with a key message that also contained a single quote. 
I am escaping the message and using doble quotes to avoid this. 

For the test, I finally decided to not use current Pages for Documents and Media, as all the locators change from English to French, and the code was going to be less readable. So I just did everything in the test itself. 
![Screenshot 2024-06-03 at 15 14 15](https://github.com/liferay-content-management/liferay-portal/assets/8373764/e8ad47d9-8fce-4275-a426-42cf66d37dbd)


# How can you verify that it works?

Follow the steps, or run the provided unit test: 

1. Change the URL from http://localhost:8080/home to http://localhost:8080/fr/home
2. Open Product Menu → Content → Documents & Media → New → Folder