### PR TITLE
LPD-30888 Technical Task | Fix Warn in test SaveAsDraftArticleMVCActionCommandTest > testProcessAction

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/SaveAsDraftArticleMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/SaveAsDraftArticleMVCActionCommandTest.java
@@ -16,6 +16,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -37,6 +38,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -52,7 +54,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 /**
  * @author Jonathan McCann
@@ -130,12 +134,29 @@ public class SaveAsDraftArticleMVCActionCommandTest {
 			previewURL.contains(String.valueOf(journalArticle.getVersion())));
 	}
 
+	private MockMultipartHttpServletRequest
+		_createMockMultipartHttpServletRequest() {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+
+		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
+
+		mockMultipartHttpServletRequest.setContentType(
+			MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + boundary);
+
+		return mockMultipartHttpServletRequest;
+	}
+
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
 			JournalArticle journalArticle)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			new MockLiferayPortletActionRequest();
+			new MockLiferayPortletActionRequest(
+				_createMockMultipartHttpServletRequest());
 
 		mockLiferayPortletActionRequest.addParameter(
 			"articleId", journalArticle.getArticleId());


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30329

Fix warning trace log : 

`2024-07-08 16:49:27.887 WARN  [com.liferay.journal.test-executor-thread][UploadServletRequestImpl:184] Unable to parse upload request: the request was rejected because no multipart boundary was found`

# How am I fixing it?

Creating mock liferay portlet action request with mock multipart http servlet request because we are expecting this type of request in SaveAsDraftArticleMVCActionCommand class.

# How can you verify that it works?

Run SaveAsDraftArticleMVCActionCommandTest > testProcessAction test and see that warn trace is not displayed in the logs.
