### PR TITLE
LPD-30519

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -82,6 +82,10 @@ public class JournalConverterImpl implements JournalConverter {
 		throws PortalException {
 
 		try {
+			if (Validator.isNull(content)) {
+				return new Fields();
+			}
+
 			Document document = SAXReaderUtil.read(content);
 
 			Fields ddmFields = new Fields();

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterTest.java
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
  * @author Marcellus Tavares
  */
 @RunWith(Arquillian.class)
-public class JournalConverterUtilTest {
+public class JournalConverterTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -393,6 +394,15 @@ public class JournalConverterUtilTest {
 			_ddmStructure, content);
 
 		_assertFields(expectedFields, actualFields);
+	}
+
+	@Test
+	public void testGetFieldsFromEmptyContent() throws Exception {
+		Assert.assertEquals(
+			new Fields(), _journalConverter.getDDMFields(_ddmStructure, null));
+		Assert.assertEquals(
+			new Fields(),
+			_journalConverter.getDDMFields(_ddmStructure, StringPool.BLANK));
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30519

There's a model listener that updates content when its structure has been modified. This model listener assumes that web content cannot have an empty content field. But this may be true, as journal uses a regular web content to represent structure default values. It is possible to create one of these default contents with that field null or empty.

# How am I fixing it?

By taking the "empty content" case into consideration in the journal converter. When this happens, instead of failing, simply return a set of empty fields.

# How can you verify that it works?

You may run `JournalArticleInfoItemFieldValuesProviderTest`, which uncovered the issue, or the new integration test `JournalConverterTest#testGetFieldsFromEmptyContent`.