### PR TITLE
LPD-29497 Add playwright test to our daily routine ci:test:content-management

### DIFF
--- a/modules/apps/notification/test.properties
+++ b/modules/apps/notification/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Notifications
+    testray.main.component.name=Notification

--- a/modules/dxp/apps/enterprise-product-notification/test.properties
+++ b/modules/dxp/apps/enterprise-product-notification/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Notifications
+    testray.main.component.name=Notification

--- a/modules/test/playwright/tests/notification-web/test.properties
+++ b/modules/test/playwright/tests/notification-web/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Notifications
+    testray.main.component.name=Notification

--- a/test.properties
+++ b/test.properties
@@ -4112,11 +4112,13 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=\
         announcements-web,\
         blogs-web,\
+        content-dashboard-web,\
         document-library-web,\
         journal-web,\
         knowledge-base-web,\
         message-boards-web,\
-        notification-web
+        questions-web,\
+        wiki-web
 
     test.batch.class.names.includes[content-management]=\
         **/adaptive-media-blogs-test/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -6463,7 +6463,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Object
     #
 
-    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][object]=object
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][object]=\
+        notification-web,\
+        object
 
     test.batch.class.names.includes[modules-integration-*-jdk8][object]=\
         **/object/**/src/testIntegration/**/*Test.java

--- a/test.properties
+++ b/test.properties
@@ -4226,6 +4226,8 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         functional-tomcat90-mysql57-jdk8,\
         js-unit-jdk8,\
         modules-semantic-versioning-jdk8,\
+        playwright-compile-jdk8,\
+        playwright-js-tomcat90-mysql57-jdk8,\
         semantic-versioning-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][content-management]=\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29497

> [!NOTE]
> Fixes some stuff in #5512

Execute our playwright test in the `ci:test:content-management` routine.


# How am I fixing it?

We are adding the suites to our daily routine 767e90e8d9de8e8d625f96d2faae2806e59a5e2b and updating/adding some playwright project references d5bca12d44998f825ec6a47859b8cc8fd50a5141.

# How can you verify that it works?

I'm not sure, we can check if it is included in our daily routine in the future.

# Why doesn't this include any test?

It's test infra-related changes, we can not test it.