### PR TITLE
LPD-28541 Fix KBArticle.viewInfoPanel paths ->  LocalFile.KBArticle tests failures 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
@@ -142,7 +142,7 @@
 
 <tr>
 	<td>INFO_TITLE</td>
-	<td>//div[@class='sidebar-header']//div[contains(@class,'component-title')]</td>
+	<td>//div[@class= 'info-panel-content']//div[@class='sidebar-header']//div[contains(@class,'component-title')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
LPD-28541 update the path por the info title to be more precise

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28533 

The path of the title of the info view column is not found after changing the h4 element. 

# How am I fixing it?

Refine the path of the title element of the info view column

# How can you verify that it works?

Run the included automated tests.

