### PR TITLE
LPD-30176 Update paths for locators looking for empty results message in Content Dashboard

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/contentdashboard/ContentDashboard.path
@@ -97,7 +97,7 @@
 </tr>
 <tr>
 	<td>EMPTY_AUDIT_GRAPH_TEXT</td>
-	<td>//*[contains(@class, 'text-truncate') and contains(text(),'There is no data')]</td>
+	<td>//div[contains(@class, 'c-empty-state-title')]//span[contains(text(), 'There is no data')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -212,7 +212,7 @@
 </tr>
 <tr>
 	<td>NO_CATEGORIES_SELECTED_TEXT</td>
-	<td>//*[contains(@class, 'text-truncate') and contains(text(),'There are no categories selected')]</td>
+	<td>//div[contains(@class, 'c-empty-state-title')]//span[contains(text(), 'There are no categories selected')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30176

# How am I fixing it?

Update the locator in order to find the text.

# How can you verify that it works?

Run the following tests:

```
ant -f build-test.xml run-selenium-test -Dtest.class=ContentDashboardAuditGraph#AuditGraphUncheckCheckbox
ant -f build-test.xml run-selenium-test -Dtest.class=ContentDashboardAuditGraph#DocumentWithNoCategories
```