### PR TITLE
LPD-31540 Problem with attachments not being displayed

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webserver/test/WebServerFileEntryTest.java
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.webserver.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.BaseWebServerTestCase;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.webdav.methods.Method;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class WebServerFileEntryTest extends BaseWebServerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_regularUser = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testServiceWithGuestRoleWithoutViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry(RandomTestUtil.randomString());
+
+		Role guestRole = RoleLocalServiceUtil.getRole(
+			group.getCompanyId(), RoleConstants.GUEST);
+
+		_addDownloadResourcePermission(guestRole);
+
+		_removeViewResourcePermission(fileEntry, guestRole);
+
+		String url = StringBundler.concat(
+			StringPool.SLASH, fileEntry.getGroupId(), StringPool.SLASH,
+			fileEntry.getFolderId(), StringPool.SLASH, fileEntry.getFileName(),
+			StringPool.SLASH, fileEntry.getUuid());
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_regularUser));
+		PrincipalThreadLocal.setName(_regularUser.getUserId());
+
+		MockHttpServletResponse mockHttpServletResponse = service(
+			Method.GET, url, Collections.emptyMap(), Collections.emptyMap(),
+			_regularUser, null);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+	}
+
+	@Test
+	public void testServiceWithRegularRoleWithOnlyDownloadPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addFileEntry(RandomTestUtil.randomString());
+
+		Role regularRole = _roleLocalService.addRole(
+			TestPropsValues.getUserId(), null, 0, RandomTestUtil.randomString(),
+			null,
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			RoleConstants.TYPE_REGULAR, null, null);
+
+		try {
+			_addDownloadResourcePermission(regularRole);
+
+			_userLocalService.addRoleUser(
+				regularRole.getRoleId(), _regularUser);
+
+			Role guestRole = RoleLocalServiceUtil.getRole(
+				group.getCompanyId(), RoleConstants.GUEST);
+
+			_removeViewResourcePermission(fileEntry, guestRole);
+
+			_removeViewResourcePermission(fileEntry, regularRole);
+
+			String url = StringBundler.concat(
+				StringPool.SLASH, fileEntry.getGroupId(), StringPool.SLASH,
+				fileEntry.getFolderId(), StringPool.SLASH,
+				fileEntry.getFileName(), StringPool.SLASH, fileEntry.getUuid());
+
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_regularUser));
+			PrincipalThreadLocal.setName(_regularUser.getUserId());
+
+			MockHttpServletResponse mockHttpServletResponse = service(
+				Method.GET, url, Collections.emptyMap(), Collections.emptyMap(),
+				_regularUser, null);
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+		}
+		finally {
+			_roleLocalService.deleteRole(regularRole);
+		}
+	}
+
+	private void _addDownloadResourcePermission(Role guestRole)
+		throws Exception {
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(guestRole.getCompanyId()), guestRole.getRoleId(),
+			ActionKeys.DOWNLOAD);
+	}
+
+	private FileEntry _addFileEntry(String fileName) throws Exception {
+		return _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, fileName,
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), (byte[])null, null, null, null,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private void _removeViewResourcePermission(FileEntry fileEntry, Role role)
+		throws Exception {
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			group.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(fileEntry.getFileEntryId()), role.getRoleId(),
+			ActionKeys.VIEW);
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@DeleteAfterTestRun
+	private User _regularUser;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -554,7 +554,7 @@ public class WebServerServlet extends HttpServlet {
 
 				try {
 					FileEntry fileEntry =
-						DLAppServiceUtil.getFileEntryByUuidAndGroupId(
+						DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
 							uuid, groupId);
 
 					image = convertFileEntry(igSmallImage, fileEntry);
@@ -925,7 +925,7 @@ public class WebServerServlet extends HttpServlet {
 			String name = pathArray[i];
 
 			try {
-				Folder folder = DLAppServiceUtil.getFolder(
+				Folder folder = DLAppLocalServiceUtil.getFolder(
 					groupId, folderId, URLCodec.decodeURL(name));
 
 				folderId = folder.getFolderId();
@@ -1243,7 +1243,7 @@ public class WebServerServlet extends HttpServlet {
 			long folderId, String title)
 		throws Exception {
 
-		FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
 			groupId, folderId, title);
 
 		httpServletResponse.addHeader(
@@ -1809,10 +1809,10 @@ public class WebServerServlet extends HttpServlet {
 		if (pathArray.length == 1) {
 			long fileShortcutId = GetterUtil.getLong(pathArray[0]);
 
-			FileShortcut dlFileShortcut = DLAppServiceUtil.getFileShortcut(
+			FileShortcut dlFileShortcut = DLAppLocalServiceUtil.getFileShortcut(
 				fileShortcutId);
 
-			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+			FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
 				dlFileShortcut.getToFileEntryId());
 
 			_checkFileEntry(fileEntry, httpServletRequest);
@@ -1822,8 +1822,9 @@ public class WebServerServlet extends HttpServlet {
 		else if (pathArray.length == 2) {
 			long groupId = GetterUtil.getLong(pathArray[0]);
 
-			FileEntry fileEntry = DLAppServiceUtil.getFileEntryByUuidAndGroupId(
-				pathArray[1], groupId);
+			FileEntry fileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					pathArray[1], groupId);
 
 			_checkFileEntry(fileEntry, httpServletRequest);
 
@@ -1855,8 +1856,9 @@ public class WebServerServlet extends HttpServlet {
 			}
 
 			try {
-				FileEntry fileEntry = DLAppServiceUtil.getFileEntryByFileName(
-					groupId, folderId, fileName);
+				FileEntry fileEntry =
+					DLAppLocalServiceUtil.getFileEntryByFileName(
+						groupId, folderId, fileName);
 
 				_checkFileEntry(fileEntry, httpServletRequest);
 
@@ -1867,7 +1869,7 @@ public class WebServerServlet extends HttpServlet {
 					_log.debug(noSuchFileEntryException);
 				}
 
-				FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
+				FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
 					groupId, folderId, fileName);
 
 				_checkFileEntry(fileEntry, httpServletRequest);
@@ -1880,8 +1882,9 @@ public class WebServerServlet extends HttpServlet {
 
 			String uuid = pathArray[3];
 
-			FileEntry fileEntry = DLAppServiceUtil.getFileEntryByUuidAndGroupId(
-				uuid, groupId);
+			FileEntry fileEntry =
+				DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+					uuid, groupId);
 
 			_checkFileEntry(fileEntry, httpServletRequest);
 


### PR DESCRIPTION
Problem with attachments not being displayed

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-31540)

Depending on the path that arrives in the Webserver servlet, there are permission issues when retrieving some images if they have the download action

# How am I fixing it?

Instead of using DLAppService, use DLAppLocalService where we can, the check for permissions is already done, so we should be fine

# How can you verify that it works?

Follow the steps in the LPD

