### PR TITLE
LPD-31157 Error  after delete knowledge base article from knowledge display portlet

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/portlet/action/test/DeleteKBArticleMVCActionCommandTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/portlet/action/test/DeleteKBArticleMVCActionCommandTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.constants.KBArticleConstants;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.model.KBFolder;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class DeleteKBArticleMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testDoProcessAction() throws Exception {
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, TestPropsValues.getUserId(),
+			PortalUtil.getClassNameId(KBFolder.class.getName()),
+			KBArticleConstants.DEFAULT_PARENT_RESOURCE_PRIM_KEY,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			null, RandomTestUtil.nextDate(), null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			"resourcePrimKey", String.valueOf(kbArticle.getResourcePrimKey()));
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Assert.assertNull(
+			_kbArticleLocalService.fetchKBArticle(kbArticle.getKbArticleId()));
+	}
+
+	private MockLiferayPortletActionRequest
+			_getMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+	@Inject(filter = "mvc.command.name=/knowledge_base/delete_kb_article")
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
@@ -7,13 +7,10 @@ package com.liferay.knowledge.base.web.internal.portlet.action;
 
 import com.liferay.knowledge.base.constants.KBPortletKeys;
 import com.liferay.knowledge.base.exception.LockedKBArticleException;
-import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.service.KBArticleService;
 import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.TrashedModel;
-import com.liferay.portal.kernel.portlet.LiferayPortletURL;
-import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -24,11 +21,8 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.util.Objects;
-
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
-import javax.portlet.PortletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -67,9 +61,6 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 				themeDisplay.getScopeGroupId(), resourcePrimKey);
 		}
 
-		KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
-			resourcePrimKey);
-
 		try {
 			if (cmd.equals(Constants.MOVE_TO_TRASH) &&
 				FeatureFlagManagerUtil.isEnabled("LPS-188058")) {
@@ -99,29 +90,6 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 			lockedKBArticleException.setCmd(Constants.DELETE);
 
 			throw lockedKBArticleException;
-		}
-
-		if (Objects.equals(
-				_portal.getPortletId(actionRequest),
-				KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
-
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
-
-
-			LiferayPortletURL liferayPortletURL = PortletURLFactoryUtil.create(
-				actionRequest, _portal.getPortletId(actionRequest),
-				themeDisplay.getPlid(), PortletRequest.RENDER_PHASE);
-
-			if (kbArticle.getParentResourcePrimKey() !=
-					kbArticle.getKbFolderId()) {
-
-				liferayPortletURL.setParameter(
-					"resourcePrimKey",
-					String.valueOf(kbArticle.getParentResourcePrimKey()));
-			}
-
-			actionResponse.sendRedirect(liferayPortletURL.toString());
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/DeleteKBArticleMVCActionCommand.java
@@ -67,6 +67,9 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 				themeDisplay.getScopeGroupId(), resourcePrimKey);
 		}
 
+		KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
+			resourcePrimKey);
+
 		try {
 			if (cmd.equals(Constants.MOVE_TO_TRASH) &&
 				FeatureFlagManagerUtil.isEnabled("LPS-188058")) {
@@ -105,8 +108,6 @@ public class DeleteKBArticleMVCActionCommand extends BaseMVCActionCommand {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-			KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
-				resourcePrimKey);
 
 			LiferayPortletURL liferayPortletURL = PortletURLFactoryUtil.create(
 				actionRequest, _portal.getPortletId(actionRequest),

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
@@ -34,7 +34,9 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
@@ -535,9 +537,35 @@ public class KBDropdownItemsProvider {
 
 				if (!Objects.equals(
 						portletDisplay.getRootPortletId(),
-						KBPortletKeys.KNOWLEDGE_BASE_ADMIN)) {
+						KBPortletKeys.KNOWLEDGE_BASE_ADMIN) &&
+					!Objects.equals(
+						portletDisplay.getRootPortletId(),
+						KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
 
 					return _createKbHomeRenderURL();
+				}
+
+				if (Objects.equals(
+						portletDisplay.getRootPortletId(),
+						KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
+
+					LiferayPortletURL liferayPortletURL =
+						PortletURLFactoryUtil.create(
+							_liferayPortletRequest,
+							PortalUtil.getPortletId(_liferayPortletRequest),
+							_themeDisplay.getPlid(),
+							PortletRequest.RENDER_PHASE);
+
+					if (kbArticle.getParentResourcePrimKey() !=
+							kbArticle.getKbFolderId()) {
+
+						liferayPortletURL.setParameter(
+							"resourcePrimKey",
+							String.valueOf(
+								kbArticle.getParentResourcePrimKey()));
+					}
+
+					return liferayPortletURL.toString();
 				}
 
 				if (((selectedItemAncestorIds == null) &&

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/KBDropdownItemsProvider.java
@@ -34,9 +34,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
@@ -549,23 +547,20 @@ public class KBDropdownItemsProvider {
 						portletDisplay.getRootPortletId(),
 						KBPortletKeys.KNOWLEDGE_BASE_DISPLAY)) {
 
-					LiferayPortletURL liferayPortletURL =
-						PortletURLFactoryUtil.create(
-							_liferayPortletRequest,
-							PortalUtil.getPortletId(_liferayPortletRequest),
-							_themeDisplay.getPlid(),
-							PortletRequest.RENDER_PHASE);
+					return PortletURLBuilder.createActionURL(
+						_liferayPortletResponse
+					).setParameter(
+						"resourcePrimKey",
+						() -> {
+							if (kbArticle.getParentResourcePrimKey() ==
+									kbArticle.getKbFolderId()) {
 
-					if (kbArticle.getParentResourcePrimKey() !=
-							kbArticle.getKbFolderId()) {
+								return null;
+							}
 
-						liferayPortletURL.setParameter(
-							"resourcePrimKey",
-							String.valueOf(
-								kbArticle.getParentResourcePrimKey()));
-					}
-
-					return liferayPortletURL.toString();
+							return kbArticle.getParentResourcePrimKey();
+						}
+					).buildString();
 				}
 
 				if (((selectedItemAncestorIds == null) &&


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-31157

When we are trying to delete a kbarticle from knowledge base display portlet an error is showed. So, this PR fix this error.

### How am I fixing it?

Getting kb article in the correct place to build the redirect url in order to avoid NoSuchArticleException.

### How can you verify that it works?

Run the added test and the failing test LocalFile.KBDisplayWidget#CanDeleteArticle