### PR TITLE
LPD-26863 Create UndoRedo Component for meta fields

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -59,6 +59,11 @@ AUI.add(
 					value: defaultLanguageId,
 				},
 
+				edited: {
+					validator: Lang.isBoolean,
+					value: false,
+				},
+
 				editor: {},
 
 				fieldPrefix: {
@@ -362,6 +367,10 @@ AUI.add(
 						value = input.val();
 					}
 
+					if (Liferay.FeatureFlags['LPD-11228']) {
+						instance.set('edited', true);
+					}
+
 					instance.updateInputLanguage(value);
 				},
 
@@ -569,6 +578,18 @@ AUI.add(
 				_selectedLanguageIdAtom: null,
 
 				_selectedLanguageIdSubscription: null,
+
+				_storeState() {
+					const instance = this;
+
+					if (instance.get('edited')) {
+						instance.set('edited', false);
+
+						Liferay.fire('journal:storeState', {
+							fieldName: instance.get('name'),
+						});
+					}
+				},
 
 				_updateHelpMessage(languageId) {
 					const instance = this;
@@ -797,6 +818,14 @@ AUI.add(
 					];
 
 					if (!instance.get('editor')) {
+						if (Liferay.FeatureFlags['LPD-11228']) {
+							eventHandles.push(
+								inputPlaceholder.on(
+									'blur',
+									A.bind('_storeState', instance)
+								)
+							);
+						}
 						eventHandles.push(
 							inputPlaceholder.on(
 								'input',

--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -17,6 +17,7 @@
 		"@liferay/layout-js-components-web": "*",
 		"@liferay/template-web": "*",
 		"classnames": "2.3.1",
+		"data-engine-js-components-web": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"moment": "2.29.4",

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -145,6 +145,19 @@ journalEditArticleDisplayContext.setViewAttributes();
 					<div class="c-gap-3 form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 						<c:choose>
 							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
+								<div>
+									<react:component
+										module="{UndoRedo} from journal-web"
+										props='<%=
+											HashMapBuilder.<String, Object>put(
+												"initialDefaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
+											).put(
+												"languageId", journalEditArticleDisplayContext.getSelectedLanguageId()
+											).build()
+										%>'
+									/>
+								</div>
+
 								<div class="align-items-center d-none mx-3 small text-danger" id="<portlet:namespace />lockErrorIndicator">
 									<liferay-ui:message key="alert-helper-error" />
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import React, {useCallback, useEffect, useState} from 'react';
+
+const META_FIELD_NAMES = {
+	description: 'descriptionMapAsXML',
+	friendlyURL: 'friendlyURL',
+	title: 'titleMapAsXML',
+};
+
+export default function UndoRedo({
+	initialDefaultLanguageId,
+	languageId,
+	portletNamespace,
+}) {
+	const [
+
+		// eslint-disable-next-line no-unused-vars
+		{defaultLanguageId, history, selectedLanguageId, step},
+		setState,
+	] = useState({
+		defaultLanguageId: initialDefaultLanguageId,
+		history: [],
+		selectedLanguageId: languageId,
+		step: -1,
+	});
+
+	const handleUndoRedo = (newStep) => {
+		const nextStep = history[newStep];
+
+		const titleInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.title}`
+		);
+
+		const descriptionInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.description}`
+		);
+
+		const friendlyURLInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+		);
+
+		if (nextStep.selectedLanguageId !== selectedLanguageId) {
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			selectedLanguageIdInput.value = nextStep.selectedLanguageId;
+
+			titleInputComponent.selectFlag(nextStep.selectedLanguageId);
+			descriptionInputComponent.selectFlag(nextStep.selectedLanguageId);
+			friendlyURLInputComponent.selectFlag(nextStep.selectedLanguageId);
+		}
+		else {
+			titleInputComponent.updateInputLanguage(
+				nextStep.titleInputComponent,
+				nextStep.selectedLanguageId
+			);
+			descriptionInputComponent.updateInputLanguage(
+				nextStep.descriptionInputComponent,
+				nextStep.selectedLanguageId
+			);
+			friendlyURLInputComponent.updateInputLanguage(
+				nextStep.friendlyURLInputComponent,
+				nextStep.selectedLanguageId
+			);
+			titleInputComponent.updateInput(nextStep.titleInputComponent);
+			descriptionInputComponent.updateInput(
+				nextStep.descriptionInputComponent
+			);
+			friendlyURLInputComponent.updateInput(
+				nextStep.friendlyURLInputComponent
+			);
+		}
+		setState({
+			defaultLanguageId: nextStep.defaultLanguageId,
+			history,
+			selectedLanguageId: nextStep.selectedLanguageId,
+			step: newStep,
+		});
+	};
+
+	const handleStoreState = useCallback(
+		({fieldName}) => {
+			const defaultLanguageIdInput = document.getElementById(
+				`${portletNamespace}defaultLanguageId`
+			);
+
+			const descriptionInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.description}`
+			);
+
+			const titleInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.title}`
+			);
+
+			const friendlyURLInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+			);
+
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			Promise.all([
+				descriptionInputComponent,
+				titleInputComponent,
+				friendlyURLInputComponent,
+			]).then(
+				([
+					descriptionInputComponent,
+					titleInputComponent,
+					friendlyURLInputComponent,
+				]) => {
+					const newHistory = {
+						defaultLanguageId: defaultLanguageIdInput.value,
+						descriptionInputComponent:
+							descriptionInputComponent.getValue(
+								selectedLanguageId
+							),
+						friendlyURLInputComponent:
+							friendlyURLInputComponent.getValue(
+								selectedLanguageId
+							),
+						name: fieldName,
+						selectedLanguageId: selectedLanguageIdInput.value,
+						titleInputComponent:
+							titleInputComponent.getValue(selectedLanguageId),
+					};
+
+					setState({
+						defaultLanguageId: defaultLanguageIdInput.value,
+						history: [...history.slice(0, step + 1), newHistory],
+						selectedLanguageId: selectedLanguageIdInput.value,
+						step: step + 1,
+					});
+				}
+			);
+		},
+		[history, portletNamespace, selectedLanguageId, step]
+	);
+
+	const localeChangeHandler = useCallback(
+		(event) => {
+			const selectedLanguageId = event.item.getAttribute('data-value');
+
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			selectedLanguageIdInput.value = selectedLanguageId;
+
+			Liferay.fire('journal:storeState', {fieldName: 'Locale Change'});
+		},
+		[portletNamespace]
+	);
+
+	useEffect(() => {
+		Liferay.after('inputLocalized:localeChanged', localeChangeHandler);
+
+		return () => {
+			Liferay.detach('inputLocalized:localeChanged', localeChangeHandler);
+		};
+	}, [localeChangeHandler]);
+
+	useEffect(() => {
+		Liferay.on('journal:storeState', handleStoreState);
+
+		return () => {
+			Liferay.detach('journal:storeState', handleStoreState);
+		};
+	}, [handleStoreState]);
+
+	useEffect(() => {
+		setTimeout(() => {
+			Liferay.fire('journal:storeState', {fieldName: 'Reset'});
+		}, 1000);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	return (
+		<>
+			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('undo')}
+				className="btn-monospaced"
+				disabled={step <= 0}
+				displayType="secondary"
+				onClick={() => {
+					handleUndoRedo(step - 1);
+				}}
+				size="sm"
+				symbol="undo"
+				title={Liferay.Language.get('undo')}
+			/>
+
+			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('redo')}
+				className="btn-monospaced"
+				disabled={!history.length || step === history.length - 1}
+				displayType="secondary"
+				onClick={() => {
+					handleUndoRedo(step + 1);
+				}}
+				size="sm"
+				symbol="redo"
+				title={Liferay.Language.get('redo')}
+			/>
+		</>
+	);
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/index.js
@@ -42,3 +42,4 @@ export {default as ImportDataDefinitionModal} from './modals/ImportDataDefinitio
 export {default as ImportScript} from './configuration/icon/ImportScript';
 export {default as ImageInput} from './ImageInput.es';
 export {default as showWarningAlert} from './showWarningAlert';
+export {default as UndoRedo} from './UndoRedo';

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -190,6 +190,44 @@ autoSaveAsDraftTest(
 	}
 );
 
+autoSaveAsDraftTest(
+	'LPD-26863: Undo/Redo buttons work with metadata fields',
+	async ({journalEditArticlePage, page, site}) => {
+		const changesSavedIndicator = await page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
+		);
+		const redoButton = page.getByTitle('Redo', {exact: true});
+		const title = getRandomString();
+		const undobutton = page.getByTitle('Undo', {exact: true});
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await journalEditArticlePage.titlePlaceholder.click();
+
+		await page.waitForTimeout(200);
+
+		await journalEditArticlePage.titlePlaceholder.fill(title);
+
+		await expect(changesSavedIndicator).toBeVisible();
+
+		await page.locator('body').click();
+
+		await undobutton.click();
+
+		await expect(undobutton).toBeDisabled();
+
+		await expect(journalEditArticlePage.titlePlaceholder).toHaveValue('');
+
+		await redoButton.click();
+
+		await expect(redoButton).toBeDisabled();
+
+		await expect(journalEditArticlePage.titlePlaceholder).toHaveValue(
+			title
+		);
+	}
+);
+
 keepTitlesUntranslated(
 	'LPD-20723: Clay link is translating asset titles/names by default in vertical card',
 	async ({apiHelpers, journalPage, page, site}) => {

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -29,6 +29,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 					cssClass='<%= "language-value " + cssClass %>'
 					editorName="<%= editorName %>"
 					name="<%= inputEditorName %>"
+					onBlurMethod='<%= randomNamespace + "onBlurMethod" %>'
 					onChangeMethod='<%= randomNamespace + "onChangeEditor" %>'
 					onInitMethod='<%= randomNamespace + "onInitEditor" %>'
 					placeholder="<%= placeholder %>"
@@ -36,12 +37,25 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 				/>
 
 				<aui:script>
+					var edited = false;
+
+					function <%= namespace + randomNamespace %>onBlurMethod() {
+						if (edited && Liferay.FeatureFlags['LPD-11228']) {
+							edited = false;
+
+							Liferay.fire('journal:storeState', {fieldName: "<%= inputEditorName %>"});
+						}
+					}
+
 					function <%= namespace + randomNamespace %>onChangeEditor() {
+						if (Liferay.FeatureFlags['LPD-11228']) edited = true;
+
 						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
 
 						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
 
 						inputLocalized.updateInputLanguage(editor.getHTML());
+
 					}
 
 					function <%= namespace + randomNamespace %>onInitEditor() {


### PR DESCRIPTION
Create UndoRedo Component for meta fields

# What is this trying to solve?

Create Undo and Redo buttons, in this PR at the moment we only include this functionality to Metadata fields.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-26863)

# How am I fixing it?

1. The first thign done in this pr is to change the FF from old LPS-141392 to new LPD-11228 to avoid confusion between them.
2. Created Undo/redo component, responsible for storing and restoring the state of metadataFields and firing the undo redo events.
3. Modifying input_localized to fire the autoSave event onblur, when a change is registered.
4. [In this commit](https://github.com/liferay-content-management/liferay-portal/pull/5559/commits/be825ea133c6cb0d071ade921c8b0b2f078af098) I have removed the code as it didn't let us to publish the Web Content.

# How can I test it?

1. Enable FFs 
`feature.flag.LPD-11228=true
feature.flag.LPD-15596=true`
2. Create a Web Content 
3. Fill the title and click outside title input
4. See Undo button enables > Click on it
5. See Redo button enables > Click on it

# Note

The changes in `frontend-js-aui-web`  have been reviewed by FEI team in this PR: https://github.com/liferay-frontend/liferay-portal/pull/4223
