### PR TITLE
LPD-30691 Add additional locator in order to find workflow status label

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
@@ -103,7 +103,7 @@
 
 <tr>
 	<td>MESSAGE_WORKFLOW_STATUS_1</td>
-	<td>//span[@class='taglib-workflow-status']/span[contains(@class,'workflow-status')] | //span[@class='label label-info']//*[contains(.,'${value1}')]</td>
+	<td>//span[@class='taglib-workflow-status']/span[contains(@class,'workflow-status')] | //span[@class='label label-info']//*[contains(.,'${value1}')] | //span[contains(@class, 'label-item-expand') and contains(.,'${value1}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30691

# How am I fixing it?

The workflow label seems to have changed so I've added a new path in order to find it.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=MBPermissions#SiteMemberCanViewTheirSavedDraftMessage`