### PR TITLE
LPD-30245 Fix [playwright] [flaky] LPD-6813: Make prefix URLs configurable

### DIFF
--- a/modules/apps/friendly-url/friendly-url-web/src/main/resources/META-INF/resources/js/SeparatorFields.tsx
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/resources/META-INF/resources/js/SeparatorFields.tsx
@@ -88,7 +88,7 @@ function Field({errors, field, url}: FieldProps) {
 				<ClayInput.GroupItem append>
 					<ClayInput
 						aria-describedby={descriptionId}
-						data-testid={name}
+						id={name}
 						name={name}
 						onChange={(event) => setValue(event.target.value)}
 						ref={ref}

--- a/modules/apps/friendly-url/friendly-url-web/src/main/resources/META-INF/resources/js/SeparatorFields.tsx
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/resources/META-INF/resources/js/SeparatorFields.tsx
@@ -102,7 +102,6 @@ function Field({errors, field, url}: FieldProps) {
 							aria-label={Liferay.Language.get(
 								'reset-to-default-value'
 							)}
-							data-testid={name + '-reset-to-default-value'}
 							displayType="secondary"
 							onClick={() => {
 								setValue(defaultValue);

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -26,9 +26,11 @@ export class FriendlyUrlInstanceSettingsPage {
 		);
 	}
 
-	async modifySeparator(testId: string, value: string) {
-		await this.page.getByTestId(testId).click();
-		await this.page.getByTestId(testId).fill(value);
+	async modifySeparator(label: string, value: string) {
+		const separatorInput = this.page.getByLabel(label);
+		await separatorInput.click();
+		await separatorInput.fill(value);
+
 		await this.saveButton.click();
 		await waitForSuccessAlert(this.page);
 	}

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -34,6 +34,7 @@ export class FriendlyUrlInstanceSettingsPage {
 	}
 
 	async resetSeparator(testId: string) {
+		await this.page.getByTestId(testId).waitFor();
 		await this.page.getByTestId(testId).click();
 		await this.page.getByRole('button', {name: 'Save'}).click();
 		await waitForSuccessAlert(this.page);

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
@@ -39,8 +40,10 @@ export class FriendlyUrlInstanceSettingsPage {
 		const separatorResetButton = this.page
 			.locator('.input-group', {has: this.page.getByLabel(label)})
 			.getByLabel('Reset to Default Value');
-		await separatorResetButton.waitFor();
-		await separatorResetButton.click();
+		await clickAndExpectToBeHidden({
+			target: separatorResetButton,
+			trigger: separatorResetButton,
+		});
 
 		await this.saveButton.click();
 		await waitForSuccessAlert(this.page);

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -35,10 +35,14 @@ export class FriendlyUrlInstanceSettingsPage {
 		await waitForSuccessAlert(this.page);
 	}
 
-	async resetSeparator(testId: string) {
-		await this.page.getByTestId(testId).waitFor();
-		await this.page.getByTestId(testId).click();
-		await this.page.getByRole('button', {name: 'Save'}).click();
+	async resetSeparator(label: string) {
+		const separatorResetButton = this.page
+			.locator('.input-group', {has: this.page.getByLabel(label)})
+			.getByLabel('Reset to Default Value');
+		await separatorResetButton.waitFor();
+		await separatorResetButton.click();
+
+		await this.saveButton.click();
 		await waitForSuccessAlert(this.page);
 	}
 }

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -153,7 +153,6 @@ export default defineConfig({
 			? process.env.PORTAL_URL
 			: 'http://localhost:8080',
 		screenshot: 'only-on-failure',
-		testIdAttribute: 'data-qa-id',
 		trace: 'retain-on-failure',
 	},
 	workers: 1,

--- a/modules/test/playwright/tests/account-admin-web/config.ts
+++ b/modules/test/playwright/tests/account-admin-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'account-admin-web',
 	testDir: 'tests/account-admin-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/change-tracking-web/config.ts
+++ b/modules/test/playwright/tests/change-tracking-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'change-tracking-web',
 	testDir: 'tests/change-tracking-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'client-extension-web',
 	testDir: 'tests/client-extension-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/commerce/config.ts
+++ b/modules/test/playwright/tests/commerce/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'commerce',
 	testDir: 'tests/commerce',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/dispatch-web/config.ts
+++ b/modules/test/playwright/tests/dispatch-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'dispatch-web',
 	testDir: 'tests/dispatch-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/export-import-web/config.ts
+++ b/modules/test/playwright/tests/export-import-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'export-import-web',
 	testDir: 'tests/export-import-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/headless-builder-impl/config.ts
+++ b/modules/test/playwright/tests/headless-builder-impl/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'headless-builder-impl',
 	testDir: 'tests/headless-builder-impl',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/headless-builder-web/config.ts
+++ b/modules/test/playwright/tests/headless-builder-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'headless-builder-web',
 	testDir: 'tests/headless-builder-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/journal-web/config.ts
+++ b/modules/test/playwright/tests/journal-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'journal-web',
 	testDir: 'tests/journal-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -527,7 +527,7 @@ prefixUrlTest(
 		const urlSeparator = 'content';
 
 		await friendlyUrlInstanceSettingsPage.modifySeparator(
-			'_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_com.liferay.journal.model.JournalArticle',
+			'Web Content URL Separator',
 			urlSeparator
 		);
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -545,7 +545,7 @@ prefixUrlTest(
 		await friendlyUrlInstanceSettingsPage.goto();
 
 		await friendlyUrlInstanceSettingsPage.resetSeparator(
-			'_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_com.liferay.journal.model.JournalArticle-reset-to-default-value'
+			'Web Content URL Separator'
 		);
 
 		expect(

--- a/modules/test/playwright/tests/knowledge-base-web/config.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/config.ts
@@ -9,4 +9,7 @@ export const config = {
 	},
 	name: 'knowledge-base-web',
 	testDir: 'tests/knowledge-base-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/message-boards-web/config.ts
+++ b/modules/test/playwright/tests/message-boards-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'message-boards-web',
 	testDir: 'tests/message-boards-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/portal-default-permissions-web/config.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'portal-default-permissions-web',
 	testDir: 'tests/portal-default-permissions-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/portlet-configuration-web/config.ts
+++ b/modules/test/playwright/tests/portlet-configuration-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'portlet-configuration-web',
 	testDir: 'tests/portlet-configuration-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
+++ b/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'product-navigation-user-personal-bar-web',
 	testDir: 'tests/product-navigation-user-personal-bar-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/search-experiences-web/config.ts
+++ b/modules/test/playwright/tests/search-experiences-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'search-experiences-web',
 	testDir: 'tests/search-experiences-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/users-admin-web/config.ts
+++ b/modules/test/playwright/tests/users-admin-web/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'users-admin-web',
 	testDir: 'tests/users-admin-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/config.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-workspace-marketplace/config.ts
@@ -6,4 +6,7 @@
 export const config = {
 	name: 'marketplace',
 	testDir: 'tests/workspaces/liferay-workspace-marketplace',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
 };

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -67,7 +67,7 @@ async function performLogin(
 export async function performLogout(page: Page) {
 	await page.goto('/');
 
-	await page.getByTestId('userPersonalMenu').click();
+	await page.getByTitle('User Profile Menu').click();
 
 	await page.getByRole('menuitem', {name: 'Sign Out'}).click();
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30245

Fixing broken test

# How am I fixing it?

The test is failing because we configured the `data-qa-id` globally 62fdc150aec50a70247fba9e00a0dbfe3f444960, I reverted it bb2de38ed2891470067105263f3592210e5e75aa.

It needed to fix the global performLogut to work without the `data-qa-id` global 1f3bc3e53a2a842bdcfd78485e2237257809c9ab.

Avoid the use of `data-testid` 55b9402649e40228abf2bdf11505811354d2a442 9db0c05986524488a121c25f1b35720efb27b033.

Avoid test flakiness because the reset click is only working sometimes 484b31a16e5ea9f38fb0871ee4b46f54b1843754.

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright test -- -g "LPD-6813"` to run the test

# Avoid flakiness by repeating 10 times

```sh
npm run playwright test -- -g "LPD-6813" --reporter list --repeat-each 10
```

![image](https://github.com/liferay-content-management/liferay-portal/assets/67901/17fe734e-2472-4410-86d6-5a8c7076a55b)

> [!NOTE]
> **Unrelated failure** at perfomLogin 