### PR TITLE
LPD-25415 use KBArticle.editScheduledDate for updating the schedule date of the articles

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/knowledge-base/JSONKnowledgeBase.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/knowledge-base/JSONKnowledgeBase.macro
@@ -140,8 +140,10 @@ definition {
 		}
 		else {
 			var increaseMinutes = StringUtil.replace(480, 0, ${increaseMinutes});
-
+			var currentDate = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
 			var displayDate = DateUtil.getDateOffsetByMinutes(${increaseMinutes}, "yyyy-MM-dd HH:mm");
+
+			echo("## * currentDate: ${currentDate}");
 
 			echo("## * displayDate: ${displayDate}");
 		}
@@ -205,8 +207,10 @@ definition {
 		}
 		else {
 			var increaseMinutes = StringUtil.replace(480, 0, ${increaseMinutes});
-
+			var currentDate = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
 			var displayDate = DateUtil.getDateOffsetByMinutes(${increaseMinutes}, "yyyy-MM-dd HH:mm");
+
+			echo("## * currentDate: ${currentDate}");
 
 			echo("## * displayDate: ${displayDate}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -248,7 +248,15 @@ definition {
 
 		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled parent article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
 
+		var beforePause = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * beforePause: ${beforePause}");
+
 		Pause(value1 = 120000);
+
+		var afterPause = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * afterPause: ${afterPause}");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -264,7 +272,15 @@ definition {
 
 		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
 
+		var beforePause2 = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * beforePause2: ${beforePause2}");
+
 		Pause(value1 = 120000);
+
+		var afterPause2 = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * afterPause2: ${afterPause2}");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -311,7 +327,15 @@ definition {
 
 		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is not published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
 
+		var beforePause = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * beforePause: ${beforePause}");
+
 		Pause(value1 = 120000);
+
+		var afterPause = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * afterPause: ${afterPause}");
 
 		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
 
@@ -321,7 +345,15 @@ definition {
 
 		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled articles are published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
 
+		var beforePause2 = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * beforePause2: ${beforePause2}");
+
 		Pause(value1 = 120000);
+
+		var afterPause2 = DateUtil.getFormattedCurrentDate("yyyy-MM-dd HH:mm");
+
+		echo("## * afterPause2: ${afterPause2}");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -225,6 +225,12 @@ definition {
 			kbArticleContent = "Knowledge Base Article Content",
 			kbArticleTitle = "Knowledge Base Article Title");
 
+		KBArticle.editScheduledDate(
+			editDraftArticle = "false",
+			increaseMinutes = 1,
+			kbArticleContent = "Knowledge Base Article Content",
+			kbArticleTitle = "Knowledge Base Article Title");
+
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
 		KBArticle.addArticleWithScheduledDate(
@@ -233,6 +239,12 @@ definition {
 			kbArticleContent = "Knowledge Base Child Article Content",
 			kbArticleTitle = "Knowledge Base Child Article Title",
 			kbParentArticleTitle = "Knowledge Base Article Title");
+
+		KBArticle.editScheduledDate(
+			editDraftArticle = "false",
+			increaseMinutes = 2,
+			kbArticleContent = "Knowledge Base Child Article Content",
+			kbArticleTitle = "Knowledge Base Child Article Title");
 
 		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled parent article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
 
@@ -275,6 +287,12 @@ definition {
 			kbArticleContent = "Knowledge Base Article Content",
 			kbArticleTitle = "Knowledge Base Article Title");
 
+		KBArticle.editScheduledDate(
+			editDraftArticle = "false",
+			increaseMinutes = 2,
+			kbArticleContent = "Knowledge Base Article Content",
+			kbArticleTitle = "Knowledge Base Article Title");
+
 		JSONKnowledgeBase.addkBChildArticle(
 			displayDate = "true",
 			groupName = "Guest",
@@ -282,6 +300,12 @@ definition {
 			kbArticleTitle = "Knowledge Base Article Title",
 			kbChildArticleContent = "Knowledge Base Child Article Content",
 			kbChildArticleTitle = "Knowledge Base Child Article Title");
+
+		KBArticle.editScheduledDate(
+			editDraftArticle = "false",
+			increaseMinutes = 1,
+			kbArticleContent = "Knowledge Base Child Article Content",
+			kbArticleTitle = "Knowledge Base Child Article Title");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 


### PR DESCRIPTION


LPD-25415 [BE] test failure in KBArticleSchedule showing 'Scheduled' when Approved is expected

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-25415

The schedule date of the articles are not correct because there is not updated properly after the creation

# How am I fixing it?

Calling KBArticle.editScheduledDate to update the dates

# How can you verify that it works?

 "Run the included automated tests." 

# Commits

- **LPD-25415 use other way to update date of the articles**
- **LPD-25415 echos to check values**
