### PR TITLE
LPD-17744 Investigate external video (YouTube)test failures

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
@@ -11,6 +11,12 @@ definition {
 
 		User.firstLoginPG();
 
+		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+
+		SystemSettings.configureSystemSetting(
+			enableSetting = "false",
+			settingFieldName = "Enabled");
+
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
@@ -14,6 +14,12 @@ definition {
 
 		User.firstLoginPG();
 
+		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+
+		SystemSettings.configureSystemSetting(
+			enableSetting = "false",
+			settingFieldName = "Enabled");
+
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(


### PR DESCRIPTION
# What is this trying to solve?
[LPD-17744](https://liferay.atlassian.net/browse/LPD-17744)

The tests were failing due to the iframe sanitizer beeing enabled but the sandbox mode was not configured. This has to be done by the user

# How am I fixing it?

I disabled the iframe sanitizer in the test setup

# How can you verify that it works?

run the tests from the ticket description
