### PR TITLE
LPD-28668 Update success message after FF removal

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/PermissionsInline.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PermissionsInline.macro
@@ -25,7 +25,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "Message#SUCCESS",
-			value1 = "Your request completed successfully.");
+			value1 = "successfully.");
 	}
 
 	@summary = "Default summary"
@@ -76,7 +76,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "Message#SUCCESS",
-			value1 = "Your request completed successfully.");
+			value1 = "successfully.");
 	}
 
 	@summary = "Default summary"
@@ -126,7 +126,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "Message#SUCCESS",
-			value1 = "Your request completed successfully.");
+			value1 = "successfully.");
 	}
 
 	@summary = "Default summary"
@@ -150,7 +150,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "Message#SUCCESS",
-			value1 = "Your request completed successfully.");
+			value1 = "successfully.");
 	}
 
 	@summary = "Default summary"
@@ -178,7 +178,7 @@ definition {
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "Message#SUCCESS",
-			value1 = "Your request completed successfully.");
+			value1 = "successfully.");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
LPD-28668 This is the pull request title

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28668

After the removal of the LPS-196847 Feature Flag on https://liferay.atlassian.net/browse/LPD-28355 , the message of success was dependent of the number of the permission changed

`Your request completed successfully. `or the lang key  `"x-permissions-were-updated-successfully"`

# How am I fixing it?

I'm changing the message to the least common multiple of both messages.

# How can you verify that it works?

Run the included automated tests.