### PR TITLE
LPD-29267 Update path for Message Boards thread workflow status label when in recycle bin

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/MessageboardsThread.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MessageboardsThread.macro
@@ -2179,7 +2179,7 @@ definition {
 		LexiconEntry.gotoEntry(rowEntry = ${threadSubject});
 
 		AssertTextEquals(
-			locator1 = "Message#WORKFLOW_STATUS",
+			locator1 = "Message#RECYCLE_BIN_WORKFLOW_STATUS",
 			value1 = "In Recycle Bin");
 
 		AssertTextEquals(

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
@@ -416,6 +416,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>RECYCLE_BIN_WORKFLOW_STATUS</td>
+	<td>//span[contains(@class,'label-info')]/span</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REQUIRED_INFO</td>
 	<td>//div[contains(@class,'required') and contains(@role,'alert')]</td>
 	<td></td>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29267

The functional test `MBThread#CanDeleteThread` is failing due to an incorrect path. The path was changed as part of https://liferay.atlassian.net/browse/LPD-25630

# How am I fixing it?

I created a new path to point to the new workflow status style. A new one was added because the path `Message#WORKFLOW_STATUS` is used in many other places where it is still a valid path.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=MBThread#CanDeleteThread`