### PR TITLE
LPD-27781 MB upgrade process should take into account ctCollectionId

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
@@ -30,14 +30,14 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 
 			try (PreparedStatement preparedStatement1 =
 					connection.prepareStatement(
-						"select categoryId, name from MBCategory order by " +
-							"name, categoryId asc");
+						"select categoryId, ctCollectionId, name from " +
+							"MBCategory order by name, categoryId asc");
 				ResultSet resultSet = preparedStatement1.executeQuery();
 				PreparedStatement preparedStatement2 =
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection,
 						"update MBCategory set friendlyURL = ? where " +
-							"categoryId = ?")) {
+							"categoryId = ? and ctCollectionId = ?")) {
 
 				int count = 0;
 				String currentFriendlyURL = null;
@@ -45,7 +45,8 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 
 				while (resultSet.next()) {
 					long categoryId = resultSet.getLong(1);
-					String name = resultSet.getString(2);
+					long ctCollectionId = resultSet.getLong(2);
+					String name = resultSet.getString(3);
 
 					currentFriendlyURL = _getFriendlyURL(categoryId, name);
 
@@ -66,6 +67,7 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 					preparedStatement2.setString(
 						1, currentFriendlyURL + suffix);
 					preparedStatement2.setLong(2, categoryId);
+					preparedStatement2.setLong(3, ctCollectionId);
 
 					preparedStatement2.addBatch();
 				}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
@@ -45,6 +45,7 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 
 				while (resultSet.next()) {
 					long ctCollectionId = resultSet.getLong(1);
+
 					long categoryId = resultSet.getLong(2);
 					String name = resultSet.getString(3);
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_5_0/FriendlyURLUpgradeProcess.java
@@ -30,22 +30,22 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 
 			try (PreparedStatement preparedStatement1 =
 					connection.prepareStatement(
-						"select categoryId, ctCollectionId, name from " +
+						"select ctCollectionId, categoryId, name from " +
 							"MBCategory order by name, categoryId asc");
 				ResultSet resultSet = preparedStatement1.executeQuery();
 				PreparedStatement preparedStatement2 =
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection,
 						"update MBCategory set friendlyURL = ? where " +
-							"categoryId = ? and ctCollectionId = ?")) {
+							"ctCollectionId = ? and categoryId = ?")) {
 
 				int count = 0;
 				String currentFriendlyURL = null;
 				String previousFriendlyURL = null;
 
 				while (resultSet.next()) {
-					long categoryId = resultSet.getLong(1);
-					long ctCollectionId = resultSet.getLong(2);
+					long ctCollectionId = resultSet.getLong(1);
+					long categoryId = resultSet.getLong(2);
 					String name = resultSet.getString(3);
 
 					currentFriendlyURL = _getFriendlyURL(categoryId, name);
@@ -66,8 +66,8 @@ public class FriendlyURLUpgradeProcess extends UpgradeProcess {
 
 					preparedStatement2.setString(
 						1, currentFriendlyURL + suffix);
-					preparedStatement2.setLong(2, categoryId);
-					preparedStatement2.setLong(3, ctCollectionId);
+					preparedStatement2.setLong(2, ctCollectionId);
+					preparedStatement2.setLong(3, categoryId);
 
 					preparedStatement2.addBatch();
 				}

--- a/modules/apps/message-boards/message-boards-test/build.gradle
+++ b/modules/apps/message-boards/message-boards-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationImplementation project(":apps:asset:asset-link-api")
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:comment:comment-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
@@ -17,9 +18,11 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-permission-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
 	testIntegrationImplementation project(":apps:social:social-activity-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:subscription:subscription-api")
 	testIntegrationImplementation project(":apps:subscription:subscription-test-util")
 	testIntegrationImplementation project(":apps:trash:trash-api")

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_5_0/test/FriendlyURLUpgradeProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_5_0/test/FriendlyURLUpgradeProcessTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.internal.upgrade.v6_5_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.message.boards.constants.MBCategoryConstants;
+import com.liferay.message.boards.model.MBCategory;
+import com.liferay.message.boards.service.MBCategoryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class FriendlyURLUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, FriendlyURLUpgradeProcessTest.class.getSimpleName(), null);
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		MBCategory productionMBCategory;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			productionMBCategory = _mbCategoryLocalService.addCategory(
+				TestPropsValues.getUserId(),
+				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				StringUtil.randomString(), StringUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			productionMBCategory.setFriendlyURL(null);
+
+			productionMBCategory = _mbCategoryLocalService.updateMBCategory(
+				productionMBCategory);
+		}
+
+		MBCategory ctCollectionMBCategory;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionMBCategory = _mbCategoryLocalService.updateCategory(
+				productionMBCategory.getCategoryId(),
+				productionMBCategory.getParentCategoryId(),
+				StringUtil.randomString(),
+				productionMBCategory.getDescription(),
+				productionMBCategory.getDisplayStyle(), null, null, null, 0,
+				false, null, null, 0, null, false, null, 0, false, null, null,
+				false, false, false,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			ctCollectionMBCategory.setFriendlyURL(null);
+
+			ctCollectionMBCategory = _mbCategoryLocalService.updateMBCategory(
+				ctCollectionMBCategory);
+		}
+
+		_runUpgradeProcess();
+
+		_multiVMPool.clear();
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionMBCategory = _mbCategoryLocalService.fetchMBCategory(
+				productionMBCategory.getCategoryId());
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			productionMBCategory = _mbCategoryLocalService.fetchMBCategory(
+				productionMBCategory.getCategoryId());
+		}
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(productionMBCategory.getName()),
+			productionMBCategory.getFriendlyURL());
+		Assert.assertEquals(
+			StringUtil.toLowerCase(ctCollectionMBCategory.getName()),
+			ctCollectionMBCategory.getFriendlyURL());
+		Assert.assertNotEquals(
+			StringUtil.toLowerCase(productionMBCategory.getName()),
+			ctCollectionMBCategory.getFriendlyURL());
+	}
+
+	private void _runUpgradeProcess() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.message.boards.internal.upgrade.v6_5_0." +
+				"FriendlyURLUpgradeProcess");
+
+		upgradeProcess.upgrade();
+	}
+
+	@Inject
+	private static CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.message.boards.internal.upgrade.registry.MBServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private CTCollection _ctCollection;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MBCategoryLocalService _mbCategoryLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27781

The upgrade process query is treating categories belonging to different collections as a unit, setting the same friendly url to all of them.

# How am I fixing it?

Take into account the collection ID when updating the categories, so that each one gets assigned the expected friendly url.

# How can you verify that it works?

Run the `FriendlyURLUpgradeProcessTest` integration test included with this PR.