### PR TITLE
LPD-27935 Remove unnecessary FeatureFlag from autoSaveAsDraftTest

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -69,7 +69,6 @@ const expect = baseExpect.extend({
 const autoSaveAsDraftTest = mergeTests(
 	baseTest,
 	featureFlagsTest({
-		'LPD-11228': true,
 		'LPD-15596': true,
 		'LPS-141392': true,
 	})


### PR DESCRIPTION
What is this trying to solve?
[LPD-27935](https://liferay.atlassian.net/browse/LPD-27935)

The tests were failing because a FF was added to the test that is not needed nor it is in master.

How am I fixing it?
I removed the FF from the test

How can you verify that it works?
run the tests from the ticket description