### PR TITLE
LPD-28728 The Web Content Structure predefinedValues are not being updated correctly

### DIFF
--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/util/LocalizedValueUtil.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/field/type/util/LocalizedValueUtil.java
@@ -190,6 +190,9 @@ public class LocalizedValueUtil {
 						JSONFactoryUtil.createJSONObject(
 							(Map<?, ?>)deserializedObject));
 				}
+				else {
+					localizedValues.put(languageId, value);
+				}
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/data-engine/data-engine-api/src/test/java/com/liferay/data/engine/field/type/util/LocalizedValueUtilTest.java
+++ b/modules/apps/data-engine/data-engine-api/src/test/java/com/liferay/data/engine/field/type/util/LocalizedValueUtilTest.java
@@ -93,6 +93,20 @@ public class LocalizedValueUtilTest {
 	}
 
 	@Test
+	public void testToLocalizedValuesMapWithBooleanValues() {
+		Map<String, Object> map = LocalizedValueUtil.toLocalizedValuesMap(
+			new LocalizedValue() {
+				{
+					addString(LocaleUtil.US, "true");
+					addString(LocaleUtil.BRAZIL, "false");
+				}
+			});
+
+		Assert.assertEquals("true", map.get("en_US"));
+		Assert.assertEquals("false", map.get("pt_BR"));
+	}
+
+	@Test
 	public void testToLocalizedValuesMapWithJSONArrayValues() throws Exception {
 		Map<String, Object> map = LocalizedValueUtil.toLocalizedValuesMap(
 			new LocalizedValue() {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java
@@ -5,6 +5,8 @@
 
 package com.liferay.journal.internal.model.listener;
 
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
@@ -22,6 +24,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.util.Portal;
 
+import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -45,7 +48,9 @@ public class DDMStructureModelListener extends BaseModelListener<DDMStructure> {
 				ddmStructure.getStructureKey()) &&
 			 Objects.equals(
 				 originalDDMStructure.getDefinition(),
-				 ddmStructure.getDefinition()))) {
+				 ddmStructure.getDefinition())) ||
+			_isPredefinedValuesUpdate(
+				originalDDMStructure.getDDMForm(), ddmStructure.getDDMForm())) {
 
 			return;
 		}
@@ -117,6 +122,41 @@ public class DDMStructureModelListener extends BaseModelListener<DDMStructure> {
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);
 		}
+	}
+
+	private boolean _isPredefinedValuesUpdate(
+		DDMForm ddmForm1, DDMForm ddmForm2) {
+
+		Map<String, DDMFormField> ddmFormFieldsMap1 =
+			ddmForm1.getDDMFormFieldsMap(true);
+
+		Map<String, DDMFormField> ddmFormFieldsMap2 =
+			ddmForm2.getDDMFormFieldsMap(true);
+
+		if (ddmFormFieldsMap1.size() != ddmFormFieldsMap2.size()) {
+			return false;
+		}
+
+		for (Map.Entry<String, DDMFormField> entry :
+				ddmFormFieldsMap1.entrySet()) {
+
+			DDMFormField ddmFormField2 = ddmFormFieldsMap2.get(entry.getKey());
+
+			if (ddmFormField2 == null) {
+				return false;
+			}
+
+			DDMFormField ddmFormField1 = entry.getValue();
+
+			if (!Objects.equals(
+					ddmFormField1.getPredefinedValue(),
+					ddmFormField2.getPredefinedValue())) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Reference

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -816,8 +816,13 @@ public class JournalArticleLocalServiceImpl
 
 		// Dynamic data mapping
 
-		updateDDMFields(
-			article, _formatContent(article, content, groupId, user));
+		DDMFormValues ddmFormValues = _formatContent(
+			article, content, groupId, user);
+
+		updateDDMFields(article, ddmFormValues);
+
+		_updateDDMStructurePredefinedValues(
+			userId, article.getDDMStructureId(), ddmFormValues, serviceContext);
 
 		return journalArticlePersistence.findByPrimaryKey(article.getId());
 	}
@@ -5363,8 +5368,13 @@ public class JournalArticleLocalServiceImpl
 
 		// Dynamic data mapping
 
-		updateDDMFields(
-			article, _formatContent(article, content, groupId, user));
+		DDMFormValues ddmFormValues = _formatContent(
+			article, content, groupId, user);
+
+		updateDDMFields(article, ddmFormValues);
+
+		_updateDDMStructurePredefinedValues(
+			userId, article.getDDMStructureId(), ddmFormValues, serviceContext);
 
 		// Small image
 
@@ -8138,6 +8148,42 @@ public class JournalArticleLocalServiceImpl
 
 		return _journalArticleLocalizationPersistence.update(
 			journalArticleLocalization);
+	}
+
+	private void _updateDDMStructurePredefinedValues(
+			long userId, long ddmStructureId, DDMFormValues ddmFormValues,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		boolean update = false;
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			ddmStructureId);
+
+		DDMForm ddmForm = ddmStructure.getDDMForm();
+
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmForm.getDDMFormFieldsMap(true);
+
+		for (DDMFormFieldValue ddmFormFieldValue :
+				ddmFormValues.getDDMFormFieldValues()) {
+
+			DDMFormField ddmFormField = ddmFormFieldsMap.get(
+				ddmFormFieldValue.getName());
+
+			if (ddmFormField != null) {
+				ddmFormField.setPredefinedValue(
+					(LocalizedValue)ddmFormFieldValue.getValue());
+
+				update = true;
+			}
+		}
+
+		if (update) {
+			_ddmStructureLocalService.updateStructure(
+				userId, ddmStructureId, ddmForm,
+				ddmStructure.getDDMFormLayout(), serviceContext);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
@@ -7,9 +7,13 @@ package com.liferay.journal.web.internal.portlet.action;
 
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
 import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
 import com.liferay.data.engine.rest.resource.exception.DataDefinitionValidationException;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -24,6 +28,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -114,6 +119,8 @@ public class UpdateDataDefinitionMVCActionCommand
 		DataDefinition dataDefinition = DataDefinition.toDTO(
 			dataDefinitionString);
 
+		_restoreDefaultValues(dataDefinitionId, dataDefinition);
+
 		dataDefinition.setDataDefinitionKey(
 			() -> ParamUtil.getString(actionRequest, "structureKey"));
 		dataDefinition.setDefaultDataLayout(
@@ -135,8 +142,35 @@ public class UpdateDataDefinitionMVCActionCommand
 		}
 	}
 
+	private void _restoreDefaultValues(
+			long dataDefinitionId, DataDefinition dataDefinition)
+		throws Exception {
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+			dataDefinitionId);
+
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmStructure.getFullHierarchyDDMFormFieldsMap(true);
+
+		for (DataDefinitionField dataDefinitionField :
+				dataDefinition.getDataDefinitionFields()) {
+
+			DDMFormField ddmFormField = ddmFormFieldsMap.get(
+				dataDefinitionField.getName());
+
+			if (ddmFormField != null) {
+				dataDefinitionField.setDefaultValue(
+					() -> LocalizedValueUtil.toLocalizedValuesMap(
+						ddmFormField.getPredefinedValue()));
+			}
+		}
+	}
+
 	@Reference
 	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/test/playwright/helpers/DataEngineApiHelper.ts
+++ b/modules/test/playwright/helpers/DataEngineApiHelper.ts
@@ -32,9 +32,7 @@ export class DataEngineApiHelper {
 		);
 	}
 
-	async getStructure(
-		id: string
-	): Promise<DataDefinition> {
+	async getStructure(id: string): Promise<DataDefinition> {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/data-definitions/${id}`
 		);

--- a/modules/test/playwright/helpers/DataEngineApiHelper.ts
+++ b/modules/test/playwright/helpers/DataEngineApiHelper.ts
@@ -31,4 +31,12 @@ export class DataEngineApiHelper {
 			{data: dataDefinition}
 		);
 	}
+
+	async getStructure(
+		id: string
+	): Promise<DataDefinition> {
+		return this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${this.basePath}/data-definitions/${id}`
+		);
+	}
 }

--- a/modules/test/playwright/tests/journal-web/fixtures/journalPagesTest.ts
+++ b/modules/test/playwright/tests/journal-web/fixtures/journalPagesTest.ts
@@ -9,6 +9,8 @@ import {FriendlyUrlInstanceSettingsPage} from '../../../pages/friendly-url-web/F
 import {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import {JournalEditArticlePage} from '../pages/JournalEditArticlePage';
 import {JournalEditArticleTranslationsPage} from '../pages/JournalEditArticleTranslationsPage';
+import {JournalEditStructureDefaultValuesPage} from '../pages/JournalEditStructureDefaultValuesPage';
+import {JournalEditStructurePage} from '../pages/JournalEditStructurePage';
 import {JournalEditTemplatePage} from '../pages/JournalEditTemplatePage';
 import {JournalPage} from '../pages/JournalPage';
 
@@ -17,6 +19,8 @@ const journalPagesTest = test.extend<{
 	friendlyUrlInstanceSettingsPage: FriendlyUrlInstanceSettingsPage;
 	journalEditArticlePage: JournalEditArticlePage;
 	journalEditArticleTranslationsPage: JournalEditArticleTranslationsPage;
+	journalEditStructureDefaultValuesPage: JournalEditStructureDefaultValuesPage;
+	journalEditStructurePage: JournalEditStructurePage;
 	journalEditTemplatePage: JournalEditTemplatePage;
 	journalPage: JournalPage;
 }>({
@@ -31,6 +35,12 @@ const journalPagesTest = test.extend<{
 	},
 	journalEditArticleTranslationsPage: async ({page}, use) => {
 		await use(new JournalEditArticleTranslationsPage(page));
+	},
+	journalEditStructureDefaultValuesPage: async ({page}, use) => {
+		await use(new JournalEditStructureDefaultValuesPage(page));
+	},
+	journalEditStructurePage: async ({page}, use) => {
+		await use(new JournalEditStructurePage(page));
 	},
 	journalEditTemplatePage: async ({page}, use) => {
 		await use(new JournalEditTemplatePage(page));

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1135,6 +1135,138 @@ baseTest(
 	}
 );
 
+baseTest(
+	'LPD-28728: the value of a repeated field of an article is the same as the structure default value',
+	async ({
+		apiHelpers,
+		journalEditArticlePage,
+		journalEditStructureDefaultValuesPage,
+		page,
+		site,
+	}) => {
+		const fieldName = 'Text1';
+		const structureName = 'Structure1';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: fieldName, repeatable: true}],
+			name: structureName,
+		});
+
+		const structure = await apiHelpers.dataEngine.createStructure(
+			site.id,
+			dataDefinition
+		);
+
+		await journalEditStructureDefaultValuesPage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		const content = getRandomString();
+
+		await journalEditStructureDefaultValuesPage.fillTextField(
+			fieldName,
+			content
+		);
+
+		await journalEditStructureDefaultValuesPage.save();
+
+		const modifiedStructure = await apiHelpers.dataEngine.getStructure(
+			structure.id
+		);
+
+		expect(modifiedStructure.dataDefinitionFields[0].defaultValue).toEqual({
+			en_US: `${content}`,
+		});
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		const textField = page.getByRole('textbox', {
+			name: fieldName,
+		});
+
+		await expect(textField).toHaveValue(content);
+
+		await page.getByLabel('Add Duplicate Field Text').click();
+
+		await expect(textField.nth(1)).toHaveValue(content);
+	}
+);
+
+baseTest(
+	'LPD-28728: the default value of a structure is not deleted after the structure update',
+	async ({
+		apiHelpers,
+		journalEditStructureDefaultValuesPage,
+		journalEditStructurePage,
+		site,
+	}) => {
+		const fieldName = 'Text1';
+		const structureName = 'Structure1';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: fieldName, repeatable: true}],
+			name: structureName,
+		});
+
+		const structure = await apiHelpers.dataEngine.createStructure(
+			site.id,
+			dataDefinition
+		);
+
+		await journalEditStructureDefaultValuesPage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		const content = getRandomString();
+
+		await journalEditStructureDefaultValuesPage.fillTextField(
+			fieldName,
+			content
+		);
+
+		await journalEditStructureDefaultValuesPage.save();
+
+		await journalEditStructurePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		await journalEditStructurePage.showFieldProperties(fieldName);
+
+		await expect(
+			journalEditStructurePage.propertyPlaceholderText
+		).toBeEmpty();
+
+		const placeholderText = getRandomString();
+
+		await journalEditStructurePage.fillFieldProperty(
+			journalEditStructurePage.propertyPlaceholderText,
+			placeholderText
+		);
+
+		await expect(
+			journalEditStructurePage.propertyPlaceholderText
+		).toHaveValue(placeholderText);
+
+		await journalEditStructurePage.save();
+
+		const modifiedStructure = await apiHelpers.dataEngine.getStructure(
+			structure.id
+		);
+
+		expect(modifiedStructure.dataDefinitionFields[0].defaultValue).toEqual({
+			en_US: `${content}`,
+		});
+	}
+);
+
 scheduleTest(
 	'Create a web content scheduled',
 	async ({journalEditArticlePage, site}) => {

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditStructureDefaultValuesPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditStructureDefaultValuesPage.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import fillAndClickOutside from '../../../utils/fillAndClickOutside';
+import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {JournalStructuresPage} from './JournalStructuresPage';
+
+export class JournalEditStructureDefaultValuesPage {
+	readonly page: Page;
+
+	readonly journalStructurePage: JournalStructuresPage;
+	readonly propertiesTab: Locator;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.journalStructurePage = new JournalStructuresPage(page);
+		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
+		this.saveButton = this.page.getByRole('button', {name: 'Save'});
+	}
+
+	async goto({
+		siteUrl,
+		structureName,
+	}: {
+		siteUrl?: Site['friendlyUrlPath'];
+		structureName?: string;
+	} = {}) {
+		await this.journalStructurePage.goto(siteUrl);
+		await this.journalStructurePage.goToJournalStructureAction(
+			'Edit Default Values',
+			structureName
+		);
+
+		await this.propertiesTab.waitFor();
+
+		await this.page.locator('body').click();
+	}
+
+	async fillTextField(name: string, content: string) {
+		const textField = this.page.getByRole('textbox', {
+			name,
+		});
+
+		await fillAndClickOutside(this.page, textField, content);
+	}
+
+	async save() {
+		await this.saveButton.click();
+
+		await waitForSuccessAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+}

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {JournalStructuresPage} from './JournalStructuresPage';
+import {waitForSuccessAlert} from "../../../utils/waitForSuccessAlert";
+
+export enum FIELD_TYPES {
+	DATE = 'Date',
+	NUMERIC = 'Numeric',
+	TEXT = 'Text',
+	SELECT_FROM_LIST = 'Select from List',
+}
+
+export class JournalEditStructurePage {
+	readonly page: Page;
+
+	readonly journalStructurePage: JournalStructuresPage;
+	readonly propertyPlaceholderText: Locator;
+	readonly propertiesTab: Locator;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.journalStructurePage = new JournalStructuresPage(page);
+		this.propertyPlaceholderText = page.getByLabel('Placeholder Text');
+		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
+		this.saveButton = this.page.getByRole('button', { name: 'Save' });
+	}
+
+	async goto({
+		siteUrl,
+		structureName,
+	}: {
+		siteUrl?: Site['friendlyUrlPath'];
+		structureName?: string;
+	} = {}) {
+		await this.journalStructurePage.goto(siteUrl);
+		await this.page.getByRole('link', { exact: true, name: `${structureName}` }).click();
+
+		await this.propertiesTab.waitFor();
+
+		await this.page.locator('body').click();
+	}
+
+	async showFieldProperties(name, type?: FIELD_TYPES) {
+		await this.page.getByText(`${type || FIELD_TYPES.TEXT}${name}`).click();
+	}
+
+	async fillFieldProperty(fieldProperty: Locator, content: string) {
+		await fieldProperty.click();
+		await fieldProperty.fill(content);
+	}
+
+	async save() {
+		await this.saveButton.click();
+
+		await waitForSuccessAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+}

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
@@ -5,8 +5,8 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import {JournalStructuresPage} from './JournalStructuresPage';
-import {waitForSuccessAlert} from "../../../utils/waitForSuccessAlert";
 
 export enum FIELD_TYPES {
 	DATE = 'Date',
@@ -29,7 +29,7 @@ export class JournalEditStructurePage {
 		this.journalStructurePage = new JournalStructuresPage(page);
 		this.propertyPlaceholderText = page.getByLabel('Placeholder Text');
 		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
-		this.saveButton = this.page.getByRole('button', { name: 'Save' });
+		this.saveButton = this.page.getByRole('button', {name: 'Save'});
 	}
 
 	async goto({
@@ -40,7 +40,9 @@ export class JournalEditStructurePage {
 		structureName?: string;
 	} = {}) {
 		await this.journalStructurePage.goto(siteUrl);
-		await this.page.getByRole('link', { exact: true, name: `${structureName}` }).click();
+		await this.page
+			.getByRole('link', {exact: true, name: `${structureName}`})
+			.click();
 
 		await this.propertiesTab.waitFor();
 

--- a/modules/test/playwright/tests/journal-web/pages/JournalStructuresPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalStructuresPage.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+
+export class JournalStructuresPage {
+	readonly page: Page;
+
+	readonly newButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.newButton = page.getByText('New', {exact: true});
+	}
+
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.journalStructures}`
+		);
+	}
+
+	async goToCreateNewStructure() {
+		await this.goto();
+		await this.newButton.click();
+	}
+
+	async goToJournalStructureAction(action: string, title: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: action,
+			}),
+			trigger: this.page
+				.getByRole('row', {name: `${title}`})
+				.getByLabel('Show Actions', {exact: true}),
+		});
+	}
+}

--- a/modules/test/playwright/types/data-definition.d.ts
+++ b/modules/test/playwright/types/data-definition.d.ts
@@ -10,6 +10,7 @@ type DataDefinition = {
 	dataDefinitionFields: DefinitionField[];
 	defaultDataLayout: DataLayout;
 	defaultLanguageId: Locale;
+	id: string;
 	name: {[keys: string]: string};
 };
 
@@ -19,6 +20,7 @@ type DefinitionField = {
 		displayStyle: 'singleline' | 'multiline';
 		fieldReference: string;
 	};
+	defaultValue: {[keys: string]: string};
 	fieldType: 'text' | 'select';
 	indexType: 'keyword' | 'text' | 'none';
 	label: {[keys: string]: string};

--- a/modules/test/playwright/utils/fillAndClickOutside.ts
+++ b/modules/test/playwright/utils/fillAndClickOutside.ts
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import getRandomString from './getRandomString';
-import {Locator, Page} from "@playwright/test";
+import {Locator, Page} from '@playwright/test';
 
-export default async function fillAndClickOutside(page: Page, element: Locator, content?: string) {
+import getRandomString from './getRandomString';
+
+export default async function fillAndClickOutside(
+	page: Page,
+	element: Locator,
+	content?: string
+) {
 	await element.click();
 	await element.fill(content || getRandomString());
 	await page.locator('body').click();

--- a/modules/test/playwright/utils/fillAndClickOutside.ts
+++ b/modules/test/playwright/utils/fillAndClickOutside.ts
@@ -4,8 +4,9 @@
  */
 
 import getRandomString from './getRandomString';
+import {Locator, Page} from "@playwright/test";
 
-export default async function fillAndClickOutside(page, element, content?) {
+export default async function fillAndClickOutside(page: Page, element: Locator, content?: string) {
 	await element.click();
 	await element.fill(content || getRandomString());
 	await page.locator('body').click();

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -15,6 +15,8 @@ export const PORTLET_URLS = {
 	fragments: '/~/control_panel/manage/-/fragments/fragment_collections',
 	journal:
 		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet',
+	journalStructures:
+		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp',
 	journalTemplates:
 		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_templates.jsp',
 	knowledgeBase:


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28728

When a repeatable field with a default value is being replicated in a Web Content, the new replicated fields don't have the default value.

# How am I fixing it?

The `predefinedValues` of Web Content Structures are currently stored in a hidden article. Now I'm also storing them in the Structure (which is the standard way used in D&M).

# How can you verify that it works?

Manually: follow the steps in Jira issue
Automatically: execute added unit and playwright tests

