### PR TITLE
LPD-29524 Use correct parameter name in order to search for keywords properly within the Message Boards widget

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -27,7 +27,7 @@ long categoryId = MBUtil.getCategoryId(request, category);
 
 	<div class="input-group">
 		<div class="input-group-item">
-			<input aria-label="<%= LanguageUtil.get(request, "search") %>" class="form-control input-group-inset input-group-inset-after search-query" data-qa-id="searchInput" id="<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() %>keywords1" name="<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() %>keywordskeywords" placeholder="<%= LanguageUtil.get(request, "keywords") %>" title="<%= LanguageUtil.get(request, "search") %>" type="text" value="<%= HtmlUtil.escapeAttribute(ParamUtil.getString(request, "keywords")) %>" />
+			<input aria-label="<%= LanguageUtil.get(request, "search") %>" class="form-control input-group-inset input-group-inset-after search-query" data-qa-id="searchInput" id="<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() %>keywords1" name="<%= (PortalUtil.getLiferayPortletResponse(portletResponse)).getNamespace() %>keywords" placeholder="<%= LanguageUtil.get(request, "keywords") %>" title="<%= LanguageUtil.get(request, "search") %>" type="text" value="<%= HtmlUtil.escapeAttribute(ParamUtil.getString(request, "keywords")) %>" />
 
 			<div class="input-group-inset-item input-group-inset-item-after">
 				<clay:button

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -137,6 +137,27 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async postMessageBoardThread({
+		articleBody,
+		headline,
+		siteId,
+	}: {
+		articleBody: string;
+		headline: string;
+		siteId: string;
+	}): Promise<MessageBoardThread> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/message-board-threads`,
+			{
+				data: {
+					articleBody,
+					headline,
+				},
+				failOnStatusCode: true,
+			}
+		);
+	}
+
 	async postStructuredContent({
 		categoryIds,
 		contentStructureId,

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -5,16 +5,21 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {messageBoardsPagesTest} from '../../fixtures/messageBoardsTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import getRandomString from '../../utils/getRandomString';
+
 export const test = mergeTests(
+	apiHelpersTest,
 	isolatedSiteTest,
 	messageBoardsPagesTest,
 	loginTest(),
 	workflowPagesTest
 );
+
 test('LPD-25630 Show the status to guest user', async ({
 	messageBoardsEditThreadPage,
 	messageBoardsPage,
@@ -47,4 +52,45 @@ test('LPD-25630 Show the status to guest user', async ({
 	);
 
 	await expect(page.getByText('Pending')).toBeVisible();
+});
+
+test('LPD-29524 Search for message board thread by keywords', async ({
+	apiHelpers,
+	messageBoardsWidgetPage,
+	page,
+	site,
+}) => {
+	const messageBoardThread1 =
+		await apiHelpers.headlessDelivery.postMessageBoardThread({
+			articleBody: getRandomString(),
+			headline: getRandomString(),
+			siteId: site.id,
+		});
+	const messageBoardThread2 =
+		await apiHelpers.headlessDelivery.postMessageBoardThread({
+			articleBody: getRandomString(),
+			headline: getRandomString(),
+			siteId: site.id,
+		});
+
+	await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
+
+	await expect(
+		page.getByRole('link', {name: messageBoardThread1.headline})
+	).toBeVisible();
+
+	await expect(
+		page.getByRole('link', {name: messageBoardThread2.headline})
+	).toBeVisible();
+
+	await page.getByTestId('searchInput').fill(messageBoardThread1.headline);
+	await page.getByTestId('searchButton').click();
+
+	await expect(
+		page.getByRole('link', {name: messageBoardThread1.headline})
+	).toBeVisible();
+
+	await expect(
+		page.getByRole('link', {name: messageBoardThread2.headline})
+	).toBeHidden();
 });

--- a/modules/test/playwright/types/message-board-thread.d.ts
+++ b/modules/test/playwright/types/message-board-thread.d.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type MessageBoardThread = {
+	articleBody: string;
+	headline: string;
+	id: string;
+};


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29524

Message Boards widget search does return correct results based on keywords

# How am I fixing it?

The name parameter was erroneously duplicated causing a mismatch between the front end and back end.

# How can you verify that it works?

Run `npm run test -- -g "LPD-29524"`

To test manually:

1. Add a Message Boards widget to the page
2. Add a new thread named test1
3. Add a new thread named test2
4. Using the Message Boards widget’s search box search for test1
5. Assert the test2 thread is also displayed