### PR TITLE
LPD-27664 Check if the file is checked out

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/portlet/action/EditInGoogleDocsMVCActionCommand.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/portlet/action/EditInGoogleDocsMVCActionCommand.java
@@ -107,11 +107,14 @@ public class EditInGoogleDocsMVCActionCommand extends BaseMVCActionCommand {
 			long fileEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
-		_dlAppService.checkOutFileEntry(fileEntryId, serviceContext);
+		FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
+
+		if (!fileEntry.isCheckedOut()) {
+			_dlAppService.checkOutFileEntry(fileEntryId, serviceContext);
+		}
 
 		return _dlOpenerGoogleDriveManager.checkOut(
-			serviceContext.getUserId(),
-			_dlAppService.getFileEntry(fileEntryId));
+			serviceContext.getUserId(), fileEntry);
 	}
 
 	private void _executeCommand(


### PR DESCRIPTION
# What is this trying to solve?
[Link to ticket](https://issues.liferay.com/browse/LPD-27664)

If the file is checked out, clicking on the Edit file in Google Docs, doesn't forward it to the Google Docs page. if the file is not checked out. The edit is working fine.

# How am I fixing it?
The root cause is that the "Edit in google docs" initiate a check out, even if it was already checked out. This overwrites the file with an empty file, causing the google type error. the fix is to check if the file is already checked out, and if not, only that time check out.

The PR doesn't have an Integration Test yet, as the fix is needed quickly. I am sending integration tests ASAP.

