### PR TITLE
LPD-28154 Fix the KBFolder#CorrectActionsAppearInToolbarAfterSelectingFolder test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -1469,7 +1469,7 @@ definition {
 
 		AssertVisible(
 			key_title = ${title},
-			locator1 = "Header#H4_TITLE");
+			locator1 = "KnowledgeBaseArticle#INFO_TITLE_VISIBLE");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
@@ -146,6 +146,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>INFO_TITLE_VISIBLE</td>
+	<td>//div[@class='sidebar-header']//div[contains(@class,'component-title') and contains(.,'${key_title}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>INFO_VERSION_SUBTITLE</td>
 	<td>//li[contains(.,'${key_entryVersion}')]//div[@class='list-group-subtitle']</td>
 	<td></td>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27915 > [LPD-28154](https://liferay.atlassian.net/browse/LPD-28154)

Fix the poshi test (selector issue related to header changes).

# How am I fixing it?

I updated a selector avoiding the headers updated here https://github.com/liferay-platform-experience/liferay-portal/pull/604

# How can you verify that it works?

I'm not sure because it isn't working in my local but in theory, running the test in local should work.

```sh
ant -f build-test.xml run-selenium-test -Dtest.class=KBFolder#CorrectActionsAppearInToolbarAfterSelectingFolder
```