### PR TITLE
LPD-31427 Can't select web content display template with the Preview feature

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalPreviewArticleContentTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalPreviewArticleContentTemplateDisplayContext.java
@@ -13,10 +13,12 @@ import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletRequestModel;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -102,6 +104,23 @@ public class JournalPreviewArticleContentTemplateDisplayContext {
 		_ddmTemplateId = ParamUtil.getLong(_renderRequest, "ddmTemplateId");
 
 		return _ddmTemplateId;
+	}
+
+	public String getDDMTemplateJSON() {
+		if (getDDMTemplateId() <= 0) {
+			return null;
+		}
+
+		DDMTemplate ddmTemplate = getDDMTemplate();
+
+		return JSONUtil.put(
+			"ddmtemplateid", ddmTemplate.getTemplateId()
+		).put(
+			"ddmtemplatekey", ddmTemplate.getTemplateKey()
+		).put(
+			"name",
+			HtmlUtil.escape(ddmTemplate.getName(_themeDisplay.getLocale()))
+		).toString();
 	}
 
 	public List<DDMTemplate> getDDMTemplates() throws PortalException {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/Template.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/Template.js
@@ -89,7 +89,8 @@ export default function ({
 
 			openSelectionModal({
 				iframeBodyCssClass: '',
-				onSelect: (selectedItem) => changeDDMTemplate(selectedItem),
+				onSelect: (selectedItem) =>
+					changeDDMTemplate(JSON.parse(selectedItem.value)),
 				selectEventName: namespaceId('preview'),
 				title: Liferay.Language.get('title'),
 				url: url.href,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
@@ -34,11 +34,7 @@ JournalPreviewArticleContentTemplateDisplayContext journalPreviewArticleContentT
 				<div class="form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 					<clay:button
 						cssClass="selector-button"
-						data-id='<%=
-							HashMapBuilder.<String, Object>put(
-								"ddmtemplateid", journalPreviewArticleContentTemplateDisplayContext.getDDMTemplateId()
-							).build()
-						%>'
+						data-value="<%= journalPreviewArticleContentTemplateDisplayContext.getDDMTemplateJSON() %>"
 						displayType="secondary"
 						label="apply"
 						type="submit"

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -280,6 +280,70 @@ autoSaveAsDraftTest(
 );
 
 baseTest(
+	'LPD-31427: Select web content display template with the Preview feature',
+	async ({journalEditArticlePage, page, site}) => {
+		page.on('dialog', (dialog) => dialog.accept());
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+
+		await page.getByText('Content', {exact: true}).waitFor();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await journalEditArticlePage.editArticle(title);
+
+		await page.getByText('Content', {exact: true}).waitFor();
+
+		await page.getByRole('link', { name: 'Default Template' }).click();
+
+		await page.getByRole('button', {name: 'Clear'}).waitFor();
+
+		await page.getByRole('button', {name: 'Clear'}).click();
+
+		await page.getByText('Content', {exact: true}).waitFor();
+
+		let templateName = page.getByLabel('Template Name');
+
+		await expect(templateName).toHaveValue('No Template');
+
+		await page.getByRole('link', { name: 'Default Template' }).click();
+
+		await page
+			.locator(
+				'[id="_com_liferay_journal_web_portlet_JournalPortlet_previewWithTemplate"]'
+			).waitFor();
+
+		await page
+			.locator(
+				'[id="_com_liferay_journal_web_portlet_JournalPortlet_previewWithTemplate"]'
+			)
+			.click();
+
+		const dialog = page.getByRole('dialog');
+
+		await expect(dialog.getByRole('heading')).toHaveText('Title');
+
+		const dialogIFrame = page.frameLocator('iframe[title="Title"]');
+
+		await dialogIFrame.getByTitle('ddm-template-id')
+			.selectOption('Basic Web Content');
+
+		await dialogIFrame.getByRole('button', {name: 'Apply'})
+			.click();
+
+		await page.getByText('Content', {exact: true}).waitFor();
+
+		templateName = page.getByLabel('Template Name');
+
+		await expect(templateName).toHaveValue('Basic Web Content');
+	}
+);
+
+baseTest(
 	'LPD-15248 Move folder to another folder via management toolbar',
 	async ({apiHelpers, journalPage, page, site}) => {
 		const childFolder = await apiHelpers.jsonWebServicesJournal.addFolder({


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-31427

### How am I fixing it?

The issue originates from passing the wrong data to the js file. I fixed the issue by generating the proper payload and forwarding it from the preview to the change event.

### How can you verify that it works?

To test manually:
1. Create a web content structure and 2 display templates for that structure.
2. Create a content of that type, give it a name, and save it.
3. From the Properties column, change the default template by accessing it from the eye icon instead of from Select.

Currently missing tests as I'm not well-versed in the frontend test architect if possible I would like to send it to the customer as fast as I can while still working on a possible playwright test.