### PR TITLE
LPD-31106 Ensure the layout is published so that the guest user can view it

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsSEO.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsSEO.testcase
@@ -76,6 +76,10 @@ definition {
 			layoutName = "Translation Content Page",
 			type = "content");
 
+		JSONLayout.publishLayout(
+			groupName = "Test Site Name",
+			layoutName = "Translation Content Page");
+
 		Navigator.openSpecificURL(url = "${portalURL}/c/portal/logout");
 
 		Navigator.openSpecificURL(url = "${portalURL}/web/test-site-name/translation-widget-page");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-31106

# How am I fixing it?

The content page was not fully published so when viewed as a guest user it was displaying a 404 error.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=TranslationsSEO#CanViewPageDefaultHreflangTags`