### PR TITLE
LPD-30456 Update integration tests

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/servlet/taglib/test/DepotBreadcrumbEntryContributorTest.java
@@ -91,6 +91,9 @@ public class DepotBreadcrumbEntryContributorTest {
 			homeBreadcrumbEntry.toString(),
 			_language.get(mockHttpServletRequest, "home"),
 			homeBreadcrumbEntry.getTitle());
+
+		_assertBreadcrumbEntryNotBrowsable(
+			breadcrumbEntries.get(breadcrumbEntries.size() - 1));
 	}
 
 	@Test
@@ -155,6 +158,9 @@ public class DepotBreadcrumbEntryContributorTest {
 				breadcrumbEntry.toString(), breadcrumbEntry.getTitle(),
 				previousBreadcrumbEntry.getTitle());
 		}
+
+		_assertBreadcrumbEntryNotBrowsable(
+			breadcrumbEntries.get(breadcrumbEntries.size() - 1));
 	}
 
 	private DepotEntry _addDepotEntry(String name, String description)
@@ -191,6 +197,15 @@ public class DepotBreadcrumbEntryContributorTest {
 		Assert.assertEquals(
 			assetLibraryBreadcrumbEntry.toString(), depotName,
 			assetLibraryBreadcrumbEntry.getTitle());
+	}
+
+	private void _assertBreadcrumbEntryNotBrowsable(
+			BreadcrumbEntry breadcrumbEntry)
+		throws Exception {
+
+		Assert.assertFalse(
+			breadcrumbEntry.toString(), breadcrumbEntry.isBrowsable());
+		Assert.assertNull(breadcrumbEntry.toString(), breadcrumbEntry.getURL());
 	}
 
 	private BreadcrumbEntry _getBreadcrumbEntry() {


### PR DESCRIPTION

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30456

This is a followup to [5651](https://github.com/liferay-content-management/liferay-portal/pull/5651).

Update existing integration tests to double check that the last breadcrumb entry is not browsable.

Although there are existing POSHI tests that already cover this, adding this assertion will make it easier to fix any regressions.

# How can you verify that it works?

Run the tests in `DepotBreadcrumbEntryContributorTest`.