### PR TITLE
LPD-29894 locked items test properties

### DIFF
--- a/modules/test/playwright/tests/locked-items-web/test.properties
+++ b/modules/test/playwright/tests/locked-items-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Locked Items

--- a/test.properties
+++ b/test.properties
@@ -4116,6 +4116,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         document-library-web,\
         journal-web,\
         knowledge-base-web,\
+        locked-items-web,\
         message-boards-web,\
         questions-web,\
         wiki-web
@@ -11723,6 +11724,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         IP Geocoder,\
         Item Selector,\
         Knowledge Base,\
+        Locked Items,\
         Mentions,\
         Message Boards,\
         Microblogs,\


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPD-29715 

# What is this trying to solve?
This test is currently displaying in Testray as belonging to “Ci Infrastructure”

# How am I solving this
I added the missing test.properties file for the playwright test, and referenced it to the content-management suite.