### PR TITLE
LPD-27919 Cannot copy document to external repository

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommand.java
@@ -28,11 +28,13 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.FileItem;
@@ -188,13 +190,13 @@ public class CopyDLObjectsMVCActionCommand extends BaseMVCActionCommand {
 		long sourceRepositoryId = ParamUtil.getLong(
 			actionRequest, "sourceRepositoryId");
 
-		Group group = _groupLocalService.getGroup(destinationRepositoryId);
+		Group group = _getRepositoryGroup(destinationRepositoryId);
 
 		long[] groupIds =
 			_siteConnectedGroupGroupProvider.
 				getCurrentAndAncestorSiteAndDepotGroupIds(group.getGroupId());
 
-		Group sourceGroup = _groupLocalService.getGroup(sourceRepositoryId);
+		Group sourceGroup = _getRepositoryGroup(sourceRepositoryId);
 
 		_checkDestinationGroup(group, groupIds, sourceGroup.getGroupId());
 
@@ -320,6 +322,21 @@ public class CopyDLObjectsMVCActionCommand extends BaseMVCActionCommand {
 		return dlObjectIds.length - errorMessages.size();
 	}
 
+	private Group _getRepositoryGroup(long repositoryId)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroup(repositoryId);
+
+		if (group != null) {
+			return group;
+		}
+
+		Repository repository = _repositoryLocalService.getRepository(
+			repositoryId);
+
+		return _groupLocalService.getGroup(repository.getGroupId());
+	}
+
 	private String _getUploadExceptionErrorMessage(
 		UploadException uploadException, ThemeDisplay themeDisplay) {
 
@@ -384,6 +401,9 @@ public class CopyDLObjectsMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
 
 	@Reference
 	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommandTest.java
@@ -1,0 +1,228 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.portlet.action;
+
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
+import com.liferay.document.library.configuration.DLSizeLimitConfigurationProvider;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.portal.json.JSONObjectImpl;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionRequest;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionResponse;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletRequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class CopyDLObjectsMVCActionCommandTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_copyDLObjectsMVCActionCommand, "_dlSizeLimitConfigurationProvider",
+			_dlSizeLimitConfigurationProvider);
+		ReflectionTestUtil.setFieldValue(
+			_copyDLObjectsMVCActionCommand, "_groupLocalService",
+			_groupLocalService);
+
+		Mockito.when(
+			_jsonFactory.createJSONObject()
+		).thenReturn(
+			new JSONObjectImpl()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_copyDLObjectsMVCActionCommand, "_jsonFactory", _jsonFactory);
+
+		ReflectionTestUtil.setFieldValue(
+			_copyDLObjectsMVCActionCommand, "_repositoryLocalService",
+			_repositoryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_copyDLObjectsMVCActionCommand, "_siteConnectedGroupGroupProvider",
+			_siteConnectedGroupGroupProvider);
+
+		_jsonPortletResponseUtilMockedStatic.when(
+			() -> JSONPortletResponseUtil.writeJSON(
+				Mockito.any(ActionRequest.class),
+				Mockito.any(ActionResponse.class),
+				Mockito.any(JSONObject.class))
+		).then(
+			invocationOnMock -> null
+		);
+
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getHttpServletRequest(Mockito.any(PortletRequest.class))
+		).thenReturn(
+			new MockHttpServletRequest()
+		);
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(portal);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_jsonPortletResponseUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testRepositoryGroupIsUsed() throws Exception {
+		long destinationGroupId = RandomTestUtil.randomLong();
+		long destinationRepositoryId = RandomTestUtil.randomLong();
+
+		_setUpRepository(destinationGroupId, destinationRepositoryId);
+
+		long sourceGroupId = RandomTestUtil.randomLong();
+
+		long sourceRepositoryId = sourceGroupId;
+
+		_setUpRepository(sourceGroupId, sourceRepositoryId);
+
+		_copyDLObjectsMVCActionCommand.doProcessAction(
+			_getMockActionRequest(destinationRepositoryId, sourceRepositoryId),
+			new MockActionResponse());
+
+		Mockito.verify(
+			_groupLocalService
+		).fetchGroup(
+			destinationRepositoryId
+		);
+
+		Mockito.verify(
+			_repositoryLocalService
+		).getRepository(
+			destinationRepositoryId
+		);
+
+		Mockito.verify(
+			_repositoryLocalService, Mockito.never()
+		).getRepository(
+			sourceRepositoryId
+		);
+	}
+
+	private MockActionRequest _getMockActionRequest(
+		long destinationRepositoryId, long sourceRepositoryId) {
+
+		MockActionRequest mockActionRequest = new MockActionRequest();
+
+		mockActionRequest.addParameter(
+			"destinationParentFolderId",
+			String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
+		mockActionRequest.addParameter(
+			"destinationRepositoryId", String.valueOf(destinationRepositoryId));
+		mockActionRequest.addParameter(
+			"sourceRepositoryId", String.valueOf(sourceRepositoryId));
+
+		return mockActionRequest;
+	}
+
+	private void _setUpRepository(long groupId, long repositoryId)
+		throws Exception {
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Mockito.when(
+			_groupLocalService.fetchGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		Mockito.when(
+			_groupLocalService.getGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		Mockito.when(
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(groupId)
+		).thenReturn(
+			new long[] {groupId}
+		);
+
+		if (groupId == repositoryId) {
+			return;
+		}
+
+		Repository repository = Mockito.mock(Repository.class);
+
+		Mockito.when(
+			repository.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Mockito.when(
+			_repositoryLocalService.getRepository(repositoryId)
+		).thenReturn(
+			repository
+		);
+	}
+
+	private final CopyDLObjectsMVCActionCommand _copyDLObjectsMVCActionCommand =
+		new CopyDLObjectsMVCActionCommand() {
+
+			@Override
+			protected void hideDefaultSuccessMessage(
+				PortletRequest portletRequest) {
+			}
+
+		};
+
+	private final DLSizeLimitConfigurationProvider
+		_dlSizeLimitConfigurationProvider = Mockito.mock(
+			DLSizeLimitConfigurationProvider.class);
+	private final GroupLocalService _groupLocalService = Mockito.mock(
+		GroupLocalService.class);
+	private final JSONFactory _jsonFactory = Mockito.mock(JSONFactory.class);
+	private final MockedStatic<JSONPortletResponseUtil>
+		_jsonPortletResponseUtilMockedStatic = Mockito.mockStatic(
+			JSONPortletResponseUtil.class);
+	private final RepositoryLocalService _repositoryLocalService = Mockito.mock(
+		RepositoryLocalService.class);
+	private final SiteConnectedGroupGroupProvider
+		_siteConnectedGroupGroupProvider = Mockito.mock(
+			SiteConnectedGroupGroupProvider.class);
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27919

Documents cannot be copied from the default group repository to any external repository.

# How am I fixing it?

The issue was that the repository ID was assumed to be a valid group ID.  For external repositories, the group ID needs to be fetched indirectly through the `Repository` model instead.

# How can you verify that it works?

A unit test is included. Additionally, you may follow the steps described in https://liferay.atlassian.net/browse/LPD-27919.