### PR TITLE
LPD-27358 Allow scheduled/expired versions to be deleted/reverted to

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -799,6 +799,29 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteExpiredVersion() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		DLFileEntry dlFileEntry = addDLFileEntryWithStatus(
+			serviceContext, WorkflowConstants.STATUS_APPROVED);
+
+		dlFileEntry = updateDLFileEntryWithStatus(
+			dlFileEntry, new ByteArrayInputStream(new byte[0]), new HashMap<>(),
+			serviceContext, WorkflowConstants.STATUS_EXPIRED);
+
+		DLFileVersion lastVersion = dlFileEntry.getLatestFileVersion(true);
+
+		DLFileEntryLocalServiceUtil.deleteFileVersion(
+			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
+			lastVersion.getVersion());
+
+		Assert.assertEquals(
+			1, dlFileEntry.getFileVersionsCount(WorkflowConstants.STATUS_ANY));
+	}
+
+	@Test
 	public void testDeleteFileEntries() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -841,6 +864,29 @@ public class DLFileEntryLocalServiceTest {
 			20,
 			DLFileEntryLocalServiceUtil.getFileEntriesCount(
 				_group.getGroupId(), folder.getFolderId()));
+	}
+
+	@Test
+	public void testDeleteScheduledVersion() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		DLFileEntry dlFileEntry = addDLFileEntryWithStatus(
+			serviceContext, WorkflowConstants.STATUS_SCHEDULED);
+
+		dlFileEntry = updateDLFileEntryWithStatus(
+			dlFileEntry, new ByteArrayInputStream(new byte[0]), new HashMap<>(),
+			serviceContext, WorkflowConstants.STATUS_SCHEDULED);
+
+		DLFileVersion lastVersion = dlFileEntry.getLatestFileVersion(true);
+
+		DLFileEntryLocalServiceUtil.deleteFileVersion(
+			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
+			lastVersion.getVersion());
+
+		Assert.assertEquals(
+			1, dlFileEntry.getFileVersionsCount(WorkflowConstants.STATUS_ANY));
 	}
 
 	@Test(expected = InvalidFileVersionException.class)
@@ -1196,6 +1242,32 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testRevertScheduledVersion() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		DLFileEntry dlFileEntry = addDLFileEntryWithStatus(
+			serviceContext, WorkflowConstants.STATUS_SCHEDULED);
+
+		DLFileVersion originalVersion = dlFileEntry.getFileVersion();
+
+		dlFileEntry = updateDLFileEntryWithStatus(
+			dlFileEntry, new ByteArrayInputStream(new byte[0]), new HashMap<>(),
+			serviceContext, WorkflowConstants.STATUS_SCHEDULED);
+
+		DLFileEntryLocalServiceUtil.revertFileEntry(
+			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
+			originalVersion.getVersion(), serviceContext);
+
+		DLFileVersion latestFileVersion = dlFileEntry.getLatestFileVersion(
+			true);
+
+		Assert.assertEquals(
+			originalVersion.getTitle(), latestFileVersion.getTitle());
+	}
+
+	@Test
 	public void testUpdateDisplayDateExpirationDateReviewDate()
 		throws Exception {
 
@@ -1508,6 +1580,29 @@ public class DLFileEntryLocalServiceTest {
 			WorkflowConstants.STATUS_APPROVED, serviceContext, new HashMap<>());
 	}
 
+	protected DLFileEntry addDLFileEntryWithStatus(
+			ServiceContext serviceContext, int status)
+		throws Exception {
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.MONTH);
+		Date expirationDate = new Date(System.currentTimeMillis() + Time.YEAR);
+
+		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, -1, new HashMap<>(), null,
+			new ByteArrayInputStream(new byte[0]), 0, displayDate,
+			expirationDate, new Date(), serviceContext);
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		return DLFileEntryLocalServiceUtil.updateStatus(
+			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
+			status, serviceContext, new HashMap<>());
+	}
+
 	protected DDMForm createDDMForm() {
 		DDMForm ddmForm = new DDMForm();
 
@@ -1607,6 +1702,32 @@ public class DLFileEntryLocalServiceTest {
 		return DLFileEntryLocalServiceUtil.updateStatus(
 			TestPropsValues.getUserId(), dlFileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_APPROVED, serviceContext, new HashMap<>());
+	}
+
+	protected DLFileEntry updateDLFileEntryWithStatus(
+			DLFileEntry dlFileEntry, InputStream inputStream,
+			Map<String, com.liferay.dynamic.data.mapping.kernel.DDMFormValues>
+				ddmFormValuesMap,
+			ServiceContext serviceContext, int status)
+		throws Exception {
+
+		dlFileEntry = DLFileEntryLocalServiceUtil.updateFileEntry(
+			TestPropsValues.getUserId(), dlFileEntry.getFileEntryId(),
+			StringUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, DLVersionNumberIncrease.MAJOR,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			ddmFormValuesMap, null, inputStream, 0,
+			dlFileEntry.getDisplayDate(), dlFileEntry.getExpirationDate(),
+			dlFileEntry.getReviewDate(), serviceContext);
+
+		DLFileVersion dlFileVersion = dlFileEntry.getLatestFileVersion(true);
+
+		dlFileVersion.setStatus(status);
+
+		DLFileVersionLocalServiceUtil.updateDLFileVersion(dlFileVersion);
+
+		return dlFileEntry;
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -664,7 +664,10 @@ public class UIItemsBuilder {
 
 	public boolean isDeleteVersionActionAvailable() throws PortalException {
 		if ((_fileEntry == null) ||
-			(_fileVersion.getStatus() != WorkflowConstants.STATUS_APPROVED) ||
+			((_fileVersion.getStatus() != WorkflowConstants.STATUS_APPROVED) &&
+			 (_fileVersion.getStatus() != WorkflowConstants.STATUS_EXPIRED) &&
+			 (_fileVersion.getStatus() !=
+				 WorkflowConstants.STATUS_SCHEDULED)) ||
 			!_fileEntryDisplayContextHelper.hasDeletePermission() ||
 			!(_fileEntry.getModel() instanceof DLFileEntry)) {
 
@@ -674,7 +677,13 @@ public class UIItemsBuilder {
 		int fileVersionsCount = _fileEntry.getFileVersionsCount(
 			WorkflowConstants.STATUS_APPROVED);
 
-		if (fileVersionsCount > 1) {
+		fileVersionsCount += _fileEntry.getFileVersionsCount(
+			WorkflowConstants.STATUS_SCHEDULED);
+
+		if ((fileVersionsCount > 1) ||
+			((fileVersionsCount == 1) &&
+			 (_fileVersion.getStatus() == WorkflowConstants.STATUS_EXPIRED))) {
+
 			return true;
 		}
 
@@ -776,7 +785,9 @@ public class UIItemsBuilder {
 	}
 
 	public boolean isRevertToVersionActionAvailable() throws PortalException {
-		if ((_fileVersion.getStatus() != WorkflowConstants.STATUS_APPROVED) ||
+		if (((_fileVersion.getStatus() != WorkflowConstants.STATUS_APPROVED) &&
+			 (_fileVersion.getStatus() !=
+				 WorkflowConstants.STATUS_SCHEDULED)) ||
 			!_fileEntryDisplayContextHelper.hasUpdatePermission()) {
 
 			return false;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -680,9 +680,12 @@ public class UIItemsBuilder {
 		fileVersionsCount += _fileEntry.getFileVersionsCount(
 			WorkflowConstants.STATUS_SCHEDULED);
 
+		int fileVersionsExpired = _fileEntry.getFileVersionsCount(
+			WorkflowConstants.STATUS_EXPIRED);
+
 		if ((fileVersionsCount > 1) ||
-			((fileVersionsCount == 1) &&
-			 (_fileVersion.getStatus() == WorkflowConstants.STATUS_EXPIRED))) {
+			((_fileVersion.getStatus() == WorkflowConstants.STATUS_EXPIRED) &&
+			 ((fileVersionsCount == 1) || (fileVersionsExpired > 1)))) {
 
 			return true;
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -894,16 +894,20 @@ public class DLFileEntryLocalServiceImpl
 						version, " for file entry ", fileEntryId));
 			}
 
-			int count = _dlFileVersionPersistence.countByF_S(
+			int fileVersionsCount = _dlFileVersionPersistence.countByF_S(
 				fileEntryId, WorkflowConstants.STATUS_APPROVED);
 
-			count += _dlFileVersionPersistence.countByF_S(
+			fileVersionsCount += _dlFileVersionPersistence.countByF_S(
 				fileEntryId, WorkflowConstants.STATUS_SCHEDULED);
 
-			if ((count <= 1) &&
+			int fileVersionsExpiredCount = _dlFileVersionPersistence.countByF_S(
+				fileEntryId, WorkflowConstants.STATUS_EXPIRED);
+
+			if ((fileVersionsCount <= 1) &&
 				!((dlFileVersion.getStatus() ==
 					WorkflowConstants.STATUS_EXPIRED) &&
-				  (count == 1))) {
+				  ((fileVersionsCount == 1) ||
+				   (fileVersionsExpiredCount > 1)))) {
 
 				throw new InvalidFileVersionException(
 					StringBundler.concat(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -885,7 +885,9 @@ public class DLFileEntryLocalServiceImpl
 			DLFileVersion dlFileVersion = _dlFileVersionPersistence.findByF_V(
 				fileEntryId, version);
 
-			if (!dlFileVersion.isApproved()) {
+			if (!dlFileVersion.isApproved() && !dlFileVersion.isExpired() &&
+				!dlFileVersion.isScheduled()) {
+
 				throw new InvalidFileVersionException(
 					StringBundler.concat(
 						"Unable to delete the unapproved file version ",
@@ -895,7 +897,14 @@ public class DLFileEntryLocalServiceImpl
 			int count = _dlFileVersionPersistence.countByF_S(
 				fileEntryId, WorkflowConstants.STATUS_APPROVED);
 
-			if (count <= 1) {
+			count += _dlFileVersionPersistence.countByF_S(
+				fileEntryId, WorkflowConstants.STATUS_SCHEDULED);
+
+			if ((count <= 1) &&
+				!((dlFileVersion.getStatus() ==
+					WorkflowConstants.STATUS_EXPIRED) &&
+				  (count == 1))) {
+
 				throw new InvalidFileVersionException(
 					StringBundler.concat(
 						"Unable to delete the only approved file version ",
@@ -1773,7 +1782,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileVersion dlFileVersion = _dlFileVersionLocalService.getFileVersion(
 			fileEntryId, version);
 
-		if (!dlFileVersion.isApproved()) {
+		if (!dlFileVersion.isApproved() && !dlFileVersion.isScheduled()) {
 			throw new InvalidFileVersionException(
 				"Unable to revert from an unapproved file version");
 		}


### PR DESCRIPTION
# What is this trying to solve?

- https://liferay.atlassian.net/browse/LPD-27358 Allow scheduled/expired versions to be deleted/reverted to

# How am I fixing it?

Modifying the revert and delete methods so that they do not throw an exception if the status is scheduled or expired

# How can you verify that it works?

a. Scheduled content
  1. Create a scheduled content. 
  2. Modify it to generate a new version.
  3. Delete this new version from the interface.

b. Expired content
  1. Create a content. 
  2. Modify it to generate a new version and assign the current time as expiration date.
  3. Wait for it to expire.
  4. Delete this new version from the interface.