### PR TITLE
LPD-30437 Fill out text field to avoid flakiness with backend validation logic

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentStructures.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentStructures.testcase
@@ -447,6 +447,11 @@ definition {
 		task ("When the web content designer define an expiration date as default values") {
 			WebContentStructures.editStructureDefaultValuesCP(structureName = "WC Structure Name");
 
+			Type(
+				key_fieldFieldLabel = "Text",
+				locator1 = "WCEditWebContent#TEXT_INPUT",
+				value1 = "Default Text");
+
 			WebContent.addExpirationDateCP(expirationDate = "01/02/3000");
 
 			PortletEntry.save();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30437

# How am I fixing it?

This test is a bit flaky as some times in the back end it thinks the article has `null` content. To avoid this I've added text to the structure's text field.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=WebContentStructures#PredefineExpirationDateInCustomStructure`