### PR TITLE
LPD-29236 Fix Test Failures in ContentDashboardAuditGraph#CheckTopPositionVocabularyXAxis

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
@@ -322,7 +322,7 @@
 </tr>
 <tr>
 	<td>X_AXIS_VOCABULARY_NAME</td>
-	<td>//*[contains(@class, 'recharts-layer recharts-cartesian-axis-tick')]//*[contains(text(), '${xAxisCategoryName}')]</td>
+	<td>//*[contains(@class, 'recharts-layer recharts-cartesian-axis recharts-xAxis xAxis')]//*[contains(@class, 'recharts-layer recharts-cartesian-axis-tick')]//*[contains(text(), '${xAxisCategoryName}')]</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Fix Test Failures in ContentDashboardAuditGraph#CheckTopPositionVocabularyXAxis

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-29236)

Fixing ContentDashboardAuditGraph#CheckTopPositionVocabularyXAxis

# How am I fixing it?

Update the locator so that it's more specific

# How can you verify that it works?

Run the poshi test
