### PR TITLE
LPD-29874 Add blacklist configuration to IframeSanitizer

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-test/src/testIntegration/java/com/liferay/adaptive/media/journal/internal/exportimport/data/handler/test/AMJournalArticleStagedModelDataHandlerTest.java
@@ -511,11 +511,15 @@ public class AMJournalArticleStagedModelDataHandlerTest
 					"com.liferay.portal.security.iframe.sanitizer." +
 						"configuration.IFrameConfiguration",
 					HashMapDictionaryBuilder.<String, Object>put(
+						"blacklist", StringPool.BLANK
+					).put(
 						"enabled", enabled
 					).put(
 						"removeIFrameTags", false
 					).put(
 						"sandboxAttributeValues", StringPool.BLANK
+					).put(
+						"whitelist", StringPool.BLANK
 					).build())) {
 
 			unsafeRunnable.run();

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -74,7 +74,8 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithIFrame() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
@@ -89,7 +90,8 @@ public class IFrameSanitizerImplTest {
 		throws Exception {
 
 		_updateCompanyConfiguration(
-			_companyId, false, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, false, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
@@ -104,7 +106,8 @@ public class IFrameSanitizerImplTest {
 		throws Exception {
 
 		_updateCompanyConfiguration(
-			_companyId, true, true, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, true, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT,
@@ -119,7 +122,8 @@ public class IFrameSanitizerImplTest {
 		throws Exception {
 
 		_updateCompanyConfiguration(
-			_companyId, true, false, "test", StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, "test",
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX,
@@ -134,13 +138,32 @@ public class IFrameSanitizerImplTest {
 		throws Exception {
 
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
 			_sanitize(
 				StringPool.BLANK, 0, _companyId,
 				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG_SANDBOX,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameBlacklistedClassName()
+		throws Exception {
+
+		String className = RandomTestUtil.randomString();
+
+		_updateCompanyConfiguration(
+			className, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+			_sanitize(
+				className, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
 				ContentTypes.TEXT_HTML));
 	}
 
@@ -172,8 +195,8 @@ public class IFrameSanitizerImplTest {
 
 		try {
 			_updateCompanyConfiguration(
-				company.getCompanyId(), false, false, StringPool.BLANK,
-				StringPool.BLANK);
+				StringPool.BLANK, company.getCompanyId(), false, false,
+				StringPool.BLANK, StringPool.BLANK);
 
 			Assert.assertEquals(
 				_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
@@ -197,7 +220,33 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithIFrameWhitelistedAll() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.STAR);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.STAR);
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+			_sanitize(
+				RandomTestUtil.randomString(), 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
+	}
+
+	@Test
+	public void testSanitizeHTMLWithIFrameWhitelistedAllExceptClassNameBlacklisted()
+		throws Exception {
+
+		String className = RandomTestUtil.randomString();
+
+		_updateCompanyConfiguration(
+			className, _companyId, true, false, StringPool.BLANK,
+			StringPool.STAR);
+
+		Assert.assertEquals(
+			_BASIC_HTML_CONTENT + _EXPECTED_IFRAME_TAG_SANDBOX_ADDED,
+			_sanitize(
+				className, 0, _companyId,
+				_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
+				ContentTypes.TEXT_HTML));
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
@@ -212,7 +261,8 @@ public class IFrameSanitizerImplTest {
 		throws Exception {
 
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		String className = RandomTestUtil.randomString();
 
@@ -224,7 +274,8 @@ public class IFrameSanitizerImplTest {
 				ContentTypes.TEXT_HTML));
 
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, className);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			className);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
@@ -237,7 +288,8 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithInvalidContentType() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_CONTENT,
@@ -259,7 +311,8 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithNullContent() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			StringPool.BLANK,
@@ -271,7 +324,8 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithNullContentType() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT + _INITIAL_IFRAME_TAG,
@@ -283,7 +337,8 @@ public class IFrameSanitizerImplTest {
 	@Test
 	public void testSanitizeHTMLWithoutIFrame() throws Exception {
 		_updateCompanyConfiguration(
-			_companyId, true, false, StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, _companyId, true, false, StringPool.BLANK,
+			StringPool.BLANK);
 
 		Assert.assertEquals(
 			_BASIC_HTML_CONTENT,
@@ -303,8 +358,9 @@ public class IFrameSanitizerImplTest {
 	}
 
 	private void _updateCompanyConfiguration(
-			long companyId, boolean enabled, boolean removeIFrameTags,
-			String sandboxAttributeValues, String whitelist)
+			String blacklist, long companyId, boolean enabled,
+			boolean removeIFrameTags, String sandboxAttributeValues,
+			String whitelist)
 		throws Exception {
 
 		ConfigurationTestUtil.updateConfiguration(
@@ -313,6 +369,8 @@ public class IFrameSanitizerImplTest {
 				_configurationProvider.saveCompanyConfiguration(
 					companyId, _CONFIGURATION_PID,
 					HashMapDictionaryBuilder.<String, Object>put(
+						"blacklist", blacklist
+					).put(
 						"enabled", enabled
 					).put(
 						"removeIFrameTags", removeIFrameTags

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/configuration/IFrameConfiguration.java
@@ -31,6 +31,9 @@ public interface IFrameConfiguration {
 	@Meta.AD(deflt = "", name = "sandbox-attribute-values", required = false)
 	public String[] sandboxAttributeValues();
 
+	@Meta.AD(name = "blacklist", required = false)
+	public String[] blacklist();
+
 	@Meta.AD(
 		deflt = "com.liferay.fragment.model.FragmentEntry|com.liferay.journal.model.JournalArticle",
 		name = "whitelist", required = false

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/IFrameSanitizerImpl.java
@@ -47,6 +47,7 @@ public class IFrameSanitizerImpl implements Sanitizer {
 			Validator.isNull(content) || Validator.isNull(contentType) ||
 			!contentType.equals(ContentTypes.TEXT_HTML) ||
 			_isWhitelisted(
+				_iFrameConfigurationHelper.getCompanyBlacklist(companyId),
 				className, classPK,
 				_iFrameConfigurationHelper.getCompanyWhitelist(companyId))) {
 
@@ -93,9 +94,18 @@ public class IFrameSanitizerImpl implements Sanitizer {
 	}
 
 	private boolean _isWhitelisted(
-		String className, long classPK, Set<String> whitelist) {
+		Set<String> blacklist, String className, long classPK,
+		Set<String> whitelist) {
 
 		String classNameAndClassPK = className + StringPool.POUND + classPK;
+
+		for (String blacklistItem : blacklist) {
+			if (blacklistItem.equals(StringPool.STAR) ||
+				classNameAndClassPK.startsWith(blacklistItem)) {
+
+				return false;
+			}
+		}
 
 		for (String whitelistItem : whitelist) {
 			if (whitelistItem.equals(StringPool.STAR) ||

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/src/main/java/com/liferay/portal/security/iframe/sanitizer/internal/configuration/helper/IFrameConfigurationHelper.java
@@ -40,6 +40,10 @@ import org.osgi.service.component.annotations.Modified;
 )
 public class IFrameConfigurationHelper {
 
+	public Set<String> getCompanyBlacklist(long companyId) {
+		return _companyBlacklist.getOrDefault(companyId, _defaultBlacklist);
+	}
+
 	public IFrameConfiguration getCompanyIFrameConfiguration(long companyId) {
 		return _companyConfigurationBeans.getOrDefault(
 			companyId, _defaultIFrameConfiguration);
@@ -76,6 +80,38 @@ public class IFrameConfigurationHelper {
 
 		_defaultWhitelist = SetUtil.fromArray(
 			_defaultIFrameConfiguration.whitelist());
+		_defaultBlacklist = SetUtil.fromArray(
+			_defaultIFrameConfiguration.blacklist());
+	}
+
+	private Set<String> _getBlacklist(long companyId) {
+		IFrameConfiguration iFrameConfiguration = getCompanyIFrameConfiguration(
+			companyId);
+
+		if (iFrameConfiguration == null) {
+			return Collections.emptySet();
+		}
+
+		return _getClassNames(
+			SetUtil.fromArray(iFrameConfiguration.blacklist()));
+	}
+
+	private Set<String> _getClassNames(Set<String> classNames) {
+		if (SetUtil.isEmpty(classNames)) {
+			return Collections.emptySet();
+		}
+
+		for (String className : classNames) {
+			className = className.trim();
+
+			if (!className.isEmpty()) {
+				className = _stripTrailingStar(className);
+
+				classNames.add(className);
+			}
+		}
+
+		return classNames;
 	}
 
 	private Set<String> _getWhitelist(long companyId) {
@@ -86,24 +122,8 @@ public class IFrameConfigurationHelper {
 			return Collections.emptySet();
 		}
 
-		Set<String> whitelist = SetUtil.fromArray(
-			iFrameConfiguration.whitelist());
-
-		if (SetUtil.isEmpty(whitelist)) {
-			return Collections.emptySet();
-		}
-
-		for (String whitelistItem : whitelist) {
-			whitelistItem = whitelistItem.trim();
-
-			if (!whitelistItem.isEmpty()) {
-				whitelistItem = _stripTrailingStar(whitelistItem);
-
-				whitelist.add(whitelistItem);
-			}
-		}
-
-		return whitelist;
+		return _getClassNames(
+			SetUtil.fromArray(iFrameConfiguration.whitelist()));
 	}
 
 	private String _stripTrailingStar(String item) {
@@ -120,11 +140,14 @@ public class IFrameConfigurationHelper {
 		return item;
 	}
 
+	private final Map<Long, Set<String>> _companyBlacklist =
+		new ConcurrentHashMap<>();
 	private final Map<Long, IFrameConfiguration> _companyConfigurationBeans =
 		new ConcurrentHashMap<>();
 	private final Map<String, Long> _companyIds = new ConcurrentHashMap<>();
 	private final Map<Long, Set<String>> _companyWhitelist =
 		new ConcurrentHashMap<>();
+	private volatile Set<String> _defaultBlacklist = new HashSet<>();
 	private volatile IFrameConfiguration _defaultIFrameConfiguration;
 	private volatile Set<String> _defaultWhitelist = new HashSet<>();
 	private ServiceRegistration<ManagedServiceFactory> _serviceRegistration;
@@ -158,6 +181,7 @@ public class IFrameConfigurationHelper {
 					ConfigurableUtil.createConfigurable(
 						IFrameConfiguration.class, dictionary));
 				_companyIds.put(pid, companyId);
+				_companyBlacklist.put(companyId, _getBlacklist(companyId));
 				_companyWhitelist.put(companyId, _getWhitelist(companyId));
 			}
 		}
@@ -167,6 +191,7 @@ public class IFrameConfigurationHelper {
 
 			if (companyId != null) {
 				_companyConfigurationBeans.remove(companyId);
+				_companyBlacklist.remove(companyId);
 				_companyWhitelist.remove(companyId);
 			}
 		}


### PR DESCRIPTION
LPD-29874 Add blacklist configuration to IframeSanitizer

~To forward this:  https://github.com/liferay-content-management/liferay-portal/pull/5627 and https://github.com/liferay-content-management/liferay-portal/pull/5640 are needed to pass~ 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28774 (story)

I want to have a blacklist configuration in the Iframe Sanitizer

# How am I fixing it?

I'm adding to the Iframe Configurator: 

```
@Meta.AD(name = "blacklist", required = false)
public String[] blacklist();
```


# How can you verify that it works?

Run the included automated tests.


<img width="973" alt="image" src="https://github.com/liferay-content-management/liferay-portal/assets/47524751/47400456-74ea-497a-b309-b939236665a8">



# Commits

- **LPD-29874 add blacklist attribute to the IFrameConfiguration**
- **LPD-29874 add blacklist to the configuration helper  and take it into account when we decide if we should sanitize or not**
- **LPD-29874 add test to check the behavior of classname blacklisted and the interaction with the whitelist**
