### PR TITLE
LPD-30614 Set thread local company ID

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -79,6 +80,7 @@ import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -112,6 +114,15 @@ public class JournalArticleContentDashboardItemTest {
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group.getGroupId());
+
+		_oldCompanyId = CompanyThreadLocal.getCompanyId();
+
+		CompanyThreadLocal.setCompanyId(_group.getCompanyId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		CompanyThreadLocal.setCompanyId(_oldCompanyId);
 	}
 
 	@Test
@@ -1204,6 +1215,8 @@ public class JournalArticleContentDashboardItemTest {
 
 	@Inject
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	private long _oldCompanyId;
 
 	@Inject
 	private Portal _portal;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30614

The feature flag for LPS-203351 is *not* at system level, but there are some places in the code where the company ID cannot be passed explicitly. As the FF checks need to rely on the thread local company, we need to set it in the tests to avoid the log from being polluted (which will make some other tests fail).

# How am I fixing it?

By setting the thread local company ID before running the tests and resetting it afterwards.

# How can you verify that it works?

Run `JournalArticleContentDashboardItemTest` and verify that not error messages related to feature flags are displayed in the logs.