### PR TITLE
LPD-1824 Cannot navigate to home folder after moving document

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -80,6 +80,7 @@ import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.temporaryrepository.TemporaryFileEntryRepository;
+import com.liferay.portal.util.RepositoryUtil;
 import com.liferay.portlet.documentlibrary.service.base.DLAppServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.util.DLAppUtil;
 import com.liferay.portlet.documentlibrary.util.DLPortletResourcePermissionUtil;
@@ -764,7 +765,11 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository destinationRepository = RepositoryProviderUtil.getRepository(
 			destinationRepositoryId);
 
-		FileShortcut fileShortcut = getFileShortcut(fileShortcutId);
+		Repository sourceRepository =
+			RepositoryProviderUtil.getFileShortcutRepository(fileShortcutId);
+
+		FileShortcut fileShortcut = sourceRepository.getFileShortcut(
+			fileShortcutId);
 
 		FileShortcut targetFileShortcut = destinationRepository.addFileShortcut(
 			getUserId(), destinationFolderId, fileShortcut.getToFileEntryId(),
@@ -772,7 +777,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		_copyResourcePermissions(
 			fileShortcut.getCompanyId(), DLFileShortcut.class.getName(),
-			fileShortcut.getFileShortcutId(),
+			fileShortcut.getRepositoryId(), fileShortcut.getFileShortcutId(),
+			targetFileShortcut.getRepositoryId(),
 			targetFileShortcut.getFileShortcutId());
 
 		return targetFileShortcut;
@@ -3261,7 +3267,9 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		_copyResourcePermissions(
 			fileEntry.getCompanyId(), DLFileEntry.class.getName(),
-			fileEntry.getFileEntryId(), targetFileEntry.getFileEntryId());
+			fileEntry.getRepositoryId(), fileEntry.getFileEntryId(),
+			targetFileEntry.getRepositoryId(),
+			targetFileEntry.getFileEntryId());
 
 		return targetFileEntry;
 	}
@@ -3379,7 +3387,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		_copyResourcePermissions(
 			sourceFolder.getCompanyId(), DLFolder.class.getName(),
-			sourceFolder.getFolderId(), targetFolder.getFolderId());
+			sourceFolder.getRepositoryId(), sourceFolder.getFolderId(),
+			targetFolder.getRepositoryId(), targetFolder.getFolderId());
 
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
@@ -3566,9 +3575,16 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	}
 
 	private void _copyResourcePermissions(
-			long companyId, String className, long sourceResourcePrimKey,
+			long companyId, String className, long sourceRepositoryId,
+			long sourceResourcePrimKey, long targetRepositoryId,
 			long targetResourcePrimKey)
 		throws PortalException {
+
+		if (RepositoryUtil.isExternalRepository(sourceRepositoryId) ||
+			RepositoryUtil.isExternalRepository(targetRepositoryId)) {
+
+			return;
+		}
 
 		for (int scope : ResourceConstants.SCOPES) {
 			_resourcePermissionLocalService.deleteResourcePermissions(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -1037,7 +1037,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, start, end,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1113,7 +1113,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, fileEntryTypeId, start, end,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1150,8 +1150,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFileEntries(
 			repositoryId, folderId, mimeTypes, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS,
-			new RepositoryModelTitleComparator<FileEntry>(true));
+			QueryUtil.ALL_POS, new RepositoryModelTitleComparator<>(true));
 	}
 
 	@Override
@@ -1757,7 +1756,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getFoldersAndFileEntriesAndFileShortcuts(
 			repositoryId, folderId, status, includeMountFolders, start, end,
-			new RepositoryModelTitleComparator<Object>(true));
+			new RepositoryModelTitleComparator<>(true));
 	}
 
 	/**
@@ -1987,7 +1986,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getGroupFileEntries(
 			groupId, userId, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, start,
-			end, new RepositoryModelModifiedDateComparator<FileEntry>());
+			end, new RepositoryModelModifiedDateComparator<>());
 	}
 
 	/**
@@ -2059,7 +2058,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 		return getGroupFileEntries(
 			groupId, userId, rootFolderId, start, end,
-			new RepositoryModelModifiedDateComparator<FileEntry>());
+			new RepositoryModelModifiedDateComparator<>());
 	}
 
 	/**

--- a/portal-impl/test/unit/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImplTest.java
@@ -1,0 +1,198 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.documentlibrary.service.impl;
+
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.util.DLValidatorUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.RepositoryUtil;
+import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DLAppServiceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_assetCategoryLocalService",
+			_assetCategoryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_assetTagLocalService", _assetTagLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_ratingsEntryLocalService",
+			_ratingsEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_dlAppServiceImpl, "_resourcePermissionLocalService",
+			_resourcePermissionLocalService);
+	}
+
+	@After
+	public void tearDown() {
+		_dLValidatorUtilMockedStatic.close();
+
+		_guestOrUserUtilMockedStatic.close();
+
+		_repositoryUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testCopyResourcesWhenRepositoryIsNotExternal()
+		throws Exception {
+
+		_setUpDependencies();
+
+		_dlAppServiceImpl.copyFileEntry(
+			_destinationRepository, _sourceFileEntry,
+			RandomTestUtil.randomLong(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[0], new ServiceContext());
+
+		Mockito.verify(
+			_resourcePermissionLocalService,
+			Mockito.times(ResourceConstants.SCOPES.length)
+		).deleteResourcePermissions(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt(),
+			Mockito.anyLong()
+		);
+
+		Mockito.verify(
+			_resourcePermissionLocalService, Mockito.times(1)
+		).copyModelResourcePermissions(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong(),
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testSkipCopyResourcesWhenRepositoryIsExternal()
+		throws Exception {
+
+		_setUpDependencies();
+
+		_repositoryUtilMockedStatic.when(
+			() -> RepositoryUtil.isExternalRepository(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		_dlAppServiceImpl.copyFileEntry(
+			_destinationRepository, _sourceFileEntry,
+			RandomTestUtil.randomLong(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			new long[0], new ServiceContext());
+
+		_repositoryUtilMockedStatic.verify(
+			() -> RepositoryUtil.isExternalRepository(Mockito.anyLong()),
+			Mockito.times(1));
+
+		Mockito.verifyNoInteractions(_resourcePermissionLocalService);
+	}
+
+	private void _setUpDependencies() throws Exception {
+		Mockito.when(
+			_sourceFileEntry.getFileVersions(WorkflowConstants.STATUS_ANY)
+		).thenReturn(
+			Arrays.asList(Mockito.mock(FileVersion.class))
+		);
+
+		Mockito.when(
+			_assetCategoryLocalService.getCategoryIds(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			new long[0]
+		);
+
+		Mockito.when(
+			_assetTagLocalService.getTagNames(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			new String[0]
+		);
+
+		_guestOrUserUtilMockedStatic.when(
+			GuestOrUserUtil::getUserId
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_destinationRepository.addFileEntry(
+				Mockito.isNull(), Mockito.anyLong(), Mockito.anyLong(),
+				Mockito.isNull(), Mockito.isNull(), Mockito.isNull(),
+				Mockito.isNull(), Mockito.isNull(), Mockito.anyString(),
+				Mockito.isNull(), Mockito.anyLong(), Mockito.isNull(),
+				Mockito.isNull(), Mockito.isNull(),
+				Mockito.any(ServiceContext.class))
+		).thenReturn(
+			_destinationFileEntry
+		);
+
+		Mockito.when(
+			_ratingsEntryLocalService.getEntries(
+				DLFileEntryConstants.getClassName(),
+				_sourceFileEntry.getFileEntryId())
+		).thenReturn(
+			Collections.emptyList()
+		);
+	}
+
+	private final AssetCategoryLocalService _assetCategoryLocalService =
+		Mockito.mock(AssetCategoryLocalService.class);
+	private final AssetTagLocalService _assetTagLocalService = Mockito.mock(
+		AssetTagLocalService.class);
+	private final FileEntry _destinationFileEntry = Mockito.mock(
+		FileEntry.class);
+	private final Repository _destinationRepository = Mockito.mock(
+		Repository.class);
+	private final DLAppServiceImpl _dlAppServiceImpl = new DLAppServiceImpl();
+	private final MockedStatic<DLValidatorUtil> _dLValidatorUtilMockedStatic =
+		Mockito.mockStatic(DLValidatorUtil.class);
+	private final MockedStatic<GuestOrUserUtil> _guestOrUserUtilMockedStatic =
+		Mockito.mockStatic(GuestOrUserUtil.class);
+	private final RatingsEntryLocalService _ratingsEntryLocalService =
+		Mockito.mock(RatingsEntryLocalService.class);
+	private final MockedStatic<RepositoryUtil> _repositoryUtilMockedStatic =
+		Mockito.mockStatic(RepositoryUtil.class);
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService = Mockito.mock(
+			ResourcePermissionLocalService.class);
+	private final FileEntry _sourceFileEntry = Mockito.mock(FileEntry.class);
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-1824

Moving a document from an external repository into any folder in a non-external repository would make that folder unusable.

# How am I fixing it?

The problem was that the code tried to copy the resource permissions from the original document. To make both copies exact, first it would try to remove the default permissions from the copy, and then replicate the permissions from the original. As external documents have no resource permissions, this would create a document with no resource permissions; this caused an exception when trying to check the VIEW permission.

# How can you verify that it works?

I've included a new unit test. Go to portal-impl and run:
```
$ ant test-class -Dtest.class=DLAppServiceImplTest
```