### PR TITLE
LPD-28606 Site Owner or Administrator to be able to add new announcement only for the site they are Site Owner/Admin for

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -362,7 +362,11 @@ public class AnnouncementsDisplayContext {
 
 	public boolean hasAddAnnouncementsEntryPermission() {
 		try {
-			if (PortletPermissionUtil.hasControlPanelAccessPermission(
+			if (GroupPermissionUtil.contains(
+					_themeDisplay.getPermissionChecker(),
+					_themeDisplay.getScopeGroupId(),
+					ActionKeys.MANAGE_ANNOUNCEMENTS) ||
+				PortletPermissionUtil.hasControlPanelAccessPermission(
 					_themeDisplay.getPermissionChecker(),
 					_themeDisplay.getScopeGroupId(),
 					AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -360,6 +360,25 @@ public class AnnouncementsDisplayContext {
 		return _UUID;
 	}
 
+	public boolean hasAddAnnouncementsEntryPermission() {
+		try {
+			if (PortletPermissionUtil.hasControlPanelAccessPermission(
+					_themeDisplay.getPermissionChecker(),
+					_themeDisplay.getScopeGroupId(),
+					AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
+
+				return true;
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return false;
+	}
+
 	public boolean isCustomizeAnnouncementsDisplayed() {
 		String portletName = _announcementsRequestHelper.getPortletName();
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view.jsp
@@ -14,7 +14,7 @@
 	/>
 </c:if>
 
-<c:if test="<%= PortletPermissionUtil.hasControlPanelAccessPermission(permissionChecker, scopeGroupId, AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN) %>">
+<c:if test="<%= announcementsDisplayContext.hasAddAnnouncementsEntryPermission() %>">
 	<div class="btn-group c-mb-4">
 		<portlet:renderURL var="addEntryURL">
 			<portlet:param name="mvcRenderCommandName" value="/announcements/edit_entry" />

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/init.jsp
@@ -57,7 +57,6 @@ page import="com.liferay.portal.kernel.service.RoleLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.UserGroupLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.UserLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.permission.PortalPermissionUtil" %><%@
-page import="com.liferay.portal.kernel.service.permission.PortletPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/announcements/announcements-web/src/test/java/com/liferay/announcements/web/internal/AnnouncementsDisplayContextTest.java
+++ b/modules/apps/announcements/announcements-web/src/test/java/com/liferay/announcements/web/internal/AnnouncementsDisplayContextTest.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal;
+
+import com.liferay.announcements.constants.AnnouncementsPortletKeys;
+import com.liferay.announcements.web.internal.display.context.AnnouncementsDisplayContext;
+import com.liferay.announcements.web.internal.display.context.helper.AnnouncementsRequestHelper;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderResponse;
+import com.liferay.segments.SegmentsEntryRetriever;
+import com.liferay.segments.configuration.provider.SegmentsConfigurationProvider;
+import com.liferay.segments.context.RequestContextMapper;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class AnnouncementsDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_groupPermissionUtilMockedStatic = Mockito.mockStatic(
+			GroupPermissionUtil.class);
+		_portletPermissionUtilMockedStatic = Mockito.mockStatic(
+			PortletPermissionUtil.class);
+	}
+
+	@After
+	public void tearDown() {
+		_groupPermissionUtilMockedStatic.close();
+		_portletPermissionUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testHasAddAnnouncementsEntryPermission() {
+		_testHasAddAnnouncementsEntryPermission(false, false, false);
+		_testHasAddAnnouncementsEntryPermission(true, true, false);
+		_testHasAddAnnouncementsEntryPermission(true, false, true);
+	}
+
+	private void _testHasAddAnnouncementsEntryPermission(
+		boolean hasAddAnnouncementsEntryPermission, boolean hasGroupPermission,
+		boolean hasPortletPermission) {
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		long scopeGroupId = RandomTestUtil.randomLong();
+
+		_groupPermissionUtilMockedStatic.when(
+			() -> GroupPermissionUtil.contains(
+				permissionChecker, scopeGroupId,
+				ActionKeys.MANAGE_ANNOUNCEMENTS)
+		).thenReturn(
+			hasGroupPermission
+		);
+
+		_portletPermissionUtilMockedStatic.when(
+			() -> PortletPermissionUtil.hasControlPanelAccessPermission(
+				permissionChecker, scopeGroupId,
+				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)
+		).thenReturn(
+			hasPortletPermission
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getPermissionChecker()
+		).thenReturn(
+			permissionChecker
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroupId()
+		).thenReturn(
+			scopeGroupId
+		);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		AnnouncementsDisplayContext announcementsDisplayContext =
+			new AnnouncementsDisplayContext(
+				Mockito.mock(AnnouncementsRequestHelper.class),
+				mockHttpServletRequest, RandomTestUtil.randomString(),
+				new MockRenderRequest(), new MockRenderResponse(),
+				Mockito.mock(RequestContextMapper.class),
+				Mockito.mock(SegmentsEntryRetriever.class),
+				Mockito.mock(SegmentsConfigurationProvider.class));
+
+		Assert.assertEquals(
+			hasAddAnnouncementsEntryPermission,
+			announcementsDisplayContext.hasAddAnnouncementsEntryPermission());
+	}
+
+	private MockedStatic<GroupPermissionUtil> _groupPermissionUtilMockedStatic;
+	private MockedStatic<PortletPermissionUtil>
+		_portletPermissionUtilMockedStatic;
+
+}


### PR DESCRIPTION
Site Owner or Administrator to be able to add new announcement only for the site they are Site Owner/Admin for

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-28606)

This pull request addresses the issue were a Site Owner or Administrator cannot see the add announcement button when adding an announcement widget to a page

# How am I fixing it?

Taking into account the group permissions when showing the button

# How can you verify that it works?

Follow the steps in the LPD or execute the unit test
