### PR TITLE
LPD 31543 / LPD-31568 [POSHI] FIX test in azure translation WC

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationAzure.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationAzure.testcase
@@ -184,7 +184,7 @@ definition {
 		Translations.viewTargetFields(
 			webContentContent = "これはWeb記事の内容です",
 			webContentDescription = "WC description",
-			webContentTitle = "これはWeb記事のタイトルです");
+			webContentTitle = "これはウェブ記事のタイトルです");
 
 		PortletEntry.publish();
 
@@ -198,7 +198,7 @@ definition {
 		Translations.viewTargetFields(
 			webContentContent = "これはWeb記事の内容です",
 			webContentDescription = "WC description",
-			webContentTitle = "これはWeb記事のタイトルです");
+			webContentTitle = "これはウェブ記事のタイトルです");
 	}
 
 }

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationAzure.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationAzure.testcase
@@ -133,9 +133,9 @@ definition {
 		Translations.autoTranslate();
 
 		Translations.viewTargetFields(
-			webContentContent = "Contenido de WC",
+			webContentContent = "Contenido del WC",
 			webContentDescription = "",
-			webContentTitle = "Título de WC");
+			webContentTitle = "Título del WC");
 
 		PortletEntry.publish();
 
@@ -147,9 +147,9 @@ definition {
 			webContentTitle = "WC title");
 
 		Translations.viewTargetFields(
-			webContentContent = "Contenido de WC",
+			webContentContent = "Contenido del WC",
 			webContentDescription = "",
-			webContentTitle = "Título de WC");
+			webContentTitle = "Título del WC");
 	}
 
 	@description = "This ensures that the web content title and content filed can be translated independently"


### PR DESCRIPTION
### Parent https://liferay.atlassian.net/browse/LPD-31542
#### Subtasks
- https://liferay.atlassian.net/browse/LPD-31543
- https://liferay.atlassian.net/browse/LPD-31568

# What is this trying to solve?

Fix failing poshi tests.

# How am I fixing it?

Translations are outdated I'm updating the older azure translations to the new expected ones

# How can you verify that it works?

Execute poshi tests: 

```sh
ant -f build-test.xml run-selenium-test -Dtest.class=LocalFile.AutoTranslationAzure#CanTranslateWC
```


```sh
ant -f build-test.xml run-selenium-test -Dtest.class=LocalFile.AutoTranslationAzure#CanTranslateWCFieldIndependently
```
