### PR TITLE
LPD-31040 Fix failures in wiki-web/wiki.spec.ts

### DIFF
--- a/modules/test/playwright/pages/wiki-web/WikiPage.ts
+++ b/modules/test/playwright/pages/wiki-web/WikiPage.ts
@@ -9,9 +9,12 @@ import {PORTLET_URLS} from '../../utils/portletUrls';
 
 export class WikiPage {
 	readonly page: Page;
+	readonly publishButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+
+		this.publishButton = page.getByRole('button', {name: 'Publish'});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -68,5 +71,9 @@ export class WikiPage {
 
 	async goToWikiNode(title: string) {
 		await this.page.getByRole('link', {exact: true, name: title}).click();
+	}
+
+	async publishPage() {
+		await this.publishButton.click();
 	}
 }

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -19,6 +19,8 @@ test('LPD-26435 Icon menu should close when another icon menu is open', async ({
 
 	await wikiPage.createNewWikiNode('Wiki Node Title');
 
+	await page.getByLabel('Order').waitFor();
+
 	const wikiNodeMenu = await page.locator(
 		'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
 	);

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -77,6 +77,8 @@ test('LPD-28898 Image added via rich text editor on Wiki tool losing reference',
 		image
 	);
 
+	await wikiPage.publishPage();
+
 	await wikiPage.goto();
 
 	await wikiPage.goToWikiNode('Main');

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -5,10 +5,11 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
 
-export const test = mergeTests(loginTest(), wikiPagesTest);
+export const test = mergeTests(isolatedSiteTest, loginTest(), wikiPagesTest);
 
 test('LPD-26435 Icon menu should close when another icon menu is open', async ({
 	page,


### PR DESCRIPTION
# Motivation

Both tests are failing in Testray, see https://liferay.atlassian.net/browse/LPD-30933 for detail. 

# How I am solving this

### 1) LPD-28898 Image added via rich text editor on Wiki tool losing reference
This test was failing because the wiki page was not saved, so I [added a click on a Publish](https://github.com/liferay-content-management/liferay-portal/pull/5676/commits/671b7d240ee84a9fbc1f2e2e9b49ecb4d4301726) button. 
```
> @liferay/playwright@1.0.0 test
> playwright test "-g" "LPD-28898" "--reporter" "list"

Running 1 test using 1 worker

  ✓  1 [wiki-web] › wiki-web/wiki.spec.ts:59:1 › LPD-28898 Image added via rich text editor on Wiki tool losing reference (20.1s)
```

### 2) LPD-26435 Icon menu should close when another icon menu is open
This was a flaky test. I added a[ waitFor for an element](https://github.com/liferay-content-management/liferay-portal/pull/5676/commits/81c042819382dff6ffb1f3599ee4442d0e490bf9) that I know is rendered via js, so this way the js is loaded and the dropdown menu will be visible for sure. 

```
> @liferay/playwright@1.0.0 test
> playwright test "-g" "LPD-26435" "--reporter" "list" "--repeat-each=10"

Running 10 tests using 1 worker

  ✓  1 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (18.2s)
  ✓  2 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (15.3s)
  ✓  3 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.4s)
  ✓  4 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.5s)
  ✓  5 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (16.5s)
  ✓  6 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.4s)
  ✓  7 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (15.4s)
  ✓  8 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.3s)
  ✓  9 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.1s)
  ✓  10 [wiki-web] › wiki-web/wiki.spec.ts:14:1 › LPD-26435 Icon menu should close when another icon menu is open (14.2s)

```
