### PR TITLE
LPD-25415 move failing Poshi test Scheduling KBArticles to Integration test

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -2310,6 +2310,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 					KBArticleTable.INSTANCE.status.neq(
 						WorkflowConstants.STATUS_PENDING)
 				)
+			).orderBy(
+				KBArticleTable.INSTANCE.createDate.ascending()
 			));
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-test/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation group: "junit", name: "junit", version: "4.13.1"
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
@@ -124,6 +124,73 @@ public class KBArticleScheduledTest {
 			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
 	}
 
+	@Test
+	public void testChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() - (2 * Time.MINUTE));
+
+		childKBArticle.setDisplayDate(displayDate);
+
+		childKBArticle = _kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		Assert.assertThrows(
+			KBArticleStatusException.class,
+			() -> _kbArticleLocalService.checkKBArticles(
+				_group.getCompanyId()));
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		parentKBArticle.setDisplayDate(displayDate);
+
+		parentKBArticle = _kbArticleLocalService.updateKBArticle(
+			parentKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+	}
+
 	@Test(expected = KBArticleStatusException.class)
 	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
@@ -62,6 +62,68 @@ public class KBArticleScheduledTest {
 			_group, _user.getUserId());
 	}
 
+	@Test
+	public void testChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		parentKBArticle.setDisplayDate(new Date());
+
+		parentKBArticle = _kbArticleLocalService.updateKBArticle(
+			parentKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+
+		childKBArticle.setDisplayDate(new Date());
+
+		childKBArticle = _kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+	}
+
 	@Test(expected = KBArticleStatusException.class)
 	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleScheduledTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.exception.KBArticleStatusException;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@FeatureFlags("LPS-188058")
+@RunWith(Arquillian.class)
+public class KBArticleScheduledTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_kbFolderClassNameId = _classNameLocalService.getClassNameId(
+			KBFolderConstants.getClassName());
+
+		_user = TestPropsValues.getUser();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group, _user.getUserId());
+	}
+
+	@Test(expected = KBArticleStatusException.class)
+	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+
+		childKBArticle.setDisplayDate(new Date());
+
+		_kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+	}
+
+	private KBArticle _addKbArticle(Date displayDate) throws Exception {
+		return _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, null, null, null, _serviceContext);
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+	private long _kbFolderClassNameId;
+	private ServiceContext _serviceContext;
+	private User _user;
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -213,56 +213,6 @@ definition {
 			listEntryLabel = "Approved");
 	}
 
-	@description = "This test ensures that a child article scheduled after the parent will be published on its scheduled date."
-	@priority = 5
-	test ChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.addArticleWithScheduledDate(
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.addArticleWithScheduledDate(
-			addChildArticleWithScheduledDate = "true",
-			increaseMinutes = 2,
-			kbArticleContent = "Knowledge Base Child Article Content",
-			kbArticleTitle = "Knowledge Base Child Article Title",
-			kbParentArticleTitle = "Knowledge Base Article Title");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled parent article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Approved");
-	}
-
 	@description = "This test ensures that a child article scheduled before the parent will not be published until its parent is published."
 	@priority = 5
 	test ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -213,55 +213,6 @@ definition {
 			listEntryLabel = "Approved");
 	}
 
-	@description = "This test ensures that a child article scheduled before the parent will not be published until its parent is published."
-	@priority = 5
-	test ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		JSONKnowledgeBase.addkBArticle(
-			displayDate = "true",
-			groupName = "Guest",
-			increaseMinutes = 2,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		JSONKnowledgeBase.addkBChildArticle(
-			displayDate = "true",
-			groupName = "Guest",
-			increaseMinutes = 1,
-			kbArticleTitle = "Knowledge Base Article Title",
-			kbChildArticleContent = "Knowledge Base Child Article Content",
-			kbChildArticleTitle = "Knowledge Base Child Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is not published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled articles are published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Approved");
-	}
-
 	@description = "This test ensures that the expired article can be published again when the date reaches a new scheduled date."
 	@priority = 4
 	test ExpiredArticleCanBePublishedWithNewScheduledDate {


### PR DESCRIPTION
LPD-25415 [BE] test failure in KBArticleSchedule showing 'Scheduled' when Approved is expected

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-25415

The POSHI test are failing because the way are they been updated

# How am I fixing it?

I decided to move to Integration test mimicking the same steps that there are on the POSHI test

# How can you verify that it works?

Run the included automated tests.

# Commits

- **LPD-25415 create integration test to check Behavior of scheduled KB articles**
- **LPD-25415 move ChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate to an integration test**
- **LPD-25415 move ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished to an integration test**
- **LPD-25415 ensure that when a parent and child article are created with the same display date, the return will be ordered by creation so first we check the parent**
