### PR TITLE
[Playwright] LPD-26753 The URL changes when a category is modified

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -5,13 +5,13 @@
 
 import {ApiHelpers} from './ApiHelpers';
 
-interface createVocabularyProps {
+interface postVocabularyProps {
 	assetTypes?: AssetType[];
 	name: string;
 	siteId: string;
 }
 
-interface createCategoryProps {
+interface postCategoryProps {
 	name: string;
 	vocabularyId: number;
 }
@@ -21,7 +21,7 @@ interface patchCategoryProps {
 	name: string;
 }
 
-interface createTagProps {
+interface postTagProps {
 	name: string;
 	siteId: string;
 }
@@ -43,11 +43,11 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param [assetTypes] the asset types to which the vocabulary can be used
 	 */
 
-	async createVocabulary({
+	async postVocabulary({
 		assetTypes,
 		name,
 		siteId,
-	}: createVocabularyProps): Promise<{id: number}> {
+	}: postVocabularyProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/taxonomy-vocabularies`,
 			{data: {assetTypes, name}}
@@ -61,10 +61,10 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param vocabularyId the parent vocabulary id
 	 */
 
-	async createCategory({
+	async postCategory({
 		name,
 		vocabularyId,
-	}: createCategoryProps): Promise<{id: number}> {
+	}: postCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
 			{data: {name}}
@@ -92,7 +92,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param siteId the id of the site in which the tag will be created
 	 */
 
-	async createTag({name, siteId}: createTagProps): Promise<{id: number}> {
+	async postTag({name, siteId}: postTagProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/keywords`,
 			{data: {name}}

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -16,6 +16,11 @@ interface createCategoryProps {
 	vocabularyId: number;
 }
 
+interface patchCategoryProps {
+	id: number;
+	name: string;
+}
+
 interface createTagProps {
 	name: string;
 	siteId: string;
@@ -63,6 +68,20 @@ export class HeadlessAdminTaxonomyApiHelper {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
 			{data: {name}}
+		);
+	}
+
+	/**
+	 * It allows update a category name
+	 *
+	 * @param name the new name of the category
+	 * @param id the category id
+	 */
+
+	async patchCategory({id, name}: patchCategoryProps): Promise<{id: number}> {
+		return this.apiHelpers.patch(
+			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-categories/${id}`,
+			{name}
 		);
 	}
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -12,7 +12,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
-import {friendlyURLCategoriesSetup} from './utils/friendlyURLCategoriesSetup';
+import {blogsCategorizedFriendlyUrlSetup} from './utils/blogsCategorizedFriendlyUrlSetup';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -74,7 +74,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	const vocabularyName = getRandomString();
 	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
 
-	await friendlyURLCategoriesSetup({
+	await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
 		displayPageTemplatesPage,
 		friendlyUrlCategories,
@@ -121,7 +121,7 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 	const vocabularyName = getRandomString();
 	const friendlyUrlCategories = ['category 1', 'category 2', 'category 3'];
 
-	await friendlyURLCategoriesSetup({
+	await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
 		displayPageTemplatesPage,
 		friendlyUrlCategories,
@@ -162,7 +162,7 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 	const vocabularyName = getRandomString();
 	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
 
-	const {categories} = await friendlyURLCategoriesSetup({
+	const {categories} = await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
 		displayPageTemplatesPage,
 		friendlyUrlCategories,

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -150,3 +150,57 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 			.join('/')}/${title}`
 	);
 });
+
+test('LPD-26753 The URL changes when a category is modified', async ({
+	apiHelpers,
+	blogsEditBlogEntryPage,
+	displayPageTemplatesPage,
+	page,
+	pageEditorPage,
+	site,
+}) => {
+	const vocabularyName = getRandomString();
+	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
+
+	const {categories} = await friendlyURLCategoriesSetup({
+		apiHelpers,
+		displayPageTemplatesPage,
+		friendlyUrlCategories,
+		page,
+		pageEditorPage,
+		site,
+		vocabularyName,
+	});
+
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		publish: true,
+		title,
+	});
+
+	const initialResponse = await page.goto(
+		`/web${site.friendlyUrlPath}/b/${title}`
+	);
+	await expect(initialResponse.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
+			'/'
+		)}/${title}`
+	);
+
+	friendlyUrlCategories[0] = `${friendlyUrlCategories[0]}-edited`;
+	await apiHelpers.headlessAdminTaxonomy.patchCategory({
+		id: categories[0].id,
+		name: friendlyUrlCategories[0],
+	});
+	const editedResponse = await page.goto(initialResponse.url());
+	await expect(editedResponse.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
+			'/'
+		)}/${title}`
+	);
+});

--- a/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
@@ -11,7 +11,7 @@ import type {ApiHelpers} from '../../../helpers/ApiHelpers';
 import type {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 
-export async function friendlyURLCategoriesSetup({
+export async function blogsCategorizedFriendlyUrlSetup({
 	apiHelpers,
 	displayPageTemplatesPage,
 	friendlyUrlCategories,

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -57,20 +57,23 @@ export async function createAssetPublisherAndConfigure({
 	);
 	await configurationModal.locator('.portlet-body').waitFor();
 
-	const configurationDynamicLabel = await configurationModal.getByText(
+	const configurationDynamicInput = await configurationModal.getByLabel(
 		'Dynamic',
 		{exact: true}
 	);
-	if (await configurationDynamicLabel.isHidden()) {
+	if (await configurationDynamicInput.isHidden()) {
 		await configurationModal
 			.getByRole('link', {name: 'Asset Selection'})
 			.click();
 	}
-	await configurationDynamicLabel.click();
-	await waitForSuccessAlert(
-		configurationModal,
-		'Success:You have successfully updated the setup.'
-	);
+	if (!(await configurationDynamicInput.isChecked())) {
+		await configurationDynamicInput.click();
+
+		await waitForSuccessAlert(
+			configurationModal,
+			'Success:You have successfully updated the setup.'
+		);
+	}
 
 	const configurationSourceAssetTypeSelect =
 		await configurationModal.getByLabel('Asset Type');

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -15,17 +15,25 @@ export async function createCategories({
 	friendlyUrlCategories: string[];
 	site: Site;
 	vocabularyName: string;
-}) {
+}): Promise<{id: number; name: string}[]> {
 	const {id: vocabularyId} =
 		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
 			name: vocabularyName,
 			siteId: site.id,
 		});
 
-	for (const categoryName of friendlyUrlCategories) {
-		await apiHelpers.headlessAdminTaxonomy.createCategory({
-			name: categoryName,
+	const categories = [];
+	for (const name of friendlyUrlCategories) {
+		const {id} = await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name,
 			vocabularyId,
 		});
+
+		categories.push({
+			id,
+			name,
+		});
 	}
+
+	return categories;
 }

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -17,14 +17,14 @@ export async function createCategories({
 	vocabularyName: string;
 }): Promise<{id: number; name: string}[]> {
 	const {id: vocabularyId} =
-		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+		await apiHelpers.headlessAdminTaxonomy.postVocabulary({
 			name: vocabularyName,
 			siteId: site.id,
 		});
 
 	const categories = [];
 	for (const name of friendlyUrlCategories) {
-		const {id} = await apiHelpers.headlessAdminTaxonomy.createCategory({
+		const {id} = await apiHelpers.headlessAdminTaxonomy.postCategory({
 			name,
 			vocabularyId,
 		});

--- a/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/friendlyURLCategoriesSetup.ts
@@ -28,7 +28,7 @@ export async function friendlyURLCategoriesSetup({
 	site: Site;
 	vocabularyName: string;
 }) {
-	await createCategories({
+	const categories = await createCategories({
 		apiHelpers,
 		friendlyUrlCategories,
 		site,
@@ -41,4 +41,6 @@ export async function friendlyURLCategoriesSetup({
 		pageEditorPage,
 		site,
 	});
+
+	return {categories};
 }

--- a/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilter.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilter.spec.ts
@@ -207,7 +207,7 @@ testWithIsolatedSite(
 
 		for (const tagName of ['Dogs', 'Cats']) {
 			tags.push(
-				await apiHelpers.headlessAdminTaxonomy.createTag({
+				await apiHelpers.headlessAdminTaxonomy.postTag({
 					name: tagName,
 					siteId: site.id,
 				})

--- a/modules/test/playwright/tests/layout-content-page-editor-web/tagsFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/tagsFragment.spec.ts
@@ -91,7 +91,7 @@ test('uses Tags fragment for Forms in a Content Page', async ({
 	// Create two tags in Wem Site
 
 	for (const tagName of ['Dogs', 'Cats']) {
-		await apiHelpers.headlessAdminTaxonomy.createTag({
+		await apiHelpers.headlessAdminTaxonomy.postTag({
 			name: tagName,
 			siteId: site.id,
 		});
@@ -101,7 +101,7 @@ test('uses Tags fragment for Forms in a Content Page', async ({
 
 	const globalSiteId = await getGlobalSiteId(apiHelpers);
 
-	const globalTag = await apiHelpers.headlessAdminTaxonomy.createTag({
+	const globalTag = await apiHelpers.headlessAdminTaxonomy.postTag({
 		name: 'Rabbits',
 		siteId: globalSiteId,
 	});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26753

We are adding a playwright test to check blog entry friendlyURL redirection using categories when categories are renamed

# How am I fixing it?

We are adding a functional test.

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright test -- -g "LPD-26753"` to only run the test

# Avoid flakiness by repeating 10 times

```sh
npm run playwright test -- -g "LPD-26753" --reporter list --repeat-each 10
```
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/13fbd6bd-a559-44e5-8b85-ca57efe09272)

# Screenrecord test execution
[blogEntry-LPD-26753-The-URL-changes-when-a-category-is-modified-blogs-web.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/41e2e914-cb6b-436c-94d1-175493929e15)
