### PR TITLE
LPD-29342 Fix announcements-web/announcements-web.spec.ts flaky test

### DIFF
--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -35,5 +35,5 @@ test('LPD-27067 Content field is required', async ({
 }) => {
 	await announcementsPage.goToCreateNewAnnouncement();
 
-	expect(await page.getByText('Content *')).toBeVisible();
+	await expect(page.getByText('Content *')).toBeVisible();
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29342

Fix announcements-web/announcements-web.spec.ts flaky test

# How am I fixing it?

Using await correctly :D

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright test -- -g "LPD-27067"` to run the test

# After the PR

```sh
npm run playwright test -- -g "LPD-27067" --reporter list --repeat-each 15
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/63861063-d504-402e-97f0-4e9ee0d30b20)


# Before de the PR

```sh
npm run playwright test -- -g "LPD-27067" --reporter list --repeat-each 15
```
![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/3b376a0f-c469-4a8a-a48a-35c415f3478a)
