### PR TITLE
LPD-30615 Fix Warn in test JournalArticleAssetEntryClassTypeIdUpgradeProcessTest

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v5_1_1/test/JournalArticleAssetEntryClassTypeIdUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v5_1_1/test/JournalArticleAssetEntryClassTypeIdUpgradeProcessTest.java
@@ -76,6 +76,18 @@ public class JournalArticleAssetEntryClassTypeIdUpgradeProcessTest
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 	}
 
+	@Override
+	@Test
+	public void testMissingCtCollectionId() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.journal.internal.upgrade.v5_1_1." +
+					"JournalArticleAssetEntryClassTypeIdUpgradeProcess",
+				LoggerTestUtil.WARN)) {
+
+			super.testMissingCtCollectionId();
+		}
+	}
+
 	@Test
 	public void testUpgrade() throws Exception {
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30615

Some expected WARN level messages were making the portal log assertor fail.

# How am I fixing it?

By capturing and discarding any WARN logs during the upgrade.  Note that we cannot use the `@ExpectedLogs` annotation, as the logging class is not visible from the test module -- so we cannot reference it in the `loggerClass` annotation attribute.

# How can you verify that it works?

Run the `JournalArticleAssetEntryClassTypeIdUpgradeProcess`, and after completion, examing the portal log and verify that there are not `WARN` level logs.