### PR TITLE
LPD-31751 Update metadata-extractor library

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -6,7 +6,7 @@
 		<libraries>
 			<library>
 				<file-name>com.liferay.adaptive.media.image.impl.jar!metadata-extractor.jar</file-name>
-				<version>2.18.0</version>
+				<version>2.19.0</version>
 				<project-name>metadata-extractor</project-name>
 				<project-url>https://drewnoakes.com/code/exif/</project-url>
 				<licenses>
@@ -3855,7 +3855,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.tika.jar!metadata-extractor.jar</file-name>
-				<version>2.18.0</version>
+				<version>2.19.0</version>
 				<project-name>metadata-extractor</project-name>
 				<project-url>https://drewnoakes.com/code/exif/</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -44,7 +44,7 @@
 		
 			
 <tr>
-<td nowrap="nowrap">com.liferay.adaptive.media.image.impl.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.18.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.adaptive.media.image.impl.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.19.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -992,7 +992,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1688,7 +1688,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1718,7 +1718,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2012,7 +2012,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.tika.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.18.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.tika.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.19.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/build.gradle
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileInclude group: "com.drewnoakes", name: "metadata-extractor", version: "2.18.0"
+	compileInclude group: "com.drewnoakes", name: "metadata-extractor", version: "2.19.0"
 
 	compileOnly group: "com.adobe.xmp", name: "xmpcore", version: "6.1.11"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"

--- a/modules/apps/portal/portal-tika/build.gradle
+++ b/modules/apps/portal/portal-tika/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileInclude group: "com.drewnoakes", name: "metadata-extractor", version: "2.18.0"
+	compileInclude group: "com.drewnoakes", name: "metadata-extractor", version: "2.19.0"
 	compileInclude group: "com.googlecode.juniversalchardet", name: "juniversalchardet", version: "1.0.3"
 	compileInclude group: "com.liferay", name: "org.gagravarr.tika", version: "0.8.LIFERAY-PATCHED-1"
 	compileInclude group: "com.liferay", name: "org.mp4parser", version: "1.9.41.2.LIFERAY-PATCHED-2"

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -555,7 +555,7 @@
 
     source.check.GradleDependencyArtifactsCheck.enforceVersionArtifacts=\
         com.adobe.xmp:xmpcore:6.1.11,\
-        com.drewnoakes:metadata-extractor:2.18.0,\
+        com.drewnoakes:metadata-extractor:2.19.0,\
         com.fasterxml.jackson-dataformat:jackson-dataformat-cbor:2.12.6,\
         com.fasterxml.jackson.core:jackson-annotations:2.16.1,\
         com.fasterxml.jackson.core:jackson-core:2.16.1,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-31751

Update the metadata-extractor to 2.19.0. This new version includes some relevant bug fixes.

# Why doesn't this include any test?

The existing tests cover this update.