### PR TITLE
LPD-27914 add info to the macro method

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -2285,9 +2285,17 @@ definition {
 
 		var dmDocumentURL = selenium.getAttribute("//img[contains(@class,'preview-file-image') and contains(@src,'${dmDocumentFileName}')]@src");
 
+		echo("## * Document URL: ${dmDocumentURL}");
+
 		var curl = '''${dmDocumentURL} -I''';
 
 		var responseHeader = JSONCurlUtil.post(${curl});
+
+		if (${responseHeader} == "") {
+			fail("FAIL. Cannot get document.");
+		}
+
+		echo("## * Headers: ${responseHeader}");
 
 		return ${responseHeader};
 	}


### PR DESCRIPTION
LPD-27914 add info to the macro method

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-27914

There is some Flaky test that use the _getFileResponseHeader_ method. to Know more about the error I want to add more info to this method.

# How am I fixing it?

This should not fix anything, only give us more information about the flaky failures

# How can you verify that it works?

Run the affected automated tests.