### PR TITLE
LPD-21844 Handling multiple partitions use case (2nd try)

### DIFF
--- a/modules/apps/repository/repository-test/build.gradle
+++ b/modules/apps/repository/repository-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-db-partition-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
@@ -14,20 +14,18 @@ import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
-import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -62,83 +60,50 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
-	public void testAddFolderInRepositoryWhenSameRepositoryIdExistsInDifferentPartition()
+	public void testCreateRepositoryWhenSameRepositoryIdExistsInDifferentPartition()
 		throws Exception {
 
 		IndexStatusManagerThreadLocal.setIndexReadOnly(true);
 
 		long counterValue = _getCounterValue();
 
-		long companyId = COMPANY_IDS[0];
-		long groupId = counterValue + 100;
 		long repositoryId = counterValue + 1000;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
 
-			User user = _userLocalService.getGuestUser(companyId);
+			long groupId = counterValue + 100;
 
-			Group group = _addGroup(user.getUserId(), groupId);
+			Repository repository = _createRepository(
+				COMPANY_IDS[0], groupId, repositoryId);
 
-			Assert.assertEquals(groupId, group.getGroupId());
-
-			com.liferay.portal.kernel.model.Repository repositoryModel =
-				_addRepository(group, user.getUserId(), repositoryId);
-
-			Assert.assertEquals(
-				repositoryId, repositoryModel.getRepositoryId());
-
-			_repositoryFactory.createRepository(
-				repositoryModel.getRepositoryId());
+			Assert.assertEquals(groupId, _getGroupId(repository));
 		}
 
-		companyId = COMPANY_IDS[1];
-		groupId = counterValue + 200;
-
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[1])) {
 
-			User user = _userLocalService.getGuestUser(companyId);
+			long groupId = counterValue + 200;
 
-			Group group = _addGroup(user.getUserId(), groupId);
+			Repository repository = _createRepository(
+				COMPANY_IDS[1], groupId, repositoryId);
 
-			Assert.assertEquals(groupId, group.getGroupId());
-
-			com.liferay.portal.kernel.model.Repository repositoryModel =
-				_addRepository(group, user.getUserId(), repositoryId);
-
-			Assert.assertEquals(
-				repositoryId, repositoryModel.getRepositoryId());
-
-			Repository repository = _repositoryFactory.createRepository(
-				repositoryModel.getRepositoryId());
-
-			String originalUserId = PrincipalThreadLocal.getName();
-
-			try {
-				PrincipalThreadLocal.setName(user.getUserId());
-
-				Folder folder = repository.addFolder(
-					null, user.getUserId(), repositoryModel.getDlFolderId(),
-					RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(), new ServiceContext());
-
-				Assert.assertEquals(
-					folder.getCompanyId(), repositoryModel.getCompanyId());
-			}
-			finally {
-				PrincipalThreadLocal.setName(originalUserId);
-			}
+			Assert.assertEquals(groupId, _getGroupId(repository));
 		}
 	}
 
-	private Group _addGroup(long userId, long groupId) throws Exception {
+	private Repository _createRepository(
+			long companyId, long groupId, long repositoryId)
+		throws Exception {
+
+		User user = _userLocalService.getGuestUser(companyId);
+
 		String name = RandomTestUtil.randomString();
 
 		_counterLocalService.reset(Counter.class.getName(), groupId - 1);
 
-		return _groupLocalService.addGroup(
-			userId, GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
+		Group group = _groupLocalService.addGroup(
+			user.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
 			GroupConstants.DEFAULT_LIVE_GROUP_ID,
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), name
@@ -150,31 +115,34 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name), true,
 			true, new ServiceContext());
-	}
 
-	private com.liferay.portal.kernel.model.Repository _addRepository(
-			Group group, long userId, long repositoryId)
-		throws PortalException {
+		Assert.assertEquals(groupId, group.getGroupId());
 
 		DLFolder dlFolder = _dlFolderLocalService.addFolder(
-			null, userId, group.getGroupId(), group.getGroupId(), false,
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			null, user.getUserId(), group.getGroupId(), group.getGroupId(),
+			false, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
 			new ServiceContext());
 
 		_counterLocalService.reset(Counter.class.getName(), repositoryId - 1);
 
-		return _repositoryLocalService.addRepository(
-			userId, group.getGroupId(),
-			_portal.getClassNameId(LiferayRepository.class.getName()),
-			dlFolder.getFolderId(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), "Test Portlet",
-			new UnicodeProperties(), true, new ServiceContext());
+		com.liferay.portal.kernel.model.Repository repositoryModel =
+			_repositoryLocalService.addRepository(
+				user.getUserId(), group.getGroupId(),
+				_portal.getClassNameId(LiferayRepository.class.getName()),
+				dlFolder.getFolderId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), "Test Portlet",
+				new UnicodeProperties(), true, new ServiceContext());
+
+		Assert.assertEquals(repositoryId, repositoryModel.getRepositoryId());
+
+		return _repositoryFactory.createRepository(
+			repositoryModel.getRepositoryId());
 	}
 
 	private long _getCounterValue() {
-		long counterValue1;
-		long counterValue2;
+		long counterValue1 = 1;
+		long counterValue2 = 1;
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
@@ -189,6 +157,15 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 
 		return Math.max(counterValue1, counterValue2);
+	}
+
+	private long _getGroupId(Repository repository) {
+		while (!(repository instanceof LiferayRepository)) {
+			repository = ReflectionTestUtil.getFieldValue(
+				repository, "_repository");
+		}
+
+		return ReflectionTestUtil.getFieldValue(repository, "_groupId");
 	}
 
 	@Inject

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.repository.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.model.Counter;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.RepositoryFactory;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.test.rule.Inject;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		BaseDBPartitionTestCase.setUpClass();
+
+		BaseDBPartitionTestCase.setUpDBPartitions();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		BaseDBPartitionTestCase.tearDownDBPartitions();
+	}
+
+	@Test
+	public void testAddFolderInRepositoryWhenSameRepositoryIdExistsInDifferentPartition()
+		throws Exception {
+
+		IndexStatusManagerThreadLocal.setIndexReadOnly(true);
+
+		long counterValue = _getCounterValue();
+
+		long companyId = COMPANY_IDS[0];
+		long groupId = counterValue + 100;
+		long repositoryId = counterValue + 1000;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+
+			User user = _userLocalService.getGuestUser(companyId);
+
+			Group group = _addGroup(user.getUserId(), groupId);
+
+			Assert.assertEquals(groupId, group.getGroupId());
+
+			com.liferay.portal.kernel.model.Repository repositoryModel =
+				_addRepository(group, user.getUserId(), repositoryId);
+
+			Assert.assertEquals(
+				repositoryId, repositoryModel.getRepositoryId());
+
+			_repositoryFactory.createRepository(
+				repositoryModel.getRepositoryId());
+		}
+
+		companyId = COMPANY_IDS[1];
+		groupId = counterValue + 200;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+
+			User user = _userLocalService.getGuestUser(companyId);
+
+			Group group = _addGroup(user.getUserId(), groupId);
+
+			Assert.assertEquals(groupId, group.getGroupId());
+
+			com.liferay.portal.kernel.model.Repository repositoryModel =
+				_addRepository(group, user.getUserId(), repositoryId);
+
+			Assert.assertEquals(
+				repositoryId, repositoryModel.getRepositoryId());
+
+			Repository repository = _repositoryFactory.createRepository(
+				repositoryModel.getRepositoryId());
+
+			String originalUserId = PrincipalThreadLocal.getName();
+
+			try {
+				PrincipalThreadLocal.setName(user.getUserId());
+
+				Folder folder = repository.addFolder(
+					null, user.getUserId(), repositoryModel.getDlFolderId(),
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(), new ServiceContext());
+
+				Assert.assertEquals(
+					folder.getCompanyId(), repositoryModel.getCompanyId());
+			}
+			finally {
+				PrincipalThreadLocal.setName(originalUserId);
+			}
+		}
+	}
+
+	private Group _addGroup(long userId, long groupId) throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		_counterLocalService.reset(Counter.class.getName(), groupId - 1);
+
+		return _groupLocalService.addGroup(
+			userId, GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
+			GroupConstants.DEFAULT_LIVE_GROUP_ID,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), name
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			GroupConstants.TYPE_SITE_OPEN, true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
+			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name), true,
+			true, new ServiceContext());
+	}
+
+	private com.liferay.portal.kernel.model.Repository _addRepository(
+			Group group, long userId, long repositoryId)
+		throws PortalException {
+
+		DLFolder dlFolder = _dlFolderLocalService.addFolder(
+			null, userId, group.getGroupId(), group.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			new ServiceContext());
+
+		_counterLocalService.reset(Counter.class.getName(), repositoryId - 1);
+
+		return _repositoryLocalService.addRepository(
+			userId, group.getGroupId(),
+			_portal.getClassNameId(LiferayRepository.class.getName()),
+			dlFolder.getFolderId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), "Test Portlet",
+			new UnicodeProperties(), true, new ServiceContext());
+	}
+
+	private long _getCounterValue() {
+		long counterValue1;
+		long counterValue2;
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+
+			counterValue1 = _counterLocalService.increment();
+		}
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[1])) {
+
+			counterValue2 = _counterLocalService.increment();
+		}
+
+		return Math.max(counterValue1, counterValue2);
+	}
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private RepositoryFactory _repositoryFactory;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryTest.java
@@ -8,12 +8,14 @@ package com.liferay.repository.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.portal.kernel.exception.NoSuchRepositoryException;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.repository.RepositoryFactoryUtil;
+import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Before;
@@ -44,16 +46,16 @@ public class RepositoryFactoryTest {
 
 		DLFolder dlFolder = DLTestUtil.addDLFolder(_group.getGroupId());
 
-		RepositoryFactoryUtil.createLocalRepository(dlFolder.getRepositoryId());
+		_repositoryFactory.createLocalRepository(dlFolder.getRepositoryId());
 	}
 
-	@Test
+	@Test(expected = NoSuchRepositoryException.class)
 	public void testCreateLocalRepositoryFromNonexistentRepositoryId()
 		throws Exception {
 
 		long repositoryId = RandomTestUtil.nextLong();
 
-		RepositoryFactoryUtil.createLocalRepository(repositoryId);
+		_repositoryFactory.createLocalRepository(repositoryId);
 	}
 
 	@Test
@@ -62,19 +64,22 @@ public class RepositoryFactoryTest {
 
 		DLFolder dlFolder = DLTestUtil.addDLFolder(_group.getGroupId());
 
-		RepositoryFactoryUtil.createRepository(dlFolder.getRepositoryId());
+		_repositoryFactory.createRepository(dlFolder.getRepositoryId());
 	}
 
-	@Test
+	@Test(expected = NoSuchRepositoryException.class)
 	public void testCreateRepositoryFromNonexistentRepositoryId()
 		throws Exception {
 
 		long repositoryId = RandomTestUtil.randomLong();
 
-		RepositoryFactoryUtil.createRepository(repositoryId);
+		_repositoryFactory.createRepository(repositoryId);
 	}
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private RepositoryFactory _repositoryFactory;
 
 }

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryProviderTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryProviderTest.java
@@ -13,8 +13,8 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.portal.kernel.exception.NoSuchRepositoryException;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.repository.RepositoryException;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -124,7 +124,7 @@ public class RepositoryProviderTest {
 		RepositoryProviderUtil.getFolderLocalRepository(folderId);
 	}
 
-	@Test(expected = RepositoryException.class)
+	@Test(expected = NoSuchRepositoryException.class)
 	public void testCreateLocalRepositoryFromNonexistentRepositoryId()
 		throws Exception {
 
@@ -240,7 +240,7 @@ public class RepositoryProviderTest {
 		RepositoryProviderUtil.getFolderRepository(folderId);
 	}
 
-	@Test(expected = RepositoryException.class)
+	@Test(expected = NoSuchRepositoryException.class)
 	public void testCreateRepositoryFromNonexistentRepositoryId()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
+++ b/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinition.java
@@ -7,6 +7,7 @@ package com.liferay.portal.repository.registry;
 
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.repository.DocumentRepository;
 import com.liferay.portal.kernel.repository.LocalRepository;
@@ -24,6 +25,9 @@ import com.liferay.portal.kernel.repository.event.RepositoryEventType;
 import com.liferay.portal.kernel.repository.registry.RepositoryDefiner;
 import com.liferay.portal.kernel.repository.registry.RepositoryEventRegistry;
 import com.liferay.portal.kernel.repository.registry.RepositoryFactoryRegistry;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.repository.InitializedLocalRepository;
 import com.liferay.portal.repository.InitializedRepository;
 import com.liferay.portal.repository.capabilities.CapabilityLocalRepository;
@@ -61,8 +65,12 @@ public class RepositoryClassDefinition
 	public LocalRepository createLocalRepository(long repositoryId)
 		throws PortalException {
 
-		if (_localRepositories.containsKey(repositoryId)) {
-			return _localRepositories.get(repositoryId);
+		Map<Long, LocalRepository> localRepositories =
+			_localRepositoriesMap.computeIfAbsent(
+				_getCompanyId(repositoryId), key -> new ConcurrentHashMap<>());
+
+		if (localRepositories.containsKey(repositoryId)) {
+			return localRepositories.get(repositoryId);
 		}
 
 		InitializedLocalRepository initializedLocalRepository =
@@ -97,7 +105,7 @@ public class RepositoryClassDefinition
 		initializedLocalRepository.setDocumentRepository(
 			capabilityLocalRepository);
 
-		_localRepositories.put(repositoryId, capabilityLocalRepository);
+		localRepositories.put(repositoryId, capabilityLocalRepository);
 
 		return capabilityLocalRepository;
 	}
@@ -106,8 +114,11 @@ public class RepositoryClassDefinition
 	public Repository createRepository(long repositoryId)
 		throws PortalException {
 
-		if (_repositories.containsKey(repositoryId)) {
-			return _repositories.get(repositoryId);
+		Map<Long, Repository> repositories = _repositoriesMap.computeIfAbsent(
+			_getCompanyId(repositoryId), key -> new ConcurrentHashMap<>());
+
+		if (repositories.containsKey(repositoryId)) {
+			return repositories.get(repositoryId);
 		}
 
 		InitializedRepository initializedRepository =
@@ -141,7 +152,7 @@ public class RepositoryClassDefinition
 		initializedRepository.setDocumentRepository(capabilityRepository);
 
 		if (!ExportImportThreadLocal.isImportInProcess()) {
-			_repositories.put(repositoryId, capabilityRepository);
+			repositories.put(repositoryId, capabilityRepository);
 		}
 
 		return capabilityRepository;
@@ -160,8 +171,8 @@ public class RepositoryClassDefinition
 	}
 
 	public void invalidateCache() {
-		_localRepositories.clear();
-		_repositories.clear();
+		_localRepositoriesMap.clear();
+		_repositoriesMap.clear();
 	}
 
 	@Override
@@ -183,8 +194,34 @@ public class RepositoryClassDefinition
 	}
 
 	protected void invalidateCachedRepository(long repositoryId) {
-		_localRepositories.remove(repositoryId);
-		_repositories.remove(repositoryId);
+		if (CompanyThreadLocal.getCompanyId() != null) {
+			Map<Long, LocalRepository> localRepositories =
+				_localRepositoriesMap.get(CompanyThreadLocal.getCompanyId());
+
+			if (localRepositories != null) {
+				localRepositories.remove(repositoryId);
+			}
+
+			Map<Long, Repository> repositories = _repositoriesMap.get(
+				CompanyThreadLocal.getCompanyId());
+
+			if (repositories != null) {
+				repositories.remove(repositoryId);
+			}
+		}
+		else {
+			for (Map<Long, LocalRepository> localRepositories :
+					_localRepositoriesMap.values()) {
+
+				localRepositories.remove(repositoryId);
+			}
+
+			for (Map<Long, Repository> repositories :
+					_repositoriesMap.values()) {
+
+				repositories.remove(repositoryId);
+			}
+		}
 	}
 
 	protected void setUpCommonCapabilities(
@@ -220,13 +257,26 @@ public class RepositoryClassDefinition
 			CacheCapability.class, new CacheCapability());
 	}
 
+	private long _getCompanyId(long repositoryId) throws PortalException {
+		Group group = GroupLocalServiceUtil.fetchGroup(repositoryId);
+
+		if (group != null) {
+			return group.getCompanyId();
+		}
+
+		com.liferay.portal.kernel.model.Repository repository =
+			RepositoryLocalServiceUtil.getRepository(repositoryId);
+
+		return repository.getCompanyId();
+	}
+
 	private static final Snapshot<PortalCapabilityLocator>
 		_portalCapabilityLocatorSnapshot = new Snapshot<>(
 			RepositoryClassDefinition.class, PortalCapabilityLocator.class);
 
-	private final Map<Long, LocalRepository> _localRepositories =
+	private final Map<Long, Map<Long, LocalRepository>> _localRepositoriesMap =
 		new ConcurrentHashMap<>();
-	private final Map<Long, Repository> _repositories =
+	private final Map<Long, Map<Long, Repository>> _repositoriesMap =
 		new ConcurrentHashMap<>();
 	private final RepositoryDefiner _repositoryDefiner;
 	private RepositoryFactory _repositoryFactory;


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-21844

I'm fixing an error that occurs because DB partitioning is not taken into account: it occurs that the same repositoryId can exist in two different partitions.

# How am I fixing it?

I've augmented the Map to account for multiple companies.

The test has been refactored from first PR #5502 , now it is located into a separate class extending from `BaseDBPartitionTestCase` as recommended by @achaparro

# How can you verify that it works?

I've created a test. Also the same steps as those included in JIRA issue can be followed.