### PR TITLE
LPD-31028 Technical Task | Fix test failures in JournalArticleModelDocumentContributorTest

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -129,6 +129,8 @@ public class JournalArticleModelDocumentContributorTest {
 	private Document _getDocument() {
 		DocumentImpl documentImpl = new DocumentImpl();
 
+		Assert.assertNotNull(_journalArticle.getDDMFormValues());
+
 		_modelDocumentContributor.contribute(documentImpl, _journalArticle);
 
 		return documentImpl;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -116,12 +116,13 @@ public class JournalArticleModelDocumentContributorTest {
 		com.liferay.portal.kernel.xml.Document document =
 			_journalArticle.getDocument();
 
+		DDMStructure ddmStructure = _journalArticle.getDDMStructure();
+
 		return _ddmIndexer.extractIndexableAttributes(
-			_journalArticle.getDDMStructure(),
+			ddmStructure,
 			_fieldsToDDMFormValuesConverter.convert(
-				_journalArticle.getDDMStructure(),
-				_journalConverter.getDDMFields(
-					_journalArticle.getDDMStructure(), document.asXML())),
+				ddmStructure,
+				_journalConverter.getDDMFields(ddmStructure, document.asXML())),
 			LocaleUtil.fromLanguageId(languageId));
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/search/spi/model/index/contributor/test/JournalArticleModelDocumentContributorTest.java
@@ -16,13 +16,14 @@ import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalConverter;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -51,8 +52,10 @@ public class JournalArticleModelDocumentContributorTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
 		_journalArticle = JournalTestUtil.addArticle(
-			TestPropsValues.getGroupId(),
+			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
 			HashMapBuilder.put(
@@ -138,6 +141,9 @@ public class JournalArticleModelDocumentContributorTest {
 
 	@Inject
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@DeleteAfterTestRun
 	private JournalArticle _journalArticle;


### PR DESCRIPTION
# What is this trying to solve?

I run the tests many times and always the run has been successful. This is not easy to determine why the tests are failing  once in a while. I reviewed it but I was not able to conclude nothing because I am not seeing any pattern. I suppose that for any reason when we are calling to journalArticle.getDDMFormValues(); in [this line](https://github.com/liferay/liferay-portal/blob/796cae0a25770283167b1c1f11bc73d5390f9f09/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java#L76) is returning a null object and for that some tests are failing. I think that the problem is in[ this line  ](https://github.com/liferay/liferay-portal/blob/518efbd11c23baab9a10494ef521f28b08dc5f8e/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java#L275) and for that reason we are getting a null object but I am not sure 100%, I am assuming things and for that reason I am adding some improves to determine why is failing  in future following executions. 

https://liferay.atlassian.net/browse/LPD-29856

# How am I fixing it?

Add some improves to determine in the future why the tests are failing.

# How can I test it?

Execute the test.

