### PR TITLE
LPD-25630 Show the status to guest user

### DIFF
--- a/modules/apps/message-boards/message-boards-web/build.gradle
+++ b/modules/apps/message-boards/message-boards-web/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:message-boards:message-boards-service")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-taglib")
 	compileOnly project(":apps:ratings:ratings-taglib")
 	compileOnly project(":apps:rss:rss-api")
 	compileOnly project(":apps:rss:rss-taglib")

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -17,6 +17,7 @@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
 taglib uri="http://liferay.com/tld/flags" prefix="liferay-flags" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/portal-workflow" prefix="liferay-portal-workflow" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/ratings" prefix="liferay-ratings" %><%@
 taglib uri="http://liferay.com/tld/rss" prefix="liferay-rss" %><%@

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -143,12 +143,15 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 							/>
 						</span>
 					</c:if>
+				</c:if>
 
-					<c:if test="<%= !message.isApproved() %>">
-						<span class="h5 text-default">
-							<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= message.getStatus() %>" />
-						</span>
-					</c:if>
+				<c:if test="<%= !message.isApproved() %>">
+					<span class="h5 text-default">
+						<liferay-portal-workflow:status
+							showStatusLabel="<%= false %>"
+							status="<%= message.getStatus() %>"
+						/>
+					</span>
 				</c:if>
 
 				<c:if test="<%= enableFlags || enableRatings %>">

--- a/modules/apps/message-boards/test.properties
+++ b/modules/apps/message-boards/test.properties
@@ -13,6 +13,8 @@
     # Relevant
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=message-boards-web
+
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
         (\

--- a/modules/test/playwright/fixtures/messageBoardsTest.ts
+++ b/modules/test/playwright/fixtures/messageBoardsTest.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {MessageBoardsEditThreadPage} from '../pages/message-boards/MessageBoardsEditThreadPage';
+import {MessageBoardsPage} from '../pages/message-boards/MessageBoardsPage';
+import {MessageBoardsWidgetPage} from '../pages/message-boards/MessageBoardsWidgetPage';
+
+const messageBoardsPagesTest = test.extend<{
+	messageBoardsEditThreadPage: MessageBoardsEditThreadPage;
+	messageBoardsPage: MessageBoardsPage;
+	messageBoardsWidgetPage: MessageBoardsWidgetPage;
+}>({
+	messageBoardsEditThreadPage: async ({page}, use) => {
+		await use(new MessageBoardsEditThreadPage(page));
+	},
+	messageBoardsPage: async ({page}, use) => {
+		await use(new MessageBoardsPage(page));
+	},
+	messageBoardsWidgetPage: async ({page}, use) => {
+		await use(new MessageBoardsWidgetPage(page));
+	},
+});
+
+export {messageBoardsPagesTest};

--- a/modules/test/playwright/pages/layout-admin-web/WidgetPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/WidgetPage.ts
@@ -34,7 +34,7 @@ export class WidgetPage {
 		await this.page
 			.getByRole('textbox', {name: 'Search Form'})
 			.fill(portletName);
-		await this.page.getByText(portletName).click();
+		await this.page.getByLabel('Widgets').getByText(portletName).click();
 		await this.page.getByRole('button', {name: 'Add Content'}).click();
 	}
 

--- a/modules/test/playwright/pages/message-boards/MessageBoardsEditThreadPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsEditThreadPage.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {MessageBoardsPage} from './MessageBoardsPage';
+
+export class MessageBoardsEditThreadPage {
+	readonly bodyFrameLocator: FrameLocator;
+	readonly bodyTextBox: Locator;
+	readonly messageBoardsPage: MessageBoardsPage;
+	readonly page: Page;
+	readonly publishButton: Locator;
+	readonly subjectSelector: Locator;
+	readonly successMessage: Locator;
+
+	constructor(page: Page) {
+		this.bodyFrameLocator = page.frameLocator('iframe');
+		this.bodyTextBox = this.bodyFrameLocator.getByRole('textbox');
+		this.messageBoardsPage = new MessageBoardsPage(page);
+		this.page = page;
+		this.publishButton = page.getByRole('button', {
+			exact: true,
+			name: 'Publish',
+		});
+		this.subjectSelector = page.getByLabel('Subject');
+	}
+
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.messageBoardsPage.goto(siteUrl);
+
+		await this.messageBoardsPage.goToCreateNewThread();
+	}
+
+	async publishNewBasicTread(
+		subject: string,
+		body: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
+
+		await this.subjectSelector.fill(subject);
+		await this.bodyTextBox.fill(body);
+
+		await this.publishButton.click();
+	}
+}

--- a/modules/test/playwright/pages/message-boards/MessageBoardsPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsPage.ts
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {PORTLET_URLS} from '../../utils/portletUrls';
+
+export class MessageBoardsPage {
+	readonly actionAddMessage: Locator;
+	readonly actionReplyMessage: Locator;
+	readonly homeCategoryPermissionsFrame: FrameLocator;
+	readonly homeCategoryPermissionsMenuItem: Locator;
+	readonly page: Page;
+	readonly optionsMenu: Locator;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.homeCategoryPermissionsFrame = page.frameLocator(
+			'iframe[title="Home Category Permissions"]'
+		);
+
+		this.actionAddMessage = this.homeCategoryPermissionsFrame.locator(
+			'#guest_ACTION_ADD_MESSAGE'
+		);
+		this.actionReplyMessage = this.homeCategoryPermissionsFrame.locator(
+			'#guest_ACTION_REPLY_TO_MESSAGE'
+		);
+		this.homeCategoryPermissionsMenuItem = page.getByRole('menuitem', {
+			name: 'Home Category Permissions',
+		});
+		this.page = page;
+		this.optionsMenu = page.getByLabel('Options');
+		this.saveButton = this.homeCategoryPermissionsFrame.getByRole(
+			'button',
+			{name: 'Save'}
+		);
+	}
+
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.messageBoardsAdmin}`
+		);
+	}
+
+	async goToCreateNewThread() {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Thread'}),
+			trigger: this.page.getByRole('button', {exact: true, name: 'New'}),
+		});
+	}
+
+	async setGuestCategoryPermissions(siteUrl?: Site['friendlyUrlPath']) {
+		await this.goto(siteUrl);
+
+		await this.optionsMenu.click();
+		await this.homeCategoryPermissionsMenuItem.click();
+
+		await this.actionAddMessage.check();
+		await this.actionReplyMessage.check();
+
+		await this.saveButton.click();
+
+		await this.page.getByLabel('close', {exact: true}).click();
+	}
+}

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {ApiHelpers} from '../../helpers/ApiHelpers';
+import getRandomString from '../../utils/getRandomString';
+import {performLogout} from '../../utils/performLogin';
+import {WidgetPage} from '../layout-admin-web/WidgetPage';
+export class MessageBoardsWidgetPage {
+	readonly apiHelpers: ApiHelpers;
+	readonly page: Page;
+	readonly widgetPage: WidgetPage;
+
+	constructor(page: Page) {
+		this.apiHelpers = new ApiHelpers(page);
+		this.page = page;
+		this.widgetPage = new WidgetPage(page);
+	}
+
+	async addMessageBoardsPortlet(site: Site) {
+		const layout = await this.apiHelpers.jsonWebServicesLayout.addLayout(
+			site.id,
+			getRandomString()
+		);
+
+		await this.page.goto(
+			'/web' + site.friendlyUrlPath + layout.friendlyURL
+		);
+
+		await this.widgetPage.addPortlet('Message Boards');
+
+		return layout;
+	}
+
+	async addGuestReply(site: Site, layout: Layout, buttonName: string) {
+		await performLogout(this.page);
+
+		await this.page.goto(
+			'/web' + site.friendlyUrlPath + layout.friendlyURL
+		);
+
+		await this.page.getByRole('link', {name: 'Thread Subject'}).click();
+
+		await this.page.getByRole('button', {name: 'Reply'}).click();
+
+		const frameLocator = this.page.frameLocator(
+			'iframe[title*="_com_liferay_message_boards_web_portlet_MBPortlet_replyMessageBody"]'
+		);
+
+		await frameLocator.getByRole('textbox').fill('test guest');
+
+		await this.page.getByRole('button', {name: buttonName}).click();
+	}
+}

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -46,11 +46,11 @@ export class MessageBoardsWidgetPage {
 
 		await this.page.getByRole('button', {name: 'Reply'}).click();
 
-		const frameLocator = this.page.frameLocator(
+		const messageBodyIframe = this.page.frameLocator(
 			'iframe[title*="_com_liferay_message_boards_web_portlet_MBPortlet_replyMessageBody"]'
 		);
 
-		await frameLocator.getByRole('textbox').fill('test guest');
+		await messageBodyIframe.getByRole('textbox').fill('test guest');
 
 		await this.page.getByRole('button', {name: buttonName}).click();
 	}

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -27,7 +27,7 @@ export class MessageBoardsWidgetPage {
 		);
 
 		await this.page.goto(
-			'/web' + site.friendlyUrlPath + layout.friendlyURL
+			`/web${site.friendlyUrlPath}${layout.friendlyURL}`
 		);
 
 		await this.widgetPage.addPortlet('Message Boards');
@@ -39,7 +39,7 @@ export class MessageBoardsWidgetPage {
 		await performLogout(this.page);
 
 		await this.page.goto(
-			'/web' + site.friendlyUrlPath + layout.friendlyURL
+			`/web${site.friendlyUrlPath}${layout.friendlyURL}`
 		);
 
 		await this.page.getByRole('link', {name: 'Thread Subject'}).click();

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -134,6 +134,7 @@ export default defineConfig({
 			? process.env.PORTAL_URL
 			: 'http://localhost:8080',
 		screenshot: 'only-on-failure',
+		testIdAttribute: 'data-qa-id',
 		trace: 'retain-on-failure',
 	},
 	workers: 1,

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -36,6 +36,7 @@ import {config as layoutPageTemplateAdminWeb} from './tests/layout-page-template
 import {config as layoutSetPrototypeWebConfig} from './tests/layout-set-prototype-web/config';
 import {config as lockedItemsConfig} from './tests/locked-items-web/config';
 import {config as loginWebConfig} from './tests/login-web/config';
+import {config as messageBoardsConfig} from './tests/message-boards-web/config';
 import {config as notificationWebConfig} from './tests/notification-web/config';
 import {config as objectWebConfig} from './tests/object-web/config';
 import {config as osbFaroWebConfig} from './tests/osb-faro-web/config';
@@ -92,6 +93,7 @@ export default defineConfig({
 		lockedItemsConfig,
 		loginWebConfig,
 		marketplaceConfig,
+		messageBoardsConfig,
 		notificationWebConfig,
 		objectWebConfig,
 		osbFaroWebConfig,

--- a/modules/test/playwright/tests/account-admin-web/config.ts
+++ b/modules/test/playwright/tests/account-admin-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'account-admin-web',
 	testDir: 'tests/account-admin-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/change-tracking-web/config.ts
+++ b/modules/test/playwright/tests/change-tracking-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'change-tracking-web',
 	testDir: 'tests/change-tracking-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'client-extension-web',
 	testDir: 'tests/client-extension-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/commerce/config.ts
+++ b/modules/test/playwright/tests/commerce/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'commerce',
 	testDir: 'tests/commerce',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/dispatch-web/config.ts
+++ b/modules/test/playwright/tests/dispatch-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'dispatch-web',
 	testDir: 'tests/dispatch-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/export-import-web/config.ts
+++ b/modules/test/playwright/tests/export-import-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'export-import-web',
 	testDir: 'tests/export-import-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/headless-builder-impl/config.ts
+++ b/modules/test/playwright/tests/headless-builder-impl/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'headless-builder-impl',
 	testDir: 'tests/headless-builder-impl',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/headless-builder-web/config.ts
+++ b/modules/test/playwright/tests/headless-builder-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'headless-builder-web',
 	testDir: 'tests/headless-builder-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/knowledge-base-web/config.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/config.ts
@@ -9,7 +9,4 @@ export const config = {
 	},
 	name: 'knowledge-base-web',
 	testDir: 'tests/knowledge-base-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/message-boards-web/config.ts
+++ b/modules/test/playwright/tests/message-boards-web/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'message-boards-web',
+	testDir: 'tests/message-boards-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/message-boards-web/config.ts
+++ b/modules/test/playwright/tests/message-boards-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'message-boards-web',
 	testDir: 'tests/message-boards-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {messageBoardsPagesTest} from '../../fixtures/messageBoardsTest';
+import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+export const test = mergeTests(
+	isolatedSiteTest,
+	messageBoardsPagesTest,
+	loginTest(),
+	workflowPagesTest
+);
+test('LPD-25630 Show the status to guest user', async ({
+	messageBoardsEditThreadPage,
+	messageBoardsPage,
+	messageBoardsWidgetPage,
+	page,
+	site,
+	workflowPage,
+}) => {
+	await messageBoardsPage.setGuestCategoryPermissions(site.friendlyUrlPath);
+
+	await messageBoardsEditThreadPage.publishNewBasicTread(
+		'Thread Subject',
+		'Thread Body',
+		site.friendlyUrlPath
+	);
+
+	await workflowPage.goto(site.friendlyUrlPath);
+
+	await workflowPage.changeWorkflow(
+		'Message Boards Message',
+		'Single Approver'
+	);
+
+	const layout = await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
+
+	await messageBoardsWidgetPage.addGuestReply(
+		site,
+		layout,
+		'Submit for Workflow'
+	);
+
+	await expect(page.getByText('Pending')).toBeVisible();
+});

--- a/modules/test/playwright/tests/message-boards-web/test.properties
+++ b/modules/test/playwright/tests/message-boards-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Message Boards

--- a/modules/test/playwright/tests/portal-default-permissions-web/config.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'portal-default-permissions-web',
 	testDir: 'tests/portal-default-permissions-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/portal-workflow-web/pages/WorkflowPage.ts
+++ b/modules/test/playwright/tests/portal-workflow-web/pages/WorkflowPage.ts
@@ -43,8 +43,8 @@ export class WorkflowPage {
 		await waitForSuccessAlert(
 			this.page,
 			disable
-				? `Success:Workflow unassigned from Web Content Article.`
-				: `Success:Workflow assigned to Web Content Article.`
+				? `Success:Workflow unassigned from ${asset}.`
+				: `Success:Workflow assigned to ${asset}.`
 		);
 	}
 }

--- a/modules/test/playwright/tests/portlet-configuration-web/config.ts
+++ b/modules/test/playwright/tests/portlet-configuration-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'portlet-configuration-web',
 	testDir: 'tests/portlet-configuration-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
+++ b/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'product-navigation-user-personal-bar-web',
 	testDir: 'tests/product-navigation-user-personal-bar-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/users-admin-web/config.ts
+++ b/modules/test/playwright/tests/users-admin-web/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'users-admin-web',
 	testDir: 'tests/users-admin-web',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/config.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'marketplace',
 	testDir: 'tests/workspaces/liferay-workspace-marketplace',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -23,6 +23,8 @@ export const PORTLET_URLS = {
 		'/~/control_panel/manage?p_p_id=com_liferay_locked_items_web_internal_portlet_LockedItemsPortlet',
 	masterPages:
 		'/~/control_panel/manage?p_p_id=com_liferay_layout_page_template_admin_web_portlet_LayoutPageTemplatesPortlet&_com_liferay_layout_page_template_admin_web_portlet_LayoutPageTemplatesPortlet_tabs1=master-layouts',
+	messageBoardsAdmin:
+		'/~/control_panel/manage?p_p_id=com_liferay_message_boards_web_portlet_MBAdminPortlet',
 	modelBuilder:
 		'/~/control_panel/manage?p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet&_com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_mvcRenderCommandName=/object_definitions/view_model_builder',
 	myWorkflowTasks:

--- a/test.properties
+++ b/test.properties
@@ -868,6 +868,7 @@
         layout-taglib,\
         locked-items-web,\
         marketplace,\
+        message-boards,\
         notification-web,\
         object-web,\
         osb-faro-web,\
@@ -4058,6 +4059,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         document-library-web,\
         journal-web,\
         knowledge-base-web,\
+        message-boards-web,\
         notification-web
 
     test.batch.class.names.includes[content-management]=\


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-25630

The pending status is not shown to guest when this user submits it for revision.
 
### How am I fixing it?

Allowing this user to see the status label if needed:

![Captura de pantalla 2024-06-11 a las 15 15 35](https://github.com/liferay-content-management/liferay-portal/assets/2728470/9a21bcbd-38dc-47d9-80f0-3a1da4e351a5)

### How can you verify that it works?

Run the included automated playwright tests:

![Captura de pantalla 2024-06-11 a las 15 16 50](https://github.com/liferay-content-management/liferay-portal/assets/2728470/ccd49132-6fa0-4f9c-8616-7cbcd140b06b)


### Commits

LPD-25630 Show the status to guest user
LPD-25630 Add tests

### Comments

Fix logic was fixed and sent to @brianchandotcom in a previous PR: https://github.com/brianchandotcom/liferay-portal/pull/150414 so it doesn't need a review.

Only tests need a Pair Review

