### PR TITLE
[Playwright] LPD-26753 The URL changes when a category is modified

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -16,6 +16,11 @@ interface createCategoryProps {
 	vocabularyId: number;
 }
 
+interface patchCategoryProps {
+	id: number;
+	name: string;
+}
+
 interface createTagProps {
 	name: string;
 	siteId: string;
@@ -63,6 +68,20 @@ export class HeadlessAdminTaxonomyApiHelper {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
 			{data: {name}}
+		);
+	}
+
+	/**
+	 * It allows update a category name
+	 *
+	 * @param name the new name of the category
+	 * @param id the category id
+	 */
+
+	async patchCategory({id, name}: patchCategoryProps): Promise<{id: number}> {
+		return this.apiHelpers.patch(
+			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-categories/${id}`,
+			{name}
 		);
 	}
 

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -57,20 +57,23 @@ export async function createAssetPublisherAndConfigure({
 	);
 	await configurationModal.locator('.portlet-body').waitFor();
 
-	const configurationDynamicLabel = await configurationModal.getByText(
+	const configurationDynamicInput = await configurationModal.getByLabel(
 		'Dynamic',
 		{exact: true}
 	);
-	if (await configurationDynamicLabel.isHidden()) {
+	if (await configurationDynamicInput.isHidden()) {
 		await configurationModal
 			.getByRole('link', {name: 'Asset Selection'})
 			.click();
 	}
-	await configurationDynamicLabel.click();
-	await waitForSuccessAlert(
-		configurationModal,
-		'Success:You have successfully updated the setup.'
-	);
+	if (await !configurationDynamicInput.isChecked()) {
+		await configurationDynamicInput.click();
+
+		await waitForSuccessAlert(
+			configurationModal,
+			'Success:You have successfully updated the setup.'
+		);
+	}
 
 	const configurationSourceAssetTypeSelect =
 		await configurationModal.getByLabel('Asset Type');

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -15,17 +15,25 @@ export async function createCategories({
 	friendlyUrlCategories: string[];
 	site: Site;
 	vocabularyName: string;
-}) {
+}): Promise<{id: number; name: string}[]> {
 	const {id: vocabularyId} =
 		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
 			name: vocabularyName,
 			siteId: site.id,
 		});
 
-	for (const categoryName of friendlyUrlCategories) {
-		await apiHelpers.headlessAdminTaxonomy.createCategory({
-			name: categoryName,
+	const categories = [];
+	for (const name of friendlyUrlCategories) {
+		const {id} = await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name,
 			vocabularyId,
 		});
+
+		categories.push({
+			id,
+			name,
+		});
 	}
+
+	return categories;
 }

--- a/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
@@ -28,7 +28,7 @@ export async function friendlyURLCategoriesSetup({
 	site: Site;
 	vocabularyName: string;
 }) {
-	await createCategories({
+	const categories = await createCategories({
 		apiHelpers,
 		friendlyUrlCategories,
 		site,
@@ -41,4 +41,6 @@ export async function friendlyURLCategoriesSetup({
 		pageEditorPage,
 		site,
 	});
+
+	return {categories};
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26753

We are adding playwright test to check blog entry friendlyURL redirection using categories when categories are renamed

# How am I fixing it?

We are adding a functional test.

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run test -- -g "LPD-26753"` to only run the test


# Avoid flakiness by repeating 10 times

```sh
npm run test -- -g "LPD-26753" --reporter list --repeat-each 10
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/0a6bd4d4-93a8-46cc-be3e-afc4e52a4785)


# Screenrecord tests execution
[blogEntry-LPD-26753-The-URL-changes-when-a-category-is-modified-blogs-web.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/217d0a9b-49ed-47dc-a7ff-aa9f0c01eef3)