### PR TITLE
LPD-31610 NullPointer accesing to "reserved-article-small-image-url" journal variable

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -328,10 +328,15 @@ public class JournalTransformer {
 			templateNodes, themeDisplay, tokens,
 			String.valueOf(article.getResourcePrimKey()));
 
+		String articleImageURL = article.getArticleImageURL(themeDisplay);
+
+		if (articleImageURL == null) {
+			articleImageURL = StringPool.BLANK;
+		}
+
 		_addReservedEl(
 			JournalStructureConstants.RESERVED_ARTICLE_SMALL_IMAGE_URL,
-			templateNodes, themeDisplay, tokens,
-			article.getArticleImageURL(themeDisplay));
+			templateNodes, themeDisplay, tokens, articleImageURL);
 
 		_addReservedEl(
 			JournalStructureConstants.RESERVED_ARTICLE_TITLE, templateNodes,

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -27,6 +27,7 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -284,6 +285,10 @@ public class JournalTransformerTest {
 			String.valueOf(_journalArticle.getResourcePrimKey()),
 			"resource-prim-key", languageId,
 			JournalStructureConstants.RESERVED_ARTICLE_RESOURCE_PRIM_KEY,
+			journalReservedTemplateVariableGroup, transformerListeners);
+		_assertReservedVariable(
+			StringPool.BLANK, "small-image-url", languageId,
+			JournalStructureConstants.RESERVED_ARTICLE_SMALL_IMAGE_URL,
 			journalReservedTemplateVariableGroup, transformerListeners);
 		_assertReservedVariable(
 			_journalArticle.getTitle(languageId), "title", languageId,


### PR DESCRIPTION
NullPointer accesing to "reserved-article-small-image-url" journal variable

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-31610)

Freemarker errors are thrown when small image is not set

# How am I fixing it?

When the small image is not set, change it to a blank string

# How can you verify that it works?

Follow the steps in the ticket or run the integration test

![error](https://github.com/user-attachments/assets/b8f56a04-5fe4-4521-ba97-cc2ad8e738ac)

