### PR TITLE
LPD-25907 set whitelist attribut on iframeconfiguration

### DIFF
--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -72,12 +72,14 @@ public class IFrameSanitizerImplTest {
 
 	@Test
 	public void testSanitizeHTMLWithIFrame() throws Exception {
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -85,12 +87,14 @@ public class IFrameSanitizerImplTest {
 	public void testSanitizeHTMLWithIFrameAndConfigurationDisabled()
 		throws Exception {
 
-		_updateCompanyConfiguration(_companyId, false, false, "");
+		_updateCompanyConfiguration(
+			_companyId, false, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -98,12 +102,14 @@ public class IFrameSanitizerImplTest {
 	public void testSanitizeHTMLWithIFrameAndRemoveIFrameTags()
 		throws Exception {
 
-		_updateCompanyConfiguration(_companyId, true, true, "");
+		_updateCompanyConfiguration(
+			_companyId, true, true, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -111,12 +117,14 @@ public class IFrameSanitizerImplTest {
 	public void testSanitizeHTMLWithIFrameAndSandboxAttributeValues()
 		throws Exception {
 
-		_updateCompanyConfiguration(_companyId, true, false, "test");
+		_updateCompanyConfiguration(
+			_companyId, true, false, "test", StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -124,12 +132,14 @@ public class IFrameSanitizerImplTest {
 	public void testSanitizeHTMLWithIFrameAndSandboxAttributeValuesEmpty()
 		throws Exception {
 
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -138,7 +148,8 @@ public class IFrameSanitizerImplTest {
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -148,18 +159,20 @@ public class IFrameSanitizerImplTest {
 
 		try {
 			_updateCompanyConfiguration(
-				company.getCompanyId(), false, false, "");
+				company.getCompanyId(), false, false, StringPool.BLANK,
+				StringPool.BLANK);
 
 			Assert.assertEquals(
 				_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
 				_sanitize(
-					_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+					StringPool.BLANK, 0, _companyId,
+					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 					ContentTypes.TEXT_HTML));
 
 			Assert.assertEquals(
 				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				_sanitize(
-					company.getCompanyId(),
+					StringPool.BLANK, 0, company.getCompanyId(),
 					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 					ContentTypes.TEXT_HTML));
 		}
@@ -170,62 +183,75 @@ public class IFrameSanitizerImplTest {
 
 	@Test
 	public void testSanitizeHTMLWithInvalidContentType() throws Exception {
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_CONTENT,
-			_sanitize(_companyId, _BASIC_CONTENT, ContentTypes.TEXT_PLAIN));
+			_sanitize(
+				StringPool.BLANK, 0, _companyId, _BASIC_CONTENT,
+				ContentTypes.TEXT_PLAIN));
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT, ContentTypes.TEXT_PLAIN));
+				StringPool.BLANK, 0, _companyId, _BASIC_HTML_CONTENT,
+				ContentTypes.TEXT_PLAIN));
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-				"text/creole"));
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG, "text/creole"));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithNullContent() throws Exception {
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			StringPool.BLANK,
-			_sanitize(_companyId, StringPool.BLANK, ContentTypes.TEXT_HTML));
+			_sanitize(
+				StringPool.BLANK, 0, _companyId, StringPool.BLANK,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithNullContentType() throws Exception {
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 			_sanitize(
-				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-				StringPool.BLANK));
+				StringPool.BLANK, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG, StringPool.BLANK));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithoutIFrame() throws Exception {
-		_updateCompanyConfiguration(_companyId, true, false, "");
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT,
-			_sanitize(_companyId, _BASIC_HTML_CONTENT, ContentTypes.TEXT_HTML));
+			_sanitize(
+				StringPool.BLANK, 0, _companyId, _BASIC_HTML_CONTENT,
+				ContentTypes.TEXT_HTML));
 	}
 
-	private String _sanitize(long companyId, String content, String contentType)
+	private String _sanitize(
+			String className, long classPK, long companyId, String content,
+			String contentType)
 		throws Exception {
 
 		return _iFrameSanitizer.sanitize(
-			companyId, 0, 0, StringPool.BLANK, 0, contentType, new String[0],
+			companyId, 0, 0, className, classPK, contentType, new String[0],
 			content, new HashMap<>());
 	}
 
 	private void _updateCompanyConfiguration(
 			long companyId, boolean enabled, boolean removeIFrameTags,
-			String sandboxAttributeValues)
+			String sandboxAttributeValues, String whitelist)
 		throws Exception {
 
 		ConfigurationTestUtil.updateConfiguration(
@@ -239,6 +265,8 @@ public class IFrameSanitizerImplTest {
 						"removeIFrameTags", removeIFrameTags
 					).put(
 						"sandboxAttributeValues", sandboxAttributeValues
+					).put(
+						"whitelist", whitelist
 					).build());
 
 				Configuration configuration =

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -154,6 +155,18 @@ public class IFrameSanitizerImplTest {
 	}
 
 	@Test
+	public void testSanitizeHTMLWithIFrameJournalArticleClassNameWhitelistedByDefault()
+		throws Exception {
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				"com.liferay.journal.model.JournalArticle", 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
 	public void testSanitizeHTMLWithIFrameScopedByCompany() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
 
@@ -179,6 +192,53 @@ public class IFrameSanitizerImplTest {
 		finally {
 			_companyLocalService.deleteCompany(company);
 		}
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameWhitelistedAll() throws Exception {
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.STAR);
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				RandomTestUtil.randomString(), 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				RandomTestUtil.randomString(), 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameWhitelistedClassName()
+		throws Exception {
+
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+
+		String className = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+			_sanitize(
+				className, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+
+		_updateCompanyConfiguration(
+			_companyId, true, false, StringPool.BLANK, className);
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				className, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
@@ -31,4 +31,10 @@ public interface IFrameConfiguration {
 	@Meta.AD(deflt = "", name = "sandbox-attribute-values", required = false)
 	public String[] sandboxAttributeValues();
 
+	@Meta.AD(
+		deflt = "com.liferay.fragment.model.FragmentEntry|com.liferay.journal.model.JournalArticle",
+		name = "whitelist", required = false
+	)
+	public String[] whitelist();
+
 }

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
@@ -15,6 +15,7 @@ import com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfigur
 import com.liferay.portal.security.iframe.sanitizer.internal.configuration.helper.IFrameConfigurationHelper;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -44,7 +45,10 @@ public class IFrameSanitizerImpl implements Sanitizer {
 
 		if (!companyIFrameConfiguration.enabled() ||
 			Validator.isNull(content) || Validator.isNull(contentType) ||
-			!contentType.equals(ContentTypes.TEXT_HTML)) {
+			!contentType.equals(ContentTypes.TEXT_HTML) ||
+			_isWhitelisted(
+				className, classPK,
+				_iFrameConfigurationHelper.getCompanyWhitelist(companyId))) {
 
 			return content;
 		}
@@ -86,6 +90,22 @@ public class IFrameSanitizerImpl implements Sanitizer {
 			});
 
 		return document;
+	}
+
+	private boolean _isWhitelisted(
+		String className, long classPK, Set<String> whitelist) {
+
+		String classNameAndClassPK = className + StringPool.POUND + classPK;
+
+		for (String whitelistItem : whitelist) {
+			if (whitelistItem.equals(StringPool.STAR) ||
+				classNameAndClassPK.startsWith(whitelistItem)) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
@@ -5,14 +5,20 @@
 
 package com.liferay.portal.security.iframe.sanitizer.internal.configuration.helper;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration;
 
+import java.util.Collections;
 import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
@@ -39,6 +45,10 @@ public class IFrameConfigurationHelper {
 			companyId, _defaultIFrameConfiguration);
 	}
 
+	public Set<String> getCompanyWhitelist(long companyId) {
+		return _companyWhitelist.getOrDefault(companyId, _defaultWhitelist);
+	}
+
 	@Activate
 	protected void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
@@ -63,12 +73,60 @@ public class IFrameConfigurationHelper {
 	protected void modified(Map<String, Object> properties) {
 		_defaultIFrameConfiguration = ConfigurableUtil.createConfigurable(
 			IFrameConfiguration.class, properties);
+
+		_defaultWhitelist = SetUtil.fromArray(
+			_defaultIFrameConfiguration.whitelist());
+	}
+
+	private Set<String> _getWhitelist(long companyId) {
+		IFrameConfiguration iFrameConfiguration = getCompanyIFrameConfiguration(
+			companyId);
+
+		if (iFrameConfiguration == null) {
+			return Collections.emptySet();
+		}
+
+		Set<String> whitelist = SetUtil.fromArray(
+			iFrameConfiguration.whitelist());
+
+		if (SetUtil.isEmpty(whitelist)) {
+			return Collections.emptySet();
+		}
+
+		for (String whitelistItem : whitelist) {
+			whitelistItem = whitelistItem.trim();
+
+			if (!whitelistItem.isEmpty()) {
+				whitelistItem = _stripTrailingStar(whitelistItem);
+
+				whitelist.add(whitelistItem);
+			}
+		}
+
+		return whitelist;
+	}
+
+	private String _stripTrailingStar(String item) {
+		if (item.equals(StringPool.STAR)) {
+			return item;
+		}
+
+		char c = item.charAt(item.length() - 1);
+
+		if (c == CharPool.STAR) {
+			return item.substring(0, item.length() - 1);
+		}
+
+		return item;
 	}
 
 	private final Map<Long, IFrameConfiguration> _companyConfigurationBeans =
 		new ConcurrentHashMap<>();
 	private final Map<String, Long> _companyIds = new ConcurrentHashMap<>();
+	private final Map<Long, Set<String>> _companyWhitelist =
+		new ConcurrentHashMap<>();
 	private volatile IFrameConfiguration _defaultIFrameConfiguration;
+	private volatile Set<String> _defaultWhitelist = new HashSet<>();
 	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
 
 	private class IFrameConfigurationManagedServiceFactory
@@ -100,6 +158,7 @@ public class IFrameConfigurationHelper {
 					ConfigurableUtil.createConfigurable(
 						IFrameConfiguration.class, dictionary));
 				_companyIds.put(pid, companyId);
+				_companyWhitelist.put(companyId, _getWhitelist(companyId));
 			}
 		}
 
@@ -108,6 +167,7 @@ public class IFrameConfigurationHelper {
 
 			if (companyId != null) {
 				_companyConfigurationBeans.remove(companyId);
+				_companyWhitelist.remove(companyId);
 			}
 		}
 


### PR DESCRIPTION
LPD-25907 This is the pull request title

To forward this https://github.com/liferay-content-management/liferay-portal/pull/5627 need to pass

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-25907

I want to have a whitelist configuration in the Iframe Sanitizer

# How am I fixing it?

I'm adding to the Iframe Configurator: 

```
@Meta.AD(
    deflt = "com.liferay.fragment.model.FragmentEntry|com.liferay.journal.model.JournalArticle",
    name = "whitelist", required = false
)
public String[] whitelist();
```



# How can you verify that it works?

Run the included automated tests.
<img width="1366" alt="image" src="https://github.com/liferay-content-management/liferay-portal/assets/47524751/3c1e6d28-d853-4247-aef8-a0f351f89ab3">

# Commits



- **LPD-25907 add whitelist configuration to the IFrame Configuration**
- **LPD-25907 add method on configuration helper to obtain the whitelist from the configuration**
- **LPD-25907 if the class is on the whitelist do not sanitize**
- **LPD-25907 change methods to get the className and classPK on the test**
- **LPD-25907 add tests to check the behavior with the whitelist value**
