### PR TITLE
LPD-29066 Sites and Library displays all sites depending on the users navigation

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -252,12 +252,6 @@ public class JournalArticleItemSelectorViewDisplayContext {
 					PortletURLBuilder.create(
 						getPortletURL()
 					).setParameter(
-						"groupType", "site"
-					).setParameter(
-						"scopeGroupType",
-						ParamUtil.getBoolean(
-							_httpServletRequest, "scopeGroupType")
-					).setParameter(
 						"showGroupSelector", true
 					).buildString());
 			}
@@ -312,6 +306,11 @@ public class JournalArticleItemSelectorViewDisplayContext {
 				_portal.getLiferayPortletResponse(_portletResponse))
 		).setParameter(
 			"displayStyle", getDisplayStyle()
+		).setParameter(
+			"groupType", "site"
+		).setParameter(
+			"scopeGroupType",
+			ParamUtil.getBoolean(_httpServletRequest, "scopeGroupType")
 		).setParameter(
 			"selectedTab", _getTitle(_httpServletRequest.getLocale())
 		).buildPortletURL();

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.web.internal.display.context;
 
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.service.JournalFolderServiceUtil;
@@ -14,22 +15,27 @@ import com.liferay.journal.web.internal.item.selector.JournalArticleItemSelector
 import com.liferay.portal.kernel.bean.BeanProperties;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -37,9 +43,10 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.staging.StagingGroupHelper;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
-import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -55,6 +62,7 @@ import org.junit.Test;
 
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Jürgen Kappler
@@ -67,10 +75,14 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() throws PortletException {
+	public void setUp() throws Exception {
+		_setUpAncestorJournalFolder();
 		_setUpBeanProperties();
+		_setUpGroup();
+		_setUpGroupLocalServiceUtil(_group);
 		_setUpHttpServletRequest();
-		_setUpJournalFolderLocalServiceUtil();
+		_setUpJournalFolder(_ancestorJournalFolder);
+		_setUpJournalFolderLocalServiceUtil(_journalFolder);
 		_setUpJournalFolderServiceUtil();
 		_setUpLanguage();
 		_setUpPortal();
@@ -82,6 +94,7 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 
 	@After
 	public void tearDown() {
+		_groupLocalServiceUtilMockedStatic.close();
 		_journalFolderLocalServiceUtilMockedStatic.close();
 		_journalFolderServiceUtilMockedStatic.close();
 		_portletURLBuilderMockedStatic.close();
@@ -91,9 +104,29 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 	}
 
 	@Test
+	public void testGetPortletBreadcrumbEntries() throws PortalException {
+		_testGetPortletBreadcrumbEntries("false");
+		_testGetPortletBreadcrumbEntries("true");
+	}
+
+	@Test
 	public void testSearchContainerWithScope() throws Exception {
 		_testSearchContainerWithScope("false");
 		_testSearchContainerWithScope("true");
+	}
+
+	private void _setUpAncestorJournalFolder() {
+		Mockito.when(
+			_ancestorJournalFolder.getFolderId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_ancestorJournalFolder.getName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
 	}
 
 	private void _setUpBeanProperties() {
@@ -102,7 +135,32 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		beanPropertiesUtil.setBeanProperties(_beanProperties);
 	}
 
+	private void _setUpGroup() throws Exception {
+		Mockito.when(
+			_group.getDescriptiveName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+	}
+
+	private void _setUpGroupLocalServiceUtil(Group group) throws Exception {
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+		Mockito.when(
+			GroupLocalServiceUtil.getGroup(Mockito.anyLong())
+		).thenReturn(
+			group
+		);
+	}
+
 	private void _setUpHttpServletRequest() {
+		Mockito.when(
+			_themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.getDefault()
+		);
+
 		Mockito.when(
 			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
 		).thenReturn(
@@ -128,8 +186,47 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		);
 	}
 
-	private void _setUpJournalFolderLocalServiceUtil() {
-		JournalFolder journalFolder = Mockito.mock(JournalFolder.class);
+	private void _setUpJournalFolder(JournalFolder ancestorJournalFolder)
+		throws Exception {
+
+		String name = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_journalFolder.getAncestors()
+		).thenReturn(
+			Arrays.asList(ancestorJournalFolder)
+		);
+
+		Mockito.when(
+			_journalFolder.getFolderId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_journalFolder.getName()
+		).thenReturn(
+			name
+		);
+
+		JournalFolder unescapeJournalFolder = Mockito.mock(JournalFolder.class);
+
+		Mockito.when(
+			unescapeJournalFolder.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			_journalFolder.toUnescapedModel()
+		).thenReturn(
+			unescapeJournalFolder
+		);
+	}
+
+	private void _setUpJournalFolderLocalServiceUtil(
+		JournalFolder journalFolder) {
+
 		_journalFolderLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			JournalFolderLocalServiceUtil.class);
 
@@ -165,6 +262,14 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 
 	private void _setUpLanguage() {
 		LanguageUtil languageUtil = new LanguageUtil();
+
+		Mockito.when(
+			_language.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenAnswer(
+			(Answer<String>)invocationOnMock -> invocationOnMock.getArgument(
+				1, String.class)
+		);
 
 		languageUtil.setLanguage(_language);
 	}
@@ -202,7 +307,7 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		);
 	}
 
-	private void _setUpPortletURLUtil() throws PortletException {
+	private void _setUpPortletURLUtil() throws Exception {
 		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
 
 		Mockito.when(
@@ -240,6 +345,93 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		);
 	}
 
+	private void _testGetPortletBreadcrumbEntries(String scopeGroupType)
+		throws PortalException {
+
+		Mockito.when(
+			_httpServletRequest.getParameter("scopeGroupType")
+		).thenReturn(
+			scopeGroupType
+		);
+
+		JournalArticleItemSelectorView journalArticleItemSelectorView =
+			Mockito.mock(JournalArticleItemSelectorView.class);
+
+		Mockito.when(
+			journalArticleItemSelectorView.getTitle(Mockito.any())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		JournalArticleItemSelectorViewDisplayContext
+			journalArticleItemSelectorViewDisplayContext =
+				new JournalArticleItemSelectorViewDisplayContext(
+					_httpServletRequest,
+					Mockito.mock(InfoItemItemSelectorCriterion.class),
+					RandomTestUtil.randomString(),
+					journalArticleItemSelectorView,
+					Mockito.mock(JournalWebConfiguration.class), _portal,
+					new MockLiferayPortletURL(),
+					Mockito.mock(ResourcePermissionLocalService.class),
+					Mockito.mock(RoleLocalService.class), false,
+					Mockito.mock(StagingGroupHelper.class));
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			journalArticleItemSelectorViewDisplayContext.
+				getPortletBreadcrumbEntries();
+
+		Assert.assertEquals(
+			breadcrumbEntries.toString(), 4, breadcrumbEntries.size());
+
+		BreadcrumbEntry breadcrumbEntry = breadcrumbEntries.get(0);
+
+		String url = breadcrumbEntry.getURL();
+
+		Assert.assertEquals("sites-and-libraries", breadcrumbEntry.getTitle());
+
+		Assert.assertTrue(url.contains("param_groupType=site"));
+		Assert.assertTrue(
+			url.contains("param_scopeGroupType=" + scopeGroupType));
+		Assert.assertTrue(url.contains("param_showGroupSelector=true"));
+
+		breadcrumbEntry = breadcrumbEntries.get(1);
+
+		url = breadcrumbEntry.getURL();
+
+		Assert.assertEquals(
+			_group.getDescriptiveName(LocaleUtil.getDefault()),
+			breadcrumbEntry.getTitle());
+
+		Assert.assertTrue(url.contains("param_groupType=site"));
+		Assert.assertTrue(
+			url.contains("param_scopeGroupType=" + scopeGroupType));
+		Assert.assertTrue(
+			url.contains(
+				"param_folderId=" +
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID));
+
+		breadcrumbEntry = breadcrumbEntries.get(2);
+
+		url = breadcrumbEntry.getURL();
+
+		Assert.assertEquals(
+			_ancestorJournalFolder.getName(), breadcrumbEntry.getTitle());
+
+		Assert.assertTrue(url.contains("param_groupType=site"));
+		Assert.assertTrue(
+			url.contains("param_scopeGroupType=" + scopeGroupType));
+		Assert.assertTrue(
+			url.contains(
+				"param_folderId=" + _ancestorJournalFolder.getFolderId()));
+
+		breadcrumbEntry = breadcrumbEntries.get(3);
+
+		Assert.assertEquals(
+			_journalFolder.getName(), breadcrumbEntry.getTitle());
+
+		Assert.assertNull(breadcrumbEntry.getURL());
+	}
+
 	private void _testSearchContainerWithScope(String scope) throws Exception {
 		Mockito.when(
 			_httpServletRequest.getParameter("scope")
@@ -271,6 +463,8 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		Assert.assertEquals(scope, iteratorURL.getParameter("scope"));
 	}
 
+	private static MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic;
 	private static MockedStatic<JournalFolderLocalServiceUtil>
 		_journalFolderLocalServiceUtilMockedStatic;
 	private static MockedStatic<JournalFolderServiceUtil>
@@ -283,10 +477,15 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 	private static MockedStatic<SearchOrderByUtil>
 		_searchOrderByUtilMockedStatic;
 
+	private final JournalFolder _ancestorJournalFolder = Mockito.mock(
+		JournalFolder.class);
 	private final BeanProperties _beanProperties = Mockito.mock(
 		BeanProperties.class);
+	private final Group _group = Mockito.mock(Group.class);
 	private final HttpServletRequest _httpServletRequest = Mockito.mock(
 		HttpServletRequest.class);
+	private final JournalFolder _journalFolder = Mockito.mock(
+		JournalFolder.class);
 	private final Language _language = Mockito.mock(Language.class);
 	private final Portal _portal = Mockito.mock(Portal.class);
 	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContextTest.java
@@ -248,7 +248,7 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 		);
 
 		JournalArticleItemSelectorViewDisplayContext
-			journalArticleItemSelectorView =
+			journalArticleItemSelectorViewDisplayContext =
 				new JournalArticleItemSelectorViewDisplayContext(
 					_httpServletRequest,
 					Mockito.mock(InfoItemItemSelectorCriterion.class),
@@ -261,7 +261,7 @@ public class JournalArticleItemSelectorViewDisplayContextTest {
 					Mockito.mock(StagingGroupHelper.class));
 
 		SearchContainer<?> searchContainer =
-			journalArticleItemSelectorView.getSearchContainer();
+			journalArticleItemSelectorViewDisplayContext.getSearchContainer();
 
 		Assert.assertNotNull(searchContainer);
 


### PR DESCRIPTION
Resent with changes for https://github.com/brianchandotcom/liferay-portal/pull/151614#issuecomment-2181696333

Sites and Library displays all sites depending on the users navigation

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-29066)

Depending on the navigation by the user, all sites are shown when selecting content in a web content display widget

# How am I fixing it?

Maintain the parameters needed to show the sites correctly

# How can you verify that it works?

Execute the unit tests that are included or follow the steps in the ticket

![wcd](https://github.com/liferay-content-management/liferay-portal/assets/4267448/896c461a-060b-42f7-92e1-6e485ca7bece)



