### PR TITLE
LPD-27486 Impedibugs for Dates filter in Content Dashboard

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -56,20 +56,16 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
@@ -672,29 +668,24 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private JSONArray _getDateTypesJSONArray() {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		Map<String, String> map = new HashMap<>();
+		ContentDashboardConstants.DateType[] dateTypes =
+			ContentDashboardConstants.DateType.values();
+
+		Arrays.sort(
+			dateTypes,
+			Comparator.comparing(
+				dateType -> _language.get(
+					httpServletRequest, dateType.getType())));
 
 		for (ContentDashboardConstants.DateType dateType :
-				ContentDashboardConstants.DateType.values()) {
+				Arrays.asList(dateTypes)) {
 
-			map.put(
-				dateType.getType(),
-				_language.get(httpServletRequest, dateType.getType()));
-		}
-
-		TreeMap<String, String> sortedMap =
-			TreeMapBuilder.<String, String>create(
-				new MapValuesComparator(map)
-			).putAll(
-				map
-			).build();
-
-		for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
 			jsonArray.put(
 				JSONUtil.put(
-					"label", entry.getValue()
+					"label",
+					_language.get(httpServletRequest, dateType.getType())
 				).put(
-					"value", entry.getKey()
+					"value", dateType.getType()
 				));
 		}
 
@@ -1056,23 +1047,5 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private final Locale _locale;
 	private final PortletResponse _portletResponse;
 	private final UserLocalService _userLocalService;
-
-	private static class MapValuesComparator implements Comparator<String> {
-
-		public MapValuesComparator(Map<String, String> map) {
-			_map = map;
-		}
-
-		@Override
-		public int compare(String key1, String key2) {
-			String value1 = _map.get(key1);
-			String value2 = _map.get(key2);
-
-			return value1.compareTo(value2);
-		}
-
-		private final Map<String, String> _map;
-
-	}
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -56,20 +56,15 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
@@ -669,38 +664,6 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 		return url;
 	}
 
-	private JSONArray _getDateTypesJSONArray() {
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		Map<String, String> map = new HashMap<>();
-
-		for (ContentDashboardConstants.DateType dateType :
-				ContentDashboardConstants.DateType.values()) {
-
-			map.put(
-				dateType.getType(),
-				_language.get(httpServletRequest, dateType.getType()));
-		}
-
-		TreeMap<String, String> sortedMap =
-			TreeMapBuilder.<String, String>create(
-				new MapValuesComparator(map)
-			).putAll(
-				map
-			).build();
-
-		for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
-			jsonArray.put(
-				JSONUtil.put(
-					"label", entry.getValue()
-				).put(
-					"value", entry.getKey()
-				));
-		}
-
-		return jsonArray;
-	}
-
 	private List<DropdownItem> _getFilterAuthorDropdownItems() {
 		List<Long> authorIds =
 			_contentDashboardAdminDisplayContext.getAuthorIds();
@@ -793,7 +756,29 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 					"props",
 					JSONUtil.toString(
 						JSONUtil.put(
-							"dateTypes", _getDateTypesJSONArray()
+							"dateTypes",
+							() -> {
+								JSONArray jsonArray =
+									JSONFactoryUtil.createJSONArray();
+
+								for (ContentDashboardConstants.DateType
+										dateType :
+											ContentDashboardConstants.DateType.
+												values()) {
+
+									jsonArray.put(
+										JSONUtil.put(
+											"label",
+											_language.get(
+												httpServletRequest,
+												dateType.getType())
+										).put(
+											"value", dateType.getType()
+										));
+								}
+
+								return jsonArray;
+							}
 						).put(
 							"filterUrl",
 							_getDateTypesFilterURL(
@@ -1056,23 +1041,5 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private final Locale _locale;
 	private final PortletResponse _portletResponse;
 	private final UserLocalService _userLocalService;
-
-	private static class MapValuesComparator implements Comparator<String> {
-
-		public MapValuesComparator(Map<String, String> map) {
-			_map = map;
-		}
-
-		@Override
-		public int compare(String key1, String key2) {
-			String value1 = _map.get(key1);
-			String value2 = _map.get(key2);
-
-			return value1.compareTo(value2);
-		}
-
-		private final Map<String, String> _map;
-
-	}
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -56,15 +56,20 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
@@ -664,6 +669,38 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 		return url;
 	}
 
+	private JSONArray _getDateTypesJSONArray() {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		Map<String, String> map = new HashMap<>();
+
+		for (ContentDashboardConstants.DateType dateType :
+				ContentDashboardConstants.DateType.values()) {
+
+			map.put(
+				dateType.getType(),
+				_language.get(httpServletRequest, dateType.getType()));
+		}
+
+		TreeMap<String, String> sortedMap =
+			TreeMapBuilder.<String, String>create(
+				new MapValuesComparator(map)
+			).putAll(
+				map
+			).build();
+
+		for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
+			jsonArray.put(
+				JSONUtil.put(
+					"label", entry.getValue()
+				).put(
+					"value", entry.getKey()
+				));
+		}
+
+		return jsonArray;
+	}
+
 	private List<DropdownItem> _getFilterAuthorDropdownItems() {
 		List<Long> authorIds =
 			_contentDashboardAdminDisplayContext.getAuthorIds();
@@ -756,29 +793,7 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 					"props",
 					JSONUtil.toString(
 						JSONUtil.put(
-							"dateTypes",
-							() -> {
-								JSONArray jsonArray =
-									JSONFactoryUtil.createJSONArray();
-
-								for (ContentDashboardConstants.DateType
-										dateType :
-											ContentDashboardConstants.DateType.
-												values()) {
-
-									jsonArray.put(
-										JSONUtil.put(
-											"label",
-											_language.get(
-												httpServletRequest,
-												dateType.getType())
-										).put(
-											"value", dateType.getType()
-										));
-								}
-
-								return jsonArray;
-							}
+							"dateTypes", _getDateTypesJSONArray()
 						).put(
 							"filterUrl",
 							_getDateTypesFilterURL(
@@ -1041,5 +1056,23 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private final Locale _locale;
 	private final PortletResponse _portletResponse;
 	private final UserLocalService _userLocalService;
+
+	private static class MapValuesComparator implements Comparator<String> {
+
+		public MapValuesComparator(Map<String, String> map) {
+			_map = map;
+		}
+
+		@Override
+		public int compare(String key1, String key2) {
+			String value1 = _map.get(key1);
+			String value2 = _map.get(key2);
+
+			return value1.compareTo(value2);
+		}
+
+		private final Map<String, String> _map;
+
+	}
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -56,16 +56,20 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
@@ -668,24 +672,29 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private JSONArray _getDateTypesJSONArray() {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		ContentDashboardConstants.DateType[] dateTypes =
-			ContentDashboardConstants.DateType.values();
-
-		Arrays.sort(
-			dateTypes,
-			Comparator.comparing(
-				dateType -> _language.get(
-					httpServletRequest, dateType.getType())));
+		Map<String, String> map = new HashMap<>();
 
 		for (ContentDashboardConstants.DateType dateType :
-				Arrays.asList(dateTypes)) {
+				ContentDashboardConstants.DateType.values()) {
 
+			map.put(
+				dateType.getType(),
+				_language.get(httpServletRequest, dateType.getType()));
+		}
+
+		TreeMap<String, String> sortedMap =
+			TreeMapBuilder.<String, String>create(
+				new MapValuesComparator(map)
+			).putAll(
+				map
+			).build();
+
+		for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
 			jsonArray.put(
 				JSONUtil.put(
-					"label",
-					_language.get(httpServletRequest, dateType.getType())
+					"label", entry.getValue()
 				).put(
-					"value", dateType.getType()
+					"value", entry.getKey()
 				));
 		}
 
@@ -1047,5 +1056,23 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	private final Locale _locale;
 	private final PortletResponse _portletResponse;
 	private final UserLocalService _userLocalService;
+
+	private static class MapValuesComparator implements Comparator<String> {
+
+		public MapValuesComparator(Map<String, String> map) {
+			_map = map;
+		}
+
+		@Override
+		public int compare(String key1, String key2) {
+			String value1 = _map.get(key1);
+			String value2 = _map.get(key2);
+
+			return value1.compareTo(value2);
+		}
+
+		private final Map<String, String> _map;
+
+	}
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -129,7 +129,13 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 			).setParameter(
 				"contentDashboardItemSubtypePayload", (String)null
 			).setParameter(
+				"dateType", (String)null
+			).setParameter(
+				"endDate", (String)null
+			).setParameter(
 				"scopeId", (String)null
+			).setParameter(
+				"startDate", (String)null
 			).setParameter(
 				"status", WorkflowConstants.STATUS_ANY
 			);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
@@ -51,7 +51,7 @@ function CustomDateModal({
 	selectedEndDate,
 	selectedStartDate,
 }: Props) {
-	const {observer, onOpenChange} = useModal({
+	const {observer, onOpenChange, open} = useModal({
 		defaultOpen: true,
 		onClose: () => onOpenChange(false),
 	});
@@ -80,6 +80,10 @@ function CustomDateModal({
 
 		navigate(url.toString());
 	};
+
+	if (!open) {
+		return null;
+	}
 
 	return (
 		<ClayModal observer={observer}>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
@@ -126,7 +126,7 @@ function CustomDateModal({
 							range
 							value={getDateRange(startDate, endDate)}
 							years={{
-								end: new Date().getFullYear(),
+								end: new Date().getFullYear() + 10,
 								start: new Date().getFullYear() - 10,
 							}}
 						/>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
@@ -43,7 +43,7 @@ export default function openCustomDateModal(props: Props) {
 	render(CustomDateModal, {...props}, document.createElement('div'));
 }
 
-function CustomDateModal({
+export function CustomDateModal({
 	dateTypes,
 	filterUrl,
 	namespace,

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/utils/openCustomDateModal.test.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/utils/openCustomDateModal.test.js
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {CustomDateModal} from '../../../src/main/resources/META-INF/resources/js/utils/openCustomDateModal';
+
+const DEFAULT_PROPS = {
+	dateTypes: [
+		{label: 'Create Date', value: 'create-date'},
+		{label: 'Display Date', value: 'display-date'},
+	],
+	filterUrl: 'example-url',
+	namespace: 'namespace',
+	selectedDateType: '',
+	selectedEndDate: '',
+	selectedStartDate: '',
+};
+
+function renderComponent(props) {
+	const componentProps = {...DEFAULT_PROPS, ...props};
+
+	render(<CustomDateModal {...componentProps} />);
+
+	act(() => {
+		jest.runAllTimers();
+	});
+}
+
+describe('CustomDateModal', () => {
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	beforeAll(() => {
+		jest.useFakeTimers();
+	});
+
+	it('renders Done button disabled when there is no date selected', () => {
+		renderComponent();
+
+		expect(screen.getByText('done')).toBeDisabled();
+	});
+
+	it('renders Done button enabled when there is a date selected', () => {
+		renderComponent({
+			selectedDateType: 'create-date',
+			selectedEndDate: '2024-02-17',
+			selectedStartDate: '2024-01-11',
+		});
+
+		expect(screen.getByText('done')).not.toBeDisabled();
+	});
+});

--- a/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.d.ts
+++ b/modules/apps/content-dashboard/content-dashboard-web/types/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.d.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+/// <reference types="react" />
+
 declare type Props = {
 	dateTypes: Array<{
 		label: string;
@@ -15,4 +17,12 @@ declare type Props = {
 	selectedStartDate: string | undefined;
 };
 export default function openCustomDateModal(props: Props): void;
+export declare function CustomDateModal({
+	dateTypes,
+	filterUrl,
+	namespace,
+	selectedDateType,
+	selectedEndDate,
+	selectedStartDate,
+}: Props): JSX.Element | null;
 export {};


### PR DESCRIPTION
Impedibugs for Dates filter in Content Dashboard

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-27486)

This PR addresses three issues found when reviewing the story for date filters in the content dashboard

This PR also addresses a bad commit, it shouldn't have been filed for LPD-27486, so I reverted two commits and updated the LPD correspondingly

# How am I fixing it?

There are three issues that are fixed

1. When the modal for selecting the date range is closed with cancel, nothing is clickable on the page
2. Cannot select a year higher than the current one
3. Cannot clear the selected date filter on "clear"

# How can you verify that it works?

1. Go to content dashboard
2. In filters, scroll to the end, and select custom date
3. Cancel
4. Checkpoint: see that you can click in the applications menu or any item in the content dashboard
5. Go again to filters, and select custom date again
6. Select any date type
7. Checkpoint: see that you can select 2025 or higher as a date
8. Accept the selection
9. Click on clear in the toolbar
10. The selection should be removed

@sandrodw3 