### PR TITLE
LPD-27931 Status for documents are not being displayed correctly if they have multiple status

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -311,7 +311,7 @@ public class FileEntryContentDashboardItem
 		try {
 			FileVersion latestFileVersion = _fileEntry.getLatestFileVersion();
 			FileVersion latestTrustedFileVersion =
-				_fileEntry.getLatestFileVersion(true);
+				_getLatestApprovedFileVersion(_fileEntry);
 
 			List<FileVersion> fileVersions = new ArrayList<>();
 
@@ -567,6 +567,17 @@ public class FileEntryContentDashboardItem
 
 		return contentDashboardItemVersions.get(
 			contentDashboardItemVersions.size() - 1);
+	}
+
+	private FileVersion _getLatestApprovedFileVersion(FileEntry fileEntry) {
+		List<FileVersion> approvedFileVersions = fileEntry.getFileVersions(
+			WorkflowConstants.STATUS_APPROVED, 0, 1);
+
+		if (ListUtil.isEmpty(approvedFileVersions)) {
+			return null;
+		}
+
+		return approvedFileVersions.get(0);
 	}
 
 	private URL _getLatestVersionURL() {

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -17,10 +17,12 @@ import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.VersionableContentDashboardItem;
 import com.liferay.content.dashboard.item.action.ContentDashboardItemAction;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.petra.string.StringPool;
@@ -57,6 +59,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.net.URL;
 import java.net.URLEncoder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -372,6 +375,53 @@ public class FileEntryContentDashboardItemTest {
 			contentDashboardItemVersion.getLabel());
 		Assert.assertEquals("1.1", contentDashboardItemVersion.getVersion());
 		Assert.assertEquals("success", contentDashboardItemVersion.getStyle());
+	}
+
+	@Test
+	public void testGetLatestContentDashboardItemVersionsWithExpiredVersion()
+		throws Exception {
+
+		FileEntry fileEntry = _getFileEntry(3);
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		_dlFileEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), dlFileEntry,
+			dlFileEntry.getLatestFileVersion(true),
+			WorkflowConstants.STATUS_EXPIRED, _serviceContext,
+			Collections.emptyMap());
+
+		VersionableContentDashboardItem<FileEntry>
+			versionableContentDashboardItem =
+				(VersionableContentDashboardItem<FileEntry>)
+					_contentDashboardItemFactory.create(
+						fileEntry.getFileEntryId());
+
+		List<ContentDashboardItemVersion> contentDashboardItemVersionList =
+			versionableContentDashboardItem.
+				getLatestContentDashboardItemVersions(LocaleUtil.getDefault());
+
+		Assert.assertEquals(
+			contentDashboardItemVersionList.toString(), 2,
+			contentDashboardItemVersionList.size());
+
+		ContentDashboardItemVersion contentDashboardItemVersion =
+			contentDashboardItemVersionList.get(0);
+
+		Assert.assertEquals(
+			LanguageUtil.get(LocaleUtil.getDefault(), "approved"),
+			contentDashboardItemVersion.getLabel());
+		Assert.assertEquals("1.1", contentDashboardItemVersion.getVersion());
+		Assert.assertEquals("success", contentDashboardItemVersion.getStyle());
+
+		contentDashboardItemVersion = contentDashboardItemVersionList.get(1);
+
+		Assert.assertEquals(
+			LanguageUtil.get(LocaleUtil.getDefault(), "expired"),
+			contentDashboardItemVersion.getLabel());
+		Assert.assertEquals("1.2", contentDashboardItemVersion.getVersion());
+		Assert.assertEquals("danger", contentDashboardItemVersion.getStyle());
 	}
 
 	@Test
@@ -698,6 +748,9 @@ public class FileEntryContentDashboardItemTest {
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -594,6 +594,40 @@ public class FileEntryContentDashboardItemTest {
 				_getMockHttpServletRequest()));
 	}
 
+	private FileEntry _getFileEntry(int numVersions) throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			"example.jpg",
+			MimeTypesUtil.getExtensionContentType(ContentTypes.IMAGE_JPEG),
+			"example.jpg", StringPool.BLANK, "description", StringPool.BLANK,
+			new byte[0], null, null, null, _serviceContext);
+
+		_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			_portal.getClassNameId(FileEntry.class.getName()),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			RandomTestUtil.randomString(),
+			LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0, 0, 0,
+			WorkflowConstants.STATUS_APPROVED, _serviceContext);
+
+		if (numVersions > 1) {
+			for (int i = 1; i < numVersions; i++) {
+				fileEntry = _dlAppLocalService.updateFileEntry(
+					fileEntry.getUserId(), fileEntry.getFileEntryId(),
+					fileEntry.getFileName(), fileEntry.getMimeType(),
+					fileEntry.getTitle(), StringUtil.randomString(),
+					fileEntry.getDescription(), RandomTestUtil.randomString(),
+					DLVersionNumberIncrease.MINOR, fileEntry.getContentStream(),
+					fileEntry.getSize(), fileEntry.getDisplayDate(),
+					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+					_serviceContext);
+			}
+		}
+
+		return fileEntry;
+	}
+
 	private MockHttpServletRequest _getMockHttpServletRequest()
 		throws Exception {
 
@@ -643,35 +677,7 @@ public class FileEntryContentDashboardItemTest {
 			_getVersionableContentDashboardItem(int numVersions)
 		throws Exception {
 
-		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			"example.jpg",
-			MimeTypesUtil.getExtensionContentType(ContentTypes.IMAGE_JPEG),
-			"example.jpg", StringPool.BLANK, "description", StringPool.BLANK,
-			new byte[0], null, null, null, _serviceContext);
-
-		_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
-			_portal.getClassNameId(FileEntry.class.getName()),
-			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
-			RandomTestUtil.randomString(),
-			LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0, 0, 0,
-			WorkflowConstants.STATUS_APPROVED, _serviceContext);
-
-		if (numVersions > 1) {
-			for (int i = 1; i < numVersions; i++) {
-				fileEntry = _dlAppLocalService.updateFileEntry(
-					fileEntry.getUserId(), fileEntry.getFileEntryId(),
-					fileEntry.getFileName(), fileEntry.getMimeType(),
-					fileEntry.getTitle(), StringUtil.randomString(),
-					fileEntry.getDescription(), RandomTestUtil.randomString(),
-					DLVersionNumberIncrease.MINOR, fileEntry.getContentStream(),
-					fileEntry.getSize(), fileEntry.getDisplayDate(),
-					fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
-					_serviceContext);
-			}
-		}
+		FileEntry fileEntry = _getFileEntry(numVersions);
 
 		return (VersionableContentDashboardItem<FileEntry>)
 			_contentDashboardItemFactory.create(fileEntry.getFileEntryId());

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/action/test/GetContentDashboardItemInfoMVCResourceCommandTest.java
@@ -19,8 +19,12 @@ import com.liferay.content.dashboard.item.ContentDashboardItemFactory;
 import com.liferay.content.dashboard.item.ContentDashboardItemVersion;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.web.test.util.ContentDashboardTestUtil;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
@@ -56,8 +60,10 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -65,6 +71,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.io.ByteArrayOutputStream;
 
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -318,18 +325,27 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			contentDashboardItem.getLatestContentDashboardItemVersions(
 				LocaleUtil.US);
 
-		ContentDashboardItemVersion contentDashboardItemVersion =
-			contentDashboardItemVersions.get(0);
-
-		JSONObject expectedJSONObject =
-			contentDashboardItemVersion.toJSONObject();
-
 		JSONArray actualJSONArray = jsonObject.getJSONArray("latestVersions");
 
-		JSONObject actualJSONObject = actualJSONArray.getJSONObject(0);
+		for (int i = 0; i < actualJSONArray.length(); i++) {
+			JSONObject actualJSONObject = actualJSONArray.getJSONObject(i);
 
-		Assert.assertEquals(
-			expectedJSONObject.toString(), actualJSONObject.toString());
+			ContentDashboardItemVersion contentDashboardItemVersion =
+				contentDashboardItemVersions.get(i);
+
+			JSONObject expectedJSONObject =
+				contentDashboardItemVersion.toJSONObject();
+
+			Assert.assertEquals(
+				expectedJSONObject.getString("statusLabel"),
+				actualJSONObject.getString("statusLabel"));
+			Assert.assertEquals(
+				expectedJSONObject.getString("statusStyle"),
+				actualJSONObject.getString("statusStyle"));
+			Assert.assertEquals(
+				expectedJSONObject.getString("version"),
+				actualJSONObject.getString("version"));
+		}
 	}
 
 	private ContentDashboardItem<?> _createContentDashboardBlogItem()
@@ -356,6 +372,25 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 			"application/pdf", new byte[0], new Date(150000),
 			new Date(System.currentTimeMillis() + Time.MINUTE),
 			new Date(150000), _serviceContext);
+
+		fileEntry = _dlAppLocalService.updateFileEntry(
+			fileEntry.getUserId(), fileEntry.getFileEntryId(),
+			fileEntry.getFileName(), fileEntry.getMimeType(),
+			fileEntry.getTitle(), StringUtil.randomString(),
+			fileEntry.getDescription(), RandomTestUtil.randomString(),
+			DLVersionNumberIncrease.MINOR, fileEntry.getContentStream(),
+			fileEntry.getSize(), fileEntry.getDisplayDate(),
+			fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+			_serviceContext);
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		_dlFileEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), dlFileEntry,
+			dlFileEntry.getLatestFileVersion(true),
+			WorkflowConstants.STATUS_EXPIRED, _serviceContext,
+			Collections.emptyMap());
 
 		return _contentDashboardFileItemFactory.create(
 			fileEntry.getPrimaryKey());
@@ -475,6 +510,12 @@ public class GetContentDashboardItemInfoMVCResourceCommandTest {
 		filter = "component.name=com.liferay.content.dashboard.journal.internal.item.JournalArticleContentDashboardItemFactory"
 	)
 	private ContentDashboardItemFactory<?> _contentDashboardJournalItemFactory;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
Expired documents with past versions still shown in Content Dahsboard even when filtering for status Approved

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-27931)

Labels for status are handled different for files than for web content. This PR addresses the issue

# How am I fixing it?

Retrieve the latest approved file version for checking

# How can you verify that it works?

Follow the steps in the ticket or execute the provided integration test

![Screenshot 2024-06-06 at 15 00 15](https://github.com/liferay-content-management/liferay-portal/assets/4267448/91d0bdb6-106b-43cb-9bde-2869a7b97914)
