### PR TITLE
LPD-32288 PDF preview images have no alt attribute

### DIFF
--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.js
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.js
@@ -38,7 +38,7 @@ const WAIT_BETWEEN_GO_TO_PAGE = 250;
  * @review
  */
 
-const DocumentPreviewer = ({baseImageURL, initialPage, totalPages}) => {
+const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 	const [currentPage, setCurrentPage] = useState(initialPage);
 	const [currentPageLoading, setCurrentPageLoading] = useState(false);
 	const [expanded, setExpanded] = useState(false);
@@ -194,6 +194,7 @@ const DocumentPreviewer = ({baseImageURL, initialPage, totalPages}) => {
 					<ClayLoadingIndicator />
 				) : (
 					<img
+						alt={alt}
 						className={`preview-file-document ${
 							!expanded && 'preview-file-document-fit'
 						}`}

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/view.jsp
@@ -46,6 +46,8 @@ String previewFileURL = previewFileURLs[0];
 		module="{DocumentPreviewer} from document-library-preview-document"
 		props='<%=
 			HashMapBuilder.<String, Object>put(
+				"alt", fileVersion.getDescription()
+			).put(
 				"baseImageURL", previewFileURL
 			).put(
 				"initialPage", 1

--- a/modules/apps/document-library/document-library-preview-document/test/DocumentPreviewer.es.js
+++ b/modules/apps/document-library/document-library-preview-document/test/DocumentPreviewer.es.js
@@ -36,4 +36,18 @@ describe('document-library-preview-document', () => {
 
 		expect(asFragment()).toMatchSnapshot();
 	});
+
+	it('renders a document previewer with alt attribute', () => {
+		const {asFragment} = render(
+			<DocumentPreviewer
+				alt="alt text"
+				baseImageURL="http://localhost/document-images/"
+				initialPage={1}
+				spritemap="icons.svg"
+				totalPages={10}
+			/>
+		);
+
+		expect(asFragment()).toMatchSnapshot();
+	});
 });

--- a/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
@@ -166,3 +166,88 @@ exports[`document-library-preview-document renders a document previewer with ten
   </div>
 </DocumentFragment>
 `;
+
+exports[`document-library-preview-document renders a document previewer with alt attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="preview-file"
+  >
+    <div
+      class="preview-file-container preview-file-max-height"
+    >
+      <img
+        alt="alt text"
+        class="preview-file-document preview-file-document-fit"
+        src="http://localhost/document-images/?previewFileIndex=1"
+      />
+    </div>
+    <div
+      class="preview-toolbar-container"
+    >
+      <div
+        class="floating-bar btn-group"
+        role="group"
+      >
+        <div
+          class="btn-group"
+          role="group"
+        >
+          <button
+            class="btn-floating-bar btn-floating-bar-text btn btn-primary"
+            title="click-to-jump-to-a-page"
+            type="button"
+          >
+            page 1 / 10
+          </button>
+        </div>
+        <button
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          disabled=""
+          title="page-above"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-top"
+            role="presentation"
+          >
+            <use
+              href="#caret-top"
+            />
+          </svg>
+        </button>
+        <button
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          title="page-below"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-bottom"
+            role="presentation"
+          >
+            <use
+              href="#caret-bottom"
+            />
+          </svg>
+        </button>
+        <div
+          class="separator-floating-bar"
+        />
+        <button
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          title="expand"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-full-size"
+            role="presentation"
+          >
+            <use
+              href="#full-size"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
# What is this trying to solve?
PDF previewer is not fully accessible, its is missing an alt attribute.
https://liferay.atlassian.net/browse/LPD-32288

# How am I fixing it?
Adding the fileVersion's description as the alt attribute, like how [ImagePreviewer](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp#L46) does it

# How can you verify that it works?
Run the included automated tests.
`cd modules/apps/document-library/document-library-preview-document`
`npm run test`
