### PR TITLE
LPD-28893 Move IFrame Sanitizer enablement to Instance Settings

### DIFF
--- a/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/internal/upgrade/v3_1_0/test/AssetDisplayLayoutUpgradeProcessTest.java
+++ b/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/internal/upgrade/v3_1_0/test/AssetDisplayLayoutUpgradeProcessTest.java
@@ -70,9 +70,7 @@ public class AssetDisplayLayoutUpgradeProcessTest
 	}
 
 	@Test
-	public void testUpgradeTypeDefaultAssetDisplayPage()
-		throws Exception {
-
+	public void testUpgradeTypeDefaultAssetDisplayPage() throws Exception {
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
@@ -106,9 +104,7 @@ public class AssetDisplayLayoutUpgradeProcessTest
 	}
 
 	@Test
-	public void testUpgradeTypeSpecificAssetDisplayPage()
-		throws Exception {
-
+	public void testUpgradeTypeSpecificAssetDisplayPage() throws Exception {
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/notification/term/evaluator/CommerceOrderItemsNotificationTermEvaluator.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/notification/term/evaluator/CommerceOrderItemsNotificationTermEvaluator.java
@@ -174,9 +174,10 @@ public class CommerceOrderItemsNotificationTermEvaluator
 					CPDefinition cpDefinition =
 						commerceOrderItem.getCPDefinition();
 
-					return portalURL +
-						_commerceMediaResolver.getDefaultURL(
-							cpDefinition.getGroupId());
+					String defaultURL = _commerceMediaResolver.getDefaultURL(
+						cpDefinition.getGroupId());
+
+					return portalURL + defaultURL;
 				}
 
 				String imageURL = _commerceMediaResolver.getURL(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/upgrade/v5_3_3/test/BrowserSnifferTemplateUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/upgrade/v5_3_3/test/BrowserSnifferTemplateUpgradeProcessTest.java
@@ -32,9 +32,7 @@ public class BrowserSnifferTemplateUpgradeProcessTest
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
-	public void testUpgradeTemplateRemoveBrowserSniffer()
-		throws Exception {
-
+	public void testUpgradeTemplateRemoveBrowserSniffer() throws Exception {
 		addDDMTemplate(".v5_3_3/ddm-template-browser-sniffer-content.ftl");
 
 		addFragmentEntry(".v5_3_3/fragment-entry-browser-sniffer-content.html");

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
@@ -160,9 +160,7 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgradeNoFriendlyURLEntryLocalization()
-		throws Exception {
-
+	public void testUpgradeNoFriendlyURLEntryLocalization() throws Exception {
 		Layout layout1 = LayoutTestUtil.addTypeContentLayout(_group);
 
 		Layout draftLayout1 = layout1.fetchDraftLayout();

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_1/test/JournalArticleLayoutClassedModelUsageUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v6_1_1/test/JournalArticleLayoutClassedModelUsageUpgradeProcessTest.java
@@ -136,9 +136,7 @@ public class JournalArticleLayoutClassedModelUsageUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgradeManualAssetPublisherSelection()
-		throws Exception {
-
+	public void testUpgradeManualAssetPublisherSelection() throws Exception {
 		JournalArticle journalArticle1 = JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_0_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_0_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -143,9 +143,7 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgradeDisplaPageWithoutFragments()
-		throws Exception {
-
+	public void testUpgradeDisplaPageWithoutFragments() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0, 0,

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
@@ -136,9 +136,7 @@ public class LayoutUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgradeWhenPrivateLayoutAlreadyExists()
-		throws Exception {
-
+	public void testUpgradeWhenPrivateLayoutAlreadyExists() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), 0,

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration-api/bnd.bnd
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Portal Configuration Module Configuration API
 Bundle-SymbolicName: com.liferay.portal.configuration.module.configuration.api
-Bundle-Version: 1.0.3
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.portal.configuration.module.configuration

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration-api/src/main/java/com/liferay/portal/configuration/module/configuration/ConfigurationProvider.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration-api/src/main/java/com/liferay/portal/configuration/module/configuration/ConfigurationProvider.java
@@ -59,6 +59,10 @@ public interface ConfigurationProvider {
 			Dictionary<String, Object> properties)
 		throws ConfigurationException;
 
+	public <T> void saveCompanyConfiguration(
+			long companyId, String pid, Dictionary<String, Object> properties)
+		throws ConfigurationException;
+
 	public <T> void saveGroupConfiguration(
 			Class<T> clazz, long groupId, Dictionary<String, Object> properties)
 		throws ConfigurationException;

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration-api/src/main/resources/com/liferay/portal/configuration/module/configuration/packageinfo
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration-api/src/main/resources/com/liferay/portal/configuration/module/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration-test/src/testIntegration/java/com/liferay/portal/configuration/module/configuration/test/ConfigurationProviderTest.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration-test/src/testIntegration/java/com/liferay/portal/configuration/module/configuration/test/ConfigurationProviderTest.java
@@ -139,6 +139,16 @@ public class ConfigurationProviderTest {
 			_properties, _configuration.getProperties(),
 			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
 			companyId);
+
+		_configurationProvider.saveCompanyConfiguration(
+			companyId, _PID, _properties);
+
+		_configuration = _getFactoryConfiguration(_PID);
+
+		assertFactoryPropertyValues(
+			_properties, _configuration.getProperties(),
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			companyId);
 	}
 
 	@Test

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationProviderImpl.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationProviderImpl.java
@@ -184,6 +184,16 @@ public class ConfigurationProviderImpl implements ConfigurationProvider {
 	}
 
 	@Override
+	public <T> void saveCompanyConfiguration(
+			long companyId, String pid, Dictionary<String, Object> properties)
+		throws ConfigurationException {
+
+		_saveFactoryConfiguration(
+			pid, ExtendedObjectClassDefinition.Scope.COMPANY, companyId,
+			properties);
+	}
+
+	@Override
 	public <T> void saveGroupConfiguration(
 			Class<T> clazz, long groupId, Dictionary<String, Object> properties)
 		throws ConfigurationException {

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-iframe-sanitizer")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -6,11 +6,12 @@
 package com.liferay.portal.security.iframe.sanitizer.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.rule.Inject;
@@ -19,13 +20,18 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.HashMap;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 /**
  * @author Roberto Díaz
+ * @author Alicia García
  */
 @RunWith(Arquillian.class)
 public class IFrameSanitizerImplTest {
@@ -35,132 +41,140 @@ public class IFrameSanitizerImplTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
+	@Before
+	public void setUp() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+	}
+
 	@Test
 	public void testSanitizeHTMLWithIFrame() throws Exception {
-		_withConfiguration(
-			true, false, "",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG,
-				_sanitize(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithIFrameAndConfigurationDisabled()
 		throws Exception {
 
-		_withConfiguration(
-			false, false, "",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-				_sanitize(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, false, false, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithIFrameAndRemoveIFrameTags()
 		throws Exception {
 
-		_withConfiguration(
-			true, true, "",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT,
-				_sanitize(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, true, true, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithIFrameAndSandboxAttributeValues()
 		throws Exception {
 
-		_withConfiguration(
-			true, false, "test",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX,
-				_sanitize(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, true, false, "test");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+				ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithInvalidContentType() throws Exception {
-		_withConfiguration(
-			true, false, "",
-			() -> {
-				Assert.assertEquals(
-					_BASIC_CONTENT,
-					_sanitize(_BASIC_CONTENT, ContentTypes.TEXT_PLAIN));
-				Assert.assertEquals(
-					_BASIC_HTML_CONTENT,
-					_sanitize(_BASIC_HTML_CONTENT, ContentTypes.TEXT_PLAIN));
-				Assert.assertEquals(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					_sanitize(
-						_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-						"text/creole"));
-			});
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			_BASIC_CONTENT,
+			_sanitize(_companyId, _BASIC_CONTENT, ContentTypes.TEXT_PLAIN));
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT, ContentTypes.TEXT_PLAIN));
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				"text/creole"));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithNullContent() throws Exception {
-		_withConfiguration(
-			true, false, "",
-			() -> Assert.assertEquals(
-				StringPool.BLANK,
-				_sanitize(StringPool.BLANK, ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_sanitize(_companyId, StringPool.BLANK, ContentTypes.TEXT_HTML));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithNullContentType() throws Exception {
-		_withConfiguration(
-			true, false, "",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-				_sanitize(
-					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
-					StringPool.BLANK)));
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				StringPool.BLANK));
 	}
 
 	@Test
 	public void testSanitizeHTMLWithoutIFrame() throws Exception {
-		_withConfiguration(
-			true, false, "",
-			() -> Assert.assertEquals(
-				_BASIC_HTML_CONTENT,
-				_sanitize(_BASIC_HTML_CONTENT, ContentTypes.TEXT_HTML)));
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT,
+			_sanitize(_companyId, _BASIC_HTML_CONTENT, ContentTypes.TEXT_HTML));
 	}
 
-	private String _sanitize(String content, String contentType)
+	private String _sanitize(long companyId, String content, String contentType)
 		throws Exception {
 
 		return _iFrameSanitizer.sanitize(
-			0, 0, 0, StringPool.BLANK, 0, contentType, new String[0], content,
-			new HashMap<>());
+			companyId, 0, 0, StringPool.BLANK, 0, contentType, new String[0],
+			content, new HashMap<>());
 	}
 
-	private void _withConfiguration(
-			boolean enabled, boolean removeIFrameTags,
-			String sandboxAttributeValues,
-			UnsafeRunnable<Exception> unsafeRunnable)
+	private void _updateCompanyConfiguration(
+			long companyId, boolean enabled, boolean removeIFrameTags,
+			String sandboxAttributeValues)
 		throws Exception {
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.portal.security.iframe.sanitizer." +
-						"configuration.IFrameConfiguration",
+		ConfigurationTestUtil.updateConfiguration(
+			_CONFIGURATION_PID,
+			() -> {
+				_configurationProvider.saveCompanyConfiguration(
+					companyId, _CONFIGURATION_PID,
 					HashMapDictionaryBuilder.<String, Object>put(
 						"enabled", enabled
 					).put(
 						"removeIFrameTags", removeIFrameTags
 					).put(
 						"sandboxAttributeValues", sandboxAttributeValues
-					).build())) {
+					).build());
 
-			unsafeRunnable.run();
-		}
+				Configuration configuration =
+					_configurationAdmin.getConfiguration(
+						_CONFIGURATION_PID, StringPool.QUESTION);
+
+				configuration.update();
+			});
 	}
 
 	private static final String _BASIC_CONTENT = "Content";
@@ -168,14 +182,29 @@ public class IFrameSanitizerImplTest {
 	private static final String _BASIC_HTML_CONTENT =
 		"<h1><strong>Content</strong></h1>";
 
-	private static final String _EXPECTED_IFRAME_TAG =
-		"<iframe src=\"test\" sandbox=\"\"></iframe>";
+	private static final String _CONFIGURATION_PID =
+		"com.liferay.portal.security.iframe.sanitizer.configuration." +
+			"IFrameConfiguration";
 
 	private static final String _EXPECTED_IFRAME_TAG_SANDBOX =
 		"<iframe src=\"test\" sandbox=\"test\"></iframe>";
 
+	private static final String _EXPECTED_IFRAME_TAG_SANDBOX_ADDED =
+		"<iframe src=\"test\" sandbox=\"\"></iframe>";
+
 	private static final String _INITIAL_IFRAME_TAG =
 		"<iframe src=\"test\"></iframe>";
+
+	private static final String _INITIAL_IFRAME_TAG_SANDBOX =
+		"<iframe src=\"test\" sandbox=\"\"></iframe>";
+
+	@Inject
+	private static ConfigurationAdmin _configurationAdmin;
+
+	private long _companyId;
+
+	@Inject
+	private ConfigurationProvider _configurationProvider;
 
 	@Inject(
 		filter = "component.name=com.liferay.portal.security.iframe.sanitizer.internal.IFrameSanitizerImpl"

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -6,12 +6,17 @@
 package com.liferay.portal.security.iframe.sanitizer.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.rule.Inject;
@@ -19,6 +24,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.HashMap;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -44,6 +50,24 @@ public class IFrameSanitizerImplTest {
 	@Before
 	public void setUp() throws Exception {
 		_companyId = TestPropsValues.getCompanyId();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		String filterString = StringBundler.concat(
+			"(&(companyId=", _companyId, ")(service.factoryPid=",
+			_CONFIGURATION_PID, ".scoped))");
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
+
+		if (ArrayUtil.isNotEmpty(configurations)) {
+			Configuration configuration = configurations[0];
+
+			if (configuration != null) {
+				configuration.delete();
+			}
+		}
 	}
 
 	@Test
@@ -94,6 +118,54 @@ public class IFrameSanitizerImplTest {
 			_sanitize(
 				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
 				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameAndSandboxAttributeValuesEmpty()
+		throws Exception {
+
+		_updateCompanyConfiguration(_companyId, true, false, "");
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameEnabledByDefault() throws Exception {
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+			_sanitize(
+				_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameScopedByCompany() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		try {
+			_updateCompanyConfiguration(
+				company.getCompanyId(), false, false, "");
+
+			Assert.assertEquals(
+				_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+				_sanitize(
+					_companyId, _BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+					ContentTypes.TEXT_HTML));
+
+			Assert.assertEquals(
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				_sanitize(
+					company.getCompanyId(),
+					_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+					ContentTypes.TEXT_HTML));
+		}
+		finally {
+			_companyLocalService.deleteCompany(company);
+		}
 	}
 
 	@Test
@@ -202,6 +274,9 @@ public class IFrameSanitizerImplTest {
 	private static ConfigurationAdmin _configurationAdmin;
 
 	private long _companyId;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private ConfigurationProvider _configurationProvider;

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/build.gradle
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
@@ -12,7 +12,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 /**
  * @author Roberto Díaz
  */
-@ExtendedObjectClassDefinition(category = "security-tools")
+@ExtendedObjectClassDefinition(
+	category = "security-tools",
+	scope = ExtendedObjectClassDefinition.Scope.COMPANY
+)
 @Meta.OCD(
 	id = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration",
 	localization = "content/Language", name = "iframe-configuration-name"

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
@@ -7,12 +7,12 @@ package com.liferay.portal.security.iframe.sanitizer.internal;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration;
+import com.liferay.portal.security.iframe.sanitizer.internal.configuration.helper.IFrameConfigurationHelper;
 
 import java.util.Map;
 
@@ -21,9 +21,8 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Roberto Díaz
@@ -40,8 +39,11 @@ public class IFrameSanitizerImpl implements Sanitizer {
 		long classPK, String contentType, String[] modes, String content,
 		Map<String, Object> options) {
 
-		if (!_iFrameConfiguration.enabled() || Validator.isNull(content) ||
-			Validator.isNull(contentType) ||
+		IFrameConfiguration companyIFrameConfiguration =
+			_iFrameConfigurationHelper.getCompanyIFrameConfiguration(companyId);
+
+		if (!companyIFrameConfiguration.enabled() ||
+			Validator.isNull(content) || Validator.isNull(contentType) ||
 			!contentType.equals(ContentTypes.TEXT_HTML)) {
 
 			return content;
@@ -50,14 +52,14 @@ public class IFrameSanitizerImpl implements Sanitizer {
 		Document document = _getDocument(content);
 
 		for (Element iFrameElement : document.getElementsByTag("iframe")) {
-			if (_iFrameConfiguration.removeIFrameTags()) {
+			if (companyIFrameConfiguration.removeIFrameTags()) {
 				iFrameElement.remove();
 			}
 			else {
 				iFrameElement.attr(
 					"sandbox",
 					StringUtil.merge(
-						_iFrameConfiguration.sandboxAttributeValues(),
+						companyIFrameConfiguration.sandboxAttributeValues(),
 						StringPool.SPACE));
 			}
 		}
@@ -73,13 +75,6 @@ public class IFrameSanitizerImpl implements Sanitizer {
 		return sb.toString();
 	}
 
-	@Activate
-	@Modified
-	protected void activate(Map<String, Object> properties) {
-		_iFrameConfiguration = ConfigurableUtil.createConfigurable(
-			IFrameConfiguration.class, properties);
-	}
-
 	private Document _getDocument(String content) {
 		Document document = Jsoup.parseBodyFragment(content);
 
@@ -93,6 +88,7 @@ public class IFrameSanitizerImpl implements Sanitizer {
 		return document;
 	}
 
-	private volatile IFrameConfiguration _iFrameConfiguration;
+	@Reference
+	private IFrameConfigurationHelper _iFrameConfigurationHelper;
 
 }

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.iframe.sanitizer.internal.configuration.helper;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedServiceFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	configurationPid = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration",
+	service = IFrameConfigurationHelper.class
+)
+public class IFrameConfigurationHelper {
+
+	public IFrameConfiguration getCompanyIFrameConfiguration(long companyId) {
+		return _companyConfigurationBeans.getOrDefault(
+			companyId, _defaultIFrameConfiguration);
+	}
+
+	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		modified(properties);
+
+		_serviceRegistration = bundleContext.registerService(
+			ManagedServiceFactory.class,
+			new IFrameConfigurationManagedServiceFactory(),
+			MapUtil.singletonDictionary(
+				Constants.SERVICE_PID,
+				"com.liferay.portal.security.iframe.sanitizer.configuration." +
+					"IFrameConfiguration.scoped"));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Modified
+	protected void modified(Map<String, Object> properties) {
+		_defaultIFrameConfiguration = ConfigurableUtil.createConfigurable(
+			IFrameConfiguration.class, properties);
+	}
+
+	private final Map<Long, IFrameConfiguration> _companyConfigurationBeans =
+		new ConcurrentHashMap<>();
+	private final Map<String, Long> _companyIds = new ConcurrentHashMap<>();
+	private volatile IFrameConfiguration _defaultIFrameConfiguration;
+	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
+
+	private class IFrameConfigurationManagedServiceFactory
+		implements ManagedServiceFactory {
+
+		@Override
+		public void deleted(String pid) {
+			_unmapPid(pid);
+		}
+
+		@Override
+		public String getName() {
+			return "com.liferay.portal.security.iframe.sanitizer." +
+				"configuration.IFrameConfiguration.scoped";
+		}
+
+		@Override
+		public void updated(String pid, Dictionary<String, ?> dictionary)
+			throws ConfigurationException {
+
+			_unmapPid(pid);
+
+			long companyId = GetterUtil.getLong(
+				dictionary.get("companyId"), CompanyConstants.SYSTEM);
+
+			if (companyId != CompanyConstants.SYSTEM) {
+				_companyConfigurationBeans.put(
+					companyId,
+					ConfigurableUtil.createConfigurable(
+						IFrameConfiguration.class, dictionary));
+				_companyIds.put(pid, companyId);
+			}
+		}
+
+		private void _unmapPid(String pid) {
+			Long companyId = _companyIds.remove(pid);
+
+			if (companyId != null) {
+				_companyConfigurationBeans.remove(companyId);
+			}
+		}
+
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -1728,7 +1728,7 @@ definition {
 	@description = "This checks that an external video embedded in a blog content can be played correctly."
 	@priority = 3
 	test ExternalVideoEmbeddedInBlogContentFieldCanBePlayed {
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
@@ -1392,7 +1392,7 @@ definition {
 	@description = "This test covers LPS-154415. It checks that an external video displays properly in the Media Gallery widget after the friendlyURL has been edited and published on a site."
 	@priority = 4
 	test CanViewExternalVideoInMGAfterFriendlyURLIsUpdated {
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",
@@ -1489,7 +1489,7 @@ definition {
 	@description = "This test covers LPS-154396."
 	@priority = 4
 	test CanViewExternalVideoInMGAfterPublish {
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",
@@ -1538,7 +1538,7 @@ definition {
 	@description = "This test covers LPS-154417. It checks that an external video with a custom friendlyURL added to the Web content field displays properly after its friendlyURL is edited and published on a site"
 	@priority = 4
 	test CanViewExternalVideotInWCAfterFriendlyURLIsUpdated {
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMRemoteStaging.testcase
@@ -838,7 +838,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",
@@ -908,7 +908,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",
@@ -979,7 +979,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",
@@ -1061,7 +1061,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		SystemSettings.openToConfigInSystemSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
+		PortalSettings.openToConfigInInstanceSettings(portletId = "com.liferay.portal.security.iframe.sanitizer.configuration.IFrameConfiguration");
 
 		SystemSettings.configureSystemSetting(
 			enableSetting = "false",

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -913,6 +913,7 @@
         modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal,\
         modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal,\
         modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/ContentSecurityPolicyNonceManager.java,\
+        modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java,\
         modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal,\
         modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/FreeMarkerTemplateResourceCache.java,\
         modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/VelocityTemplateResourceCache.java,\


### PR DESCRIPTION
LPD-28893 Move IFrame Sanitizer enablement to Instance Settings

Resent from https://github.com/liferay-content-management/liferay-portal/pull/5599 with some sort and a new test after : https://github.com/brianchandotcom/liferay-portal/pull/151722#issuecomment-2194524487

@brianchandotcom On the test, the reorder of the iframe attributes: the sandbox attribute is added, if needed, on the sanitizer via JSoup library on the last position, and I could not find the way to order it with this tool. So to do not mismatch the constant, that some of them would be one way and others another (the generated and the not generated) I did not order none to be more consistent on the test. Please tell me if you want other way.


# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28893

adding the company scope to the iframe configuration we will allow several companies to have or not have the iframe sanitizer and others enabled and disabled at choice

# How am I fixing it?

I'm adding the scope company to the Configuration. With this some changes on the update of the configuration must be made (helper) and while testing I realized that with groups we can search configuration with PID but for companies not, so I recreated the same behavior for both (internally was calling the pid)

# How can you verify that it works?

Run the included automated tests.

new Integration test for all the changes and old POSHI test should pass

# Commits

- **LPD-28893 change scope to company level for the IFrameConfiguration**
- **LPD-28893 create helper and use it on**
- **LPD-28893 add helper to the source formatter exclusion because if not can not be found**
- **LPD-28893 add saveCompanyConfiguration  with pid to unify methods with saveGroupConfiguration**
- **LPD-28893 baseline**
- **LPD-28893 change test to test saveCompanyConfiguration with pid too**
- **LPD-28893 fix POSHI test and integration test with new behavior**
- **LPD-28893 New test to check that the changed configuration works with company scope now, that the iframe sanitizer is enabled by default, that when sandbox added without values is still empty but exists**
