### PR TITLE
LPD-27932 JournalArticleSmallImageSourceUpgradeProcessTest failing in oracle db due to a SQL syntax error.

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_0/JournalArticleSmallImageSourceUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v6_1_0/JournalArticleSmallImageSourceUpgradeProcess.java
@@ -38,8 +38,8 @@ public class JournalArticleSmallImageSourceUpgradeProcess
 			StringBundler.concat(
 				"update JournalArticle set smallImageSource = ",
 				JournalArticleConstants.SMALL_IMAGE_SOURCE_URL,
-				" where smallImage = [$TRUE$] and not (smallImageURL is null ",
-				"or smallImageURL = '')"));
+				" where smallImage = [$TRUE$] and (smallImageURL is not null ",
+				"or smallImageURL != '')"));
 	}
 
 }


### PR DESCRIPTION
JournalArticleSmallImageSourceUpgradeProcessTest failing in oracle db due to a SQL syntax error

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-27932)

JournalArticleSmallImageSourceUpgradeProcessTest fails for Oracle DB 

# How am I fixing it?

Change the query so that it works for oracle an other DBs

# How can you verify that it works?

Launch the JournalArticleSmallImageSourceUpgradeProcessTest in several DB (Oracle would be better since it's were the problem is visible)

# Why doesn't this include any test?

Tests was already present and was failing for Oracle DB, so no more tests are needed
