### PR TITLE
LPD-22238  Asset Library: Cannot configure mimetype limits for DM

### DIFF
--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/FileSizePerMimeType.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/FileSizePerMimeType.js
@@ -1,8 +1,0 @@
-/**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
- */
-
-import {FileSizePerMimeType} from '@liferay/document-library-web';
-
-export default FileSizePerMimeType;

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/index.js
@@ -9,6 +9,5 @@ export {default as DepotAdminManagementToolbarPropsTransformer} from './DepotAdm
 export {default as DepotEntryDropdownDefaultEventHandler} from './DepotEntryDropdownDefaultEventHandler.es';
 export {default as DepotEntryDropdownPropsTransformer} from './DepotEntryDropdownPropsTransformer';
 export {default as DepotRoles} from './DepotRoles';
-export {default as FileSizePerMimeType} from './FileSizePerMimeType';
 export {default as Languages} from './Languages.es';
 export {default as StagingIndicator} from './StagingIndicator';

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/documents_and_media.jsp
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/screen/navigation/entries/documents_and_media.jsp
@@ -30,7 +30,7 @@ DepotAdminDLDisplayContext depotAdminDLDisplayContext = (DepotAdminDLDisplayCont
 				<span aria-hidden="true" class="loading-animation"></span>
 
 				<react:component
-					module="{FileSizePerMimeType} from depot-web"
+					module="{FileSizeMimetypes} from document-library-web"
 					props="<%= depotAdminDLDisplayContext.getFileSizePerMimeTypeData() %>"
 				/>
 			</div>


### PR DESCRIPTION
[LPD-22238](https://liferay.atlassian.net/browse/LPD-22238)
What is this trying to solve?
The FileSizeMimetypes react component did not load properly

[Link to ticket](https://liferay.atlassian.net/browse/LPD-26863)

How am I fixing it?
I imported the module directly from document-library-web

How can I test it?
follow ticket description

Why no test?
I had to fix an import there is no additional business logic that needs to be tested here, the component is covered by
LocalFile.DepotMimeTypeLimits#ALTakesEffectOverInstanceLimit
LocalFile.DepotMimeTypeLimits#CanLimitMultipleMimeTypesSize
LocalFile.DepotMimeTypeLimits#CanLimitSizeOnlyInCurrentDepot
LocalFile.DepotMimeTypeLimits#SystemTakesEffectOverALLimit