### PR TITLE
LPD-28234 Fix failing test WebContentUpgradeWithWithSecondComplexStructure#CanAddDefaultValueToWebContentStructure

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
@@ -143,7 +143,9 @@ definition {
 
 		AssertVisible(locator1 = "WCEditWebContent#SIDEBAR");
 
-		AssertVisible(locator1 = "Sidebar#FORM_BUILDER");
+		// This pause is needed to avoid the deletion of typed text caused by a slow second data engine load. See LPD-28234
+
+		Pause(value1 = 3000);
 
 		Type(
 			key_fieldFieldLabel = "Label UF Comunicado",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28234

There is a flaky error: sometimes the first input in the default values form of a Web Content Structure is empty, when it should have a value because the test is typing a value in.

Locally, this error only occurs on the first execution of the test, after the fresh start of the portal.

# How am I fixing it?

The problem is that the the load of the form is made twice:
* First load: the input has an empty value. This empty value is correctly loaded from the DB. 
* The test is typing the new value in the already available input.
* (Slow) Second load (related to languages handling): the input is again set to empty.

There is no visible difference between the first and the second load of the form, so it cannot be tracked by Selenium. The only possible solutin is to add a PAUSE instruction. Another costly solution would be to change how the form handling works.

# How can you verify that it works?

After importing the 7.3 database and data folder, and executing the portal with the automatic upgrade enabled, execute locally: `ant -f build-test.xml run-selenium-test -Dtest.class=WebContentUpgradeWithWithSecondComplexStructure#CanAddDefaultValueToWebContentStructure`

# Why doesn't this include any test?

I'm fixing a test.