### PR TITLE
LPD-29597 User cannot access global site Documents and Media through Item Selector despite having correct permissions

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/util/ItemSelectorRepositoryEntryBrowserUtil.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/util/ItemSelectorRepositoryEntryBrowserUtil.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -65,24 +64,16 @@ public class ItemSelectorRepositoryEntryBrowserUtil {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		Folder folder = null;
-
-		if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			folder = DLAppServiceUtil.getFolder(folderId);
-		}
-
-		Group group = themeDisplay.getScopeGroup();
-
-		if (folder != null) {
-			group = GroupServiceUtil.getGroup(folder.getGroupId());
-		}
+		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		_addPortletBreadcrumbEntry(
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, httpServletRequest,
-			group.getDescriptiveName(httpServletRequest.getLocale()),
-			EntryURLUtil.getGroupPortletURL(group, liferayPortletRequest));
+			scopeGroup.getDescriptiveName(httpServletRequest.getLocale()),
+			EntryURLUtil.getGroupPortletURL(scopeGroup, liferayPortletRequest));
 
-		if (folder != null) {
+		if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			Folder folder = DLAppServiceUtil.getFolder(folderId);
+
 			List<Folder> ancestorFolders = folder.getAncestors();
 
 			Collections.reverse(ancestorFolders);

--- a/modules/apps/item-selector/item-selector-test/build.gradle
+++ b/modules/apps/item-selector/item-selector-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-api")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-criteria-api")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-taglib")

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/ItemSelectorRepositoryEntryBrowserUtilTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/ItemSelectorRepositoryEntryBrowserUtilTest.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.item.selector.test.taglib.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.item.selector.taglib.servlet.taglib.ImageSelectorTag;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class ItemSelectorRepositoryEntryBrowserUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_setUpThemeDisplay();
+	}
+
+	@Test
+	public void testAddPortletBreadcrumbEntries() throws Exception {
+		DLFolder dlFolder = DLTestUtil.addDLFolder(_company.getGroupId());
+
+		DLTestUtil.addDLFileEntry(dlFolder.getFolderId());
+
+		User user = UserTestUtil.addUser();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, _themeDisplay);
+
+			MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+				new MockLiferayPortletActionRequest();
+
+			mockLiferayPortletActionRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, _themeDisplay);
+
+			Bundle bundle = FrameworkUtil.getBundle(ImageSelectorTag.class);
+
+			Class<?> clazz = bundle.loadClass(
+				"com.liferay.item.selector.taglib.internal.util." +
+					"ItemSelectorRepositoryEntryBrowserUtil");
+
+			ReflectionTestUtil.invoke(
+				clazz, "addPortletBreadcrumbEntries",
+				new Class<?>[] {
+					long.class, String.class, HttpServletRequest.class,
+					LiferayPortletRequest.class, LiferayPortletResponse.class,
+					PortletURL.class
+				},
+				dlFolder.getFolderId(), "", mockHttpServletRequest,
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse(),
+				new MockLiferayPortletURL());
+
+			List<BreadcrumbEntry> breadcrumbEntries =
+				(List<BreadcrumbEntry>)mockHttpServletRequest.getAttribute(
+					WebKeys.PORTLET_BREADCRUMBS);
+
+			Assert.assertEquals(
+				breadcrumbEntries.toString(), 3, breadcrumbEntries.size());
+
+			BreadcrumbEntry breadcrumbEntry = breadcrumbEntries.get(2);
+
+			Assert.assertEquals(dlFolder.getName(), breadcrumbEntry.getTitle());
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+	}
+
+	private void _setUpThemeDisplay() throws Exception {
+		_themeDisplay.setCompany(_company);
+
+		_themeDisplay.setRefererGroupId(_company.getGroupId());
+		_themeDisplay.setScopeGroupId(_company.getGroupId());
+		_themeDisplay.setSiteGroupId(_company.getGroupId());
+		_themeDisplay.setUser(TestPropsValues.getUser());
+	}
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private Company _company;
+	private final ThemeDisplay _themeDisplay = new ThemeDisplay();
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29597

# How am I fixing it?

The issue is reproducible because we are trying to fetch a group that the user does not have permission to view. However, this group was already presented to the user as an option and they can view the documents.

This logic was added as part of https://liferay.atlassian.net/browse/LPS-118808. However, even without the changes for LPS-118808 I cannot reproduce that issue. That is why I decided to revert some of those changes in order to fix this current issue.

If a more conservative approach seems better we can change the logic to the following:

```
if (folder != null && (group.getGroupId() != folder.getGroupId())) {
	group = GroupLocalServiceUtil.getGroup(folder.getGroupId());
}
```

This will only fetch the group if there is a difference. Also, it uses the local service to avoid permission issues since if the user is clicking on this folder that means they have already selected the group and thus have permission.

Please let me know your thoughts and if a different approach would be better.

# How can you verify that it works?

In `modules/apps/item-selector/item-selector-test` run `gw testIntegration --tests *.ItemSelectorRepositoryEntryBrowserUtilTest`

To test manually please see the steps on https://liferay.atlassian.net/browse/LPD-29597.