### PR TITLE
LPD-30614 Enable class rules

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
@@ -81,6 +81,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,6 +100,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 @RunWith(Arquillian.class)
 public class JournalArticleContentDashboardItemTest {
 
+	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30614

The feature flag for LPS-203351 is not at system level, but there are some places in the code where the company ID cannot be passed explicitly. As the FF checks need to rely on the thread local company, we need to set it in the tests to avoid the log from being polluted (which will make some other tests fail).

This will enable the `CompanyProviderClassTestRule`, that sets the company thread local.

Note that there's no other way to fix this than setting the thread local. There's code that relies on it, as the API doesn't accept a company id.  E.g.:
```
public class JournalArticleAssetDisplayPageFriendlyURLResolver
	extends BaseAssetDisplayPageFriendlyURLResolver {

	@Override
	public String getDefaultURLSeparator() {
		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
	}

	@Override
	public String getKey() {
		return JournalArticle.class.getName();
	}

	@Override
	public boolean isURLSeparatorConfigurable() {
		return FeatureFlagManagerUtil.isEnabled("LPS-203351");
	}

}
```
# How can you verify that it works?

Run `JournalArticleContentDashboardItemTest` and verify that not error messages related to feature flags are displayed in the logs.