### PR TITLE
LPD-29527 Create test for LPP-52349

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -259,15 +259,9 @@ autoSaveAsDraftTest(
 			'Untitled ' + structureName
 		);
 
-		await titlePlaceholder.click();
-
-		await page.waitForTimeout(200);
-
-		await titlePlaceholder.fill(title);
+		await fillAndClickOutside(page, titlePlaceholder, title);
 
 		await expect(changesSavedIndicator).toBeVisible();
-
-		await page.locator('body').click();
 
 		await fillAndClickOutside(page, localizableField, title);
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -202,11 +202,11 @@ autoSaveAsDraftTest(
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-		await journalEditArticlePage.titlePlaceholder.click();
+		await journalEditArticlePage.titleInput.click();
 
 		await page.waitForTimeout(200);
 
-		await journalEditArticlePage.titlePlaceholder.fill(title);
+		await journalEditArticlePage.titleInput.fill(title);
 
 		await expect(changesSavedIndicator).toBeVisible();
 
@@ -216,15 +216,13 @@ autoSaveAsDraftTest(
 
 		await expect(undobutton).toBeDisabled();
 
-		await expect(journalEditArticlePage.titlePlaceholder).toHaveValue('');
+		await expect(journalEditArticlePage.titleInput).toHaveValue('');
 
 		await redoButton.click();
 
 		await expect(redoButton).toBeDisabled();
 
-		await expect(journalEditArticlePage.titlePlaceholder).toHaveValue(
-			title
-		);
+		await expect(journalEditArticlePage.titleInput).toHaveValue(title);
 	}
 );
 
@@ -1011,6 +1009,113 @@ translationTest(
 	}
 );
 
+baseTest(
+	'LPD-29527 - Can delete translation of a web content created from a structure with at least one required and non-localizable field',
+	async ({apiHelpers, journalEditArticlePage, journalPage, page, site}) => {
+		const basicTextFieldName = 'Text1234';
+		const content = getRandomString();
+		const nonLocalizableFieldName = 'TextNonLocalizable';
+		const structureName = 'Structure 1';
+		const title = getRandomString();
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [
+				{name: basicTextFieldName},
+				{
+					localizable: false,
+					name: nonLocalizableFieldName,
+					required: true,
+				},
+			],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		await fillAndClickOutside(
+			page,
+			journalEditArticlePage.titleInput,
+			title
+		);
+
+		await fillAndClickOutside(
+			page,
+			page.getByLabel(basicTextFieldName),
+			content
+		);
+
+		await fillAndClickOutside(
+			page,
+			page.getByLabel(nonLocalizableFieldName),
+			content
+		);
+
+		const translationButton = page.locator(
+			'[id="_com_liferay_journal_web_portlet_JournalPortlet__com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXMLMenu"]'
+		);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'Not translated into Catalan. Press enter to edit Catalan translation.',
+			}),
+			trigger: translationButton,
+		});
+
+		await expect(async () => {
+			await fillAndClickOutside(page, journalEditArticlePage.titleInput);
+
+			await translationButton.click();
+
+			await expect(
+				page.getByRole('menuitem', {
+					exact: true,
+					name: 'Translated into Catalan. Press enter to edit Catalan translation.',
+				})
+			).toBeVisible();
+		}).toPass();
+
+		await journalEditArticlePage.publishButton.click();
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was created successfully.`
+		);
+
+		await page.getByLabel('Close', {exact: true});
+
+		await journalPage.goToJournalArticleAction(
+			'Delete Translations',
+			title
+		);
+
+		await page
+			.frameLocator('iframe[title="Delete Translations"]')
+			.getByLabel('català')
+			.check();
+
+		page.on('dialog', (dialog) => dialog.accept());
+
+		await page.getByRole('button', {name: 'Delete'}).click();
+
+		await journalEditArticlePage.editArticle(title);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'Not translated into Catalan. Press enter to edit Catalan translation.',
+			}),
+			trigger: translationButton,
+		});
+	}
+);
+
 scheduleTest(
 	'Create a web content selecting permissions in the modal',
 	async ({journalEditArticlePage, journalPage, page, site}) => {
@@ -1034,7 +1139,7 @@ scheduleTest(
 
 		const title = getRandomString();
 
-		await journalEditArticlePage.titlePlaceholder.fill(title);
+		await journalEditArticlePage.titleInput.fill(title);
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -17,7 +17,7 @@ export class JournalEditArticlePage {
 	readonly propertiesTab: Locator;
 	readonly publishButton: Locator;
 	readonly submitForWorkflowButton: Locator;
-	readonly titlePlaceholder: Locator;
+	readonly titleInput: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -28,9 +28,7 @@ export class JournalEditArticlePage {
 		this.submitForWorkflowButton = page.getByRole('button', {
 			name: 'Submit for Workflow',
 		});
-		this.titlePlaceholder = page.getByPlaceholder(
-			'Untitled Basic Web Content'
-		);
+		this.titleInput = page.getByPlaceholder('Untitled ');
 	}
 
 	async goto({
@@ -126,7 +124,7 @@ export class JournalEditArticlePage {
 	}
 
 	async fillTitle(title: string) {
-		await fillAndClickOutside(this.page, this.titlePlaceholder, title);
+		await fillAndClickOutside(this.page, this.titleInput, title);
 	}
 
 	async editAndPublishExistingBasicArticle(title: string) {

--- a/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
+++ b/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
@@ -12,6 +12,7 @@ interface Props {
 interface Field {
 	localizable?: boolean;
 	name: string;
+	required?: boolean;
 	repeatable?: boolean;
 }
 
@@ -23,7 +24,12 @@ export default function getDataStructureDefinition({
 	return {
 		availableLanguageIds: [defaultLanguageId],
 		dataDefinitionFields: fields.map(
-			({localizable = true, name: fieldName, repeatable = false}) => {
+			({
+				localizable = true,
+				name: fieldName,
+				repeatable = false,
+				required = false,
+			}) => {
 				return {
 					customProperties: {
 						dataType: 'string',
@@ -37,6 +43,7 @@ export default function getDataStructureDefinition({
 					},
 					localizable,
 					name: fieldName,
+					required,
 					repeatable,
 					showLabel: true,
 				};


### PR DESCRIPTION
Test automation for LPP-52349 - Deleting a translated web content created from a structure with at least one required and non-localizable field is not possible

# What is this trying to solve?

Create automation test for [LPP-52349](https://liferay.atlassian.net/browse/LPP-52349)

[Link to ticket](https://liferay.atlassian.net/browse/LPD-29527)

# How am I fixing it?

1. Create functional test following the steps in the ticket

# How can I test it?

1. Manually: Follow the steps [in this bug](https://liferay.atlassian.net/browse/LPD-15352) 
2. Or execute the test 

