### PR TITLE
LPD-27633 Remove site breadcrumb when moving categories in Message Boards

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/select_category.jsp
@@ -31,7 +31,7 @@ else {
 <clay:container-fluid>
 	<aui:form method="post" name="selectCategoryFm">
 		<liferay-site-navigation:breadcrumb
-			breadcrumbEntries="<%= BreadcrumbEntriesUtil.getBreadcrumbEntries(request, true, false, false, false, true) %>"
+			breadcrumbEntries="<%= BreadcrumbEntriesUtil.getBreadcrumbEntries(request, false, false, false, false, true) %>"
 		/>
 
 		<liferay-ui:search-container

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -21,10 +21,10 @@ export class MessageBoardsWidgetPage {
 	}
 
 	async addMessageBoardsPortlet(site: Site) {
-		const layout = await this.apiHelpers.jsonWebServicesLayout.addLayout(
-			site.id,
-			getRandomString()
-		);
+		const layout = await this.apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
 
 		await this.page.goto(
 			`/web${site.friendlyUrlPath}${layout.friendlyURL}`

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -54,4 +54,20 @@ export class MessageBoardsWidgetPage {
 
 		await this.page.getByRole('button', {name: buttonName}).click();
 	}
+
+	async addCategory(site: Site, layout: Layout, categoryName: string) {
+		await this.page.goto(
+			`/web${site.friendlyUrlPath}${layout.friendlyURL}`
+		);
+
+		await this.page.getByRole('link', {name: 'Add Category'}).click();
+
+		await this.page
+			.locator(
+				'[id="_com_liferay_message_boards_web_portlet_MBPortlet_name"]'
+			)
+			.fill(categoryName);
+
+		await this.page.getByRole('button', {name: 'Save'}).click();
+	}
 }

--- a/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
+++ b/modules/test/playwright/pages/message-boards/MessageBoardsWidgetPage.ts
@@ -60,7 +60,12 @@ export class MessageBoardsWidgetPage {
 			`/web${site.friendlyUrlPath}${layout.friendlyURL}`
 		);
 
-		await this.page.getByRole('link', {name: 'Add Category'}).click();
+		const categoryMenu = this.page.getByRole('link', {
+			name: 'Add Category',
+		});
+
+		await categoryMenu.waitFor();
+		await categoryMenu.click();
 
 		await this.page
 			.locator(

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -109,11 +109,12 @@ test('LPD-27633 Do not show site in breadcrumb', async ({
 
 	await messageBoardsWidgetPage.addCategory(site, layout, categoryName);
 
-	await page
-		.locator(
-			'[id="_com_liferay_message_boards_web_portlet_MBPortlet_mbCategoriesSearchContainer_1_menu"]'
-		)
-		.click();
+	const searchMenu = page.locator(
+		'[id="_com_liferay_message_boards_web_portlet_MBPortlet_mbCategoriesSearchContainer_1_menu"]'
+	);
+
+	await searchMenu.waitFor();
+	await searchMenu.click();
 
 	await page.getByRole('menuitem', {name: 'Move'}).click();
 

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -94,3 +94,35 @@ test('LPD-29524 Search for message board thread by keywords', async ({
 		page.getByRole('link', {name: messageBoardThread2.headline})
 	).toBeHidden();
 });
+
+test('LPD-27633 Do not show site in breadcrumb', async ({
+	messageBoardsPage,
+	messageBoardsWidgetPage,
+	page,
+	site,
+	workflowPage,
+}) => {
+	await page.goto(site.friendlyUrlPath);
+
+	const layout = await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
+
+	const categoryName = getRandomString();
+
+	await messageBoardsWidgetPage.addCategory(site, layout, categoryName);
+
+	await page
+		.locator(
+			'[id="_com_liferay_message_boards_web_portlet_MBPortlet_mbCategoriesSearchContainer_1_menu"]'
+		)
+		.click();
+
+	await page.getByRole('menuitem', {name: 'Move'}).click();
+
+	await page.getByRole('button', {name: 'Select'}).click();
+
+	await expect(
+		page
+			.frameLocator('iframe[title="Select Category"]')
+			.getByText(site.name)
+	).toBeHidden();
+});

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -100,9 +100,8 @@ test('LPD-27633 Do not show site in breadcrumb', async ({
 	messageBoardsWidgetPage,
 	page,
 	site,
-	workflowPage,
 }) => {
-	await page.goto(site.friendlyUrlPath);
+	await messageBoardsPage.goto(site.friendlyUrlPath);
 
 	const layout = await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
 

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -96,13 +96,10 @@ test('LPD-29524 Search for message board thread by keywords', async ({
 });
 
 test('LPD-27633 Do not show site in breadcrumb', async ({
-	messageBoardsPage,
 	messageBoardsWidgetPage,
 	page,
 	site,
 }) => {
-	await messageBoardsPage.goto(site.friendlyUrlPath);
-
 	const layout = await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
 
 	const categoryName = getRandomString();


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-27633

I am removing the site from the breadcrumbs when moving a category in message boards.

# How am I fixing it?
Passing in the correct booleans when getting the breadcrumbs

# How can you verify that it works?
Run npm run playwright test -- -g 'LPD-27633' to run the test