### PR TITLE
LPD-30519 Accept empty content when converting to ddm fields

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -82,6 +82,10 @@ public class JournalConverterImpl implements JournalConverter {
 		throws PortalException {
 
 		try {
+			if (Validator.isNull(content)) {
+				return new Fields();
+			}
+
 			Document document = SAXReaderUtil.read(content);
 
 			Fields ddmFields = new Fields();

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/util/test/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/util/test/JournalConverterImplTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.journal.util.test;
+package com.liferay.journal.internal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
  * @author Marcellus Tavares
  */
 @RunWith(Arquillian.class)
-public class JournalConverterUtilTest {
+public class JournalConverterImplTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/util/test/JournalHelperImplTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/util/test/JournalHelperImplTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.journal.util.test;
+package com.liferay.journal.internal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.constants.JournalFolderConstants;
@@ -44,7 +44,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
  * @author Noor Najjar
  */
 @RunWith(Arquillian.class)
-public class JournalHelperTest {
+public class JournalHelperImplTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/test/util/test/JournalTestUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/test/util/test/JournalTestUtilTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.journal.util.test;
+package com.liferay.journal.test.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -393,6 +394,15 @@ public class JournalConverterUtilTest {
 			_ddmStructure, content);
 
 		_assertFields(expectedFields, actualFields);
+	}
+
+	@Test
+	public void testGetFieldsFromEmptyContent() throws Exception {
+		Assert.assertEquals(
+			new Fields(), _journalConverter.getDDMFields(_ddmStructure, null));
+		Assert.assertEquals(
+			new Fields(),
+			_journalConverter.getDDMFields(_ddmStructure, StringPool.BLANK));
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30519

This is a followup to the previous pr [5652](https://github.com/liferay-content-management/liferay-portal/pull/5652), applying feedback given in [152058](https://github.com/brianchandotcom/liferay-portal/pull/152058). Only the last two commits have changed.

There's a model listener that updates content when its structure has been modified. This model listener assumes that web content cannot have an empty content field. But this may be true, as journal uses a regular web content to represent structure default values. It is possible to create one of these default contents with that field null or empty.

# How am I fixing it?

By taking the "empty content" case into consideration in the journal converter. When this happens, instead of failing, simply return a set of empty fields.

# How can you verify that it works?

You may run `JournalArticleInfoItemFieldValuesProviderTest`, which uncovered the issue, or the new integration test `JournalConverterTest#testGetFieldsFromEmptyContent`.