### PR TITLE
LPD-28898 Image added via rich text editor on Wiki tool losing reference.

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -285,7 +285,10 @@
 					let imagePath = r[1];
 					const imagePathPrefix = options ? options.imagePrefix : '';
 
-					if (imagePathPrefix) {
+					if (
+						imagePathPrefix &&
+						!imagePath.startsWith('data:image/')
+					) {
 						if (!/^https?:\/\//gi.test(imagePath)) {
 							imagePath = imagePathPrefix + imagePath;
 						}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -287,11 +287,10 @@
 
 					if (
 						imagePathPrefix &&
-						!imagePath.startsWith('data:image/')
+						!imagePath.startsWith('data:image/') &&
+						!/^https?:\/\//gi.test(imagePath)
 					) {
-						if (!/^https?:\/\//gi.test(imagePath)) {
-							imagePath = imagePathPrefix + imagePath;
-						}
+						imagePath = imagePathPrefix + imagePath;
 					}
 
 					const image = document.createElement('img');

--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -100,7 +100,12 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 
 		append(" src=\"");
 
-		if (imageNode.isAbsoluteLink()) {
+		if (imageNode.isAbsoluteLink() ||
+			imageNode.getLink(
+			).startsWith(
+				"data:image/"
+			)) {
+
 			append(HtmlUtil.escapeAttribute(imageNode.getLink()));
 		}
 		else {

--- a/modules/apps/wiki/wiki-engine-creole/src/test/java/com/liferay/wiki/engine/creole/TranslationToXHTMLTest.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/test/java/com/liferay/wiki/engine/creole/TranslationToXHTMLTest.java
@@ -452,6 +452,14 @@ public class TranslationToXHTMLTest {
 	}
 
 	@Test
+	public void testParseImageTagInBase64Format() throws Exception {
+		Assert.assertEquals(
+			"<p><img src=\"data:image/jpeg;base64\" alt=\"alternative " +
+				"text\"/> </p>",
+			translate("image-6.creole"));
+	}
+
+	@Test
 	public void testParseLinkEmpty() throws Exception {
 		Assert.assertEquals("<p></p>", translate("link-8.creole"));
 	}

--- a/modules/apps/wiki/wiki-engine-creole/src/test/resources/com/liferay/wiki/engine/creole/dependencies/image-6.creole
+++ b/modules/apps/wiki/wiki-engine-creole/src/test/resources/com/liferay/wiki/engine/creole/dependencies/image-6.creole
@@ -1,0 +1,1 @@
+{{data:image/jpeg;base64|alternative text}}

--- a/modules/test/playwright/pages/wiki-web/WikiPage.ts
+++ b/modules/test/playwright/pages/wiki-web/WikiPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../utils/portletUrls';
 
@@ -20,11 +20,53 @@ export class WikiPage {
 		);
 	}
 
+	async addSourceContentToWikiPage(content: string) {
+		await this.page.getByLabel('Source').waitFor();
+
+		await this.page.getByLabel('Source').click();
+
+		await this.page
+			.getByLabel(
+				'Editor, _com_liferay_wiki_web_portlet_WikiAdminPortlet_contentEditor',
+				{exact: true}
+			)
+			.fill(content);
+
+		await this.page.getByLabel('Source').click();
+	}
+
+	async assertAddedImage(locator: Locator, image: string) {
+		await expect(locator).toHaveAttribute('src', image);
+	}
+
 	async createNewWikiNode(wikiNodeTitle: string) {
 		await this.page.getByRole('link', {name: 'Add Wiki'}).click();
 
 		await this.page.getByLabel('Name').fill(wikiNodeTitle);
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
+	}
+
+	async goToEditFirstWikiPage() {
+		await this.page
+			.locator(
+				'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiPages_1"]'
+			)
+			.getByLabel('Show Actions')
+			.click();
+		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
+	}
+
+	async goToFirstWikiPage() {
+		await this.page
+			.locator(
+				'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiPages_1"]'
+			)
+			.getByRole('link')
+			.click();
+	}
+
+	async goToWikiNode(title: string) {
+		await this.page.getByRole('link', {exact: true, name: title}).click();
 	}
 }

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -52,3 +52,36 @@ test('LPD-26435 Icon menu should close when another icon menu is open', async ({
 		await page.getByRole('link', {name: 'Delete'}).click();
 	});
 });
+
+test('LPD-28898 Image added via rich text editor on Wiki tool losing reference', async ({
+	page,
+	wikiPage,
+}) => {
+	await wikiPage.goto();
+
+	await wikiPage.goToWikiNode('Main');
+
+	await wikiPage.goToEditFirstWikiPage();
+
+	const image =
+		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOAAAADgCAMAAAAt85rTAAAAeFBMVEX///8LY84AXM+frr4AYM0AWcwAXMwAUspRgta9zO2NquIAYc0AXs35+ffL0tqotsS5zOkRadH///sAV8u0xefv8/sueNOyye2HpN5vldjA0efu8fR5ntnn7PJjktiowuVfjNfR3ezX4OqOqtpIhdcob9CNseMYbtMc8dVDAAADbUlEQVR4nO2da3OqMBBAQwv4CGoFi4+qtbW2//8fFmE6t9mAo3cwpMw5H3e2jqcwCYlLVikAAAAAAAAAAAAAAAAAAAAAAAAAAACAP8hkOnt0xGw6ca73vAyyB2dkyfLZrd9TnoWBQ3SWP7n1S1zqnUlcGj679zsburtLl5l7vyDIlq78JonuQjAMXI2l004uYHEJp44EZw/dCD7MHAk+diX4iCCCCCKIIII+CuokNqnWUlpEq0c8K/naB7/uBHVwWI1/sxqW4dyMjvfzwkXP12Z0lV9p2J1gctiJlLe8uIbZJjWjL9u4SN6+mNF0c+WzbXeC8djKGRaCAyu6iIIgGlnhQW8ERwgi6AIEFYImCCLYLggqBE0QRLBdbMGVTElLwVSGy9XEwkr2XjAcvomvvDkVi9joVRju9kmxHtyLxWP6GvkuGASnocnpHNRfIppXybkIf3m/oi+uoaSM6tqolez/nowjELyfoM4GJlF528UieqkyQ0cy2bpzO9w2zDdmRvp6HjjiTzGKvn80Guq5HHI31m5il/OgnPGqedD6TX3ROCGEQ+sjVrE/grc8yTQJWsljBO8FggpBBBWCdwRBhSCCCsE7gqDqm2CyFoUTaldWWbyL6OQov/M/wVwWarysZeV7hwve+XZksNiXX/pjYYaPl/bP9mbyYjv3Z8Eb6CQyqf75oYherGmSH2Ens+mE4H8L6rj2Fq3HSq52oqy73KNbtBhkxAixv+D3dRQjUrXXJgaZkU+DTLKvnSbqiY9ys+09832aaJjo66n/fdDviR5BBBFEsE0QVAiaIIhguyCoEDTxX7C+CKFB0CrGmwx8L0JoKCOpJ/wQu4npZ3xeBvtcRtJUCNRgKJPLK+V1IZAjEHQueFM5ZX1FpteC1xbEVttntTW1fgveUtKsT/J92DdrpvFO8JaidHseVB7Ng02C1l82v1bg95MMgj8g+BsE7waCCAoQRLBdEERQ0DNBazXxZwVrjjwq1oNx7ZFHYS7eklW7gz9VFg1Yh1atLx1aNRTnXh0Cj7YNmwxvOXYsrE32W7BlEEQQQQQRRNAHwd4fJN77o+AngdNmGj/oxFljlL63Y+h/Q43et0Qpm9o4baoROm5qc25LlLhsSxS4bkuket9YCgAAAAAAAAAAAAAAAAAAAAAAAAAAAKAFvgGY6WrR7U77yAAAAABJRU5ErkJggg==';
+
+	await wikiPage.addSourceContentToWikiPage(`{{${image}|alternate text}}`);
+
+	const ckeditorIframeLocator = page.frameLocator(
+		'iframe[title="Editor, _com_liferay_wiki_web_portlet_WikiAdminPortlet_contentEditor"]'
+	);
+
+	await wikiPage.assertAddedImage(
+		ckeditorIframeLocator.getByAltText('alternate text'),
+		image
+	);
+
+	await wikiPage.goto();
+
+	await wikiPage.goToWikiNode('Main');
+
+	await wikiPage.goToFirstWikiPage();
+
+	await wikiPage.assertAddedImage(page.getByAltText('alternate text'), image);
+});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28898

There is an error when we are adding an image using copy paste and we should take into account when we are parsing it using creole parser. So, this PR include the necessary  code to perform it. 

# How am I fixing it?

1. Take into account when we are parsing xhtml for image nodes that including images content in base64.
2. Take into account in creole ckeditor when we are parsing images in base64. I sent a [PR to frontent infra team](https://github.com/liferay-frontend/liferay-portal/pull/4272) to review that part of code but I also included here in order to do a functional test. 

# How can you verify that it works?

Run included tests and follow the steps to reproduce the LPD bug.