### PR TITLE
LPD-28338 Add test for LPS-166010 Upgraded structures are not getting imported

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
@@ -13,6 +13,7 @@ import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -22,6 +23,8 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -45,6 +48,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +69,11 @@ public class ImportDataDefinitionMVCActionCommandTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
 
 	@Test
 	public void testDataLayoutFieldNamesAreEqualToDataDefinitionFieldNames()
@@ -380,8 +389,8 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		Page<DataDefinition> page =
 			dataDefinitionResource.
 				getSiteDataDefinitionByContentTypeContentTypePage(
-					TestPropsValues.getGroupId(), "journal",
-					"Imported Structure", Pagination.of(1, 1), null);
+					_group.getGroupId(), "journal", "Imported Structure",
+					Pagination.of(1, 1), null);
 
 		List<DataDefinition> items = (List<DataDefinition>)page.getItems();
 
@@ -397,7 +406,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 
 		themeDisplay.setLayout(layout);
 
-		themeDisplay.setScopeGroupId(TestPropsValues.getGroupId());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
 		themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
 		themeDisplay.setUser(TestPropsValues.getUser());
 
@@ -437,6 +446,9 @@ public class ImportDataDefinitionMVCActionCommandTest {
 
 	@Inject
 	private File _file;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject(filter = "mvc.command.name=/journal/import_data_definition")
 	private MVCActionCommand _mvcActionCommand;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
@@ -178,6 +178,33 @@ public class ImportDataDefinitionMVCActionCommandTest {
 	}
 
 	@Test
+	public void testProcessActionWithFieldNamesWithoutRandomDigits()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_createMockLiferayPortletActionRequest(
+				"valid_data_definition_with_field_names_without_random_" +
+					"digits.json",
+				"Imported Structure");
+
+		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Assert.assertNotNull(
+			SessionMessages.get(
+				mockLiferayPortletActionRequest,
+				_portal.getPortletId(mockLiferayPortletActionRequest) +
+					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE));
+		Assert.assertNotNull(
+			SessionMessages.get(
+				mockLiferayPortletActionRequest,
+				"importDataDefinitionSuccessMessage"));
+	}
+
+	@Test
 	public void testProcessActionWithInvalidDataDefinition() throws Exception {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_createMockLiferayPortletActionRequest(

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/valid_data_definition_with_field_names_without_random_digits.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/valid_data_definition_with_field_names_without_random_digits.json
@@ -1,0 +1,258 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataType": "string",
+				"direction": [
+					"vertical"
+				],
+				"displayStyle": "singleline",
+				"fieldNamespace": "",
+				"fieldReference": "Text12293201",
+				"hideField": false,
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"objectFieldName": "",
+				"options": {
+				},
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Text"
+			},
+			"localizable": true,
+			"name": "Text12293201",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"collapsible": false,
+				"ddmStructureId": "",
+				"ddmStructureLayoutId": "",
+				"fieldReference": "FieldsGroup19507604",
+				"labelAtStructureLevel": true,
+				"rows": [
+					{
+						"columns": [
+							{
+								"fields": [
+									"Numeric34461674"
+								],
+								"size": 5
+							},
+							{
+								"fields": [
+									"Date46675757"
+								],
+								"size": 7
+							}
+						]
+					}
+				],
+				"upgradedStructure": false
+			},
+			"defaultValue": {
+			},
+			"fieldType": "fieldset",
+			"indexable": false,
+			"label": {
+				"en_US": "Fields Group"
+			},
+			"localizable": false,
+			"name": "FieldsGroup19507604",
+			"nestedDataDefinitionFields": [
+				{
+					"customProperties": {
+						"characterOptions": false,
+						"confirmationErrorMessage": {
+							"en_US": ""
+						},
+						"confirmationLabel": {
+							"en_US": ""
+						},
+						"dataType": "integer",
+						"direction": [
+							"vertical"
+						],
+						"fieldNamespace": "",
+						"fieldReference": "Numeric34461674",
+						"hideField": false,
+						"inputMask": false,
+						"inputMaskFormat": {
+							"en_US": ""
+						},
+						"labelAtStructureLevel": true,
+						"nativeField": false,
+						"numericInputMask": {
+							"en_US": {
+								"append": "",
+								"appendType": "prefix",
+								"symbols": {
+									"decimalSymbol": ".",
+									"thousandsSeparator": "none"
+								}
+							}
+						},
+						"objectFieldName": "",
+						"placeholder": {
+							"en_US": ""
+						},
+						"requireConfirmation": false,
+						"requiredErrorMessage": {
+							"en_US": ""
+						},
+						"tooltip": {
+							"en_US": ""
+						},
+						"visibilityExpression": ""
+					},
+					"defaultValue": {
+						"en_US": ""
+					},
+					"fieldType": "numeric",
+					"indexType": "keyword",
+					"indexable": true,
+					"label": {
+						"en_US": "Numeric"
+					},
+					"localizable": true,
+					"name": "Numeric34461674",
+					"nestedDataDefinitionFields": [
+					],
+					"readOnly": false,
+					"repeatable": false,
+					"required": false,
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					}
+				},
+				{
+					"customProperties": {
+						"dataType": "date",
+						"fieldNamespace": "",
+						"fieldReference": "Date46675757",
+						"labelAtStructureLevel": true,
+						"nativeField": false,
+						"objectFieldName": "",
+						"requiredErrorMessage": {
+							"en_US": ""
+						},
+						"visibilityExpression": ""
+					},
+					"defaultValue": {
+						"en_US": ""
+					},
+					"fieldType": "date",
+					"indexType": "keyword",
+					"indexable": true,
+					"label": {
+						"en_US": "Date"
+					},
+					"localizable": true,
+					"name": "Date46675757",
+					"nestedDataDefinitionFields": [
+					],
+					"readOnly": false,
+					"repeatable": false,
+					"required": false,
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					}
+				}
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+			}
+		}
+	],
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Text12293201"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"FieldsGroup19507604"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "Exported Structure"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "Exported Structure"
+	},
+	"storageType": "default"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-28338

# What is this trying to solve?

Add test to test https://liferay.atlassian.net/browse/LPS-166010. Add test for use case when we are importing a json structure and the fields do not have the 8 random digits like in 7.4.x because they come from 7.3.x. 

# How am I fixing it?

Adding the test to test the fix

# How can you verify that it works?

Run the included tests.
