### PR TITLE
LPD-30815 Questions widget configuration options do not save properly

### DIFF
--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/action/QuestionsConfigurationAction.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/action/QuestionsConfigurationAction.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.questions.web.internal.constants.QuestionsPortletKeys;
@@ -52,6 +53,17 @@ public class QuestionsConfigurationAction
 
 		ModifiableSettings modifiableSettings =
 			settings.getModifiableSettings();
+
+		String rootTopicId = ParamUtil.getString(
+			actionRequest, "preferences--rootTopicId--");
+
+		modifiableSettings.setValue("rootTopicId", rootTopicId);
+
+		String showCardsForTopicNavigation = ParamUtil.getString(
+			actionRequest, "preferences--showCardsForTopicNavigation--");
+
+		modifiableSettings.setValue(
+			"showCardsForTopicNavigation", showCardsForTopicNavigation);
 
 		for (String key : _KEYS) {
 			UnicodeProperties unicodeProperties =

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -144,8 +144,8 @@ catch (Exception exception) {
 					var form = document.<portlet:namespace />fm;
 
 					Liferay.Util.setFormValues(form, {
-						rootTopicName: Liferay.Util.unescape(event.name),
-						rootTopicId: event.categoryid,
+						rootTopicName: Liferay.Util.unescape(event.resourcename),
+						rootTopicId: event.resourceid,
 					});
 
 					var removeRootTopicButton = document.getElementById(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30815

# How am I fixing it?

The first issue was that the names for the variables had changed. The second issue was that only some of the preferences were being saved.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanConfigureRootTopic`

To test manually:

1. Go to Product Menu - Content & Data - Message Boards
2. Add a new Message Boards Category
3. Add a Questions widget to the page
4. Open the widget’s configuration
5. Uncheck “Show Cards for Topic Navigation”
6. For Root Topic ID select the newly created category
7. Save