### PR TITLE
LPD-30456 Last breadcrumb entry in Asset Library is clickable

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/servlet/taglib/DepotBreadcrumbEntryContributorImpl.java
@@ -115,6 +115,12 @@ public class DepotBreadcrumbEntryContributorImpl
 
 		breadcrumbEntries.addAll(originalBreadcrumbEntries);
 
+		BreadcrumbEntry breadcrumbEntry = breadcrumbEntries.get(
+			breadcrumbEntries.size() - 1);
+
+		breadcrumbEntry.setBrowsable(false);
+		breadcrumbEntry.setURL(null);
+
 		return breadcrumbEntries;
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30456

The last breadcrumb when browsing through asset libraries is always clickable.

# How am I fixing it?

By always making sure the last element returned for asset libraries is not browsable, and its URL is `null`.

# How can you verify that it works?

You may run either of these tests:
- LocalFile.DepotExportImport#ExportedDepotWithCustomizeDMCanBeImportedToDepot
- LocalFile.DepotApplication#CanNavigateViaBreadcrumb

# Why doesn't this include any test?

This case is already covered by two different poshi tests (see preview section).