### PR TITLE
LPD-28832 Apply current build configuration to document-library-opener-google-drive-web module

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/node-scripts.config.js
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/node-scripts.config.js
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: [(c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: [LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+module.exports = {
+	npmscripts: {},
+};

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/package.json
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@liferay/document-library-opener-google-drive-web",
+	"private": true,
+	"scripts": {
+		"build": "node-scripts build",
+		"checkFormat": "node-scripts format --check",
+		"format": "node-scripts format"
+	},
+	"version": "3.0.48"
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,0 +1,32 @@
+{
+	"@generated": "4e37e54a86b1ab0cf1bc53da2a9b670da521909b",
+	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"baseUrl": ".",
+		"checkJs": false,
+		"composite": true,
+		"emitDeclarationOnly": true,
+		"jsx": "react",
+		"module": "es6",
+		"moduleResolution": "node",
+		"sourceMap": false,
+		"strict": true,
+		"target": "es2020",
+		"declarationDir": "../../../../../../../../.tsc/types",
+		"paths": {
+		},
+		"rootDir": "../../../../../../../..",
+		"tsBuildInfoFile": "../../../../../../../../.tsc/buildinfo/@liferay/document-library-opener-google-drive-web.tsbuildinfo",
+		"typeRoots": [
+			"../../../../../../../../node_modules/@types"
+		]
+	},
+	"include": [
+		"**/*.ts",
+		"**/*.tsx",
+		"../../../../../../../../global.d.ts"
+	],
+	"references": [
+	]
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -6,17 +6,17 @@
 		"baseUrl": ".",
 		"checkJs": false,
 		"composite": true,
+		"declarationDir": "../../../../../../../../.tsc/types",
 		"emitDeclarationOnly": true,
 		"jsx": "react",
 		"module": "es6",
 		"moduleResolution": "node",
-		"sourceMap": false,
-		"strict": true,
-		"target": "es2020",
-		"declarationDir": "../../../../../../../../.tsc/types",
 		"paths": {
 		},
 		"rootDir": "../../../../../../../..",
+		"sourceMap": false,
+		"strict": true,
+		"target": "es2020",
 		"tsBuildInfoFile": "../../../../../../../../.tsc/buildinfo/@liferay/document-library-opener-google-drive-web.tsbuildinfo",
 		"typeRoots": [
 			"../../../../../../../../node_modules/@types"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "f183bd9d959b8c88abc59206f33c1546d9218cb1",
+	"@generated": "961351e8aeaab5cce1eef4d696cd9a3be5c36560",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -20,6 +20,9 @@
 			],
 			"@liferay/template-web": [
 				"../../../../../../../template/template-web/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"data-engine-js-components-web": [
+				"../../../../../../../data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts"
 			],
 			"frontend-js-components-web": [
 				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -51,6 +54,9 @@
 		},
 		{
 			"path": "../../../../../../../template/template-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-global-css/assets/global.css
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-global-css/assets/global.css
@@ -228,7 +228,7 @@ pre[class*='language-'] {
 	align-items: center;
 	background-color: var(--color-action-primary-default, #0b5fff);
 	border-radius: 10px;
-	color: var(--color-neutral-0, #ffffff);
+	color: var(--color-neutral-0, #fff);
 	justify-content: space-between;
 	padding: 12px;
 
@@ -269,7 +269,7 @@ pre[class*='language-'] {
 	height: 40px;
 	justify-content: space-between;
 	margin-top: 1rem;
-	
+
 	.menu-previous-lesson {
 		gap: 0.5rem;
 		padding: 8px 16px;

--- a/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-site-initializer/site-initializer/fragments/group/liferay-learn/fragments/sign-in/index.js
+++ b/workspaces/liferay-learn-workspace/client-extensions/liferay-learn-site-initializer/site-initializer/fragments/group/liferay-learn/fragments/sign-in/index.js
@@ -14,7 +14,7 @@ if (!themeDisplay.isSignedIn()) {
 	signInMessage.textContent = 'to save your progress';
 
 	const signInContainer = document.querySelector('.signin-container');
-	
+
 	signInContainer.appendChild(signInLink);
 	signInContainer.appendChild(signInMessage);
 }


### PR DESCRIPTION
# What is this trying to solve?
[Link to ticket](https://liferay.atlassian.net/browse/LPD-28832)

Add package.json, node-scripts.config.js and other necessary files so that the CSS in the modules is built correctly.

# How am I fixing it?
Added `package.json` and empty `node-scripts.config.js` file. I think nothing else is needed. There is no react component, and there is only  inline js in a JSP file. Custom css for this module is injected via `<liferay-util:html-top> `

I had to add also `tsconfig.json` (otherwise SF fails) 

# How can you verify that it works?
Not sure... 

<img width="728" alt="Screenshot 2024-06-18 at 17 41 14" src="https://github.com/liferay-content-management/liferay-portal/assets/8373764/1f9d098f-57cf-4c19-9856-ffbe7016d8b5">


No tests needed for this task, is only an improvement for the build. 