### PR TITLE
LPD-29684 Migrate POSHI test to integration test and little fix 

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -65,6 +66,148 @@ public class CheckFileEntrySchedulerJobConfigurationTest {
 		UserTestUtil.setUser(TestPropsValues.getUser());
 	}
 
+	@FeatureFlags("LPD-10701")
+	@Test
+	public void testCheckFileEntriesAnExpiredFileEntryCanBePublishedWithDisplayDate()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		FileEntry fileEntry = _dlAppService.addFileEntry(
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Date expirationDate = new Date(
+			System.currentTimeMillis() - Time.MINUTE);
+
+		dlFileEntry.setExpirationDate(expirationDate);
+
+		dlFileEntry = _dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+
+		DLFileVersion dlFileVersion =
+			_dlFileVersionLocalService.fetchLatestFileVersion(
+				dlFileEntry.getFileEntryId(), false);
+
+		dlFileVersion.setExpirationDate(expirationDate);
+
+		dlFileVersion = _dlFileVersionLocalService.updateDLFileVersion(
+			dlFileVersion);
+
+		_dlFileEntryLocalService.updateStatus(
+			dlFileVersion.getUserId(), dlFileVersion.getFileVersionId(),
+			WorkflowConstants.STATUS_EXPIRED, serviceContext, new HashMap<>());
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			dlFileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileEntry.getStatus());
+
+		Date displayDate = new Date(System.currentTimeMillis() + Time.DAY);
+
+		fileEntry = _dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), StringPool.BLANK,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileEntry.getTitle(),
+			"urltitle", StringPool.BLANK, StringPool.BLANK,
+			DLVersionNumberIncrease.MINOR, (byte[])null, displayDate, null,
+			null, serviceContext);
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, dlFileEntry.getStatus());
+
+		displayDate = new Date(System.currentTimeMillis() + 10);
+
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), StringPool.BLANK,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileEntry.getTitle(),
+			"urltitle", StringPool.BLANK, StringPool.BLANK,
+			DLVersionNumberIncrease.MINOR, (byte[])null, displayDate, null,
+			null, serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_SCHEDULED, dlFileEntry.getStatus());
+
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 1);
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileEntry.getStatus());
+	}
+
+	@Test
+	public void testCheckFileEntriesAnExpiredFileEntryCanBeRepublished()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		FileEntry fileEntry = _dlAppService.addFileEntry(
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
+			serviceContext);
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Date expirationDate = new Date(
+			System.currentTimeMillis() - Time.MINUTE);
+
+		dlFileEntry.setExpirationDate(expirationDate);
+
+		dlFileEntry = _dlFileEntryLocalService.updateDLFileEntry(dlFileEntry);
+
+		DLFileVersion dlFileVersion =
+			_dlFileVersionLocalService.fetchLatestFileVersion(
+				dlFileEntry.getFileEntryId(), false);
+
+		dlFileVersion.setExpirationDate(expirationDate);
+
+		dlFileVersion = _dlFileVersionLocalService.updateDLFileVersion(
+			dlFileVersion);
+
+		_dlFileEntryLocalService.updateStatus(
+			dlFileVersion.getUserId(), dlFileVersion.getFileVersionId(),
+			WorkflowConstants.STATUS_EXPIRED, serviceContext, new HashMap<>());
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			dlFileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileEntry.getStatus());
+
+		fileEntry = _dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), StringPool.BLANK,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileEntry.getTitle(),
+			"urltitle", StringPool.BLANK, StringPool.BLANK,
+			DLVersionNumberIncrease.MINOR, (byte[])null, null, null, null,
+			serviceContext);
+
+		dlFileEntry = _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileEntry.getStatus());
+	}
 
 	@Test
 	public void testCheckFileEntriesChangingCheckIntervalShouldExpireFileEntries()

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/scheduler/test/CheckFileEntrySchedulerJobConfigurationTest.java
@@ -65,6 +65,101 @@ public class CheckFileEntrySchedulerJobConfigurationTest {
 		UserTestUtil.setUser(TestPropsValues.getUser());
 	}
 
+
+	@Test
+	public void testCheckFileEntriesChangingCheckIntervalShouldExpireFileEntries()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		FileEntry fileEntry1 = _dlAppService.addFileEntry(
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
+			serviceContext);
+
+		FileEntry fileEntry2 = _dlAppService.addFileEntry(
+			null, _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
+			serviceContext);
+
+		Date expirationDate = new Date(
+			System.currentTimeMillis() - Time.MINUTE);
+
+		DLFileEntry dlFileEntry1 = _dlFileEntryLocalService.getFileEntry(
+			fileEntry1.getFileEntryId());
+
+		dlFileEntry1.setExpirationDate(expirationDate);
+
+		dlFileEntry1 = _dlFileEntryLocalService.updateDLFileEntry(dlFileEntry1);
+
+		DLFileVersion dlFileVersion1 = dlFileEntry1.getFileVersion();
+
+		dlFileVersion1.setExpirationDate(expirationDate);
+
+		_dlFileVersionLocalService.updateDLFileVersion(dlFileVersion1);
+
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 2);
+
+		dlFileEntry1 = _dlFileEntryLocalService.getFileEntry(
+			fileEntry1.getFileEntryId());
+
+		dlFileVersion1 = dlFileEntry1.getFileVersion();
+
+		DLFileEntry dlFileEntry2 = _dlFileEntryLocalService.getFileEntry(
+			fileEntry2.getFileEntryId());
+
+		DLFileVersion dlFileVersion2 = dlFileEntry2.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileEntry1.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileVersion1.getStatus());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileEntry2.getStatus());
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, dlFileVersion2.getStatus());
+
+		expirationDate = new Date(
+			System.currentTimeMillis() - (3 * Time.MINUTE));
+
+		dlFileEntry2 = _dlFileEntryLocalService.getFileEntry(
+			fileEntry2.getFileEntryId());
+
+		dlFileEntry2.setExpirationDate(expirationDate);
+
+		dlFileEntry2 = _dlFileEntryLocalService.updateDLFileEntry(dlFileEntry2);
+
+		dlFileVersion2 = dlFileEntry2.getFileVersion();
+
+		dlFileVersion2.setExpirationDate(expirationDate);
+
+		_dlFileVersionLocalService.updateDLFileVersion(dlFileVersion2);
+
+		_dlFileEntryLocalService.checkFileEntries(_group.getCompanyId(), 4);
+
+		dlFileEntry2 = _dlFileEntryLocalService.getFileEntry(
+			fileEntry2.getFileEntryId());
+
+		dlFileVersion2 = dlFileEntry2.getFileVersion();
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileEntry2.getStatus());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, dlFileVersion2.getStatus());
+	}
+
 	@Test
 	public void testExpireFileVersions() throws Exception {
 		ServiceContext serviceContext =

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -389,9 +389,18 @@ public class DLFileEntryLocalServiceImpl
 
 		Date date = new Date();
 
-		_dates.computeIfAbsent(
+		_dates.compute(
 			companyId,
-			key -> new Date(date.getTime() - (checkInterval * Time.MINUTE)));
+			(key, value) -> {
+				Date checkDate = new Date(
+					date.getTime() - (checkInterval * Time.MINUTE));
+
+				if ((value != null) && value.before(checkDate)) {
+					return value;
+				}
+
+				return checkDate;
+			});
 
 		long userId = _getActiveCompanyAdminUserId(companyId);
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -2901,51 +2901,6 @@ definition {
 			specialCharacters = "true");
 	}
 
-	@description = "This test ensures that the user can republish an expired document after disabling expiration date."
-	@priority = 4
-	test CanRepublishDocumentAfterDisablingExpirationDate {
-		property custom.properties = "company.default.time.zone=America/Los_Angeles";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		DMDocument.updateCheckInterval(fieldValue = 1);
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Document_5.txt",
-			groupName = "Guest",
-			mimeType = "text/plain",
-			sourceFileName = "Document_5.txt");
-
-		DMNavigator.openToEditEntryInSite(
-			dmDocumentTitle = "Document_5.txt",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		DMDocument.setExpirationDate(
-			enableExpirationDate = "true",
-			increaseMinutes = 1);
-
-		Navigator.openURL();
-
-		Notifications.waitForNotificationFlexibly(flexibleRefreshingTime = 3000);
-
-		DMNavigator.openToEditEntryInSite(
-			dmDocumentTitle = "Document_5.txt",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		DMDocument.publishExpiredDocument(
-			disableExpirationDate = "true",
-			dmDocumentTitle = "Document_5.txt");
-
-		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
-
-		DMDocument.viewStatus(
-			dmDocumentStatus = "Approved",
-			dmDocumentTitle = "Document_5.txt");
-	}
-
 	@description = "This case covers LPS-97708. It ensures that a document can be restored from the Recycle Bin even if its original folder no longer exists."
 	@priority = 3
 	@refactordone


### PR DESCRIPTION
LPD-29684 migrate DMFileEntry#CanRepublishDocumentAfterDisablingExpirationDate

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29684

Migrating the flaky test DMFileEntry#CanRepublishDocumentAfterDisablingExpirationDate to a integhration test. On the development I found taht a corner case 
On some cases, where we change the interval for checking the files, we let some files outside the checking and we are not expire/publish them, so we should take the date of the earliest date.
 So created test to check if changing the interval allow to expire the files that are outside on the previous interval 

# How am I fixing it?

On thing : migrating to a integration test with the steps of the CanRepublishDocumentAfterDisablingExpirationDate poshi test:
On the other hand, checkiong if the date we are changing is before or after the registerd (if) on the hash and do not change if is is after.

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-29684 add test to check if changing the interval allow to expire the files that are outside on the previous interval**
- **LPD-29684 on some cases, where we change the interval for checking the files, we let some files outside the checking and we are not expire/publish them, so we should take the date of the earliest date.**
- **LPD-29684 Migrate the test that ensures the user can republish an expired document after disabling expiration date.**
