### PR TITLE
LPD-28452 should only create one draft even with a scheduled file

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -7,7 +7,7 @@ package com.liferay.document.library.app.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetEntry;
-import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.document.library.app.service.test.util.DLAppServiceTestUtil;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -15,10 +15,9 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
-import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.store.DLStore;
 import com.liferay.document.library.kernel.store.DLStoreRequest;
-import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.string.StringPool;
@@ -38,6 +37,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
@@ -91,7 +91,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileVersion fileVersion = fileEntry.getLatestFileVersion();
 
-		AssetEntry latestAssetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry latestAssetEntry = _assetEntryLocalService.fetchEntry(
 			DLFileEntryConstants.getClassName(),
 			fileVersion.getFileVersionId());
 
@@ -100,7 +100,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		AssertUtils.assertEqualsSorted(
 			assetTagNames, latestAssetEntry.getTagNames());
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		Assert.assertNotNull(assetEntry);
@@ -139,7 +139,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 
 		FileVersion fileVersion = fileEntry.getLatestFileVersion();
 
-		AssetEntry latestAssetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry latestAssetEntry = _assetEntryLocalService.fetchEntry(
 			DLFileEntryConstants.getClassName(),
 			fileVersion.getFileVersionId());
 
@@ -148,7 +148,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		AssertUtils.assertEqualsSorted(
 			assetTagNames, latestAssetEntry.getTagNames());
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		Assert.assertNotNull(assetEntry);
@@ -180,7 +180,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			DLVersionNumberIncrease.MINOR, bytes, null, null, null,
 			serviceContext);
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		AssertUtils.assertEqualsSorted(assetTagNames, assetEntry.getTagNames());
@@ -193,19 +193,19 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
-		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+		FileEntry fileEntry = dlAppService.addFileEntry(
 			null, group.getGroupId(), parentFolder.getFolderId(),
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
 			RandomTestUtil.randomString(), null, null, null,
 			new UnsyncByteArrayInputStream(CONTENT.getBytes()),
 			CONTENT.length(), null, null, null, serviceContext);
 
-		DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.getDLFileEntry(
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
 			fileEntry.getFileEntryId());
 
 		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
-		DLStoreUtil.updateFile(
+		_dlStore.updateFile(
 			DLStoreRequest.builder(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName()
@@ -213,7 +213,7 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 				dlFileVersion.getVersion()
 			).build(),
 			new UnsyncByteArrayInputStream(CONTENT.getBytes()));
-		DLStoreUtil.deleteFile(
+		_dlStore.deleteFile(
 			dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
 
@@ -487,5 +487,14 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			DLVersionNumberIncrease.MAJOR, null, 0, null, null, null,
 			serviceContext);
 	}
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLStore _dlStore;
 
 }

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenUpdatingAFileEntryTest.java
@@ -488,6 +488,70 @@ public class DLAppServiceWhenUpdatingAFileEntryTest extends BaseDLAppTestCase {
 			serviceContext);
 	}
 
+	@Test
+	public void testUpdateFileEntryPublishingAFileShouldOnlyHaveOneAssetEntryFromDrafts()
+		throws Exception {
+
+		_testUpdateFileEntryShouldOnlyHaveOneAssetEntryFromDrafts(null);
+	}
+
+	@Test
+	public void testUpdateFileEntrySchedulingAFileShouldOnlyHaveOneAssetEntryFromDrafts()
+		throws Exception {
+
+		_testUpdateFileEntryShouldOnlyHaveOneAssetEntryFromDrafts(
+			new Date(System.currentTimeMillis() + Time.DAY));
+	}
+
+	private void _testUpdateFileEntryShouldOnlyHaveOneAssetEntryFromDrafts(
+			Date displayDate)
+		throws Exception {
+
+		String fileName = RandomTestUtil.randomString();
+		byte[] bytes = CONTENT.getBytes();
+
+		FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			parentFolder.getFolderId(), fileName, fileName, displayDate, null,
+			null, null);
+
+		int initialAssetEntriesCount =
+			_assetEntryLocalService.getAssetEntriesCount();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MINOR, bytes, displayDate,
+			null, null, serviceContext);
+
+		dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MINOR, bytes, displayDate,
+			null, null, serviceContext);
+
+		Assert.assertEquals(
+			initialAssetEntriesCount + 1,
+			_assetEntryLocalService.getAssetEntriesCount());
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), fileName, ContentTypes.TEXT_PLAIN,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.MINOR, bytes, displayDate,
+			null, null, serviceContext);
+
+		Assert.assertEquals(
+			initialAssetEntriesCount,
+			_assetEntryLocalService.getAssetEntriesCount());
+	}
+
 	@Inject
 	private AssetEntryLocalService _assetEntryLocalService;
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -473,7 +473,8 @@ public class DLAppHelperLocalServiceImpl
 			if (dlFileVersion.isApproved()) {
 				visible = true;
 			}
-			else {
+
+			if (!dlFileVersion.isApproved() && !dlFileVersion.isScheduled()) {
 				String version = dlFileVersion.getVersion();
 
 				if (!version.equals(DLFileEntryConstants.VERSION_DEFAULT)) {


### PR DESCRIPTION
LPD-26922 Check document workflow after revert of a commit from LPD-19196

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26922

After the changes made on https://github.com/liferay-content-management/liferay-portal/pull/5482/ we should check what were the intention of the original code and check if after the revert the changes are ok.

# How am I fixing it?

We realized that on scheduling a file, we where creating several drafts so we added that option on the code.

# How can you verify that it works?

Run the included automated tests.

For the https://liferay.atlassian.net/browse/LPD-26758 the execution of the Poshi test :  DepotWorkflow#CanRejectAndResubmitImage is enough 

# Commits


- **LPD-26922 use injection instead of Utils**
- **LPD-26922 add test to check that when updating a file, only one draft asset entry is created , if it is scheduled or published**
- **LPD-26922 do not create a draft assetEntry if there is an exiting one even if is scheduled**
