### PR TITLE
LPD-29028 Error response status is 400 when adding an External Video Shortcut via the REST API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -543,7 +543,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
 		if (binaryFile == null) {
-			throw new BadRequestException("No file found in body");
+			binaryFile = new BinaryFile(null, null, null, 0);
 		}
 
 		String fileName = null;
@@ -946,15 +946,14 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			FileEntry fileEntry, MultipartBody multipartBody)
 		throws Exception {
 
-		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
-
 		Document document = multipartBody.getValueAsNullableInstance(
 			"document", Document.class);
 
-		if ((binaryFile == null) && (document == null)) {
-			throw new BadRequestException(
-				"Document and file are not found in body");
+		if (document == null) {
+			throw new BadRequestException("Document not found in body");
 		}
+
+		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
 		if (binaryFile == null) {
 			binaryFile = new BinaryFile(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -47,7 +47,9 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -200,6 +202,22 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		super.testPostDocumentFolderDocument();
 
 		_testPostDocumentFolderDocumentWithDLFileEntryType();
+	}
+
+	@Override
+	@Test
+	public void testPostSiteDocument() throws Exception {
+		super.testPostSiteDocument();
+
+		_testPostSiteDocumentWithNoMultipartFiles();
+	}
+
+	@Override
+	@Test
+	public void testPutDocument() throws Exception {
+		super.testPutDocument();
+
+		_testPutSiteDocumentWithNoMultipartFiles();
 	}
 
 	@Override
@@ -475,6 +493,40 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		_assertDLFileEntryType(dlFileEntryType, childGroup);
 
 		GroupTestUtil.deleteGroup(childGroup);
+	}
+
+	private void _testPostSiteDocumentWithNoMultipartFiles() throws Exception {
+		Document randomDocument = randomDocument();
+
+		Document postDocument = testPostSiteDocument_addDocument(
+			randomDocument, new HashMap<>());
+
+		assertEquals(randomDocument, postDocument);
+		assertValid(postDocument);
+
+		Assert.assertEquals(StringPool.BLANK, postDocument.getContentUrl());
+		Assert.assertEquals(
+			0, GetterUtil.getLong(postDocument.getSizeInBytes()));
+	}
+
+	private void _testPutSiteDocumentWithNoMultipartFiles() throws Exception {
+		Document postDocument = testPutDocument_addDocument();
+
+		Document randomDocument = randomDocument();
+
+		Document putDocument = documentResource.putDocument(
+			postDocument.getId(), randomDocument, new HashMap<>());
+
+		assertEquals(randomDocument, putDocument);
+		assertValid(putDocument);
+
+		Assert.assertEquals(
+			"1.1",
+			HttpComponentsUtil.getParameter(
+				putDocument.getContentUrl(), "version", false));
+
+		Assert.assertEquals(
+			postDocument.getSizeInBytes(), putDocument.getSizeInBytes());
 	}
 
 	@Inject


### PR DESCRIPTION
Error response status is 400 when adding an External Video Shortcut via the REST API

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-29028)

Users cannot add documents without specifying a file even though it's not needed to do so

# How am I fixing it?

Remove restriction so that the users can add/update files to DL without specifying binary files

# How can you verify that it works?

Either run the provided integration tests, or:

1. Go to Site Settings > Site Configuration, and write down the site ID
2. Go to http://localhost:8080/o/api
3. Search for /v1.0/sites/{siteId}/documets
4. Specify the site ID 
5. In the body specify a document, something like this, only basic fields:

```
{
  "fileName": "fileName1.txt",
  "friendlyUrlPath": "file-name-1",
  "title": "file-name-1"
}
```

6. Leave checkbox alone (Send empty value checked by default)
7. Execute
8. Go to Documents & Media for the site and the document will be created

Same steps will be able to test PUT method instead of post


