### PR TITLE
LPD-26755 The URL redirects to the correct language when a category has a translation

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -11,7 +11,7 @@ interface postVocabularyProps {
 	siteId: string;
 }
 
-interface postCategoryProps {
+export interface postCategoryProps {
 	name: string;
 	name_i18n?: {['ES-es']: string};
 	vocabularyId: number;

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -44,7 +44,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param [assetTypes] the asset types to which the vocabulary can be used
 	 */
 
-	async postVocabulary({
+	async postSiteTaxonomyVocabulary({
 		assetTypes,
 		name,
 		siteId,
@@ -62,7 +62,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param vocabularyId the parent vocabulary id
 	 */
 
-	async postCategory({
+	async postTaxonomyVocabularyTaxonomyCategory({
 		name,
 		name_i18n,
 		vocabularyId,
@@ -74,13 +74,16 @@ export class HeadlessAdminTaxonomyApiHelper {
 	}
 
 	/**
-	 * It allows update a category name
+	 * It allows partially update a category name
 	 *
 	 * @param name the new name of the category
 	 * @param id the category id
 	 */
 
-	async patchCategory({id, name}: patchCategoryProps): Promise<{id: number}> {
+	async patchTaxonomyCategory({
+		id,
+		name,
+	}: patchCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.patch(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-categories/${id}`,
 			{name}
@@ -94,7 +97,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param siteId the id of the site in which the tag will be created
 	 */
 
-	async postTag({name, siteId}: postTagProps): Promise<{id: number}> {
+	async postSiteKeyword({name, siteId}: postTagProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/keywords`,
 			{data: {name}}
@@ -107,7 +110,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param id the id of the tag
 	 */
 
-	async deleteTag({id}: {id: number}) {
+	async deleteKeyword({id}: {id: number}) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/keywords/${id}`
 		);

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -13,6 +13,7 @@ interface postVocabularyProps {
 
 interface postCategoryProps {
 	name: string;
+	name_i18n?: {['ES-es']: string};
 	vocabularyId: number;
 }
 
@@ -63,11 +64,12 @@ export class HeadlessAdminTaxonomyApiHelper {
 
 	async postCategory({
 		name,
+		name_i18n,
 		vocabularyId,
 	}: postCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
-			{data: {name}}
+			{data: {name, name_i18n}}
 		);
 	}
 

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -5,24 +5,24 @@
 
 import {ApiHelpers} from './ApiHelpers';
 
-interface postVocabularyProps {
+interface postSiteTaxonomyVocabularyProps {
 	assetTypes?: AssetType[];
 	name: string;
 	siteId: string;
 }
 
-export interface postCategoryProps {
+export interface postTaxonomyVocabularyTaxonomyCategoryProps {
 	name: string;
 	name_i18n?: {['ES-es']: string};
 	vocabularyId: number;
 }
 
-interface patchCategoryProps {
+interface patchTaxonomyCategoryProps {
 	id: number;
 	name: string;
 }
 
-interface postTagProps {
+interface postSiteKeywordProps {
 	name: string;
 	siteId: string;
 }
@@ -48,7 +48,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 		assetTypes,
 		name,
 		siteId,
-	}: postVocabularyProps): Promise<{id: number}> {
+	}: postSiteTaxonomyVocabularyProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/taxonomy-vocabularies`,
 			{data: {assetTypes, name}}
@@ -66,7 +66,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 		name,
 		name_i18n,
 		vocabularyId,
-	}: postCategoryProps): Promise<{id: number}> {
+	}: postTaxonomyVocabularyTaxonomyCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
 			{data: {name, name_i18n}}
@@ -83,7 +83,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	async patchTaxonomyCategory({
 		id,
 		name,
-	}: patchCategoryProps): Promise<{id: number}> {
+	}: patchTaxonomyCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.patch(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-categories/${id}`,
 			{name}
@@ -97,7 +97,10 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 * @param siteId the id of the site in which the tag will be created
 	 */
 
-	async postSiteKeyword({name, siteId}: postTagProps): Promise<{id: number}> {
+	async postSiteKeyword({
+		name,
+		siteId,
+	}: postSiteKeywordProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/keywords`,
 			{data: {name}}

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -228,7 +228,7 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 
 	await test.step('Check redirection and edited category in the initial friendly URL', async () => {
 		friendlyUrlCategories[0].name = `${friendlyUrlCategories[0].name}-edited`;
-		await apiHelpers.headlessAdminTaxonomy.patchCategory({
+		await apiHelpers.headlessAdminTaxonomy.patchTaxonomyCategory({
 			id: categories[0].id,
 			name: friendlyUrlCategories[0].name,
 		});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -72,7 +72,11 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	site,
 }) => {
 	const vocabularyName = getRandomString();
-	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
+	const friendlyUrlCategories = [
+		{name: 'category-1'},
+		{name: 'category-2'},
+		{name: 'category-3'},
+	];
 
 	await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
@@ -90,13 +94,18 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		friendlyUrl: {
+			categories: friendlyUrlCategories.map(({name}) => name),
+			vocabularyName,
+		},
 		publish: false,
 		title,
 	});
 
 	await expect(
-		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
+		page.getByText(
+			`/-/blogs/${friendlyUrlCategories.map(({name}) => name).join('/')}/`
+		)
 	).toBeVisible();
 
 	await blogsEditBlogEntryPage.publishBlogEntry();
@@ -104,9 +113,9 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
 
 	await expect(response.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
-			'/'
-		)}/${title}`
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+			.map(({name}) => name)
+			.join('/')}/${title}`
 	);
 });
 
@@ -119,7 +128,11 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 	site,
 }) => {
 	const vocabularyName = getRandomString();
-	const friendlyUrlCategories = ['category 1', 'category 2', 'category 3'];
+	const friendlyUrlCategories = [
+		{name: 'category 1'},
+		{name: 'category 2'},
+		{name: 'category 3'},
+	];
 
 	await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
@@ -137,7 +150,10 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		friendlyUrl: {
+			categories: friendlyUrlCategories.map(({name}) => name),
+			vocabularyName,
+		},
 		publish: true,
 		title,
 	});
@@ -146,7 +162,7 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 
 	await expect(response.url()).toContain(
 		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
-			.map((category) => encodeURIComponent(category))
+			.map(({name}) => encodeURIComponent(name))
 			.join('/')}/${title}`
 	);
 });
@@ -160,7 +176,11 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 	site,
 }) => {
 	const vocabularyName = getRandomString();
-	const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
+	const friendlyUrlCategories = [
+		{name: 'category-1'},
+		{name: 'category-2'},
+		{name: 'category-3'},
+	];
 
 	const {categories} = await blogsCategorizedFriendlyUrlSetup({
 		apiHelpers,
@@ -178,7 +198,10 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		friendlyUrl: {
+			categories: friendlyUrlCategories.map(({name}) => name),
+			vocabularyName,
+		},
 		publish: true,
 		title,
 	});
@@ -187,20 +210,69 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 		`/web${site.friendlyUrlPath}/b/${title}`
 	);
 	await expect(initialResponse.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
-			'/'
-		)}/${title}`
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+			.map(({name}) => name)
+			.join('/')}/${title}`
 	);
 
-	friendlyUrlCategories[0] = `${friendlyUrlCategories[0]}-edited`;
+	friendlyUrlCategories[0].name = `${friendlyUrlCategories[0].name}-edited`;
 	await apiHelpers.headlessAdminTaxonomy.patchCategory({
 		id: categories[0].id,
-		name: friendlyUrlCategories[0],
+		name: friendlyUrlCategories[0].name,
 	});
 	const editedResponse = await page.goto(initialResponse.url());
 	await expect(editedResponse.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
-			'/'
-		)}/${title}`
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+			.map(({name}) => name)
+			.join('/')}/${title}`
+	);
+});
+
+test('LPD-26755 The URL redirects to the correct language when a category has a translation', async ({
+	apiHelpers,
+	blogsEditBlogEntryPage,
+	displayPageTemplatesPage,
+	page,
+	pageEditorPage,
+	site,
+}) => {
+	const vocabularyName = getRandomString();
+	const friendlyUrlCategories = [
+		{name: 'lifestyle', name_i18n: {['ES-es']: 'estilo-de-vida'}},
+		{name: 'fashion', name_i18n: {['ES-es']: 'moda'}},
+		{name: 'places', name_i18n: {['ES-es']: 'lugares'}},
+	];
+
+	await blogsCategorizedFriendlyUrlSetup({
+		apiHelpers,
+		displayPageTemplatesPage,
+		friendlyUrlCategories,
+		page,
+		pageEditorPage,
+		site,
+		vocabularyName,
+	});
+
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {
+			categories: friendlyUrlCategories.map(({name}) => name),
+			vocabularyName,
+		},
+		publish: true,
+		title,
+	});
+
+	const response = await page.goto(
+		`/es/web${site.friendlyUrlPath}/b/${title}`
+	);
+	await expect(response.url()).toContain(
+		`/es/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+			.map((category) => category.name_i18n['ES-es'])
+			.join('/')}/${title}`
 	);
 });

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -102,21 +102,29 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 		title,
 	});
 
-	await expect(
-		page.getByText(
-			`/-/blogs/${friendlyUrlCategories.map(({name}) => name).join('/')}/`
-		)
-	).toBeVisible();
+	await test.step('Check input addon categories preview', async () => {
+		await expect(
+			page.getByText(
+				`/-/blogs/${friendlyUrlCategories
+					.map(({name}) => name)
+					.join('/')}/`
+			)
+		).toBeVisible();
+	});
 
-	await blogsEditBlogEntryPage.publishBlogEntry();
+	await test.step('Check categories in friendly URL', async () => {
+		await blogsEditBlogEntryPage.publishBlogEntry();
 
-	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
+		const response = await page.goto(
+			`/web${site.friendlyUrlPath}/b/${title}`
+		);
 
-	await expect(response.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
-			.map(({name}) => name)
-			.join('/')}/${title}`
-	);
+		await expect(response.url()).toContain(
+			`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+				.map(({name}) => name)
+				.join('/')}/${title}`
+		);
+	});
 });
 
 test('LPD-24858 Categories with blank spaces in friendly URL', async ({
@@ -209,23 +217,29 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 	const initialResponse = await page.goto(
 		`/web${site.friendlyUrlPath}/b/${title}`
 	);
-	await expect(initialResponse.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
-			.map(({name}) => name)
-			.join('/')}/${title}`
-	);
 
-	friendlyUrlCategories[0].name = `${friendlyUrlCategories[0].name}-edited`;
-	await apiHelpers.headlessAdminTaxonomy.patchCategory({
-		id: categories[0].id,
-		name: friendlyUrlCategories[0].name,
+	await test.step('Check categories in friendly URL', async () => {
+		await expect(initialResponse.url()).toContain(
+			`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+				.map(({name}) => name)
+				.join('/')}/${title}`
+		);
 	});
-	const editedResponse = await page.goto(initialResponse.url());
-	await expect(editedResponse.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
-			.map(({name}) => name)
-			.join('/')}/${title}`
-	);
+
+	await test.step('Check redirection and edited category in the initial friendly URL', async () => {
+		friendlyUrlCategories[0].name = `${friendlyUrlCategories[0].name}-edited`;
+		await apiHelpers.headlessAdminTaxonomy.patchCategory({
+			id: categories[0].id,
+			name: friendlyUrlCategories[0].name,
+		});
+
+		const editedResponse = await page.goto(initialResponse.url());
+		await expect(editedResponse.url()).toContain(
+			`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories
+				.map(({name}) => name)
+				.join('/')}/${title}`
+		);
+	});
 });
 
 test('LPD-26755 The URL redirects to the correct language when a category has a translation', async ({

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -95,7 +95,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
 		friendlyUrl: {
-			categories: friendlyUrlCategories.map(({name}) => name),
+			categories: friendlyUrlCategories,
 			vocabularyName,
 		},
 		publish: false,
@@ -151,7 +151,7 @@ test('LPD-24858 Categories with blank spaces in friendly URL', async ({
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
 		friendlyUrl: {
-			categories: friendlyUrlCategories.map(({name}) => name),
+			categories: friendlyUrlCategories,
 			vocabularyName,
 		},
 		publish: true,
@@ -199,7 +199,7 @@ test('LPD-26753 The URL changes when a category is modified', async ({
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
 		friendlyUrl: {
-			categories: friendlyUrlCategories.map(({name}) => name),
+			categories: friendlyUrlCategories,
 			vocabularyName,
 		},
 		publish: true,
@@ -260,7 +260,7 @@ test('LPD-26755 The URL redirects to the correct language when a category has a 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
 		friendlyUrl: {
-			categories: friendlyUrlCategories.map(({name}) => name),
+			categories: friendlyUrlCategories,
 			vocabularyName,
 		},
 		publish: true,

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -8,10 +8,10 @@ import {Locator, Page} from '@playwright/test';
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import {BlogsPage} from './BlogsPage';
 
-import type {postCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
+import type {postTaxonomyVocabularyTaxonomyCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
 
 type editBlogEntryAddfriendlyUrlType = {
-	categories: Pick<postCategoryProps, 'name'>[];
+	categories: Pick<postTaxonomyVocabularyTaxonomyCategoryProps, 'name'>[];
 	vocabularyName: string;
 };
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -8,8 +8,10 @@ import {Locator, Page} from '@playwright/test';
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import {BlogsPage} from './BlogsPage';
 
+import type {postCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
+
 type editBlogEntryAddfriendlyUrlType = {
-	categories: string[];
+	categories: Pick<postCategoryProps, 'name'>[];
 	vocabularyName: string;
 };
 
@@ -56,8 +58,8 @@ export class BlogsEditBlogEntryPage {
 
 		await categoriesSelectorIframe.getByText(vocabularyName).click();
 
-		for (const categoryName of categories) {
-			await categoriesSelectorIframe.getByText(categoryName).click();
+		for (const {name} of categories) {
+			await categoriesSelectorIframe.getByText(name).click();
 		}
 
 		await this.page

--- a/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
@@ -4,7 +4,7 @@
  */
 
 import {createAssetPublisherAndConfigure} from './createAssetPublisherAndConfigure';
-import {createCategories} from './createCategories';
+import {TCategory, createCategories} from './createCategories';
 import {createDPTandMarkAsDefault} from './createDPTandMarkAsDefault';
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
@@ -22,7 +22,7 @@ export async function blogsCategorizedFriendlyUrlSetup({
 }: {
 	apiHelpers: ApiHelpers;
 	displayPageTemplatesPage: DisplayPageTemplatesPage;
-	friendlyUrlCategories: {name: string; name_i18n?: {'ES-es': string}}[];
+	friendlyUrlCategories: TCategory[];
 	page;
 	pageEditorPage: PageEditorPage;
 	site: Site;

--- a/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
@@ -22,7 +22,7 @@ export async function blogsCategorizedFriendlyUrlSetup({
 }: {
 	apiHelpers: ApiHelpers;
 	displayPageTemplatesPage: DisplayPageTemplatesPage;
-	friendlyUrlCategories: string[];
+	friendlyUrlCategories: {name: string; name_i18n?: {'ES-es': string}}[];
 	page;
 	pageEditorPage: PageEditorPage;
 	site: Site;

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -4,6 +4,9 @@
  */
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
+import type {postCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
+
+export type TCategory = Omit<postCategoryProps, 'vocabularyId'>;
 
 export async function createCategories({
 	apiHelpers,
@@ -12,13 +15,10 @@ export async function createCategories({
 	vocabularyName,
 }: {
 	apiHelpers: ApiHelpers;
-	friendlyUrlCategories: {
-		name: string;
-		name_i18n?: {'ES-es': string};
-	}[];
+	friendlyUrlCategories: TCategory[];
 	site: Site;
 	vocabularyName: string;
-}): Promise<{id: number; name: string}[]> {
+}): Promise<({id: number} & TCategory)[]> {
 	const {id: vocabularyId} =
 		await apiHelpers.headlessAdminTaxonomy.postVocabulary({
 			name: vocabularyName,
@@ -36,6 +36,7 @@ export async function createCategories({
 		categories.push({
 			id,
 			name,
+			name_i18n,
 		});
 	}
 

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -20,18 +20,21 @@ export async function createCategories({
 	vocabularyName: string;
 }): Promise<({id: number} & TCategory)[]> {
 	const {id: vocabularyId} =
-		await apiHelpers.headlessAdminTaxonomy.postVocabulary({
+		await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
 			name: vocabularyName,
 			siteId: site.id,
 		});
 
 	const categories = [];
 	for (const {name, name_i18n} of friendlyUrlCategories) {
-		const {id} = await apiHelpers.headlessAdminTaxonomy.postCategory({
-			name,
-			name_i18n,
-			vocabularyId,
-		});
+		const {id} =
+			await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+				{
+					name,
+					name_i18n,
+					vocabularyId,
+				}
+			);
 
 		categories.push({
 			id,

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -4,9 +4,12 @@
  */
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
-import type {postCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
+import type {postTaxonomyVocabularyTaxonomyCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
 
-export type TCategory = Omit<postCategoryProps, 'vocabularyId'>;
+export type TCategory = Omit<
+	postTaxonomyVocabularyTaxonomyCategoryProps,
+	'vocabularyId'
+>;
 
 export async function createCategories({
 	apiHelpers,

--- a/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createCategories.ts
@@ -12,7 +12,10 @@ export async function createCategories({
 	vocabularyName,
 }: {
 	apiHelpers: ApiHelpers;
-	friendlyUrlCategories: string[];
+	friendlyUrlCategories: {
+		name: string;
+		name_i18n?: {'ES-es': string};
+	}[];
 	site: Site;
 	vocabularyName: string;
 }): Promise<{id: number; name: string}[]> {
@@ -23,9 +26,10 @@ export async function createCategories({
 		});
 
 	const categories = [];
-	for (const name of friendlyUrlCategories) {
+	for (const {name, name_i18n} of friendlyUrlCategories) {
 		const {id} = await apiHelpers.headlessAdminTaxonomy.postCategory({
 			name,
+			name_i18n,
 			vocabularyId,
 		});
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilter.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/collectionFilter.spec.ts
@@ -202,7 +202,7 @@ testWithIsolatedSite(
 
 		for (const tagName of ['Dogs', 'Cats']) {
 			tags.push(
-				await apiHelpers.headlessAdminTaxonomy.postTag({
+				await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
 					name: tagName,
 					siteId: site.id,
 				})

--- a/modules/test/playwright/tests/layout-content-page-editor-web/tagsFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/tagsFragment.spec.ts
@@ -88,7 +88,7 @@ test('uses Tags fragment for Forms in a Content Page', async ({
 	// Create two tags in Wem Site
 
 	for (const tagName of ['Dogs', 'Cats']) {
-		await apiHelpers.headlessAdminTaxonomy.postTag({
+		await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
 			name: tagName,
 			siteId: wemSite.id,
 		});
@@ -98,7 +98,7 @@ test('uses Tags fragment for Forms in a Content Page', async ({
 
 	const globalSiteId = await getGlobalSiteId(apiHelpers);
 
-	const globalTag = await apiHelpers.headlessAdminTaxonomy.postTag({
+	const globalTag = await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
 		name: 'Rabbits',
 		siteId: globalSiteId,
 	});
@@ -138,7 +138,7 @@ test('uses Tags fragment for Forms in a Content Page', async ({
 
 	// Remove the tag created on Global
 
-	await apiHelpers.headlessAdminTaxonomy.deleteTag({
+	await apiHelpers.headlessAdminTaxonomy.deleteKeyword({
 		id: globalTag.id,
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26755

We are adding a playwright test to check friendly URL redirection to the correct language when a category has a translation

# How am I fixing it?

We are adding a functional test.

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright test -- -g "LPD-26755"` to run the test

# Local test results


## Blogs-web

```sh
npm run playwright test -- --project blogs-web --reporter list
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/41812521-f572-4d6a-94dd-df0989898089)

## Repeat the test

```sh
npm run playwright test -- -g "LPD-26755" --reporter list --repeat-each 10
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/74f823b7-e213-4100-9335-4c453c292f77)

> [!IMPORTANT]  
> Unrelated fail in login

# Screenrecord test execution

[blogEntry-LPD-26755-The-URL-redirects-to-the-correct-language-when-a-category-has-a-translation-blogs-web.webm](https://github.com/liferay-content-management/liferay-portal/assets/67901/5fb43663-2784-4567-8862-2189ab4e0bc6)

# UI Screenshot with visible URL
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/4a27520d-64dd-4e92-82a3-bad7fb241dd5)


---

Added the last commit 099cce86058f00716185e49587c650d5a75582bd to change apiHelpers.headlessAdminTaxonomy to the API ones

For example `postVocabulary` --> `postSiteTaxonomyVocabulary`

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/a5afa9bb-07d8-403f-807c-2dedb0a92ef0)

