### PR TITLE
LPD-31655 Action menu unresponsive when viewing journal article's history in card view

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
@@ -106,6 +106,12 @@ renderResponse.setTitle(article.getTitle(locale));
 				<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "icon") %>'>
 					<liferay-ui:search-container-column-text>
 						<clay:vertical-card
+							additionalProps='<%=
+								HashMapBuilder.<String, Object>put(
+									"trashEnabled", componentContext.get("trashEnabled")
+								).build()
+							%>'
+							propsTransformer="{ElementsDefaultPropsTransformer} from journal-web"
 							verticalCard="<%= new JournalArticleHistoryVerticalCard(articleVersion, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
 						/>
 					</liferay-ui:search-container-column-text>

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -370,6 +370,42 @@ baseTest(
 	}
 );
 
+baseTest(
+	'LPD-31655: Ensure article action menu functions when viewing history in card view',
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		const title = getRandomString();
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: title},
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await journalPage.changeView('list');
+
+		await page.getByLabel(`Actions for ${title}`).waitFor();
+		await page.getByLabel(`Actions for ${title}`).click();
+
+		await page.getByRole('menuitem', {name: 'View History'}).click();
+
+		await journalPage.changeView('cards');
+
+		await page.getByLabel(`More Actions`).waitFor();
+		await page.getByLabel(`More Actions`).click();
+
+		await page.getByRole('menuitem', {name: 'Compare to...'}).click();
+
+		await expect(
+			page.getByRole('heading', {name: 'Compare Versions'})
+		).toBeVisible();
+	}
+);
+
 keepTitlesUntranslated(
 	'LPD-20723: Clay link is translating asset titles/names by default in vertical card',
 	async ({apiHelpers, journalPage, page, site}) => {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-31655

# How am I fixing it?

The change adds in necessary parameters in order for the clicks to function properly. This is copied from the changes made in LPS-187505 (https://github.com/liferay-frontend/liferay-portal/pull/3463)

# How can you verify that it works?

Run `npm run playwright -- test -g 'LPD-31655'`

To test manually:

1. Create a Basic Web Content Article and Publish
2. Choose [View History] from the Action Menu
3. Change the Display mode to [Card View]
4. Click on the items in the Action menu