### PR TITLE
LPD-24858 Blog's friendly URL is broken when editing a category with a space

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -1886,10 +1886,18 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			_portal.getClassNameId(FriendlyURLEntry.class),
 			mainFriendlyURLEntry.getFriendlyURLEntryId());
 
-		List<AssetCategory> assetCategories = assetEntry.getCategories();
-
 		long[] friendlyURLAssetCategoryIds = GetterUtil.getLongValues(
 			serviceContext.getAttribute("friendlyURLAssetCategoryIds"));
+
+		if (assetEntry == null) {
+			if (ArrayUtil.isEmpty(friendlyURLAssetCategoryIds)) {
+				return false;
+			}
+
+			return true;
+		}
+
+		List<AssetCategory> assetCategories = assetEntry.getCategories();
 
 		if (assetCategories.containsAll(
 				ListUtil.toList(friendlyURLAssetCategoryIds))) {

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/display/contributor/portlet/BlogsAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/display/contributor/portlet/BlogsAssetDisplayPageFriendlyURLResolver.java
@@ -41,8 +41,8 @@ public class BlogsAssetDisplayPageFriendlyURLResolver
 	@Override
 	protected boolean isSameFriendlyURL(String url1, String url2) {
 		return Objects.equals(
-			_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(url1),
-			_friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(url2));
+			_friendlyURLNormalizer.normalizeWithEncoding(url1),
+			_friendlyURLNormalizer.normalizeWithEncoding(url2));
 	}
 
 	@Reference

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsEditEntryDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsEditEntryDisplayContext.java
@@ -593,6 +593,10 @@ public class BlogsEditEntryDisplayContext {
 			PortalUtil.getClassNameId(FriendlyURLEntry.class),
 			friendlyURLEntry.getFriendlyURLEntryId());
 
+		if (assetEntry == null) {
+			return new long[0];
+		}
+
 		_assetCategoryIds = assetEntry.getCategoryIds();
 
 		return _assetCategoryIds;

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -109,3 +109,44 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 		)}/${title}`
 	);
 });
+
+test('LPD-24858 Categories with blank spaces in friendly URL', async ({
+	apiHelpers,
+	blogsEditBlogEntryPage,
+	displayPageTemplatesPage,
+	page,
+	pageEditorPage,
+	site,
+}) => {
+	const vocabularyName = getRandomString();
+	const friendlyUrlCategories = ['category 1', 'category 2', 'category 3'];
+
+	await friendlyURLCategoriesSetup({
+		apiHelpers,
+		displayPageTemplatesPage,
+		friendlyUrlCategories,
+		page,
+		pageEditorPage,
+		site,
+		vocabularyName,
+	});
+
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		publish: true,
+		title,
+	});
+
+	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
+
+	await expect(response.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+			.map((category) => encodeURIComponent(category))
+			.join('/')}/${title}`
+	);
+});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-24858

When you have a non-default site with a category with spaces the URL crashes with ERR_TOO_MANY_REDIRECTS

# How am I fixing it?

Using `normalizeWithEncoding` when it is needed

# How can you verify that it works?

```sh
npm run test -- -g "LPD-24858"
```

# Tested repeatedly in local
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/a62bea68-e2ad-43bb-880f-31865aaa6eda)


# Screen record of test execution
[5a52f8c78d24759ebf0f714bc910df686cf40974.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/5eb2f57d-62b6-47c8-bdc0-3d3c9bdf3259)
