### PR TITLE
LPD-24176 Add test to our daily routine and link playwright to relevant

### DIFF
--- a/modules/apps/announcements/announcements-web/test.properties
+++ b/modules/apps/announcements/announcements-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Relevant
+##
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=announcements-web

--- a/modules/apps/blogs/blogs-web/test.properties
+++ b/modules/apps/blogs/blogs-web/test.properties
@@ -2,6 +2,8 @@
 ## Relevant
 ##
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=blogs-web
+
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Blogs") AND \
         (testray.main.component.name == "Upgrades Content Management")

--- a/modules/apps/document-library/document-library-web/test.properties
+++ b/modules/apps/document-library/document-library-web/test.properties
@@ -2,6 +2,8 @@
 ## Relevant
 ##
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=document-library-web
+
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Document Management") AND \
         (testray.main.component.name == "Upgrades Content Management")

--- a/modules/apps/journal/journal-web/test.properties
+++ b/modules/apps/journal/journal-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Relevant
+##
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=journal-web

--- a/modules/apps/knowledge-base/knowledge-base-web/test.properties
+++ b/modules/apps/knowledge-base/knowledge-base-web/test.properties
@@ -2,6 +2,8 @@
 ## Relevant
 ##
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=knowledge-base-web
+
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Knowledge Base") AND \
         (testray.main.component.name == "Upgrades Content Management")

--- a/modules/apps/notifications/notifications-web/test.properties
+++ b/modules/apps/notifications/notifications-web/test.properties
@@ -2,6 +2,8 @@
 ## Relevant
 ##
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=notification-web
+
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Notifications") AND \
         (testray.main.component.name == "Upgrades Content Management")

--- a/test.properties
+++ b/test.properties
@@ -4125,6 +4125,14 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Content Management
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=\
+        announcements-web,\
+        blogs-web,\
+        document-library-web,\
+        journal-web,\
+        knowledge-base-web,\
+        notification-web
+
     test.batch.class.names.includes[content-management]=\
         **/adaptive-media-blogs-test/**/*Test.java,\
         **/adaptive-media-blogs-web-test/**/*Test.java,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-24176

Execute the our playwright test in our `ci:test:content-management` routine.

This PR links our playwright test to our current relevant suite.

For example, if some code on documents and media is updated the playwright test on [document-library-web](https://github.com/liferay/liferay-portal/tree/59431935c110c3274bde292e0587ad8bcd3e2248/modules/test/playwright/tests/document-library-web) will execute in on the PR with the `ci:test:relevant` command.


# How am I fixing it?

I'm following the steps shared in [slack channel](https://liferay.slack.com/archives/C06A59K5D46/p1713174409459909) and connecting the points with @sandrodw3 's help

# How can you verify that it works?

I'm not sure, we can check if it is included in our daily routine in the future.

# Why doesn't this include any test?

It's test infra-related changes, we can not test it.