### PR TITLE
LPD-28842 Cannot select web content from Global Site when selecting site scope

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
@@ -10,7 +10,11 @@ import com.liferay.item.selector.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.item.selector.taglib.internal.util.GroupItemSelectorProviderRegistryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -101,6 +105,19 @@ public class GroupSelectorTag extends IncludeTag {
 		if (_isScopeGroupType(httpServletRequest) && groupType.equals("site")) {
 			_groups = new ArrayList<>();
 
+			if (!group.isCompany()) {
+				try {
+					_groups.add(
+						GroupLocalServiceUtil.getCompanyGroup(
+							group.getCompanyId()));
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(portalException);
+					}
+				}
+			}
+
 			_groups.add(group);
 
 			return _groups;
@@ -138,8 +155,19 @@ public class GroupSelectorTag extends IncludeTag {
 	}
 
 	private int _getGroupsCount(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Group group = _getGroup(themeDisplay);
+
 		if (_isScopeGroupType(httpServletRequest)) {
-			_groupsCount = 1;
+			if (group.isCompany()) {
+				_groupsCount = 1;
+			}
+			else {
+				_groupsCount = 2;
+			}
 
 			return _groupsCount;
 		}
@@ -153,12 +181,6 @@ public class GroupSelectorTag extends IncludeTag {
 
 			return _groupsCount;
 		}
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		Group group = _getGroup(themeDisplay);
 
 		_groupsCount = groupSelectorProvider.getGroupsCount(
 			group.getCompanyId(), group.getGroupId(),
@@ -197,6 +219,9 @@ public class GroupSelectorTag extends IncludeTag {
 
 		return _scopeGroupType;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GroupSelectorTag.class);
 
 	private List<Group> _groups;
 	private int _groupsCount = -1;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
@@ -92,10 +92,6 @@ public class GroupSelectorTag extends IncludeTag {
 	private List<Group> _getGroups(HttpServletRequest httpServletRequest) {
 		String groupType = _getGroupType(httpServletRequest);
 
-		GroupItemSelectorProvider groupItemSelectorProvider =
-			GroupItemSelectorProviderRegistryUtil.getGroupItemSelectorProvider(
-				groupType);
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -123,6 +119,16 @@ public class GroupSelectorTag extends IncludeTag {
 			return _groups;
 		}
 
+		GroupItemSelectorProvider groupItemSelectorProvider =
+			GroupItemSelectorProviderRegistryUtil.getGroupItemSelectorProvider(
+				groupType);
+
+		if (groupItemSelectorProvider == null) {
+			_groups = Collections.emptyList();
+
+			return _groups;
+		}
+
 		int cur = ParamUtil.getInteger(
 			httpServletRequest, SearchContainer.DEFAULT_CUR_PARAM,
 			SearchContainer.DEFAULT_CUR);
@@ -132,12 +138,6 @@ public class GroupSelectorTag extends IncludeTag {
 
 		int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
 			cur, delta);
-
-		if (groupItemSelectorProvider == null) {
-			_groups = Collections.emptyList();
-
-			return _groups;
-		}
 
 		List<Group> groups = groupItemSelectorProvider.getGroups(
 			group.getCompanyId(), group.getGroupId(),

--- a/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTagTest.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/test/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTagTest.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.item.selector.taglib.servlet.taglib;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class GroupSelectorTagTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws PortalException {
+		_companyGroup = Mockito.mock(Group.class);
+
+		Mockito.when(
+			_companyGroup.isCompany()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			GroupLocalServiceUtil.getCompanyGroup(_COMPANY_ID)
+		).thenReturn(
+			_companyGroup
+		);
+	}
+
+	@After
+	public void tearDown() {
+		_groupLocalServiceUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testSetAttributes() {
+		_testSetAttributes(Arrays.asList(_companyGroup), 1, _companyGroup);
+
+		Group group = _getGroup();
+
+		_testSetAttributes(Arrays.asList(_companyGroup, group), 2, group);
+	}
+
+	private Group _getGroup() {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID
+		);
+		Mockito.when(
+			group.isCompany()
+		).thenReturn(
+			false
+		);
+
+		return group;
+	}
+
+	private void _testSetAttributes(
+		List<Group> expectedGroups, long expectedGroupsCount, Group group) {
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			group
+		);
+
+		HttpServletRequest httpServletRequest =
+			new TestMockHttpServletRequest();
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		GroupSelectorTag groupSelectorTag = new GroupSelectorTag();
+
+		groupSelectorTag.setAttributes(httpServletRequest);
+
+		List<Group> actualGroups = (ArrayList)httpServletRequest.getAttribute(
+			"liferay-item-selector:group-selector:groups");
+
+		Assert.assertEquals(
+			actualGroups.toString(), expectedGroups.size(),
+			actualGroups.size());
+
+		for (int i = 0; i < expectedGroups.size(); i++) {
+			Assert.assertEquals(expectedGroups.get(i), actualGroups.get(i));
+		}
+
+		long actualGroupsCount = GetterUtil.getLong(
+			httpServletRequest.getAttribute(
+				"liferay-item-selector:group-selector:groupsCount"));
+
+		Assert.assertEquals(expectedGroupsCount, actualGroupsCount);
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private Group _companyGroup;
+	private final MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+	private static class TestMockHttpServletRequest
+		extends MockHttpServletRequest {
+
+		@Override
+		public String getParameter(String name) {
+			if (Objects.equals(name, "groupType")) {
+				return "site";
+			}
+
+			if (Objects.equals(name, "scopeGroupType")) {
+				return "true";
+			}
+
+			return super.getParameter(name);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Cannot select web content from Global Site when selecting site scope

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-28842)

In previous versions, the users could select web content from Global Site without the need to change the scope in the configuration. This was lost during a bug fix.

# How am I fixing it?

Just add the Global Site to the Sites that the user can select web content from

# How can you verify that it works?

Follow the tests in the ticket or run the unit tests

![global](https://github.com/liferay-content-management/liferay-portal/assets/4267448/f747ccdf-d615-4711-843a-e64c5a2eed30)
