### PR TITLE
LPD-31141 Add the groupId improves current performance with millions of files

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1906,6 +1906,19 @@ public class DLFileEntryLocalServiceImpl
 
 		indexableActionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
+				if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+					DLFolder folder = _dlFolderLocalService.fetchDLFolder(
+						folderId);
+
+					if (folder != null) {
+						Property groupIdProperty = PropertyFactoryUtil.forName(
+							"groupId");
+
+						dynamicQuery.add(
+							groupIdProperty.eq(folder.getGroupId()));
+					}
+				}
+
 				Property folderIdProperty = PropertyFactoryUtil.forName(
 					"folderId");
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -333,6 +333,19 @@ public class DLFileShortcutLocalServiceImpl
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
+				if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+					DLFolder folder = _dlFolderLocalService.fetchDLFolder(
+						folderId);
+
+					if (folder != null) {
+						Property groupIdProperty = PropertyFactoryUtil.forName(
+							"groupId");
+
+						dynamicQuery.add(
+							groupIdProperty.eq(folder.getGroupId()));
+					}
+				}
+
 				Property folderIdProperty = PropertyFactoryUtil.forName(
 					"folderId");
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -8,6 +8,8 @@ package com.liferay.portlet.documentlibrary.service.impl;
 import com.liferay.document.library.kernel.exception.NoSuchFileVersionException;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.kernel.util.comparator.DLFileVersionVersionComparator;
@@ -187,6 +189,19 @@ public class DLFileVersionLocalServiceImpl
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
+				if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+					DLFolder folder = _dlFolderLocalService.fetchDLFolder(
+						folderId);
+
+					if (folder != null) {
+						Property groupIdProperty = PropertyFactoryUtil.forName(
+							"groupId");
+
+						dynamicQuery.add(
+							groupIdProperty.eq(folder.getGroupId()));
+					}
+				}
+
 				Property folderIdProperty = PropertyFactoryUtil.forName(
 					"folderId");
 


### PR DESCRIPTION
LPD-31141 Performance issues in Move folder method to perform simple move with a high number of FileEntries

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-31141

When the user has millions of elements in the D&M a move folder action takes a too much time

### How am I fixing it?

Adding the groupId if possible in order to take advantage of DB indexes

### How can you verify that it works?

Since this is fixing a performance issue and to reproduce it millions of elements are required, **this could not be automated**.

We have introduced this piece of code based in the tests performed in customers systems with this amount of data.

In any case we also have some test related with this methods so we could assert that this new code is not breaking them:

- com.liferay.document.library.service.test.DLFileVersionLocalServiceTreeTest#testRebuildTree
- com.liferay.document.library.service.test.DLFileEntryLocalServiceTreeTest#testRebuildTree
- com.liferay.document.library.service.test.DLFileShortcutLocalServiceTreeTest#testRebuildTree
