### PR TITLE
LPD-27706 Update text to match error produced by Vimeo

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -331,7 +331,7 @@ definition {
 
 				AssertTextEquals.assertPartialText(
 					locator1 = "Message#ERROR_INVALID_VIMEO_VIDEO",
-					value1 = "The embed code for this video is not valid.");
+					value1 = "This video does not exist.");
 			}
 			else {
 				AssertTextEquals(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27706

Fix failing tests in LocalFile.ItemSelector#CannotPreviewVideosWithInvalidURL

# How am I fixing it?

The error message coming from Vimeo has changed so the test is being updated.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=ItemSelector#CannotPreviewVideosWithInvalidURL`