### PR TITLE
LPD-27537 Guest user cannot view Knowledge Base Article through struts action /knowledge_base/find_kb_article

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/auth/publicpath/AuthPublicPath.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/auth/publicpath/AuthPublicPath.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.auth.publicpath;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(
+	property = "auth.public.path=/knowledge_base/find_kb_article",
+	service = Object.class
+)
+public class AuthPublicPath {
+}

--- a/modules/test/playwright/tests/knowledge-base-web/config.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/config.ts
@@ -9,4 +9,7 @@ export const config = {
 	},
 	name: 'knowledge-base-web',
 	testDir: 'tests/knowledge-base-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -10,31 +10,63 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {knowledgeBasePages} from '../../fixtures/knowledgeBasePagesTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {liferayConfig} from '../../liferay.config';
 import {KnowledgeBaseEditArticlePage} from '../../pages/knowledge-base-web/KnowledgeBaseEditArticlePage';
 import getLoggedInPage from '../../utils/getLoggedInPage';
 import getRandomString from '../../utils/getRandomString';
+import {performLogout} from '../../utils/performLogin';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {KnowledgeBaseUrls} from './utils/knowledgeBaseUrls';
 
-const testFeatureFlagsDisabled = mergeTests(
+const baseTest = mergeTests(
 	apiHelpersTest,
-	featureFlagsTest({
-		'LPD-11003': false,
-		'LPS-188058': false,
-	}),
 	isolatedSiteTest,
 	knowledgeBasePages,
 	loginTest()
 );
+
+const testFeatureFlagsDisabled = mergeTests(
+	baseTest,
+	featureFlagsTest({
+		'LPD-11003': false,
+		'LPS-188058': false,
+	})
+);
 const testFeatureFlagsEnabled = mergeTests(
-	apiHelpersTest,
+	baseTest,
 	featureFlagsTest({
 		'LPD-11003': true,
 		'LPS-188058': true,
-	}),
-	isolatedSiteTest,
-	knowledgeBasePages,
-	loginTest()
+	})
+);
+
+baseTest(
+	'LPD-27537: Article should be shown to guest users',
+	async ({apiHelpers, page, site}) => {
+		const content = getRandomString();
+		const title = getRandomString();
+
+		const knowledgeBaseArticle =
+			await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+				articleBody: content,
+				siteId: site.id,
+				title,
+			});
+
+		await performLogout(page);
+
+		await page.goto(
+			liferayConfig.environment.baseUrl +
+				'/c/knowledge_base/find_kb_article?resourcePrimKey=' +
+				knowledgeBaseArticle.id
+		);
+
+		await expect(
+			page.getByText('Error:Your request failed to complete.')
+		).toBeHidden();
+
+		await expect(page.getByText('Knowledge Base Article')).toBeVisible();
+	}
 );
 
 testFeatureFlagsEnabled(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27537

Guest user cannot view Knowledge Base Article through struts action /knowledge_base/find_kb_article

# How am I fixing it?

These changes add `/knowledge_base/find_kb_article` to the public path so authentication is not required.

This path was previously a public path when Knowledge Base was still a plugin (https://github.com/liferay/liferay-plugins/blob/6.2.x/portlets/knowledge-base-portlet/docroot/WEB-INF/src/portal.properties#L14-L15) and seems to have been lost during the migration to an OSGi module.

If this was done purposefully and the path should require authentication please let me know. Additionally, any feedback on the Playwright test would be appreciated.

# How can you verify that it works?

Run `npm run test -- -g "LPD-27537"`

To test manually please see the steps on https://liferay.atlassian.net/browse/LPD-27537