### PR TITLE
LPD-28764 Migrate KBArticleSchedule testcase to integration test

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 25.0.1
+Bundle-Version: 26.0.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalService.java
@@ -485,6 +485,10 @@ public interface KBArticleLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle getLatestKBArticle(long resourcePrimKey, int[] statuses)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle getLatestKBArticleByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceUtil.java
@@ -630,6 +630,13 @@ public class KBArticleLocalServiceUtil {
 		return getService().getLatestKBArticle(resourcePrimKey, status);
 	}
 
+	public static KBArticle getLatestKBArticle(
+			long resourcePrimKey, int[] statuses)
+		throws PortalException {
+
+		return getService().getLatestKBArticle(resourcePrimKey, statuses);
+	}
+
 	public static KBArticle getLatestKBArticleByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleLocalServiceWrapper.java
@@ -713,6 +713,14 @@ public class KBArticleLocalServiceWrapper
 	}
 
 	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey, int[] statuses)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbArticleLocalService.getLatestKBArticle(
+			resourcePrimKey, statuses);
+	}
+
+	@Override
 	public KBArticle getLatestKBArticleByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticlePersistence.java
@@ -1408,51 +1408,51 @@ public interface KBArticlePersistence
 		throws NoSuchArticleException;
 
 	/**
-	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the matching kb articles
 	 */
 	public java.util.List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status);
+		long[] resourcePrimKeys, int[] statuses);
 
 	/**
-	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
 	public java.util.List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end);
+		long[] resourcePrimKeys, int[] statuses, int start, int end);
 
 	/**
-	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
 	public java.util.List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator);
 
@@ -1464,7 +1464,7 @@ public interface KBArticlePersistence
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1472,7 +1472,7 @@ public interface KBArticlePersistence
 	 * @return the ordered range of matching kb articles
 	 */
 	public java.util.List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<KBArticle>
 			orderByComparator,
 		boolean useFinderCache);
@@ -1495,13 +1495,13 @@ public interface KBArticlePersistence
 	public int countByR_S(long resourcePrimKey, int status);
 
 	/**
-	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the number of matching kb articles
 	 */
-	public int countByR_S(long[] resourcePrimKeys, int status);
+	public int countByR_S(long[] resourcePrimKeys, int[] statuses);
 
 	/**
 	 * Returns all the kb articles where groupId = &#63; and externalReferenceCode = &#63;.

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/persistence/KBArticleUtil.java
@@ -1755,61 +1755,62 @@ public class KBArticleUtil {
 	}
 
 	/**
-	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the matching kb articles
 	 */
 	public static List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status) {
+		long[] resourcePrimKeys, int[] statuses) {
 
-		return getPersistence().findByR_S(resourcePrimKeys, status);
+		return getPersistence().findByR_S(resourcePrimKeys, statuses);
 	}
 
 	/**
-	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
 	public static List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end) {
+		long[] resourcePrimKeys, int[] statuses, int start, int end) {
 
-		return getPersistence().findByR_S(resourcePrimKeys, status, start, end);
+		return getPersistence().findByR_S(
+			resourcePrimKeys, statuses, start, end);
 	}
 
 	/**
-	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
 	 * @return the ordered range of matching kb articles
 	 */
 	public static List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		OrderByComparator<KBArticle> orderByComparator) {
 
 		return getPersistence().findByR_S(
-			resourcePrimKeys, status, start, end, orderByComparator);
+			resourcePrimKeys, statuses, start, end, orderByComparator);
 	}
 
 	/**
@@ -1820,7 +1821,7 @@ public class KBArticleUtil {
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -1828,12 +1829,12 @@ public class KBArticleUtil {
 	 * @return the ordered range of matching kb articles
 	 */
 	public static List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
 
 		return getPersistence().findByR_S(
-			resourcePrimKeys, status, start, end, orderByComparator,
+			resourcePrimKeys, statuses, start, end, orderByComparator,
 			useFinderCache);
 	}
 
@@ -1859,14 +1860,14 @@ public class KBArticleUtil {
 	}
 
 	/**
-	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the number of matching kb articles
 	 */
-	public static int countByR_S(long[] resourcePrimKeys, int status) {
-		return getPersistence().countByR_S(resourcePrimKeys, status);
+	public static int countByR_S(long[] resourcePrimKeys, int[] statuses) {
+		return getPersistence().countByR_S(resourcePrimKeys, statuses);
 	}
 
 	/**

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 14.1.0

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 4.7.0
+version 5.0.0

--- a/modules/apps/knowledge-base/knowledge-base-service/service.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/service.xml
@@ -77,7 +77,7 @@
 		</finder>
 		<finder name="R_S" return-type="Collection">
 			<finder-column arrayable-operator="OR" name="resourcePrimKey" />
-			<finder-column name="status" />
+			<finder-column arrayable-operator="OR" name="status" />
 		</finder>
 		<finder name="G_ERC" return-type="Collection">
 			<finder-column name="groupId" />

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -138,7 +138,7 @@ public class KBArticleStagedModelDataHandler
 				KBArticle parentKBArticle =
 					_kbArticleLocalService.getLatestKBArticle(
 						kbArticle.getParentResourcePrimKey(),
-						WorkflowConstants.STATUS_APPROVED);
+						getExportableStatuses());
 
 				StagedModelDataHandlerUtil.exportReferenceStagedModel(
 					portletDataContext, kbArticle, parentKBArticle,

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -111,6 +111,7 @@ import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -502,8 +503,10 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 			// Attachments
 
-			_portletFileRepository.deletePortletFolder(
-				kbArticle.getAttachmentsFolderId());
+			if (!GroupThreadLocal.isDeleteInProcess()) {
+				_portletFileRepository.deletePortletFolder(
+					kbArticle.getAttachmentsFolderId());
+			}
 
 			// Subscriptions
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -929,7 +929,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			}
 			else {
 				curKBArticles = kbArticlePersistence.findByR_S(
-					ArrayUtil.toArray(params[1]), status);
+					ArrayUtil.toArray(params[1]), new int[] {status});
 			}
 
 			kbArticles.addAll(curKBArticles);
@@ -1022,6 +1022,26 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 
 		return kbArticlePersistence.findByR_S_First(
 			resourcePrimKey, status, new KBArticleVersionComparator());
+	}
+
+	@Override
+	public KBArticle getLatestKBArticle(long resourcePrimKey, int[] statuses)
+		throws PortalException {
+
+		if (ArrayUtil.contains(statuses, WorkflowConstants.STATUS_ANY)) {
+			return kbArticlePersistence.findByResourcePrimKey_First(
+				resourcePrimKey, new KBArticleVersionComparator());
+		}
+
+		List<KBArticle> kbArticles = kbArticlePersistence.findByR_S(
+			new long[] {resourcePrimKey}, statuses, 0, 1,
+			new KBArticleVersionComparator());
+
+		if (!kbArticles.isEmpty()) {
+			return kbArticles.get(0);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -5341,52 +5341,52 @@ public class KBArticlePersistenceImpl
 	}
 
 	/**
-	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the matching kb articles
 	 */
 	@Override
-	public List<KBArticle> findByR_S(long[] resourcePrimKeys, int status) {
+	public List<KBArticle> findByR_S(long[] resourcePrimKeys, int[] statuses) {
 		return findByR_S(
-			resourcePrimKeys, status, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			resourcePrimKeys, statuses, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 			null);
 	}
 
 	/**
-	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns a range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @return the range of matching kb articles
 	 */
 	@Override
 	public List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end) {
+		long[] resourcePrimKeys, int[] statuses, int start, int end) {
 
-		return findByR_S(resourcePrimKeys, status, start, end, null);
+		return findByR_S(resourcePrimKeys, statuses, start, end, null);
 	}
 
 	/**
-	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns an ordered range of all the kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * <p>
 	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>KBArticleModelImpl</code>.
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5394,11 +5394,11 @@ public class KBArticlePersistenceImpl
 	 */
 	@Override
 	public List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		OrderByComparator<KBArticle> orderByComparator) {
 
 		return findByR_S(
-			resourcePrimKeys, status, start, end, orderByComparator, true);
+			resourcePrimKeys, statuses, start, end, orderByComparator, true);
 	}
 
 	/**
@@ -5409,7 +5409,7 @@ public class KBArticlePersistenceImpl
 	 * </p>
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @param start the lower bound of the range of kb articles
 	 * @param end the upper bound of the range of kb articles (not inclusive)
 	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
@@ -5418,7 +5418,7 @@ public class KBArticlePersistenceImpl
 	 */
 	@Override
 	public List<KBArticle> findByR_S(
-		long[] resourcePrimKeys, int status, int start, int end,
+		long[] resourcePrimKeys, int[] statuses, int start, int end,
 		OrderByComparator<KBArticle> orderByComparator,
 		boolean useFinderCache) {
 
@@ -5429,9 +5429,17 @@ public class KBArticlePersistenceImpl
 			resourcePrimKeys = ArrayUtil.sortedUnique(resourcePrimKeys);
 		}
 
-		if (resourcePrimKeys.length == 1) {
+		if (statuses == null) {
+			statuses = new int[0];
+		}
+		else if (statuses.length > 1) {
+			statuses = ArrayUtil.sortedUnique(statuses);
+		}
+
+		if ((resourcePrimKeys.length == 1) && (statuses.length == 1)) {
 			return findByR_S(
-				resourcePrimKeys[0], status, start, end, orderByComparator);
+				resourcePrimKeys[0], statuses[0], start, end,
+				orderByComparator);
 		}
 
 		try (SafeCloseable safeCloseable =
@@ -5445,14 +5453,15 @@ public class KBArticlePersistenceImpl
 
 				if (useFinderCache) {
 					finderArgs = new Object[] {
-						StringUtil.merge(resourcePrimKeys), status
+						StringUtil.merge(resourcePrimKeys),
+						StringUtil.merge(statuses)
 					};
 				}
 			}
 			else if (useFinderCache) {
 				finderArgs = new Object[] {
-					StringUtil.merge(resourcePrimKeys), status, start, end,
-					orderByComparator
+					StringUtil.merge(resourcePrimKeys),
+					StringUtil.merge(statuses), start, end, orderByComparator
 				};
 			}
 
@@ -5467,7 +5476,8 @@ public class KBArticlePersistenceImpl
 						if (!ArrayUtil.contains(
 								resourcePrimKeys,
 								kbArticle.getResourcePrimKey()) ||
-							(status != kbArticle.getStatus())) {
+							!ArrayUtil.contains(
+								statuses, kbArticle.getStatus())) {
 
 							list = null;
 
@@ -5496,7 +5506,17 @@ public class KBArticlePersistenceImpl
 					sb.append(WHERE_AND);
 				}
 
-				sb.append(_FINDER_COLUMN_R_S_STATUS_2);
+				if (statuses.length > 0) {
+					sb.append("(");
+
+					sb.append(_FINDER_COLUMN_R_S_STATUS_7);
+
+					sb.append(StringUtil.merge(statuses));
+
+					sb.append(")");
+
+					sb.append(")");
+				}
 
 				sb.setStringAt(
 					removeConjunction(sb.stringAt(sb.index() - 1)),
@@ -5518,10 +5538,6 @@ public class KBArticlePersistenceImpl
 					session = openSession();
 
 					Query query = session.createQuery(sql);
-
-					QueryPos queryPos = QueryPos.getInstance(query);
-
-					queryPos.add(status);
 
 					list = (List<KBArticle>)QueryUtil.list(
 						query, getDialect(), start, end);
@@ -5624,14 +5640,14 @@ public class KBArticlePersistenceImpl
 	}
 
 	/**
-	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = &#63;.
+	 * Returns the number of kb articles where resourcePrimKey = any &#63; and status = any &#63;.
 	 *
 	 * @param resourcePrimKeys the resource prim keys
-	 * @param status the status
+	 * @param statuses the statuses
 	 * @return the number of matching kb articles
 	 */
 	@Override
-	public int countByR_S(long[] resourcePrimKeys, int status) {
+	public int countByR_S(long[] resourcePrimKeys, int[] statuses) {
 		if (resourcePrimKeys == null) {
 			resourcePrimKeys = new long[0];
 		}
@@ -5639,12 +5655,19 @@ public class KBArticlePersistenceImpl
 			resourcePrimKeys = ArrayUtil.sortedUnique(resourcePrimKeys);
 		}
 
+		if (statuses == null) {
+			statuses = new int[0];
+		}
+		else if (statuses.length > 1) {
+			statuses = ArrayUtil.sortedUnique(statuses);
+		}
+
 		try (SafeCloseable safeCloseable =
 				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
 					KBArticle.class)) {
 
 			Object[] finderArgs = new Object[] {
-				StringUtil.merge(resourcePrimKeys), status
+				StringUtil.merge(resourcePrimKeys), StringUtil.merge(statuses)
 			};
 
 			Long count = (Long)finderCache.getResult(
@@ -5669,7 +5692,17 @@ public class KBArticlePersistenceImpl
 					sb.append(WHERE_AND);
 				}
 
-				sb.append(_FINDER_COLUMN_R_S_STATUS_2);
+				if (statuses.length > 0) {
+					sb.append("(");
+
+					sb.append(_FINDER_COLUMN_R_S_STATUS_7);
+
+					sb.append(StringUtil.merge(statuses));
+
+					sb.append(")");
+
+					sb.append(")");
+				}
 
 				sb.setStringAt(
 					removeConjunction(sb.stringAt(sb.index() - 1)),
@@ -5683,10 +5716,6 @@ public class KBArticlePersistenceImpl
 					session = openSession();
 
 					Query query = session.createQuery(sql);
-
-					QueryPos queryPos = QueryPos.getInstance(query);
-
-					queryPos.add(status);
 
 					count = (Long)query.uniqueResult();
 
@@ -5713,6 +5742,9 @@ public class KBArticlePersistenceImpl
 
 	private static final String _FINDER_COLUMN_R_S_STATUS_2 =
 		"kbArticle.status = ?";
+
+	private static final String _FINDER_COLUMN_R_S_STATUS_7 =
+		"kbArticle.status IN (";
 
 	private FinderPath _finderPathWithPaginationFindByG_ERC;
 	private FinderPath _finderPathWithoutPaginationFindByG_ERC;

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
@@ -23,9 +23,12 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +77,54 @@ public class KBArticleStagedModelDataHandlerTest
 			0L,
 			(long)ReflectionTestUtil.getFieldValue(
 				exportedKBArticle, "_classNameId"));
+	}
+
+	@FeatureFlags("LPS-188058")
+	@Test
+	public void testExportImportScheduledKBArticleCanBePublished()
+		throws Exception {
+
+		initExport();
+
+		KBArticle kbArticle = _addKBArticle(
+			new Date(System.currentTimeMillis() + Time.DAY),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			ClassNameLocalServiceUtil.getClassNameId(
+				KBFolderConstants.getClassName()),
+			_createServiceContext(stagingGroup));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, kbArticle);
+
+		initImport();
+
+		KBArticle exportedKBArticle = (KBArticle)readExportedStagedModel(
+			kbArticle);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedKBArticle);
+
+		KBArticle importedKBArticle = (KBArticle)getStagedModel(
+			kbArticle.getUuid(), liveGroup);
+
+		Assert.assertEquals(
+			kbArticle.getExternalReferenceCode(),
+			importedKBArticle.getExternalReferenceCode());
+		Assert.assertEquals(
+			kbArticle.isScheduled(), importedKBArticle.isScheduled());
+
+		importedKBArticle.setDisplayDate(
+			new Date(System.currentTimeMillis() - (Time.MINUTE * 10)));
+
+		importedKBArticle = _kbArticleLocalService.updateKBArticle(
+			importedKBArticle);
+
+		_kbArticleLocalService.checkKBArticles(liveGroup.getCompanyId());
+
+		importedKBArticle = _kbArticleLocalService.fetchKBArticle(
+			importedKBArticle.getKbArticleId());
+
+		Assert.assertFalse(importedKBArticle.isScheduled());
 	}
 
 	@Test
@@ -166,16 +217,26 @@ public class KBArticleStagedModelDataHandlerTest
 	}
 
 	private KBArticle _addKBArticle(
-			long parentResourcePrimKey, long parentResourceClassNameId,
-			ServiceContext serviceContext)
+			Date displayDate, long parentResourcePrimKey,
+			long parentResourceClassNameId, ServiceContext serviceContext)
 		throws Exception {
 
 		return _kbArticleLocalService.addKBArticle(
 			null, serviceContext.getUserId(), parentResourceClassNameId,
 			parentResourcePrimKey, StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
-			StringUtil.randomString(), null, null, RandomTestUtil.nextDate(),
-			null, null, null, serviceContext);
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, serviceContext);
+	}
+
+	private KBArticle _addKBArticle(
+			long parentResourcePrimKey, long parentResourceClassNameId,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return _addKBArticle(
+			RandomTestUtil.nextDate(), parentResourcePrimKey,
+			parentResourceClassNameId, serviceContext);
 	}
 
 	private ServiceContext _createServiceContext(Group group) throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticlePersistenceTest.java
@@ -363,7 +363,7 @@ public class KBArticlePersistenceTest {
 	public void testCountByR_SArrayable() throws Exception {
 		_persistence.countByR_S(
 			new long[] {RandomTestUtil.nextLong(), 0L},
-			RandomTestUtil.nextInt());
+			new int[] {RandomTestUtil.nextInt(), 0});
 	}
 
 	@Test

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -1625,6 +1625,66 @@ public class KBArticleLocalServiceTest {
 			null, _serviceContext);
 	}
 
+	@FeatureFlags("LPS-188058")
+	@Test
+	public void testUpdateKBArticleDisplayDateUpdatesStatusToApproved()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() + (2 * Time.DAY));
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, null, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() - (2 * Time.DAY));
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
+	}
+
+	@FeatureFlags("LPS-188058")
+	@Test
+	public void testUpdateKBArticleDisplayDateUpdatesStatusToScheduled()
+		throws Exception {
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() - (2 * Time.DAY));
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, null, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() + (2 * Time.DAY));
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+	}
+
 	@Test
 	public void testUpdateKBArticleExpirationDateUpdatesStatus()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -1627,6 +1627,40 @@ public class KBArticleLocalServiceTest {
 
 	@FeatureFlags("LPS-188058")
 	@Test
+	public void testUpdateKBArticleDisplayDateOnDraftArticleUpdatesStatusToScheduled()
+		throws Exception {
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		Date displayDate = new Date(
+			System.currentTimeMillis() - (2 * Time.DAY));
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			displayDate, null, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, kbArticle.getStatus());
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+
+		displayDate = new Date(System.currentTimeMillis() + (2 * Time.DAY));
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+	}
+
+	@FeatureFlags("LPS-188058")
+	@Test
 	public void testUpdateKBArticleDisplayDateUpdatesStatusToApproved()
 		throws Exception {
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -1627,6 +1627,53 @@ public class KBArticleLocalServiceTest {
 
 	@FeatureFlags("LPS-188058")
 	@Test
+	public void testUpdateKBArticleDisplayDateExpiredArticleCanBePublished()
+		throws Exception {
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), StringUtil.randomString(), null, null,
+			new Date(), null, null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
+
+		kbArticle = _kbArticleLocalService.expireKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(), _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, kbArticle.getStatus());
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, displayDate, null, null,
+			null, null, _serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, kbArticle.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() - Time.DAY);
+
+		kbArticle.setDisplayDate(displayDate);
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
+
+		_kbArticleLocalService.checkKBArticles(_group.getCompanyId());
+
+		kbArticle = _kbArticleLocalService.fetchKBArticle(
+			kbArticle.getKbArticleId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, kbArticle.getStatus());
+	}
+
+	@FeatureFlags("LPS-188058")
+	@Test
 	public void testUpdateKBArticleDisplayDateOnDraftArticleUpdatesStatusToScheduled()
 		throws Exception {
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -25,45 +25,6 @@ definition {
 		}
 	}
 
-	@description = "This test ensures that users can edit a scheduled article."
-	@priority = 5
-	test CanEditScheduledArticle {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		JSONKnowledgeBase.addkBArticle(
-			displayDate = "true",
-			groupName = "Guest",
-			increaseMinutes = 5,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		var tooltipMessageDate = DateUtil.getDateOffsetByMinutes(5, "MMMM d");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.editScheduledDate(
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title",
-			tooltipMessageDate = ${tooltipMessageDate});
-
-		KBArticle.viewCP(
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title",
-			kbStatus = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.viewCP(
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title",
-			kbStatus = "Approved");
-	}
-
 	@description = "This test ensures that users can add an article with an invalid scheduled date."
 	@priority = 4
 	test CannotAddArticleWithInvalidScheduledDate {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -75,49 +75,4 @@ definition {
 			kbStatus = "Approved");
 	}
 
-	@description = "This test ensures that the scheduled article can be published in the live site after reaching the scheduled date."
-	@priority = 4
-	test ScheduledArticleCanBePublshedOnLiveSite {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONLayout.addPublicLayout(
-			groupName = "Site Name",
-			layoutName = "knowledge base Page");
-
-		JSONStaging.enableLocalStaging(groupName = "Site Name");
-
-		KBAdmin.openKBAdmin(siteURLKey = "site-name-staging");
-
-		KBArticle.addArticleWithScheduledDate(
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		Navigator.gotoStagedSitePage(
-			pageName = "knowledge base Page",
-			siteName = "Site Name");
-
-		Staging.gotoPublishToLive();
-
-		Staging.publishToLive();
-
-		KBAdmin.openKBAdmin(siteURLKey = "site-name");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "site-name");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -37,42 +37,6 @@ definition {
 			kbArticleTitle = "Knowledge Base Article Title");
 	}
 
-	@description = "This test ensures that users can publish a draft article with a scheduled date."
-	@priority = 4
-	test CanScheduleDraftArticle {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		JSONKnowledgeBase.addkBArticle(
-			groupName = "Guest",
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title",
-			workflowAction = "DRAFT");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.editScheduledDate(
-			editDraftArticle = "true",
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Approved");
-	}
-
 	@description = "This test ensures that the expired article can be published again when the date reaches a new scheduled date."
 	@priority = 4
 	test ExpiredArticleCanBePublishedWithNewScheduledDate {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticleSchedule.testcase
@@ -37,42 +37,4 @@ definition {
 			kbArticleTitle = "Knowledge Base Article Title");
 	}
 
-	@description = "This test ensures that the expired article can be published again when the date reaches a new scheduled date."
-	@priority = 4
-	test ExpiredArticleCanBePublishedWithNewScheduledDate {
-		KBArticle.updateCheckInterval(fieldValue = 1);
-
-		JSONKnowledgeBase.addkBArticle(
-			groupName = "Guest",
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		LexiconEntry.gotoEntryMenuItem(
-			menuItem = "Expire",
-			rowEntry = "Knowledge Base Article Title");
-
-		KBArticle.editScheduledDate(
-			editExpiredArticle = "true",
-			increaseMinutes = 1,
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title");
-
-		LexiconList.viewListEntryLabel(
-			listEntry = "Knowledge Base Article Title",
-			listEntryLabel = "Scheduled");
-
-		// We need to wait for the system time to pass by 1 minute in order to verify the scheduled article is published. There is currently no easy way to manipulate the system time in CI for automation. 1 minute is the shortest value we can set while ensuring the stability of the test. See LPS-188060.
-
-		Pause(value1 = 120000);
-
-		KBAdmin.openKBAdmin(siteURLKey = "guest");
-
-		KBArticle.viewCP(
-			kbArticleContent = "Knowledge Base Article Content",
-			kbArticleTitle = "Knowledge Base Article Title",
-			kbStatus = "Approved");
-	}
-
 }


### PR DESCRIPTION
LPD-28764 Migrate Update Test to integration test

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28764

Some POSHI test of KBArticle Schedule are [flaky](https://liferay.atlassian.net/browse/LPD-28228) and others can be migrated to integration test

# How am I fixing it?

I'm migrating some test when we update the KBArticle. On this [case](https://liferay.atlassian.net/browse/LPD-28228) we changed the service to allow scheduled articles to be imported/exported.

# How can you verify that it works?

Run the included automated tests.

# Commits

- **LPD-28764 migrate POSHI test to integration test to tests that ensures that users can edit a scheduled article.**
- **LPD-28764 migrate POSHI test to integration test that ensures that users can publish a draft article with a scheduled date.**
- **LPD-28764 modify service to allow export by several statuses**
- **LPD-28764 add method to get the latest KB article with several statutes**
- **LPD-28764 buildService**
- **LPD-28764 baseline**
- **LPD-28764 obtain the parent article from all the exportable statuses**
- **LPD-28764 migrate POSHI test to ensure that the scheduled article can be published in the live site after reaching the scheduled date.**
- **LPD-28764 do not do certain actions if we are in delete site process, this prevent the 'Unable to delete data for portlet null in group' on tests**
- **LPD-28764 extract common code by default**
- **LPD-28764 migrate POSHI test to integration test, this test ensures that the expired article can be published again when the date reaches a new scheduled date.**
