### PR TITLE
LPD-25415 move failing Poshi test Scheduling KBArticles to Integration test

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -2310,6 +2310,8 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 					KBArticleTable.INSTANCE.status.neq(
 						WorkflowConstants.STATUS_PENDING)
 				)
+			).orderBy(
+				KBArticleTable.INSTANCE.createDate.ascending()
 			));
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -38,10 +38,8 @@ import com.liferay.portal.kernel.lock.LockManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -59,6 +57,7 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalServiceUtil;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalServiceUtil;
 import com.liferay.subscription.service.SubscriptionLocalServiceUtil;
@@ -73,7 +72,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -91,7 +89,9 @@ public class KBArticleLocalServiceTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -101,19 +101,10 @@ public class KBArticleLocalServiceTest {
 		_kbFolderClassNameId = ClassNameLocalServiceUtil.getClassNameId(
 			KBFolderConstants.getClassName());
 
-		_originalName = PrincipalThreadLocal.getName();
-
-		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
-
 		_user = TestPropsValues.getUser();
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group, _user.getUserId());
-	}
-
-	@After
-	public void tearDown() {
-		PrincipalThreadLocal.setName(_originalName);
 	}
 
 	@Test
@@ -763,6 +754,37 @@ public class KBArticleLocalServiceTest {
 			childKBFolder.getKbFolderId(), kbFolder.getKbFolderId());
 		Assert.assertEquals(
 			originalKBArticleTreePath, kbArticle.buildTreePath());
+	}
+
+	@FeatureFlags("LPS-188058")
+	@Test(expected = KBArticleStatusException.class)
+	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+
+		childKBArticle.setDisplayDate(new Date());
+
+		_kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
 	}
 
 	@Test
@@ -1586,12 +1608,16 @@ public class KBArticleLocalServiceTest {
 	}
 
 	private KBArticle _addKbArticle() throws PortalException {
+		return _addKbArticle(new Date());
+	}
+
+	private KBArticle _addKbArticle(Date displayDate) throws PortalException {
 		return _kbArticleLocalService.addKBArticle(
 			null, _user.getUserId(), _kbFolderClassNameId,
 			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(), null, null,
-			new Date(), null, null, null, _serviceContext);
+			displayDate, null, null, null, _serviceContext);
 	}
 
 	private void _testKBArticleLock(
@@ -1672,11 +1698,7 @@ public class KBArticleLocalServiceTest {
 	@Inject
 	private KBFolderLocalService _kbFolderLocalService;
 
-	private String _originalName;
 	private ServiceContext _serviceContext;
 	private User _user;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -757,6 +757,69 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@FeatureFlags("LPS-188058")
+	@Test
+	public void testChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		parentKBArticle.setDisplayDate(new Date());
+
+		parentKBArticle = _kbArticleLocalService.updateKBArticle(
+			parentKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+
+		childKBArticle.setDisplayDate(new Date());
+
+		childKBArticle = _kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+	}
+
+	@FeatureFlags("LPS-188058")
 	@Test(expected = KBArticleStatusException.class)
 	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -820,6 +820,78 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@FeatureFlags("LPS-188058")
+	@Test
+	public void testChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle parentKBArticle = _addKbArticle(displayDate);
+
+		KBArticle childKBArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), parentKBArticle.getClassNameId(),
+			parentKBArticle.getResourcePrimKey(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, _serviceContext);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() - (2 * Time.MINUTE));
+
+		childKBArticle.setDisplayDate(displayDate);
+
+		childKBArticle = _kbArticleLocalService.updateKBArticle(childKBArticle);
+
+		try {
+			_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(exception instanceof KBArticleStatusException);
+		}
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, parentKBArticle.getStatus());
+
+		parentKBArticle.setDisplayDate(displayDate);
+
+		parentKBArticle = _kbArticleLocalService.updateKBArticle(
+			parentKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		childKBArticle = _kbArticleLocalService.fetchKBArticle(
+			childKBArticle.getKbArticleId());
+		parentKBArticle = _kbArticleLocalService.fetchKBArticle(
+			parentKBArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, childKBArticle.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, parentKBArticle.getStatus());
+	}
+
+	@FeatureFlags("LPS-188058")
 	@Test(expected = KBArticleStatusException.class)
 	public void testChildArticleScheduledFailsIfScheduledBeforeParent()
 		throws Exception {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -213,56 +213,6 @@ definition {
 			listEntryLabel = "Approved");
 	}
 
-	@description = "This test ensures that a child article scheduled after the parent will be published on its scheduled date."
-	@priority = 5
-	test ChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.addArticleWithScheduledDate(
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.addArticleWithScheduledDate(
-			addChildArticleWithScheduledDate = "true",
-			increaseMinutes = 2,
-			kbArticleContent = "Knowledge Base Child Article Content",
-			kbArticleTitle = "Knowledge Base Child Article Title",
-			kbParentArticleTitle = "Knowledge Base Article Title");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled parent article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Approved");
-	}
-
 	@description = "This test ensures that a child article scheduled before the parent will not be published until its parent is published."
 	@priority = 5
 	test ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -213,55 +213,6 @@ definition {
 			listEntryLabel = "Approved");
 	}
 
-	@description = "This test ensures that a child article scheduled before the parent will not be published until its parent is published."
-	@priority = 5
-	test ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		JSONKnowledgeBase.addkBArticle(
-			displayDate = "true",
-			groupName = "Guest",
-			increaseMinutes = 2,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		JSONKnowledgeBase.addkBChildArticle(
-			displayDate = "true",
-			groupName = "Guest",
-			increaseMinutes = 1,
-			kbArticleTitle = "Knowledge Base Article Title",
-			kbChildArticleContent = "Knowledge Base Child Article Content",
-			kbChildArticleTitle = "Knowledge Base Child Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled child article is not published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled articles are published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-
-		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Child Article Title",
-			listEntryLabel = "Approved");
-	}
-
 	@description = "This test ensures that the expired article can be published again when the date reaches a new scheduled date."
 	@priority = 4
 	test ExpiredArticleCanBePublishedWithNewScheduledDate {


### PR DESCRIPTION
LPD-25415 [BE] test failure in KBArticleSchedule showing 'Scheduled' when Approved is expected

resent to place them on the right file https://github.com/brianchandotcom/liferay-portal/pull/151078#issuecomment-2152407687

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-25415

The POSHI test are failing because the way are they been updated

# How am I fixing it?

I decided to move to Integration test mimicking the same steps that there are on the POSHI test

# How can you verify that it works?

Run the included automated tests.

# Commits

- **LPD-25415 create integration test to check Behavior of scheduled KB articles**
- **LPD-25415 move ChildArticleScheduledAfterParentCanBePublishedOnItsScheduledDate to an integration test**
- **LPD-25415 move ChildArticleScheduledBeforeParentCanBePublishedWhenParentIsPublished to an integration test**
- **LPD-25415 ensure that when a parent and child article are created with the same display date, the return will be ordered by creation so first we check the parent**