### PR TITLE
LPD-17715 take into account the iframe sanitizer when comparing the content of the journal articles

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-journal-test/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:journal:journal-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 
 	testIntegrationRuntimeOnly project(":apps:asset:asset-test-util")

--- a/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
@@ -107,7 +107,7 @@ public class AMJournalArticleStagedModelDataHandlerTest
 	}
 
 	@Test
-	public void testExportImportContentWithMultipleDynamicReferences()
+	public void testExportImportContentWithMultipleDynamicReferencesIFrameSanitizerDisabled()
 		throws Exception {
 
 		_testExportImportContentWithMultipleDynamicReferences(false);
@@ -121,7 +121,7 @@ public class AMJournalArticleStagedModelDataHandlerTest
 	}
 
 	@Test
-	public void testExportImportContentWithMultipleStaticReferences()
+	public void testExportImportContentWithMultipleStaticReferencesIFrameSanitizerDisabled()
 		throws Exception {
 
 		_testExportImportContentWithMultipleStaticReferences(false);

--- a/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
@@ -110,152 +110,28 @@ public class AMJournalArticleStagedModelDataHandlerTest
 	public void testExportImportContentWithMultipleDynamicReferences()
 		throws Exception {
 
-		ServiceContext serviceContext = _getServiceContext();
-
-		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
-		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
-
-		boolean enabled = false;
-
-		String content = _getDynamicContent(enabled, fileEntry1, fileEntry2);
-
-		_withIFrameSanitizerConfiguration(
-			enabled,
-			() -> {
-				JournalArticle journalArticle = _addJournalArticle(
-					content, serviceContext);
-
-				ExportImportThreadLocal.setPortletImportInProcess(true);
-
-				try {
-					exportImportStagedModel(journalArticle);
-				}
-				finally {
-					ExportImportThreadLocal.setPortletImportInProcess(false);
-				}
-
-				JournalArticle importedJournalArticle =
-					(JournalArticle)getStagedModel(
-						journalArticle.getUuid(), liveGroup);
-
-				_assertXMLEquals(
-					_getExpectedDynamicContent(enabled, fileEntry1, fileEntry2),
-					importedJournalArticle.getContent());
-			});
+		_testExportImportContentWithMultipleDynamicReferences(false);
 	}
 
 	@Test
 	public void testExportImportContentWithMultipleDynamicReferencesIFrameSanitizerEnabled()
 		throws Exception {
 
-		ServiceContext serviceContext = _getServiceContext();
-
-		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
-		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
-
-		boolean enabled = true;
-
-		String content = _getDynamicContent(enabled, fileEntry1, fileEntry2);
-
-		_withIFrameSanitizerConfiguration(
-			enabled,
-			() -> {
-				JournalArticle journalArticle = _addJournalArticle(
-					content, serviceContext);
-
-				ExportImportThreadLocal.setPortletImportInProcess(true);
-
-				try {
-					exportImportStagedModel(journalArticle);
-				}
-				finally {
-					ExportImportThreadLocal.setPortletImportInProcess(false);
-				}
-
-				JournalArticle importedJournalArticle =
-					(JournalArticle)getStagedModel(
-						journalArticle.getUuid(), liveGroup);
-
-				_assertXMLEquals(
-					_getExpectedDynamicContent(enabled, fileEntry1, fileEntry2),
-					importedJournalArticle.getContent());
-			});
+		_testExportImportContentWithMultipleDynamicReferences(true);
 	}
 
 	@Test
 	public void testExportImportContentWithMultipleStaticReferences()
 		throws Exception {
 
-		ServiceContext serviceContext = _getServiceContext();
-
-		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
-		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
-
-		String content = _getStaticContent(fileEntry1, fileEntry2);
-
-		boolean enabled = false;
-
-		_withIFrameSanitizerConfiguration(
-			enabled,
-			() -> {
-				JournalArticle journalArticle = _addJournalArticle(
-					content, serviceContext);
-
-				ExportImportThreadLocal.setPortletImportInProcess(true);
-
-				try {
-					exportImportStagedModel(journalArticle);
-				}
-				finally {
-					ExportImportThreadLocal.setPortletImportInProcess(false);
-				}
-
-				JournalArticle importedJournalArticle =
-					(JournalArticle)getStagedModel(
-						journalArticle.getUuid(), liveGroup);
-
-				_assertXMLEquals(
-					_getExpectedStaticContent(enabled, fileEntry1, fileEntry2),
-					importedJournalArticle.getContent());
-			});
+		_testExportImportContentWithMultipleStaticReferences(false);
 	}
 
 	@Test
 	public void testExportImportContentWithMultipleStaticReferencesIFrameSanitizerEnabled()
 		throws Exception {
 
-		ServiceContext serviceContext = _getServiceContext();
-
-		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
-		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
-
-		String content = _getStaticContent(fileEntry1, fileEntry2);
-
-		boolean enabled = true;
-
-		_withIFrameSanitizerConfiguration(
-			enabled,
-			() -> {
-				JournalArticle journalArticle = _addJournalArticle(
-					content, serviceContext);
-
-				ExportImportThreadLocal.setPortletImportInProcess(true);
-
-				try {
-					exportImportStagedModel(journalArticle);
-				}
-				finally {
-					ExportImportThreadLocal.setPortletImportInProcess(false);
-				}
-
-				JournalArticle importedJournalArticle =
-					(JournalArticle)getStagedModel(
-						journalArticle.getUuid(), liveGroup);
-
-				_assertXMLEquals(
-					_getExpectedStaticContent(enabled, fileEntry1, fileEntry2),
-					importedJournalArticle.getContent());
-			});
+		_testExportImportContentWithMultipleStaticReferences(true);
 	}
 
 	@Test
@@ -552,6 +428,78 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		sb.setIndex(sb.index() - 1);
 
 		return _getContent(sb.toString());
+	}
+
+	private void _testExportImportContentWithMultipleDynamicReferences(
+			boolean enabled)
+		throws Exception {
+
+		ServiceContext serviceContext = _getServiceContext();
+
+		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
+		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
+
+		String content = _getDynamicContent(enabled, fileEntry1, fileEntry2);
+
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, serviceContext);
+
+				ExportImportThreadLocal.setPortletImportInProcess(true);
+
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
+
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedDynamicContent(enabled, fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
+	}
+
+	private void _testExportImportContentWithMultipleStaticReferences(
+			boolean enabled)
+		throws Exception {
+
+		ServiceContext serviceContext = _getServiceContext();
+
+		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
+		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
+
+		String content = _getStaticContent(fileEntry1, fileEntry2);
+
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, serviceContext);
+
+				ExportImportThreadLocal.setPortletImportInProcess(true);
+
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
+
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedStaticContent(enabled, fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
 	}
 
 	private void _withIFrameSanitizerConfiguration(

--- a/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -114,15 +115,15 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
 		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
 
-		String content = _getDynamicContent(fileEntry1, fileEntry2);
 		boolean enabled = false;
 
+		String content = _getDynamicContent(enabled, fileEntry1, fileEntry2);
 
 		_withIFrameSanitizerConfiguration(
 			enabled,
 			() -> {
 				JournalArticle journalArticle = _addJournalArticle(
-					content, _getServiceContext());
+					content, serviceContext);
 
 				ExportImportThreadLocal.setPortletImportInProcess(true);
 
@@ -138,7 +139,45 @@ public class AMJournalArticleStagedModelDataHandlerTest
 						journalArticle.getUuid(), liveGroup);
 
 				_assertXMLEquals(
-					_getExpectedDynamicContent(fileEntry1, fileEntry2),
+					_getExpectedDynamicContent(enabled, fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
+	}
+
+	@Test
+	public void testExportImportContentWithMultipleDynamicReferencesIFrameSanitizerEnabled()
+		throws Exception {
+
+		ServiceContext serviceContext = _getServiceContext();
+
+		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
+		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
+
+		boolean enabled = true;
+
+		String content = _getDynamicContent(enabled, fileEntry1, fileEntry2);
+
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, serviceContext);
+
+				ExportImportThreadLocal.setPortletImportInProcess(true);
+
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
+
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedDynamicContent(enabled, fileEntry1, fileEntry2),
 					importedJournalArticle.getContent());
 			});
 	}
@@ -176,7 +215,45 @@ public class AMJournalArticleStagedModelDataHandlerTest
 						journalArticle.getUuid(), liveGroup);
 
 				_assertXMLEquals(
-					_getExpectedStaticContent(fileEntry1, fileEntry2),
+					_getExpectedStaticContent(enabled, fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
+	}
+
+	@Test
+	public void testExportImportContentWithMultipleStaticReferencesIFrameSanitizerEnabled()
+		throws Exception {
+
+		ServiceContext serviceContext = _getServiceContext();
+
+		FileEntry fileEntry1 = _addImageFileEntry(serviceContext);
+		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
+
+		String content = _getStaticContent(fileEntry1, fileEntry2);
+
+		boolean enabled = true;
+
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, serviceContext);
+
+				ExportImportThreadLocal.setPortletImportInProcess(true);
+
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
+
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedStaticContent(enabled, fileEntry1, fileEntry2),
 					importedJournalArticle.getContent());
 			});
 	}
@@ -227,7 +304,7 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		FileEntry fileEntry = _addImageFileEntry(serviceContext);
 
 		return _addJournalArticle(
-			_getContent(_getImgTag(fileEntry)), serviceContext);
+			_getContent(_getImgTag(fileEntry, false)), serviceContext);
 	}
 
 	@Override
@@ -240,7 +317,7 @@ public class AMJournalArticleStagedModelDataHandlerTest
 
 		return Collections.singletonList(
 			_addJournalArticle(
-				_getContent(_getImgTag(fileEntry)), serviceContext));
+				_getContent(_getImgTag(fileEntry, false)), serviceContext));
 	}
 
 	@Override
@@ -355,13 +432,14 @@ public class AMJournalArticleStagedModelDataHandlerTest
 			"[$CONTENT$]", html);
 	}
 
-	private String _getDynamicContent(FileEntry... fileEntries)
+	private String _getDynamicContent(
+			boolean sanitize, FileEntry... fileEntries)
 		throws Exception {
 
 		StringBundler sb = new StringBundler(fileEntries.length);
 
 		for (FileEntry fileEntry : fileEntries) {
-			sb.append(_getImgTag(fileEntry));
+			sb.append(_getImgTag(fileEntry, sanitize));
 			sb.append(StringPool.NEW_LINE);
 		}
 
@@ -370,7 +448,8 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		return _getContent(sb.toString());
 	}
 
-	private String _getExpectedDynamicContent(FileEntry... fileEntries)
+	private String _getExpectedDynamicContent(
+			boolean sanitize, FileEntry... fileEntries)
 		throws Exception {
 
 		List<FileEntry> importedFileEntries = new ArrayList<>();
@@ -382,10 +461,11 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		}
 
 		return _getDynamicContent(
-			importedFileEntries.toArray(new FileEntry[0]));
+			sanitize, importedFileEntries.toArray(new FileEntry[0]));
 	}
 
-	private String _getExpectedStaticContent(FileEntry... fileEntries)
+	private String _getExpectedStaticContent(
+			boolean sanitize, FileEntry... fileEntries)
 		throws Exception {
 
 		StringBundler sb = new StringBundler(fileEntries.length * 2);
@@ -395,9 +475,19 @@ public class AMJournalArticleStagedModelDataHandlerTest
 				_dlAppLocalService.getFileEntryByUuidAndGroupId(
 					fileEntry.getUuid(), liveGroup.getGroupId());
 
-			sb.append(
-				_amImageHTMLTagFactory.create(
-					_getImgTag(importedFileEntry), importedFileEntry));
+			String amImageHTMLTag = _amImageHTMLTagFactory.create(
+				_getImgTag(importedFileEntry, sanitize), importedFileEntry);
+
+			if (sanitize) {
+				amImageHTMLTag = SanitizerUtil.sanitize(
+					importedFileEntry.getCompanyId(),
+					importedFileEntry.getGroupId(),
+					importedFileEntry.getUserId(),
+					JournalArticle.class.getName(), 0, ContentTypes.TEXT_HTML,
+					amImageHTMLTag);
+			}
+
+			sb.append(amImageHTMLTag);
 
 			sb.append(StringPool.NEW_LINE);
 		}
@@ -407,7 +497,13 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		return _getContent(sb.toString());
 	}
 
-	private String _getImgTag(FileEntry fileEntry) throws Exception {
+	private String _getImgTag(FileEntry fileEntry, boolean sanitize)
+		throws Exception {
+
+		if (sanitize) {
+			return _getSanitizedImgTag(fileEntry.getFileEntryId());
+		}
+
 		return _getImgTag(fileEntry.getFileEntryId());
 	}
 
@@ -425,10 +521,17 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		sb.append(fileEntry.getFileEntryId());
 		sb.append("\">");
 		sb.append("<source></source>");
-		sb.append(_getImgTag(fileEntry));
+		sb.append(_getImgTag(fileEntry, false));
 		sb.append("</picture>");
 
 		return sb.toString();
+	}
+
+	private String _getSanitizedImgTag(long fileEntryId) throws Exception {
+		return String.format(
+			"<img alt=\"alt\" class=\"a class\" src=\"theURL\" " +
+				"data-fileentryid=\"%s\">",
+			fileEntryId);
 	}
 
 	private ServiceContext _getServiceContext() throws Exception {

--- a/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
@@ -26,9 +26,11 @@ import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.util.JournalContent;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -44,6 +46,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -112,25 +115,32 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		FileEntry fileEntry2 = _addImageFileEntry(serviceContext);
 
 		String content = _getDynamicContent(fileEntry1, fileEntry2);
+		boolean enabled = false;
 
-		JournalArticle journalArticle = _addJournalArticle(
-			content, _getServiceContext());
 
-		ExportImportThreadLocal.setPortletImportInProcess(true);
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, _getServiceContext());
 
-		try {
-			exportImportStagedModel(journalArticle);
-		}
-		finally {
-			ExportImportThreadLocal.setPortletImportInProcess(false);
-		}
+				ExportImportThreadLocal.setPortletImportInProcess(true);
 
-		JournalArticle importedJournalArticle = (JournalArticle)getStagedModel(
-			journalArticle.getUuid(), liveGroup);
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
 
-		_assertXMLEquals(
-			_getExpectedDynamicContent(fileEntry1, fileEntry2),
-			importedJournalArticle.getContent());
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedDynamicContent(fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
 	}
 
 	@Test
@@ -144,24 +154,31 @@ public class AMJournalArticleStagedModelDataHandlerTest
 
 		String content = _getStaticContent(fileEntry1, fileEntry2);
 
-		JournalArticle journalArticle = _addJournalArticle(
-			content, serviceContext);
+		boolean enabled = false;
 
-		ExportImportThreadLocal.setPortletImportInProcess(true);
+		_withIFrameSanitizerConfiguration(
+			enabled,
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					content, serviceContext);
 
-		try {
-			exportImportStagedModel(journalArticle);
-		}
-		finally {
-			ExportImportThreadLocal.setPortletImportInProcess(false);
-		}
+				ExportImportThreadLocal.setPortletImportInProcess(true);
 
-		JournalArticle importedJournalArticle = (JournalArticle)getStagedModel(
-			journalArticle.getUuid(), liveGroup);
+				try {
+					exportImportStagedModel(journalArticle);
+				}
+				finally {
+					ExportImportThreadLocal.setPortletImportInProcess(false);
+				}
 
-		_assertXMLEquals(
-			_getExpectedStaticContent(fileEntry1, fileEntry2),
-			importedJournalArticle.getContent());
+				JournalArticle importedJournalArticle =
+					(JournalArticle)getStagedModel(
+						journalArticle.getUuid(), liveGroup);
+
+				_assertXMLEquals(
+					_getExpectedStaticContent(fileEntry1, fileEntry2),
+					importedJournalArticle.getContent());
+			});
 	}
 
 	@Test
@@ -432,6 +449,26 @@ public class AMJournalArticleStagedModelDataHandlerTest
 		sb.setIndex(sb.index() - 1);
 
 		return _getContent(sb.toString());
+	}
+
+	private void _withIFrameSanitizerConfiguration(
+			boolean enabled, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.portal.security.iframe.sanitizer." +
+						"configuration.IFrameConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", enabled
+					).put(
+						"removeIFrameTags", false
+					).put(
+						"sandboxAttributeValues", ""
+					).build())) {
+
+			unsafeRunnable.run();
+		}
 	}
 
 	private JournalArticle _withPortletImportEnabled(


### PR DESCRIPTION
# Investigate failing tests in com.liferay.adaptive.media.journal.internal.exportimport.data.handler.test.AMJournalArticleStagedModelDataHandlerTest

# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-17715
After developing the iframe sanitizer, the content is sanitized with jSoup so we should compare on different manner if is enabled or not.

# How am I fixing it?
adding the configuration to each test that depends on it and enable and disable it on each case.

# How can you verify that it works?
"Run the included automated tests."


- **LPD-17715 iframe sanitizer clear the data on different way than without it.**
- **LPD-17715 add test with the iframe sanitizer enabled**
- **LPD-17715 extract common code**
- **LPD-17715 rename**
