### PR TITLE
LPD-31536 Change initial state mechanism

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -152,6 +152,8 @@ journalEditArticleDisplayContext.setViewAttributes();
 											HashMapBuilder.<String, Object>put(
 												"initialDefaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
 											).put(
+												"initialFields", journalEditArticleDisplayContext.getFieldMap()
+											).put(
 												"languageId", journalEditArticleDisplayContext.getSelectedLanguageId()
 											).build()
 										%>'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -14,6 +14,7 @@ const META_FIELD_NAMES = {
 
 export default function UndoRedo({
 	initialDefaultLanguageId,
+	initialFields,
 	languageId,
 	portletNamespace,
 }) {
@@ -24,9 +25,27 @@ export default function UndoRedo({
 		setState,
 	] = useState({
 		defaultLanguageId: initialDefaultLanguageId,
-		history: [],
+		history: [
+			{
+				defaultLanguageId: initialDefaultLanguageId,
+				descriptionInputComponent:
+					initialFields[`${META_FIELD_NAMES.description}`][
+						`${initialDefaultLanguageId}`
+					] || '',
+				friendlyURLInputComponent:
+					initialFields[`${META_FIELD_NAMES.friendlyURL}`][
+						`${initialDefaultLanguageId}`
+					] || '',
+				name: 'Reset',
+				selectedLanguageId: languageId,
+				titleInputComponent:
+					initialFields[`${META_FIELD_NAMES.title}`][
+						`${initialDefaultLanguageId}`
+					] || '',
+			},
+		],
 		selectedLanguageId: languageId,
-		step: -1,
+		step: 0,
 	});
 
 	const handleUndoRedo = (newStep) => {
@@ -174,14 +193,6 @@ export default function UndoRedo({
 			Liferay.detach('journal:storeState', handleStoreState);
 		};
 	}, [handleStoreState]);
-
-	useEffect(() => {
-		setTimeout(() => {
-			Liferay.fire('journal:storeState', {fieldName: 'Reset'});
-		}, 1000);
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	return (
 		<>

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -161,11 +161,9 @@ autoSaveAsDraftTest(
 
 		await fillAndClickOutside(page, localizableField, content);
 
-		const changesSavedIndicator = await page.locator(
-			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
-		);
-
-		await expect(changesSavedIndicator).toBeVisible();
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
 
 		await page.getByTitle('Go to Web Content').click();
 
@@ -193,12 +191,7 @@ autoSaveAsDraftTest(
 autoSaveAsDraftTest(
 	'LPD-26863: Undo/Redo buttons work with metadata fields',
 	async ({journalEditArticlePage, page, site}) => {
-		const changesSavedIndicator = await page.locator(
-			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
-		);
-		const redoButton = page.getByTitle('Redo', {exact: true});
 		const title = getRandomString();
-		const undobutton = page.getByTitle('Undo', {exact: true});
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
@@ -209,20 +202,22 @@ autoSaveAsDraftTest(
 				title
 			);
 
-			await expect(undobutton).toBeEnabled();
+			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
 
-		await expect(changesSavedIndicator).toBeVisible();
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
 
-		await undobutton.click();
+		await journalEditArticlePage.undoButton.click();
 
-		await expect(undobutton).toBeDisabled();
+		await expect(journalEditArticlePage.undoButton).toBeDisabled();
 
 		await expect(journalEditArticlePage.titleInput).toHaveValue('');
 
-		await redoButton.click();
+		await journalEditArticlePage.redoButton.click();
 
-		await expect(redoButton).toBeDisabled();
+		await expect(journalEditArticlePage.redoButton).toBeDisabled();
 
 		await expect(journalEditArticlePage.titleInput).toHaveValue(title);
 	}
@@ -247,12 +242,7 @@ autoSaveAsDraftTest(
 			structureName,
 		});
 
-		const changesSavedIndicator = await page.locator(
-			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
-		);
-		const redoButton = await page.getByTitle('Redo', {exact: true});
 		const title = getRandomString();
-		const undoButton = await page.getByTitle('Undo', {exact: true});
 
 		const localizableField = await page.getByRole('textbox', {
 			name: localizableFieldName,
@@ -265,22 +255,26 @@ autoSaveAsDraftTest(
 				title
 			);
 
-			await expect(undoButton).toBeEnabled();
+			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
 
-		await expect(changesSavedIndicator).toBeVisible();
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
 
 		await fillAndClickOutside(page, localizableField, title);
 
-		await expect(changesSavedIndicator).toBeVisible();
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
 
-		await undoButton.click();
+		await journalEditArticlePage.undoButton.click();
 
 		await expect(localizableField).toHaveValue('');
 
-		await redoButton.click();
+		await journalEditArticlePage.redoButton.click();
 
-		await expect(redoButton).toBeDisabled();
+		await expect(journalEditArticlePage.redoButton).toBeDisabled();
 
 		await expect(localizableField).toHaveValue(title);
 	}

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -202,15 +202,13 @@ autoSaveAsDraftTest(
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-		await journalEditArticlePage.titleInput.click();
-
-		await page.waitForTimeout(200);
-
-		await journalEditArticlePage.titleInput.fill(title);
+		await fillAndClickOutside(
+			page,
+			journalEditArticlePage.titleInput,
+			title
+		);
 
 		await expect(changesSavedIndicator).toBeVisible();
-
-		await page.locator('body').click();
 
 		await undobutton.click();
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -202,11 +202,15 @@ autoSaveAsDraftTest(
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-		await fillAndClickOutside(
-			page,
-			journalEditArticlePage.titleInput,
-			title
-		);
+		await expect(async () => {
+			await fillAndClickOutside(
+				page,
+				journalEditArticlePage.titleInput,
+				title
+			);
+
+			await expect(undobutton).toBeEnabled();
+		}).toPass();
 
 		await expect(changesSavedIndicator).toBeVisible();
 
@@ -253,11 +257,16 @@ autoSaveAsDraftTest(
 		const localizableField = await page.getByRole('textbox', {
 			name: localizableFieldName,
 		});
-		const titlePlaceholder = await page.getByPlaceholder(
-			'Untitled ' + structureName
-		);
 
-		await fillAndClickOutside(page, titlePlaceholder, title);
+		await expect(async () => {
+			await fillAndClickOutside(
+				page,
+				journalEditArticlePage.titleInput,
+				title
+			);
+
+			await expect(undoButton).toBeEnabled();
+		}).toPass();
 
 		await expect(changesSavedIndicator).toBeVisible();
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -149,11 +149,7 @@ autoSaveAsDraftTest(
 			structureName,
 		});
 
-		await fillAndClickOutside(
-			page,
-			page.getByPlaceholder('Untitled ' + structureName),
-			title
-		);
+		await journalEditArticlePage.fillTitle(title);
 
 		const localizableField = page.getByRole('textbox', {
 			name: localizableFieldName,
@@ -190,17 +186,13 @@ autoSaveAsDraftTest(
 
 autoSaveAsDraftTest(
 	'LPD-26863: Undo/Redo buttons work with metadata fields',
-	async ({journalEditArticlePage, page, site}) => {
+	async ({journalEditArticlePage, site}) => {
 		const title = getRandomString();
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
 		await expect(async () => {
-			await fillAndClickOutside(
-				page,
-				journalEditArticlePage.titleInput,
-				title
-			);
+			await journalEditArticlePage.fillTitle(title);
 
 			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
@@ -249,11 +241,7 @@ autoSaveAsDraftTest(
 		});
 
 		await expect(async () => {
-			await fillAndClickOutside(
-				page,
-				journalEditArticlePage.titleInput,
-				title
-			);
+			await journalEditArticlePage.fillTitle(title);
 
 			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
@@ -1033,11 +1021,7 @@ baseTest(
 			structureName,
 		});
 
-		await fillAndClickOutside(
-			page,
-			journalEditArticlePage.titleInput,
-			title
-		);
+		await journalEditArticlePage.fillTitle(title);
 
 		await fillAndClickOutside(
 			page,
@@ -1064,7 +1048,7 @@ baseTest(
 		});
 
 		await expect(async () => {
-			await fillAndClickOutside(page, journalEditArticlePage.titleInput);
+			await journalEditArticlePage.fillTitle(title);
 
 			await translationButton.click();
 
@@ -1134,7 +1118,7 @@ scheduleTest(
 
 		const title = getRandomString();
 
-		await journalEditArticlePage.titleInput.fill(title);
+		await journalEditArticlePage.fillTitle(title);
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -13,22 +13,30 @@ import {JournalPage} from './JournalPage';
 export class JournalEditArticlePage {
 	readonly page: Page;
 
+	readonly changesSavedIndicator: Locator;
 	readonly journalPage: JournalPage;
 	readonly propertiesTab: Locator;
 	readonly publishButton: Locator;
+	readonly redoButton: Locator;
 	readonly submitForWorkflowButton: Locator;
 	readonly titleInput: Locator;
+	readonly undoButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
+		this.changesSavedIndicator = page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
+		);
 		this.journalPage = new JournalPage(page);
 		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
+		this.redoButton = page.getByTitle('Redo', {exact: true});
 		this.submitForWorkflowButton = page.getByRole('button', {
 			name: 'Submit for Workflow',
 		});
 		this.titleInput = page.getByPlaceholder('Untitled ');
+		this.undoButton = page.getByTitle('Undo', {exact: true});
 	}
 
 	async goto({


### PR DESCRIPTION
LPD-31536 Change initial state mechanism

# What is this trying to solve?

Change initial state mechanism of undo/redo component

[Link to ticket](https://liferay.atlassian.net/browse/LPD-31536)

# How am I fixing it?

As we were retrieving the initial state with a time out that waits for the page to be loaded, this was a very innefficient approach and caused some flaky tests. We have decided to send the initial state vaiues from metadata fields from the backend so in this way we don't have to wait until this values are loaded.

# How can I test it?

Execute the test journalArticle.spec.ts > 'LPD-26863: Undo/Redo buttons work with metadata fields' and expect to pass the test.

# Steps of the test:

- Enable FF 'LPD-11228': true,
		'LPD-15596': true,
- Create a WC
- Fill the title 
- Click on undo button
- See the title input value is empty string
- Click on redo button
- See the title appears in title input

Without this change this test does not pass because we had a time out of 1 second to wait for the page to load the values, and Playwright was filling the title faster than this timeout so teh undo/redo was not working for this initial state case.