### PR TITLE
LPD-31402 Ensure that stream is always closed.

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/ImageImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ImageImpl.java
@@ -41,22 +41,29 @@ public class ImageImpl extends ImageBaseImpl {
 
 			InputStream inputStream = null;
 
-			if ((dlFileEntry != null) &&
-				(dlFileEntry.getLargeImageId() == imageId)) {
+			try {
+				if ((dlFileEntry != null) &&
+					(dlFileEntry.getLargeImageId() == imageId)) {
 
-				inputStream = DLStoreUtil.getFileAsStream(
-					dlFileEntry.getCompanyId(),
-					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
-					StringPool.BLANK);
+					inputStream = DLStoreUtil.getFileAsStream(
+						dlFileEntry.getCompanyId(),
+						dlFileEntry.getDataRepositoryId(),
+						dlFileEntry.getName(), StringPool.BLANK);
+				}
+				else {
+					inputStream = ImageLocalServiceUtil.getImageInputStream(
+						getCompanyId(), imageId, getType());
+				}
+
+				byte[] bytes = FileUtil.getBytes(inputStream);
+
+				_textObj = bytes;
 			}
-			else {
-				inputStream = ImageLocalServiceUtil.getImageInputStream(
-					getCompanyId(), imageId, getType());
+			finally {
+				if (inputStream != null) {
+					inputStream.close();
+				}
 			}
-
-			byte[] bytes = FileUtil.getBytes(inputStream);
-
-			_textObj = bytes;
 		}
 		catch (Exception exception) {
 			_log.error("Unable to read image " + imageId, exception);


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-31402 Adapt remaining keeps leaking connections with S3 even after LPS-182336.
### How am I fixing it?
Ensuring that connection are always closed. The same way @dantewang delivered to the customer.
### How can you verify that it works?
Configure the storage connection with S3.
Upload a huge amount of image files.
Go to Control Panel/Adaptive Media, create a new resolution and start the Adapt Remaining operation for it.
The progress bar gets stuck in some cases.
### Why does this pull not include tests?
This cannot be observed reliably from a test. We'd need to check that a progress bar gets stuck over time, which may lead to flakiness if the bar progresses too slowly or too fast.