### PR TITLE
LPD-27556 Web content displayed in a DPT is not being expired

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6078,54 +6078,23 @@ public class JournalArticleLocalServiceImpl
 									"Expiring article " + article.getId());
 							}
 
-							if (isExpireAllArticleVersions(companyId)) {
-								List<JournalArticle> currentArticles =
-									journalArticleLocalService.getArticles(
-										article.getGroupId(),
-										article.getArticleId(),
-										QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-										new ArticleVersionComparator(true));
+							ServiceContext serviceContext =
+								new ServiceContext();
 
-								for (JournalArticle currentArticle :
-										currentArticles) {
+							serviceContext.setCommand(Constants.UPDATE);
+							serviceContext.setScopeGroupId(
+								article.getGroupId());
 
-									if (currentArticle.getVersion() >=
-											article.getVersion()) {
-
-										continue;
-									}
-
-									currentArticle.setExpirationDate(
-										article.getExpirationDate());
-									currentArticle.setStatus(
-										WorkflowConstants.STATUS_EXPIRED);
-
-									currentArticle =
-										journalArticlePersistence.update(
-											currentArticle);
-
-									notifySubscribers(
-										0, currentArticle, "expired",
-										new ServiceContext());
-								}
-							}
-
-							article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-
-							JournalArticle updatedJournalArticle =
-								journalArticleLocalService.updateJournalArticle(
-									article);
-
-							notifySubscribers(
-								0, updatedJournalArticle, "expired",
-								new ServiceContext());
-
-							updatePreviousApprovedArticle(
-								updatedJournalArticle);
+							journalArticleLocalService.expireArticle(
+								_portal.getValidUserId(
+									article.getCompanyId(),
+									article.getStatusByUserId()),
+								article.getGroupId(), article.getArticleId(),
+								null, serviceContext);
 
 							if (indexer != null) {
 								indexableActionableDynamicQuery.addDocuments(
-									indexer.getDocument(updatedJournalArticle));
+									indexer.getDocument(article));
 							}
 
 							return null;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6038,9 +6038,6 @@ public class JournalArticleLocalServiceImpl
 		IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			getIndexableActionableDynamicQuery();
 
-		Indexer<JournalArticle> indexer = IndexerRegistryUtil.getIndexer(
-			JournalArticle.class);
-
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
 				Property classNameIdProperty = PropertyFactoryUtil.forName(
@@ -6091,11 +6088,6 @@ public class JournalArticleLocalServiceImpl
 									article.getStatusByUserId()),
 								article.getGroupId(), article.getArticleId(),
 								null, serviceContext);
-
-							if (indexer != null) {
-								indexableActionableDynamicQuery.addDocuments(
-									indexer.getDocument(article));
-							}
 
 							return null;
 						});

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -102,7 +102,6 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
@@ -162,7 +161,10 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
@@ -6067,53 +6069,76 @@ public class JournalArticleLocalServiceImpl
 		indexableActionableDynamicQuery.setCompanyId(companyId);
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
-				if (_log.isDebugEnabled()) {
-					_log.debug("Expiring article " + article.getId());
+				try {
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> {
+							if (_log.isDebugEnabled()) {
+								_log.debug(
+									"Expiring article " + article.getId());
+							}
+
+							if (isExpireAllArticleVersions(companyId)) {
+								List<JournalArticle> currentArticles =
+									journalArticleLocalService.getArticles(
+										article.getGroupId(),
+										article.getArticleId(),
+										QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+										new ArticleVersionComparator(true));
+
+								for (JournalArticle currentArticle :
+										currentArticles) {
+
+									if (currentArticle.getVersion() >=
+											article.getVersion()) {
+
+										continue;
+									}
+
+									currentArticle.setExpirationDate(
+										article.getExpirationDate());
+									currentArticle.setStatus(
+										WorkflowConstants.STATUS_EXPIRED);
+
+									currentArticle =
+										journalArticlePersistence.update(
+											currentArticle);
+
+									notifySubscribers(
+										0, currentArticle, "expired",
+										new ServiceContext());
+								}
+							}
+
+							article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+							JournalArticle updatedJournalArticle =
+								journalArticleLocalService.updateJournalArticle(
+									article);
+
+							notifySubscribers(
+								0, updatedJournalArticle, "expired",
+								new ServiceContext());
+
+							updatePreviousApprovedArticle(
+								updatedJournalArticle);
+
+							if (indexer != null) {
+								indexableActionableDynamicQuery.addDocuments(
+									indexer.getDocument(updatedJournalArticle));
+							}
+
+							return null;
+						});
 				}
-
-				if (isExpireAllArticleVersions(companyId)) {
-					List<JournalArticle> currentArticles =
-						journalArticleLocalService.getArticles(
-							article.getGroupId(), article.getArticleId(),
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-							new ArticleVersionComparator(true));
-
-					for (JournalArticle currentArticle : currentArticles) {
-						if (currentArticle.getVersion() >=
-								article.getVersion()) {
-
-							continue;
-						}
-
-						currentArticle.setExpirationDate(
-							article.getExpirationDate());
-						currentArticle.setStatus(
-							WorkflowConstants.STATUS_EXPIRED);
-
-						currentArticle = journalArticlePersistence.update(
-							currentArticle);
-
-						notifySubscribers(
-							0, currentArticle, "expired", new ServiceContext());
+				catch (Throwable throwable) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Error expiring article " + article.getId(),
+							throwable);
 					}
 				}
-
-				article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-
-				article = journalArticleLocalService.updateJournalArticle(
-					article);
-
-				notifySubscribers(0, article, "expired", new ServiceContext());
-
-				updatePreviousApprovedArticle(article);
-
-				if (indexer != null) {
-					indexableActionableDynamicQuery.addDocuments(
-						indexer.getDocument(article));
-				}
 			});
-		indexableActionableDynamicQuery.setTransactionConfig(
-			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
 		indexableActionableDynamicQuery.performActions();
 	}
@@ -6156,24 +6181,42 @@ public class JournalArticleLocalServiceImpl
 			});
 		actionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
-				if (_log.isDebugEnabled()) {
-					_log.debug("Publishing article " + article.getId());
+				try {
+					TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> {
+							if (_log.isDebugEnabled()) {
+								_log.debug(
+									"Publishing article " + article.getId());
+							}
+
+							long userId = _portal.getValidUserId(
+								article.getCompanyId(),
+								article.getStatusByUserId());
+
+							ServiceContext serviceContext =
+								new ServiceContext();
+
+							serviceContext.setCommand(Constants.UPDATE);
+							serviceContext.setScopeGroupId(
+								article.getGroupId());
+
+							journalArticleLocalService.updateStatus(
+								userId, article.getId(),
+								WorkflowConstants.STATUS_APPROVED,
+								new HashMap<>(), serviceContext);
+
+							return null;
+						});
 				}
-
-				long userId = _portal.getValidUserId(
-					article.getCompanyId(), article.getStatusByUserId());
-
-				ServiceContext serviceContext = new ServiceContext();
-
-				serviceContext.setCommand(Constants.UPDATE);
-				serviceContext.setScopeGroupId(article.getGroupId());
-
-				journalArticleLocalService.updateStatus(
-					userId, article.getId(), WorkflowConstants.STATUS_APPROVED,
-					new HashMap<>(), serviceContext);
+				catch (Throwable throwable) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Error publishing article " + article.getId(),
+							throwable);
+					}
+				}
 			});
-		actionableDynamicQuery.setTransactionConfig(
-			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
 		actionableDynamicQuery.performActions();
 	}
@@ -8281,6 +8324,11 @@ public class JournalArticleLocalServiceImpl
 
 	@Reference
 	private SystemEventLocalService _systemEventLocalService;
+
+	private final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW,
+			new Class<?>[] {PortalException.class, SystemException.class});
 
 	@Reference
 	private TrashEntryLocalService _trashEntryLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
@@ -108,6 +109,34 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 	}
 
 	@Test
+	public void testExpireJournalArticleWithoutAffectingOthersExpirationErrors()
+		throws Exception {
+
+		JournalArticle expectedArticle = addArticle(
+			_group.getGroupId(), false, true, false);
+
+		Date date = new Date(System.currentTimeMillis() - Time.HOUR);
+
+		expectedArticle.setExpirationDate(date);
+
+		expectedArticle = _journalArticleLocalService.updateJournalArticle(
+			expectedArticle);
+
+		_assetEntryLocalService.deleteEntry(
+			JournalArticle.class.getName(),
+			expectedArticle.getResourcePrimKey());
+
+		_assertCheckArticles(date, date, WorkflowConstants.STATUS_EXPIRED);
+
+		JournalArticle actualArticle = _journalArticleLocalService.fetchArticle(
+			expectedArticle.getId());
+
+		Assert.assertNotNull(actualArticle);
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, actualArticle.getStatus());
+	}
+
+	@Test
 	public void testExpireScheduledJournalArticleDisplayDateAndExpirationDateWithinTheSameInterval()
 		throws Exception {
 
@@ -129,6 +158,34 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 		Date date = new Date(now - Time.HOUR);
 
 		_assertCheckArticles(date, date, WorkflowConstants.STATUS_EXPIRED);
+	}
+
+	@Test
+	public void testScheduleJournalArticleWithoutAffectingOthersSchedulingErrors()
+		throws Exception {
+
+		JournalArticle expectedArticle = addArticle(
+			_group.getGroupId(), true, true, true);
+
+		Date date = new Date(System.currentTimeMillis() - Time.HOUR);
+
+		expectedArticle.setDisplayDate(date);
+
+		expectedArticle = _journalArticleLocalService.updateJournalArticle(
+			expectedArticle);
+
+		_assetEntryLocalService.deleteEntry(
+			JournalArticle.class.getName(),
+			expectedArticle.getResourcePrimKey());
+
+		_assertCheckArticles(date, null, WorkflowConstants.STATUS_APPROVED);
+
+		JournalArticle actualArticle = _journalArticleLocalService.fetchArticle(
+			expectedArticle.getId());
+
+		Assert.assertNotNull(actualArticle);
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, actualArticle.getStatus());
 	}
 
 	@Test
@@ -349,6 +406,9 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 	private static final int _MODE_DEFAULT = 0;
 
 	private static final int _MODE_POSTPONE_EXPIRATION = 1;
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27556

# What is this trying to solve?

Avoid inconsistence data affect to all article expirations/publications.  

1. Add a transaction for all changes behind expiration or publication perform actions in order to rollback the data in case it fails. 
2. Catch exception to allow performing other expiration or publication tasks.
3. Delte unnecessary sentence for actionable query because now all actions behind perform action is being executed behind a transaction: 

```
 indexableActionableDynamicQuery.setTransactionConfig(
			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
```


# How am I fixing it?

Adding catch sentence in perform action method of actionable query and also add a Transaction using TransactionInvokerUtil.

# How can you verify that it works?

Run the included tests.
