### PR TITLE
LPD-29225 Fix test failure in AICreator#CannotEnableOpenAIFromSiteSettingsAfterDisableItFromInstanceSettings

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/ai-creator/AICreator.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/ai-creator/AICreator.testcase
@@ -127,7 +127,7 @@ definition {
 				checkboxName = "Enable ChatGPT to Create Content",
 				locator1 = "Checkbox#ANY_CHECKBOX");
 
-			Alert.viewInfoMessageSpecific(infoMessage = "To enable OpenAI in this site, it must also be enabled from instance settings.");
+			Alert.viewInfoMessageSpecific(infoMessage = "To enable ChatGPT for this site, first enable it for your instance.");
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29225

The test is waiting for an inexistent info label and fails

# How am I fixing it?

I've used the correct label value.

# How can you verify that it works?

Execute locally `ant -f build-test.xml run-selenium-test -Dtest.class=AICreator#CannotEnableOpenAIFromSiteSettingsAfterDisableItFromInstanceSettings`