### PR TITLE
LPD-28708 change path for FRAGMENT_SIDEBAR_CENTER_TEXT

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
@@ -659,7 +659,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_CENTER_TEXT</td>
-	<td>//div[contains(@class,'text-center')]//span[@class='text-truncate']</td>
+	<td>//div[contains(@class,'text-center')]//div[@class='c-empty-state-title']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
LPD-28708 change path for FRAGMENT_SIDEBAR_CENTER_TEXT

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28708

After some changes made by Clay team on the ClayEmptyState element the POSHI test are failing so we should change them

# How am I fixing it?

The Path for the element FRAGMENT_SIDEBAR_CENTER_TEXT should be changed

# How can you verify that it works?

Run the included automated tests.
