### PR TITLE
LPD-27245 Enable AI creator test 

### DIFF
--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -54,6 +54,10 @@ test('LPD-6677 Can add images to DM when API Key is provided', async ({
 
 	await aiCreatorInstanceSettingsPage.addApiKey();
 
+	await expect(
+		page.getByText('Success:Your request completed successfully.')
+	).toBeVisible();
+
 	await documentLibraryPage.goto();
 
 	await documentLibraryPage.openCreateAIImage();

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -42,7 +42,7 @@ test('LPD-6717 and LPD-6691 Create AI Image option is hidden when disabled from 
 	await aiCreatorInstanceSettingsPage.enableDalleCreateImages();
 });
 
-test.skip('LPD-6677 Can add images to DM when API Key is provided', async ({
+test('LPD-6677 Can add images to DM when API Key is provided', async ({
 	aiCreatorInstanceSettingsPage,
 	documentLibraryPage,
 	gogoShellPage,

--- a/modules/test/playwright/tests/document-library-web/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
+++ b/modules/test/playwright/tests/document-library-web/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
@@ -1,0 +1,1 @@
+maxChallenges=I"-1"

--- a/modules/test/playwright/tests/document-library-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/document-library-web/env/portal-ext.properties
@@ -1,0 +1,1 @@
+captcha.enforce.disabled=true


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPD-27245

This test was disabled because of the captcha in the Gogo Shell. Now there is a way to disable that captcha for testing purposes. 