### PR TITLE
LPD-26902 Assign "Antivirus" component to Security

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4248,7 +4248,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (testray.main.component.name ~ "AI-Creator") OR \
             (testray.main.component.name ~ "Adaptive Media") OR \
             (testray.main.component.name ~ "Announcements") OR \
-            (testray.main.component.name ~ "Antivirus") OR \
             (testray.main.component.name ~ "Asset Sharing") OR \
             (testray.main.component.name ~ "Auto Tagging") OR \
             (testray.main.component.name ~ "Blogs") OR \
@@ -9751,6 +9750,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
             (testray.component.names ~ "Password Policies") OR \
             (testray.main.component.name == "Audit") OR \
             (testray.main.component.name ~ "AntiSamy") OR \
+            (testray.main.component.name ~ "Antivirus") OR \
             (testray.main.component.name ~ "CAPTCHA") OR \
             (testray.main.component.name ~ "Content Security Policy") OR \
             (testray.main.component.name ~ "Cookies") OR \
@@ -11687,7 +11687,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         AI-Creator,\
         Akismet,\
         Announcements,\
-        Antivirus,\
         Asset Framework,\
         Asset Sharing,\
         Auto Tagging,\
@@ -11895,6 +11894,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
 
     testray.team.security.component.names=\
         AntiSamy,\
+        Antivirus,\
         Audit,\
         CAPTCHA,\
         Content Security Policy,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26902

The Antivirus test component is wrongly assigned to Content Management. The component belongs to the Security Team, so assign the test suite to them.