### PR TITLE
LPD-29214 Update poshi path

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
@@ -167,7 +167,7 @@
 </tr>
 <tr>
 	<td>QUESTIONS_DEFAULT_SUBSCRIPTION_TOPICS</td>
-	<td>//div[contains(@class,'questions-container')]/div[contains(.,'Topics')]/div[contains(@class,'c-empty-state')]//span/span[contains(.,'There are no results.')]</td>
+	<td>//div[contains(@class,'questions-container')]/div[contains(.,'Topics')]/div[contains(@class,'c-empty-state')]//div/span[contains(.,'There are no results.')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29214

A Questions poshi test is failing, as the underlying markup has changed.

# How am I fixing it?

By updating the poshi path.

# How can you verify that it works?

Run the `QuestionsSubscriptionEnhanchement#CanUnsubscribeATag` and see it passing.