### PR TITLE
LPD-30452 Subtopic with non Latin characters cannot be added in Questions widget

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImpl.java
@@ -40,122 +40,12 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override
 	public String normalizeWithEncoding(String friendlyURL) {
-		if (Validator.isNull(friendlyURL)) {
-			return friendlyURL;
-		}
+		return _normalizeWithEncoding(friendlyURL, false, false);
+	}
 
-		String decodedFriendlyURL = HttpComponentsUtil.decodePath(friendlyURL);
-
-		if (Validator.isNull(decodedFriendlyURL)) {
-			decodedFriendlyURL = HttpComponentsUtil.decodePath(
-				StringUtil.replace(
-					friendlyURL, CharPool.PERCENT, CharPool.POUND));
-		}
-
-		StringBuilder sb = new StringBuilder(decodedFriendlyURL.length());
-
-		boolean modified = false;
-
-		ByteBuffer byteBuffer = null;
-		CharBuffer charBuffer = null;
-
-		CharsetEncoder charsetEncoder = null;
-
-		for (int i = 0; i < decodedFriendlyURL.length(); i++) {
-			char c = decodedFriendlyURL.charAt(i);
-
-			if ((CharPool.UPPER_CASE_A <= c) && (c <= CharPool.UPPER_CASE_Z)) {
-				sb.append((char)(c + 32));
-
-				modified = true;
-			}
-			else if (((CharPool.LOWER_CASE_A <= c) &&
-					  (c <= CharPool.LOWER_CASE_Z)) ||
-					 ((CharPool.NUMBER_0 <= c) && (c <= CharPool.NUMBER_9)) ||
-					 (c == CharPool.PERIOD) || (c == CharPool.SLASH) ||
-					 (c == CharPool.STAR) || (c == CharPool.UNDERLINE)) {
-
-				sb.append(c);
-			}
-			else if (Arrays.binarySearch(_REPLACE_CHARS, c) >= 0) {
-				if ((i == 0) || (CharPool.DASH != sb.charAt(sb.length() - 1))) {
-					sb.append(CharPool.DASH);
-
-					if (c != CharPool.DASH) {
-						modified = true;
-					}
-				}
-				else {
-					modified = true;
-				}
-			}
-			else {
-				c = Character.toLowerCase(c);
-
-				if (charsetEncoder == null) {
-					charsetEncoder = CharsetEncoderUtil.getCharsetEncoder(
-						StringPool.UTF8);
-
-					byteBuffer = ByteBuffer.allocate(4);
-					charBuffer = CharBuffer.allocate(2);
-				}
-				else {
-					byteBuffer.clear();
-					charBuffer.clear();
-				}
-
-				charBuffer.put(c);
-
-				boolean endOfInput = false;
-
-				if ((decodedFriendlyURL.length() - 1) == i) {
-					endOfInput = true;
-				}
-
-				if (Character.isHighSurrogate(c) &&
-					((i + 1) < decodedFriendlyURL.length())) {
-
-					c = decodedFriendlyURL.charAt(i + 1);
-
-					if (Character.isLowSurrogate(c)) {
-						charBuffer.put(c);
-
-						i++;
-					}
-					else {
-						endOfInput = true;
-					}
-				}
-
-				charBuffer.flip();
-
-				charsetEncoder.encode(charBuffer, byteBuffer, endOfInput);
-
-				byteBuffer.flip();
-
-				while (byteBuffer.hasRemaining()) {
-					byte b = byteBuffer.get();
-
-					sb.append(CharPool.PERCENT);
-					sb.append(_HEX_DIGITS[(b >> 4) & 0x0F]);
-					sb.append(_HEX_DIGITS[b & 0x0F]);
-				}
-
-				if (endOfInput) {
-					charsetEncoder.flush(byteBuffer);
-
-					charsetEncoder.reset();
-				}
-
-				modified = true;
-			}
-		}
-
-		if (modified) {
-			return sb.toString();
-		}
-
-		return friendlyURL;
+	@Override
+	public String normalizeWithEncodingPeriodsAndSlashes(String friendlyURL) {
+		return _normalizeWithEncoding(friendlyURL, true, true);
 	}
 
 	@Override
@@ -207,6 +97,146 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 					}
 				}
 				else {
+					modified = true;
+				}
+			}
+		}
+
+		if (modified) {
+			return sb.toString();
+		}
+
+		return friendlyURL;
+	}
+
+	private String _normalizeWithEncoding(
+		String friendlyURL, boolean periods, boolean slashes) {
+
+		if (Validator.isNull(friendlyURL)) {
+			return friendlyURL;
+		}
+
+		String decodedFriendlyURL = HttpComponentsUtil.decodePath(friendlyURL);
+
+		if (Validator.isNull(decodedFriendlyURL)) {
+			decodedFriendlyURL = HttpComponentsUtil.decodePath(
+				StringUtil.replace(
+					friendlyURL, CharPool.PERCENT, CharPool.POUND));
+		}
+
+		StringBuilder sb = new StringBuilder(decodedFriendlyURL.length());
+
+		boolean modified = false;
+
+		ByteBuffer byteBuffer = null;
+		CharBuffer charBuffer = null;
+
+		CharsetEncoder charsetEncoder = null;
+
+		for (int i = 0; i < decodedFriendlyURL.length(); i++) {
+			char c = decodedFriendlyURL.charAt(i);
+
+			if ((CharPool.UPPER_CASE_A <= c) && (c <= CharPool.UPPER_CASE_Z)) {
+				sb.append((char)(c + 32));
+
+				modified = true;
+			}
+			else if (((CharPool.LOWER_CASE_A <= c) &&
+					  (c <= CharPool.LOWER_CASE_Z)) ||
+					 ((CharPool.NUMBER_0 <= c) && (c <= CharPool.NUMBER_9)) ||
+					 (!periods && (c == CharPool.PERIOD)) ||
+					 (!slashes && (c == CharPool.SLASH)) ||
+					 (c == CharPool.STAR) || (c == CharPool.UNDERLINE)) {
+
+				sb.append(c);
+			}
+			else if (Arrays.binarySearch(_REPLACE_CHARS, c) >= 0) {
+				if ((i == 0) || (CharPool.DASH != sb.charAt(sb.length() - 1))) {
+					sb.append(CharPool.DASH);
+
+					if (c != CharPool.DASH) {
+						modified = true;
+					}
+				}
+				else {
+					modified = true;
+				}
+			}
+			else {
+				if ((periods && (c == CharPool.PERIOD)) ||
+					(slashes && (c == CharPool.SLASH))) {
+
+					if ((i == 0) ||
+						(CharPool.DASH != sb.charAt(sb.length() - 1))) {
+
+						sb.append(CharPool.DASH);
+
+						if (c != CharPool.DASH) {
+							modified = true;
+						}
+					}
+					else {
+						modified = true;
+					}
+				}
+				else {
+					c = Character.toLowerCase(c);
+
+					if (charsetEncoder == null) {
+						charsetEncoder = CharsetEncoderUtil.getCharsetEncoder(
+							StringPool.UTF8);
+
+						byteBuffer = ByteBuffer.allocate(4);
+						charBuffer = CharBuffer.allocate(2);
+					}
+					else {
+						byteBuffer.clear();
+						charBuffer.clear();
+					}
+
+					charBuffer.put(c);
+
+					boolean endOfInput = false;
+
+					if ((decodedFriendlyURL.length() - 1) == i) {
+						endOfInput = true;
+					}
+
+					if (Character.isHighSurrogate(c) &&
+						((i + 1) < decodedFriendlyURL.length())) {
+
+						c = decodedFriendlyURL.charAt(i + 1);
+
+						if (Character.isLowSurrogate(c)) {
+							charBuffer.put(c);
+
+							i++;
+						}
+						else {
+							endOfInput = true;
+						}
+					}
+
+					charBuffer.flip();
+
+					charsetEncoder.encode(charBuffer, byteBuffer, endOfInput);
+
+					byteBuffer.flip();
+
+					while (byteBuffer.hasRemaining()) {
+						byte b = byteBuffer.get();
+
+						sb.append(CharPool.PERCENT);
+						sb.append(_HEX_DIGITS[(b >> 4) & 0x0F]);
+						sb.append(_HEX_DIGITS[b & 0x0F]);
+					}
+
+					if (endOfInput) {
+						charsetEncoder.flush(byteBuffer);
+
+						charsetEncoder.reset();
+					}
+
 					modified = true;
 				}
 			}

--- a/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.nio.CharsetEncoderUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.net.URLEncoder;
@@ -124,6 +125,25 @@ public class FriendlyURLNormalizerImplTest {
 	}
 
 	@Test
+	public void testNormalizeWithEncodingPeriodsAndSlashes() throws Exception {
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode("friendlyUrl");
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode("\u5F15");
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode("テスト");
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode("اختبار");
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode("\uD801\uDC37");
+		_testNormalizeWithEncodingPeriodAndSlashesUnicode(
+			String.valueOf(Character.MAX_HIGH_SURROGATE));
+		Assert.assertEquals(
+			"-",
+			_friendlyURLNormalizerImpl.normalizeWithEncodingPeriodsAndSlashes(
+				"./"));
+		Assert.assertEquals(
+			URLEncoder.encode("テ-ス-ト-テ-abc"),
+			_friendlyURLNormalizerImpl.normalizeWithEncodingPeriodsAndSlashes(
+				"テ-ス/ト.テ-//..../abc"));
+	}
+
+	@Test
 	public void testNormalizeWithEncodingRemove() throws Exception {
 		Assert.assertEquals(
 			StringPool.DASH,
@@ -234,6 +254,15 @@ public class FriendlyURLNormalizerImplTest {
 	public void testNormalizeWordWithNonasciiCharacters() {
 		Assert.assertEquals(
 			"wordnc", _friendlyURLNormalizerImpl.normalize("word\u00F1\u00C7"));
+	}
+
+	private void _testNormalizeWithEncodingPeriodAndSlashesUnicode(String s)
+		throws Exception {
+
+		Assert.assertEquals(
+			URLEncoder.encode(StringUtil.toLowerCase(s), StringPool.UTF8),
+			_friendlyURLNormalizerImpl.normalizeWithEncodingPeriodsAndSlashes(
+				s));
 	}
 
 	private void _testNormalizeWithEncodingUnicode(String s) throws Exception {

--- a/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/test/java/com/liferay/friendly/url/internal/util/FriendlyURLNormalizerImplTest.java
@@ -141,6 +141,10 @@ public class FriendlyURLNormalizerImplTest {
 			URLEncoder.encode("テ-ス-ト-テ-abc"),
 			_friendlyURLNormalizerImpl.normalizeWithEncodingPeriodsAndSlashes(
 				"テ-ス/ト.テ-//..../abc"));
+		Assert.assertEquals(
+			"friendly-url-1",
+			_friendlyURLNormalizerImpl.normalizeWithEncodingPeriodsAndSlashes(
+				"friendly-url------/././.-1"));
 	}
 
 	@Test

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/spi/model/index/contributor/MBMessageModelDocumentContributor.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/spi/model/index/contributor/MBMessageModelDocumentContributor.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.RelatedEntryIndexer;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistryUtil;
 import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -91,7 +92,9 @@ public class MBMessageModelDocumentContributor
 
 		document.addKeyword("parentMessageId", mbMessage.getParentMessageId());
 		document.addKeyword("threadId", mbMessage.getThreadId());
-		document.addKeywordSortable("urlSubject", mbMessage.getUrlSubject());
+		document.addKeywordSortable(
+			"urlSubject",
+			HttpComponentsUtil.decodePath(mbMessage.getUrlSubject()));
 
 		if (mbMessage.getMessageId() == mbMessage.getRootMessageId()) {
 			boolean answered = false;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -550,7 +550,10 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 	public MBCategory getMBCategory(long groupId, String friendlyURL)
 		throws PortalException {
 
-		return mbCategoryPersistence.findByG_F(groupId, friendlyURL);
+		return mbCategoryPersistence.findByG_F(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				friendlyURL));
 	}
 
 	@Override
@@ -942,7 +945,9 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 			name = String.valueOf(categoryId);
 		}
 		else {
-			name = _friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(name);
+			name =
+				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+					name);
 		}
 
 		name = ModelHintsUtil.trimString(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -306,7 +306,10 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 	@Override
 	public MBCategory fetchMBCategory(long groupId, String friendlyURL) {
-		return mbCategoryPersistence.fetchByG_F(groupId, friendlyURL);
+		return mbCategoryPersistence.fetchByG_F(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				friendlyURL));
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -959,7 +959,9 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 			groupId, friendlyURL);
 
 		for (int i = 1; mbCategory != null; i++) {
-			friendlyURL = name + StringPool.DASH + i;
+			friendlyURL =
+				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+					name + StringPool.DASH + i);
 
 			mbCategory = mbCategoryPersistence.fetchByG_F(groupId, friendlyURL);
 		}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -958,10 +958,16 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 		MBCategory mbCategory = mbCategoryPersistence.fetchByG_F(
 			groupId, friendlyURL);
 
+		if (mbCategory == null) {
+			return friendlyURL;
+		}
+
+		if (!StringUtil.endsWith(friendlyURL, StringPool.DASH)) {
+			name = name + StringPool.DASH;
+		}
+
 		for (int i = 1; mbCategory != null; i++) {
-			friendlyURL =
-				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
-					name + StringPool.DASH + i);
+			friendlyURL = name + i;
 
 			mbCategory = mbCategoryPersistence.fetchByG_F(groupId, friendlyURL);
 		}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -991,7 +991,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 	public MBMessage fetchMBMessageByUrlSubject(
 		long groupId, String urlSubject) {
 
-		return mbMessagePersistence.fetchByG_US(groupId, urlSubject);
+		return mbMessagePersistence.fetchByG_US(
+			groupId,
+			_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+				urlSubject));
 	}
 
 	@Override
@@ -2374,8 +2377,9 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			subject = String.valueOf(id);
 		}
 		else {
-			subject = _friendlyURLNormalizer.normalizeWithPeriodsAndSlashes(
-				subject);
+			subject =
+				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+					subject);
 		}
 
 		return ModelHintsUtil.trimString(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2355,7 +2355,9 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			groupId, uniqueUrlSubject);
 
 		for (int i = 1; mbMessage != null; i++) {
-			uniqueUrlSubject = urlSubject + StringPool.DASH + i;
+			uniqueUrlSubject =
+				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+					urlSubject + StringPool.DASH + i);
 
 			mbMessage = mbMessagePersistence.fetchByG_US(
 				groupId, uniqueUrlSubject);

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2354,10 +2354,16 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		MBMessage mbMessage = mbMessagePersistence.fetchByG_US(
 			groupId, uniqueUrlSubject);
 
+		if (mbMessage == null) {
+			return uniqueUrlSubject;
+		}
+
+		if (!StringUtil.endsWith(uniqueUrlSubject, StringPool.DASH)) {
+			urlSubject = urlSubject + StringPool.DASH;
+		}
+
 		for (int i = 1; mbMessage != null; i++) {
-			uniqueUrlSubject =
-				_friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
-					urlSubject + StringPool.DASH + i);
+			uniqueUrlSubject = urlSubject + i;
 
 			mbMessage = mbMessagePersistence.fetchByG_US(
 				groupId, uniqueUrlSubject);

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageIndexerIndexedFieldsTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlParser;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -225,9 +226,11 @@ public class MBMessageIndexerIndexedFieldsTest {
 		).put(
 			"threadId", String.valueOf(mbMessage.getThreadId())
 		).put(
-			"urlSubject", mbMessage.getUrlSubject()
+			"urlSubject",
+			HttpComponentsUtil.decodePath(mbMessage.getUrlSubject())
 		).put(
-			"urlSubject_String_sortable", mbMessage.getUrlSubject()
+			"urlSubject_String_sortable",
+			HttpComponentsUtil.decodePath(mbMessage.getUrlSubject())
 		).put(
 			"visible", "true"
 		).build();

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionLabel.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionLabel.es.js
@@ -13,7 +13,7 @@ const getSectionTitle = (section) => {
 		return section.title;
 	}
 
-	if (stringToSlug(section.title) === section.friendlyUrlPath) {
+	if (stringToSlug(section.title) === decodeURI(section.friendlyUrlPath)) {
 		return section.title;
 	}
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionLabel.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/SectionLabel.es.js
@@ -17,7 +17,7 @@ const getSectionTitle = (section) => {
 		return section.title;
 	}
 
-	return `${section.title} (${slugToText(section.friendlyUrlPath)})`;
+	return `${section.title} (${slugToText(decodeURI(section.friendlyUrlPath))})`;
 };
 
 export default function SectionLabel({section}) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizer.java
@@ -17,6 +17,8 @@ public interface FriendlyURLNormalizer {
 
 	public String normalizeWithEncoding(String friendlyURL);
 
+	public String normalizeWithEncodingPeriodsAndSlashes(String friendlyURL);
+
 	public String normalizeWithPeriods(String friendlyURL);
 
 	public String normalizeWithPeriodsAndSlashes(String friendlyURL);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizerUtil.java
@@ -27,6 +27,16 @@ public class FriendlyURLNormalizerUtil {
 		return friendlyURLNormalizer.normalizeWithEncoding(friendlyURL);
 	}
 
+	public static String normalizeWithEncodingPeriodsAndSlashes(
+		String friendlyURL) {
+
+		FriendlyURLNormalizer friendlyURLNormalizer =
+			_friendlyURLNormalizerSnapshot.get();
+
+		return friendlyURLNormalizer.normalizeWithEncodingPeriodsAndSlashes(
+			friendlyURL);
+	}
+
 	public static String normalizeWithPeriodsAndSlashes(String friendlyURL) {
 		FriendlyURLNormalizer friendlyURLNormalizer =
 			_friendlyURLNormalizerSnapshot.get();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.1.0
+version 79.2.0


### PR DESCRIPTION
### What is this trying to solve?

We have some tests that we are testing with non latin characters and in a day this was a requirement if not we wouldn't have created the tests, so, for that, we have  to fix it. 

https://liferay.atlassian.net/browse/LPD-30452

### How am I fixing it?

Enabling encoding for questions friendly urls creating new method to normalize friendly urls with encoding, periods and slashes and using this new method to change api methods for categories and messages.

### How can you verify that it works?

Executing unit tests included and executing poshi failing tests.