### PR TITLE
LPD-28007 Revert "LPD-17744 Disable Iframe sanitizer at setup"

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
@@ -11,12 +11,6 @@ definition {
 
 		User.firstLoginPG();
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
-
-		SystemSettings.configureSystemSetting(
-			enableSetting = "false",
-			settingFieldName = "Enabled");
-
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
@@ -14,12 +14,6 @@ definition {
 
 		User.firstLoginPG();
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
-
-		SystemSettings.configureSystemSetting(
-			enableSetting = "false",
-			settingFieldName = "Enabled");
-
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(


### PR DESCRIPTION
LPD-28007 Investigate "ElementNotFoundPoshiRunnerException: Element is not present at "//span[contains(@class,'custom-control-label-text') and contains(.,'Enabled')"

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28007


# How am I fixing it?

The fix for LPD-17744 was causing more test to fail than fix so revert the fix

# How can you verify that it works?

Run the included automated tests.

# Commits

This reverts commit eeff6825a4cc4d46dc56aec929bd18162a8e3856.
