### PR TITLE
LPD-30961 Fix tests due to incorrect file name capitalization

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentSiteIntegration.testcase
@@ -967,7 +967,7 @@ definition {
 		ContentPages.viewFragmentImage(
 			fragmentName = "image",
 			id = "image-square",
-			image = "document_1");
+			image = "Document_1");
 	}
 
 	@description = "This ensures that a depot image in MG widget can be rendered correctly on a connected site after moving it to a folder."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFriendlyURL.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFriendlyURL.testcase
@@ -456,7 +456,7 @@ definition {
 		ContentPages.viewFragmentImage(
 			fragmentName = "image",
 			id = "image-square",
-			image = "document_1");
+			image = "Document_1");
 	}
 
 	@description = "This ensures that the friendlyURL can be used when a user accesses a document template."


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30961

# How am I fixing it?

The document is being uploaded with a first capital letter but when trying to find it on screen later it was lowercase.

# How can you verify that it works?

Run:

`ant -f build-test.xml run-selenium-test -Dtest.class=DepotDocumentSiteIntegration#CanViewImageViaImageFragmentAfterMovingToFolder`
`ant -f build-test.xml run-selenium-test -Dtest.class=MBPermissions#SiteMemberCanViewTheirSavedDraftMessage`