### PR TITLE
LPD-30577 change app_name with name of new credentials

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/MicrosoftLogin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MicrosoftLogin.macro
@@ -64,7 +64,7 @@ definition {
 	macro confirmSharepointApp() {
 		WaitForElementPresent.waitForLastScript();
 
-		var app_name = "SharePoint Online";
+		var app_name = "CM 2024/2025";
 
 		if (IsElementPresent(locator1 = "MicrosoftLogin#LOGIN_STAY_SIGNED_IN_CONFIRMATION")) {
 			AssertClick(


### PR DESCRIPTION
LPD-30577 Update the Sharepoint authentication on CI

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30577

After the update of the credentials on https://liferay.atlassian.net/browse/LRCI-4313 we should update the new credentials on the poshi test. On this case the app name

# How am I fixing it?

Changin the app name for the new one of the new credential

# How can you verify that it works?

Run the included automated tests.