### PR TITLE
LPD-27711 Fix test failures due to method name change in LPD-26453

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/portlet/action/test/UpdateMembershipsMVCActionCommandTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/portlet/action/test/UpdateMembershipsMVCActionCommandTest.java
@@ -144,7 +144,7 @@ public class UpdateMembershipsMVCActionCommandTest {
 
 		try {
 			ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_validateGroups",
+				_mvcActionCommand, "_validateGroupIds",
 				new Class<?>[] {ActionRequest.class},
 				new MockActionRequest(
 					permissionChecker,
@@ -248,7 +248,7 @@ public class UpdateMembershipsMVCActionCommandTest {
 				new long[] {role.getRoleId()});
 
 			ReflectionTestUtil.invoke(
-				_mvcActionCommand, "_validateGroups",
+				_mvcActionCommand, "_validateGroupIds",
 				new Class<?>[] {ActionRequest.class},
 				new MockActionRequest(
 					permissionChecker,


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27711

Fix failing tests in UpdateMembershipsMVCActionCommandTest

# How am I fixing it?

In LPD-26453 there was source formatting applied which changed the name of the method thus breaking the test.

# How can you verify that it works?

Run the included automated tests (UpdateMembershipsMVCActionCommandTest)