### PR TITLE
LPD-29264 Move question tests to content-management test suit

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4189,6 +4189,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         **/message-boards-web/**/*Test.java,\
         **/notifications-uad-test/**/*Test.java,\
         **/notifications-web-test/**/*Test.java,\
+        **/questions-web/test/*test.js,\
         **/ratings-test/**/*Test.java,\
         **/reading-time-test/**/*Test.java,\
         **/repository-test/**/*Test.java,\
@@ -4248,6 +4249,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (testray.main.component.name ~ "My Subscriptions") OR \
             (testray.main.component.name ~ "Notifications") OR \
             (testray.main.component.name ~ "Online Editing") OR \
+            (testray.main.component.name ~ "Questions") OR \
             (testray.main.component.name ~ "Ratings") OR \
             (testray.main.component.name ~ "Recycle Bin") OR \
             (testray.main.component.name ~ "Sharepoint") OR \
@@ -8685,34 +8687,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][publications-lxc]=\
         (${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][publications]}) AND \
         (test.liferay.virtual.instance != false)
-
-    #
-    # Questions
-    #
-
-    test.batch.class.names.includes[questions]=\
-        **/message-boards-comment/**/*Test.java,\
-        **/message-boards-parser-bbcode/**/*Test.java,\
-        **/message-boards-service/**/*Test.java,\
-        **/message-boards-test/**/*Test.java,\
-        **/message-boards-test-util/**/*Test.java,\
-        **/message-boards-uad-test/**/*Test.java,\
-        **/message-boards-web/**/*Test.java,\
-        **/questions-web/test/*test.js
-
-    test.batch.dist.app.servers[questions]=tomcat
-
-    test.batch.names[questions]=\
-        functional-tomcat90-mysql57-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-unit-jdk8
-
-    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][questions]=\
-        (\
-            (portal.acceptance != quarantine) AND \
-            (portal.upstream == true)\
-        ) AND \
-        (testray.main.component.name == "Questions")
 
     #
     # Relevant


### PR DESCRIPTION
Move question tests to content-management test suit

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-29264)

As the title says, move the questions test suit so that it's part of the content management suit

