### PR TITLE
LPD-1824 Cannot navigate to home folder after moving document

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -80,6 +80,7 @@ import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.temporaryrepository.TemporaryFileEntryRepository;
+import com.liferay.portal.util.RepositoryUtil;
 import com.liferay.portlet.documentlibrary.service.base.DLAppServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.util.DLAppUtil;
 import com.liferay.portlet.documentlibrary.util.DLPortletResourcePermissionUtil;
@@ -764,16 +765,26 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository destinationRepository = RepositoryProviderUtil.getRepository(
 			destinationRepositoryId);
 
-		FileShortcut fileShortcut = getFileShortcut(fileShortcutId);
+		Repository sourceRepository =
+			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+
+		FileShortcut fileShortcut = sourceRepository.getFileShortcut(fileShortcutId);
 
 		FileShortcut targetFileShortcut = destinationRepository.addFileShortcut(
 			getUserId(), destinationFolderId, fileShortcut.getToFileEntryId(),
 			serviceContext);
 
-		_copyResourcePermissions(
-			fileShortcut.getCompanyId(), DLFileShortcut.class.getName(),
-			fileShortcut.getFileShortcutId(),
-			targetFileShortcut.getFileShortcutId());
+		if (!RepositoryUtil.isExternalRepository(
+				sourceRepository.getRepositoryId()) &&
+			!RepositoryUtil.isExternalRepository(destinationRepositoryId)) {
+
+			_copyResourcePermissions(
+				fileShortcut.getCompanyId(), DLFileShortcut.class.getName(),
+				fileShortcut.getRepositoryId(),
+				fileShortcut.getFileShortcutId(),
+				targetFileShortcut.getRepositoryId(),
+				targetFileShortcut.getFileShortcutId());
+		}
 
 		return targetFileShortcut;
 	}
@@ -3261,7 +3272,9 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		_copyResourcePermissions(
 			fileEntry.getCompanyId(), DLFileEntry.class.getName(),
-			fileEntry.getFileEntryId(), targetFileEntry.getFileEntryId());
+			fileEntry.getRepositoryId(), fileEntry.getFileEntryId(),
+			targetFileEntry.getRepositoryId(),
+			targetFileEntry.getFileEntryId());
 
 		return targetFileEntry;
 	}
@@ -3379,7 +3392,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		_copyResourcePermissions(
 			sourceFolder.getCompanyId(), DLFolder.class.getName(),
-			sourceFolder.getFolderId(), targetFolder.getFolderId());
+			sourceFolder.getRepositoryId(), sourceFolder.getFolderId(),
+			targetFolder.getRepositoryId(), targetFolder.getFolderId());
 
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
@@ -3566,9 +3580,16 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	}
 
 	private void _copyResourcePermissions(
-			long companyId, String className, long sourceResourcePrimKey,
+			long companyId, String className, long sourceRepositoryId,
+			long sourceResourcePrimKey, long targetRepositoryId,
 			long targetResourcePrimKey)
 		throws PortalException {
+
+		if (RepositoryUtil.isExternalRepository(sourceRepositoryId) ||
+			RepositoryUtil.isExternalRepository(targetRepositoryId)) {
+
+			return;
+		}
 
 		for (int scope : ResourceConstants.SCOPES) {
 			_resourcePermissionLocalService.deleteResourcePermissions(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -22,10 +22,10 @@ import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.processor.DLProcessorHelperUtil;
+import com.liferay.document.library.kernel.processor.DLProcessorHelper;
 import com.liferay.document.library.kernel.service.DLAppHelperLocalService;
 import com.liferay.document.library.kernel.util.DLAppHelperThreadLocal;
-import com.liferay.document.library.kernel.util.DLValidatorUtil;
+import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.document.library.kernel.util.comparator.FolderNameComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelModifiedDateComparator;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
@@ -41,14 +41,14 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.lock.Lock;
-import com.liferay.portal.kernel.lock.LockManagerUtil;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryException;
-import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
+import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -552,7 +552,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public void cancelCheckOut(long fileEntryId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		FileEntry fileEntry = repository.getFileEntry(fileEntryId);
@@ -598,7 +598,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			String changeLog, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		repository.checkInFileEntry(
@@ -642,7 +642,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String lockUuid, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		repository.checkInFileEntry(
@@ -682,7 +682,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		FileEntry fileEntry = repository.checkOutFileEntry(
@@ -726,7 +726,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		FileEntry fileEntry = repository.checkOutFileEntry(
@@ -748,7 +748,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		throws PortalException {
 
 		Repository sourceRepository =
-			RepositoryProviderUtil.getFileEntryRepository(fileEntryId);
+			_repositoryProvider.getFileEntryRepository(fileEntryId);
 
 		return copyFileEntry(
 			getRepository(destinationRepositoryId),
@@ -762,13 +762,14 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long destinationRepositoryId, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository destinationRepository = RepositoryProviderUtil.getRepository(
+		Repository destinationRepository = _repositoryProvider.getRepository(
 			destinationRepositoryId);
 
 		Repository sourceRepository =
-			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+			_repositoryProvider.getFileShortcutRepository(fileShortcutId);
 
-		FileShortcut fileShortcut = sourceRepository.getFileShortcut(fileShortcutId);
+		FileShortcut fileShortcut = sourceRepository.getFileShortcut(
+			fileShortcutId);
 
 		FileShortcut targetFileShortcut = destinationRepository.addFileShortcut(
 			getUserId(), destinationFolderId, fileShortcut.getToFileEntryId(),
@@ -851,7 +852,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public void deleteFileEntry(long fileEntryId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		_dlAppHelperLocalService.deleteFileEntry(
@@ -890,8 +891,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public void deleteFileShortcut(long fileShortcutId) throws PortalException {
-		Repository repository =
-			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+		Repository repository = _repositoryProvider.getFileShortcutRepository(
+			fileShortcutId);
 
 		repository.deleteFileShortcut(fileShortcutId);
 	}
@@ -905,7 +906,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public void deleteFileVersion(long fileVersionId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFileVersionRepository(
+		Repository repository = _repositoryProvider.getFileVersionRepository(
 			fileVersionId);
 
 		repository.deleteFileVersion(fileVersionId);
@@ -924,7 +925,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	public void deleteFileVersion(long fileEntryId, String version)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		repository.deleteFileVersion(fileEntryId, version);
@@ -939,7 +940,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public void deleteFolder(long folderId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFolderRepository(
+		Repository repository = _repositoryProvider.getFolderRepository(
 			folderId);
 
 		Folder folder = repository.getFolder(folderId);
@@ -1299,7 +1300,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public FileEntry getFileEntry(long fileEntryId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		return repository.getFileEntry(fileEntryId);
@@ -1328,7 +1329,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 				throw noSuchFileEntryException;
 			}
 
-			Repository repository = RepositoryProviderUtil.getFolderRepository(
+			Repository repository = _repositoryProvider.getFolderRepository(
 				folderId);
 
 			return repository.getFileEntry(folderId, title);
@@ -1379,7 +1380,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 				throw noSuchFileEntryException;
 			}
 
-			Repository repository = RepositoryProviderUtil.getFolderRepository(
+			Repository repository = _repositoryProvider.getFolderRepository(
 				folderId);
 
 			return repository.getFileEntryByFileName(folderId, fileName);
@@ -1448,8 +1449,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	public FileShortcut getFileShortcut(long fileShortcutId)
 		throws PortalException {
 
-		Repository repository =
-			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+		Repository repository = _repositoryProvider.getFileShortcutRepository(
+			fileShortcutId);
 
 		return repository.getFileShortcut(fileShortcutId);
 	}
@@ -1465,7 +1466,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	public FileVersion getFileVersion(long fileVersionId)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileVersionRepository(
+		Repository repository = _repositoryProvider.getFileVersionRepository(
 			fileVersionId);
 
 		return repository.getFileVersion(fileVersionId);
@@ -1480,7 +1481,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 */
 	@Override
 	public Folder getFolder(long folderId) throws PortalException {
-		Repository repository = RepositoryProviderUtil.getFolderRepository(
+		Repository repository = _repositoryProvider.getFolderRepository(
 			folderId);
 
 		return repository.getFolder(folderId);
@@ -2423,8 +2424,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, long newFolderId, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository fromRepository =
-			RepositoryProviderUtil.getFileEntryRepository(fileEntryId);
+		Repository fromRepository = _repositoryProvider.getFileEntryRepository(
+			fileEntryId);
 
 		Repository toRepository = getFolderRepository(
 			newFolderId, serviceContext.getScopeGroupId());
@@ -2467,7 +2468,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long folderId, long parentFolderId, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository fromRepository = RepositoryProviderUtil.getFolderRepository(
+		Repository fromRepository = _repositoryProvider.getFolderRepository(
 			folderId);
 
 		Repository toRepository = getFolderRepository(
@@ -2514,12 +2515,11 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			String lockUuid, long companyId, long expirationTime)
 		throws PortalException {
 
-		Lock lock = LockManagerUtil.getLockByUuidAndCompanyId(
-			lockUuid, companyId);
+		Lock lock = _lockManager.getLockByUuidAndCompanyId(lockUuid, companyId);
 
 		long fileEntryId = GetterUtil.getLong(lock.getKey());
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		return repository.refreshFileEntryLock(
@@ -2543,12 +2543,11 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			String lockUuid, long companyId, long expirationTime)
 		throws PortalException {
 
-		Lock lock = LockManagerUtil.getLockByUuidAndCompanyId(
-			lockUuid, companyId);
+		Lock lock = _lockManager.getLockByUuidAndCompanyId(lockUuid, companyId);
 
 		long folderId = GetterUtil.getLong(lock.getKey());
 
-		Repository repository = RepositoryProviderUtil.getFolderRepository(
+		Repository repository = _repositoryProvider.getFolderRepository(
 			folderId);
 
 		return repository.refreshFolderLock(
@@ -2569,7 +2568,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			long fileEntryId, String version, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		repository.revertFileEntry(
@@ -2893,7 +2892,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		mimeType = DLAppUtil.getMimeType(sourceFileName, mimeType, title, file);
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		FileEntry fileEntry = repository.updateFileEntry(
@@ -2987,7 +2986,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			}
 		}
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		FileEntry fileEntry = repository.updateFileEntry(
@@ -3018,7 +3017,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 				displayDate, expirationDate, reviewDate, serviceContext);
 		}
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		_withDLAppHelperDisabled(
@@ -3049,7 +3048,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			Date expirationDate, Date reviewDate, ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository = RepositoryProviderUtil.getFileEntryRepository(
+		Repository repository = _repositoryProvider.getFileEntryRepository(
 			fileEntryId);
 
 		_withDLAppHelperDisabled(
@@ -3091,8 +3090,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		Repository repository =
-			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+		Repository repository = _repositoryProvider.getFileShortcutRepository(
+			fileShortcutId);
 
 		return repository.updateFileShortcut(
 			getUserId(), fileShortcutId, folderId, toFileEntryId,
@@ -3206,7 +3205,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		String sourceFileName = DLAppUtil.getSourceFileName(latestFileVersion);
 
-		DLValidatorUtil.validateFileSize(
+		_dlValidator.validateFileSize(
 			toRepository.getRepositoryId(), sourceFileName,
 			latestFileVersion.getMimeType(), latestFileVersion.getSize());
 
@@ -3398,7 +3397,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				for (FileEntry fileEntry : fileEntries) {
-					DLProcessorHelperUtil.trigger(fileEntry, null);
+					_dlProcessorHelper.trigger(fileEntry, null);
 				}
 
 				return null;
@@ -3526,14 +3525,14 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			return getRepository(groupId);
 		}
 
-		return RepositoryProviderUtil.getFolderRepository(folderId);
+		return _repositoryProvider.getFolderRepository(folderId);
 	}
 
 	protected Repository getRepository(long repositoryId)
 		throws PortalException {
 
 		try {
-			return RepositoryProviderUtil.getRepository(repositoryId);
+			return _repositoryProvider.getRepository(repositoryId);
 		}
 		catch (InvalidRepositoryIdException invalidRepositoryIdException) {
 			throw new NoSuchGroupException(
@@ -3757,11 +3756,23 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	@BeanReference(type = DLAppHelperLocalService.class)
 	private DLAppHelperLocalService _dlAppHelperLocalService;
 
+	@BeanReference
+	private DLProcessorHelper _dlProcessorHelper;
+
+	@BeanReference
+	private DLValidator _dlValidator;
+
+	@BeanReference
+	private LockManager _lockManager;
+
 	@BeanReference(type = RatingsEntryLocalService.class)
 	private RatingsEntryLocalService _ratingsEntryLocalService;
 
 	@BeanReference(type = RepositoryPersistence.class)
 	private RepositoryPersistence _repositoryPersistence;
+
+	@BeanReference
+	private RepositoryProvider _repositoryProvider;
 
 	@BeanReference(type = ResourcePermissionLocalService.class)
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -1043,7 +1043,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, start, end,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1119,7 +1119,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, fileEntryTypeId, start, end,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1156,8 +1156,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, mimeTypes, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			QueryUtil.ALL_POS, new RepositoryModelTitleComparator<>(true));
 	}
 
 	@Override
@@ -1763,7 +1762,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFoldersAndFileEntriesAndFileShortcuts(
 			repositoryId, folderId, status, includeMountFolders, start, end,
-			new RepositoryModelTitleComparator<Object>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1993,7 +1992,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getGroupFileEntries(
 			groupId, userId, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, start,
-			end, new RepositoryModelModifiedDateComparator<FileEntry>());
+			end, new RepositoryModelModifiedDateComparator<>());
 	}
 
 	/**
@@ -2065,7 +2064,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getGroupFileEntries(
 			groupId, userId, rootFolderId, start, end,
-			new RepositoryModelModifiedDateComparator<FileEntry>());
+			new RepositoryModelModifiedDateComparator<>());
 	}
 
 	/**

--- a/portal-impl/test/unit/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImplTest.java
@@ -1,0 +1,202 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.documentlibrary.service.impl;
+
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.RepositoryProvider;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.RepositoryUtil;
+import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DLAppServiceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_assetCategoryLocalService",
+			_assetCategoryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_assetTagLocalService", _assetTagLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_dlValidator", _dlValidator);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_repositoryProvider", _repositoryProvider);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_ratingsEntryLocalService",
+			_ratingsEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_resourcePermissionLocalService",
+			_resourcePermissionLocalService);
+	}
+
+	@After
+	public void tearDown() {
+		_guestOrUserUtilMockedStatic.close();
+
+		_repositoryUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testCopyResourcesWhenRepositoryIsNotExternal()
+		throws Exception {
+
+		_setUpDependencies();
+
+		_dlAppServiceImpl.copyFileEntry(
+			_destinationRepository, _sourceFileEntry,
+			RandomTestUtil.randomLong(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[0], new ServiceContext());
+
+		Mockito.verify(
+			_resourcePermissionLocalService,
+			Mockito.times(ResourceConstants.SCOPES.length)
+		).deleteResourcePermissions(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt(),
+			Mockito.anyLong()
+		);
+
+		Mockito.verify(
+			_resourcePermissionLocalService, Mockito.times(1)
+		).copyModelResourcePermissions(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(),
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testSkipCopyResourcesWhenRepositoryIsExternal()
+		throws Exception {
+
+		_setUpDependencies();
+
+		_repositoryUtilMockedStatic.when(
+			() -> RepositoryUtil.isExternalRepository(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		_dlAppServiceImpl.copyFileEntry(
+			_destinationRepository, _sourceFileEntry,
+			RandomTestUtil.randomLong(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[0], new ServiceContext());
+
+		_repositoryUtilMockedStatic.verify(
+			() -> RepositoryUtil.isExternalRepository(Mockito.anyLong()),
+			Mockito.times(1));
+
+		Mockito.verifyNoInteractions(_resourcePermissionLocalService);
+	}
+
+	private void _setUpDependencies() throws Exception {
+		Mockito.when(
+			_sourceFileEntry.getFileVersions(WorkflowConstants.STATUS_ANY)
+		).thenReturn(
+			Arrays.asList(Mockito.mock(FileVersion.class))
+		);
+
+		Mockito.when(
+			_assetCategoryLocalService.getCategoryIds(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			new long[0]
+		);
+
+		Mockito.when(
+			_assetTagLocalService.getTagNames(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			new String[0]
+		);
+
+		_guestOrUserUtilMockedStatic.when(
+			GuestOrUserUtil::getUserId
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_destinationRepository.addFileEntry(
+				Mockito.isNull(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.isNull(), Mockito.isNull(), Mockito.isNull(),
+				Mockito.isNull(), Mockito.isNull(), Mockito.anyString(),
+				Mockito.isNull(), Mockito.anyLong(), Mockito.isNull(),
+				Mockito.isNull(), Mockito.isNull(),
+				Mockito.any(ServiceContext.class))
+		).thenReturn(
+			_destinationFileEntry
+		);
+
+		Mockito.when(
+			_ratingsEntryLocalService.getEntries(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			Collections.emptyList()
+		);
+	}
+
+	private final AssetCategoryLocalService _assetCategoryLocalService =
+		Mockito.mock(AssetCategoryLocalService.class);
+	private final AssetTagLocalService _assetTagLocalService = Mockito.mock(
+		AssetTagLocalService.class);
+	private final FileEntry _destinationFileEntry = Mockito.mock(
+		FileEntry.class);
+	private final Repository _destinationRepository = Mockito.mock(
+		Repository.class);
+	private final DLAppServiceImpl _dlAppServiceImpl = new DLAppServiceImpl();
+	private final DLValidator _dlValidator = Mockito.mock(DLValidator.class);
+	private final MockedStatic<GuestOrUserUtil> _guestOrUserUtilMockedStatic =
+		Mockito.mockStatic(GuestOrUserUtil.class);
+	private final RatingsEntryLocalService _ratingsEntryLocalService =
+		Mockito.mock(RatingsEntryLocalService.class);
+	private final RepositoryProvider _repositoryProvider = Mockito.mock(
+		RepositoryProvider.class);
+	private final MockedStatic<RepositoryUtil> _repositoryUtilMockedStatic =
+		Mockito.mockStatic(RepositoryUtil.class);
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService = Mockito.mock(
+			ResourcePermissionLocalService.class);
+	private final FileEntry _sourceFileEntry = Mockito.mock(FileEntry.class);
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-1824

Moving a document from an external repository into any folder in a non-external repository would make that folder unusable.

# How am I fixing it?

The problem was that the code tried to copy the resource permissions from the original document. To make both copies exact, first it would try to remove the default permissions from the copy, and then replicate the permissions from the original. As external documents have no resource permissions, this would create a document with no resource permissions; this caused an exception when trying to check the VIEW permission.

# How can you verify that it works?

I've included a new unit test. Go to portal-impl and run:
```
$ ant test-class -Dtest.class=DLAppServiceImplTest
```