### PR TITLE
LPD-30550 reorder the clicking on FIELD_ADD_DUPLICATE

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -745,20 +745,18 @@ definition {
 					value1 = ${webContentText});
 			}
 			else {
+				Click(locator1 = "FormFields#FIELD_ADD_DUPLICATE");
+
 				Type(
 					key_fieldFieldLabel = ${webContentTextFieldLabel},
 					locator1 = "WCEditWebContent#TEXT_INPUT",
 					value1 = ${webContentText});
 			}
 
-			if (isSet(duplicateField)) {
-				Click(locator1 = "FormFields#FIELD_ADD_DUPLICATE");
-
-				Type(
-					key_fieldFieldLabel = ${webContentTextFieldLabel},
-					locator1 = "WCEditWebContent#TEXT_INPUT_2",
-					value1 = "${webContentText} Duplicate Field");
-			}
+			Type(
+				key_fieldFieldLabel = ${webContentTextFieldLabel},
+				locator1 = "WCEditWebContent#TEXT_INPUT_2",
+				value1 = "${webContentText} Duplicate Field");
 		}
 
 		if (isSet(webContentUpload)) {


### PR DESCRIPTION
Hi Team,

May I ask you to review this PR?

Issue is failing poshi test :https://liferay.atlassian.net/browse/LPD-30550.

**Caused** by clicking on the FormFields#FIELD_ADD_DUPLICATE, was not success, and could not fill the duplicated field. 

**Rootcause**: after filling the first fiead, for a moment the button becomes disabled, and cannot be clicked.

**Solution**: Click on the button and create the second field before filling them