### PR TITLE
LPD-26390 UndoRedo for locale changes

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
@@ -36,6 +36,7 @@ const HISTORY = {
 	EDITED: 'mark_edited',
 	NEXT: 'next_step',
 	PREV: 'prev_step',
+	RESET: 'reset_history',
 };
 
 const LANGUAGE = {

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -31,6 +31,10 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 	const Components = components ?? mergeVariants(editable, variants);
 
 	useEffect(() => {
+		dispatch({type: EVENT_TYPES.HISTORY.RESET});
+	}, [defaultLanguageId, dispatch]);
+
+	useEffect(() => {
 		const handleStoreState = () => {
 			dispatch({type: EVENT_TYPES.HISTORY.ADD});
 		};

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
@@ -55,6 +55,14 @@ export default function historyReducer(state, action) {
 					currentStep: state.history.currentStep - 1,
 				},
 			};
+		case EVENT_TYPES.HISTORY.RESET:
+			return {
+				history: {
+					...state.history,
+					currentStep: 0,
+					steps: [state],
+				},
+			};
 		default:
 			return state;
 	}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -477,6 +477,11 @@ AUI.add(
 							item: event.item,
 							source: instance,
 						});
+
+						Liferay.fire('journal:localeChanged', {
+							item: event.item,
+							source: instance,
+						});
 					}
 				},
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutRendererLanguageProxy.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutRendererLanguageProxy.es.js
@@ -38,6 +38,10 @@ export default function ({currentLanguageId, namespace}) {
 					);
 
 					defaultLanguageIdInput.value = selectedLanguageId;
+
+					Liferay.fire('journal:defaultLocaleChanged', {
+						item: event.item,
+					});
 				}
 			);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -403,6 +403,10 @@ export default function _JournalPortlet({
 								friendlyUrlInputComponent.updateInput(
 									friendlyURL
 								);
+
+								Liferay.fire('journal:update-friendly-url', {
+									friendlyURL,
+								});
 							}
 						}
 					}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -70,7 +70,8 @@ export default function UndoRedo({
 		titleInputComponent = component;
 	});
 
-	const handleUndo = (newStep) => {
+	const handleUndo = () => {
+		const newStep = step - 1;
 		const nextStep = history[newStep];
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
@@ -164,7 +165,8 @@ export default function UndoRedo({
 		});
 	};
 
-	const handleRedo = (newStep) => {
+	const handleRedo = () => {
+		const newStep = step + 1;
 		const nextStep = history[newStep];
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
@@ -425,7 +427,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:redo');
-					handleRedo(step + 1);
+					handleRedo();
 				}}
 				size="sm"
 				symbol="redo"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -48,19 +48,119 @@ export default function UndoRedo({
 		step: 0,
 	});
 
-	const handleUndoRedo = (newStep) => {
+	const handleUndo = (newStep) => {
+		const descriptionInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.description}`
+		);
+		const friendlyURLInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+		);
 		const nextStep = history[newStep];
-
 		const titleInputComponent = Liferay.component(
 			`${portletNamespace}${META_FIELD_NAMES.title}`
 		);
 
+		if (nextStep.selectedLanguageId !== selectedLanguageId) {
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			descriptionInputComponent
+				.get('translatedLanguages')
+				.values()
+				.map((lang) => {
+					if (
+						!nextStep.descriptionTranslatedLanguages.includes(lang)
+					) {
+						descriptionInputComponent
+							.get('translatedLanguages')
+							.remove(lang);
+						descriptionInputComponent.removeInputLanguage(lang);
+						descriptionInputComponent._updateTranslationStatus(
+							selectedLanguageId
+						);
+					}
+				});
+			descriptionInputComponent.selectFlag(nextStep.selectedLanguageId);
+			friendlyURLInputComponent
+				.get('translatedLanguages')
+				.values()
+				.map((lang) => {
+					if (
+						!nextStep.friendlyURLTranslatedLanguages.includes(lang)
+					) {
+						friendlyURLInputComponent
+							.get('translatedLanguages')
+							.remove(lang);
+						friendlyURLInputComponent.removeInputLanguage(lang);
+						friendlyURLInputComponent._updateTranslationStatus(
+							selectedLanguageId
+						);
+					}
+				});
+			friendlyURLInputComponent.selectFlag(nextStep.selectedLanguageId);
+			titleInputComponent
+				.get('translatedLanguages')
+				.values()
+				.map((lang) => {
+					if (!nextStep.titleTranslatedLanguages.includes(lang)) {
+						titleInputComponent
+							.get('translatedLanguages')
+							.remove(lang);
+						titleInputComponent.removeInputLanguage(lang);
+						titleInputComponent._updateTranslationStatus(
+							selectedLanguageId
+						);
+					}
+				});
+			titleInputComponent.selectFlag(nextStep.selectedLanguageId);
+
+			selectedLanguageIdInput.value = nextStep.selectedLanguageId;
+		}
+
+		descriptionInputComponent.updateInputLanguage(
+			nextStep.descriptionInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		friendlyURLInputComponent.updateInputLanguage(
+			nextStep.friendlyURLInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		titleInputComponent.updateInputLanguage(
+			nextStep.titleInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		descriptionInputComponent.updateInput(
+			nextStep.descriptionInputComponent
+		);
+
+		friendlyURLInputComponent.updateInput(
+			nextStep.friendlyURLInputComponent
+		);
+
+		titleInputComponent.updateInput(nextStep.titleInputComponent);
+
+		setState({
+			defaultLanguageId: nextStep.defaultLanguageId,
+			history,
+			selectedLanguageId: nextStep.selectedLanguageId,
+			step: newStep,
+		});
+	};
+
+	const handleRedo = (newStep) => {
 		const descriptionInputComponent = Liferay.component(
 			`${portletNamespace}${META_FIELD_NAMES.description}`
 		);
-
 		const friendlyURLInputComponent = Liferay.component(
 			`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+		);
+		const nextStep = history[newStep];
+		const titleInputComponent = Liferay.component(
+			`${portletNamespace}${META_FIELD_NAMES.title}`
 		);
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
@@ -70,31 +170,72 @@ export default function UndoRedo({
 
 			selectedLanguageIdInput.value = nextStep.selectedLanguageId;
 
-			titleInputComponent.selectFlag(nextStep.selectedLanguageId);
+			nextStep.descriptionTranslatedLanguages.map((lang) => {
+				if (
+					!descriptionInputComponent
+						.get('translatedLanguages')
+						.has(lang)
+				) {
+					descriptionInputComponent
+						.get('translatedLanguages')
+						.add(lang);
+					descriptionInputComponent._updateTranslationStatus(
+						nextStep.selectedLanguageId
+					);
+				}
+			});
 			descriptionInputComponent.selectFlag(nextStep.selectedLanguageId);
+			nextStep.friendlyURLTranslatedLanguages.map((lang) => {
+				if (
+					!friendlyURLInputComponent
+						.get('translatedLanguages')
+						.has(lang)
+				) {
+					friendlyURLInputComponent
+						.get('translatedLanguages')
+						.add(lang);
+					friendlyURLInputComponent._updateTranslationStatus(
+						nextStep.selectedLanguageId
+					);
+				}
+			});
 			friendlyURLInputComponent.selectFlag(nextStep.selectedLanguageId);
+			nextStep.titleTranslatedLanguages.map((lang) => {
+				if (!titleInputComponent.get('translatedLanguages').has(lang)) {
+					titleInputComponent.get('translatedLanguages').add(lang);
+					titleInputComponent._updateTranslationStatus(
+						nextStep.selectedLanguageId
+					);
+				}
+			});
+			titleInputComponent.selectFlag(nextStep.selectedLanguageId);
 		}
-		else {
-			titleInputComponent.updateInputLanguage(
-				nextStep.titleInputComponent,
-				nextStep.selectedLanguageId
-			);
-			descriptionInputComponent.updateInputLanguage(
-				nextStep.descriptionInputComponent,
-				nextStep.selectedLanguageId
-			);
-			friendlyURLInputComponent.updateInputLanguage(
-				nextStep.friendlyURLInputComponent,
-				nextStep.selectedLanguageId
-			);
-			titleInputComponent.updateInput(nextStep.titleInputComponent);
-			descriptionInputComponent.updateInput(
-				nextStep.descriptionInputComponent
-			);
-			friendlyURLInputComponent.updateInput(
-				nextStep.friendlyURLInputComponent
-			);
-		}
+
+		descriptionInputComponent.updateInputLanguage(
+			nextStep.descriptionInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		friendlyURLInputComponent.updateInputLanguage(
+			nextStep.friendlyURLInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		titleInputComponent.updateInputLanguage(
+			nextStep.titleInputComponent,
+			nextStep.selectedLanguageId
+		);
+
+		descriptionInputComponent.updateInput(
+			nextStep.descriptionInputComponent
+		);
+
+		friendlyURLInputComponent.updateInput(
+			nextStep.friendlyURLInputComponent
+		);
+
+		titleInputComponent.updateInput(nextStep.titleInputComponent);
+
 		setState({
 			defaultLanguageId: nextStep.defaultLanguageId,
 			history,
@@ -314,7 +455,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:undo');
-					handleUndoRedo(step - 1);
+					handleUndo(step - 1);
 				}}
 				size="sm"
 				symbol="undo"
@@ -328,7 +469,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:redo');
-					handleUndoRedo(step + 1);
+					handleRedo(step + 1);
 				}}
 				size="sm"
 				symbol="redo"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -28,17 +28,17 @@ export default function UndoRedo({
 		history: [
 			{
 				defaultLanguageId: initialDefaultLanguageId,
-				descriptionInputComponent:
+				descriptionInputValue:
 					initialFields[`${META_FIELD_NAMES.description}`][
 						`${initialDefaultLanguageId}`
 					] || '',
-				friendlyURLInputComponent:
+				friendlyURLInputValue:
 					initialFields[`${META_FIELD_NAMES.friendlyURL}`][
 						`${initialDefaultLanguageId}`
 					] || '',
 				name: 'Reset',
 				selectedLanguageId: languageId,
-				titleInputComponent:
+				titleInputValue:
 					initialFields[`${META_FIELD_NAMES.title}`][
 						`${initialDefaultLanguageId}`
 					] || '',
@@ -202,19 +202,19 @@ export default function UndoRedo({
 
 			const newHistory = {
 				defaultLanguageId: defaultLanguageIdInput.value,
-				descriptionInputComponent:
+				descriptionInputValue:
 					descriptionInputComponent.getValue(selectedLanguageId),
 				descriptionTranslatedLanguages: descriptionInputComponent
 					.get('translatedLanguages')
 					.values(),
-				friendlyURLInputComponent:
+				friendlyURLInputValue:
 					friendlyURLInputComponent.getValue(selectedLanguageId),
 				friendlyURLTranslatedLanguages: friendlyURLInputComponent
 					.get('translatedLanguages')
 					.values(),
 				name: fieldName,
 				selectedLanguageId: selectedLanguageIdInput.value,
-				titleInputComponent:
+				titleInputValue:
 					titleInputComponent.getValue(selectedLanguageId),
 				titleTranslatedLanguages: titleInputComponent
 					.get('translatedLanguages')
@@ -241,25 +241,25 @@ export default function UndoRedo({
 
 	const updateMetadataFields = (step, newStep) => {
 		descriptionInputComponent.updateInputLanguage(
-			step.descriptionInputComponent,
+			step.descriptionInputValue,
 			step.selectedLanguageId
 		);
 
 		friendlyURLInputComponent.updateInputLanguage(
-			step.friendlyURLInputComponent,
+			step.friendlyURLInputValue,
 			step.selectedLanguageId
 		);
 
 		titleInputComponent.updateInputLanguage(
-			step.titleInputComponent,
+			step.titleInputValue,
 			step.selectedLanguageId
 		);
 
-		descriptionInputComponent.updateInput(step.descriptionInputComponent);
+		descriptionInputComponent.updateInput(step.descriptionInputValue);
 
-		friendlyURLInputComponent.updateInput(step.friendlyURLInputComponent);
+		friendlyURLInputComponent.updateInput(step.friendlyURLInputValue);
 
-		titleInputComponent.updateInput(step.titleInputComponent);
+		titleInputComponent.updateInput(step.titleInputValue);
 
 		setState({
 			defaultLanguageId: step.defaultLanguageId,
@@ -281,13 +281,13 @@ export default function UndoRedo({
 
 			const newHistory = {
 				defaultLanguageId: defaultLanguageIdInput.value,
-				descriptionInputComponent: descriptionInputComponent.getValue(
+				descriptionInputValue: descriptionInputComponent.getValue(
 					selectedLanguageIdInput.value
 				),
 				descriptionTranslatedLanguages: descriptionInputComponent
 					.get('translatedLanguages')
 					.values(),
-				friendlyURLInputComponent: friendlyURLInputComponent.getValue(
+				friendlyURLInputValue: friendlyURLInputComponent.getValue(
 					selectedLanguageIdInput.value
 				),
 				friendlyURLTranslatedLanguages: friendlyURLInputComponent
@@ -295,7 +295,7 @@ export default function UndoRedo({
 					.values(),
 				name: fieldName,
 				selectedLanguageId: selectedLanguageIdInput.value,
-				titleInputComponent: titleInputComponent.getValue(
+				titleInputValue: titleInputComponent.getValue(
 					selectedLanguageIdInput.value
 				),
 				titleTranslatedLanguages: titleInputComponent

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -132,37 +132,7 @@ export default function UndoRedo({
 			selectedLanguageIdInput.value = nextStep.selectedLanguageId;
 		}
 
-		descriptionInputComponent.updateInputLanguage(
-			nextStep.descriptionInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		friendlyURLInputComponent.updateInputLanguage(
-			nextStep.friendlyURLInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		titleInputComponent.updateInputLanguage(
-			nextStep.titleInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		descriptionInputComponent.updateInput(
-			nextStep.descriptionInputComponent
-		);
-
-		friendlyURLInputComponent.updateInput(
-			nextStep.friendlyURLInputComponent
-		);
-
-		titleInputComponent.updateInput(nextStep.titleInputComponent);
-
-		setState({
-			defaultLanguageId: nextStep.defaultLanguageId,
-			history,
-			selectedLanguageId: nextStep.selectedLanguageId,
-			step: newStep,
-		});
+		updateMetadataFields(nextStep, newStep);
 	};
 
 	const handleRedo = () => {
@@ -217,37 +187,7 @@ export default function UndoRedo({
 			titleInputComponent.selectFlag(nextStep.selectedLanguageId);
 		}
 
-		descriptionInputComponent.updateInputLanguage(
-			nextStep.descriptionInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		friendlyURLInputComponent.updateInputLanguage(
-			nextStep.friendlyURLInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		titleInputComponent.updateInputLanguage(
-			nextStep.titleInputComponent,
-			nextStep.selectedLanguageId
-		);
-
-		descriptionInputComponent.updateInput(
-			nextStep.descriptionInputComponent
-		);
-
-		friendlyURLInputComponent.updateInput(
-			nextStep.friendlyURLInputComponent
-		);
-
-		titleInputComponent.updateInput(nextStep.titleInputComponent);
-
-		setState({
-			defaultLanguageId: nextStep.defaultLanguageId,
-			history,
-			selectedLanguageId: nextStep.selectedLanguageId,
-			step: newStep,
-		});
+		updateMetadataFields(nextStep, newStep);
 	};
 
 	const handleStoreState = useCallback(
@@ -298,6 +238,36 @@ export default function UndoRedo({
 			titleInputComponent,
 		]
 	);
+
+	const updateMetadataFields = (step, newStep) => {
+		descriptionInputComponent.updateInputLanguage(
+			step.descriptionInputComponent,
+			step.selectedLanguageId
+		);
+
+		friendlyURLInputComponent.updateInputLanguage(
+			step.friendlyURLInputComponent,
+			step.selectedLanguageId
+		);
+
+		titleInputComponent.updateInputLanguage(
+			step.titleInputComponent,
+			step.selectedLanguageId
+		);
+
+		descriptionInputComponent.updateInput(step.descriptionInputComponent);
+
+		friendlyURLInputComponent.updateInput(step.friendlyURLInputComponent);
+
+		titleInputComponent.updateInput(step.titleInputComponent);
+
+		setState({
+			defaultLanguageId: step.defaultLanguageId,
+			history,
+			selectedLanguageId: step.selectedLanguageId,
+			step: newStep,
+		});
+	};
 
 	const resetStoreState = useCallback(
 		({fieldName}) => {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -179,10 +179,10 @@ export default function UndoRedo({
 	);
 
 	useEffect(() => {
-		Liferay.after('inputLocalized:localeChanged', localeChangeHandler);
+		Liferay.after('journal:localeChanged', localeChangeHandler);
 
 		return () => {
-			Liferay.detach('inputLocalized:localeChanged', localeChangeHandler);
+			Liferay.detach('journal:localeChanged', localeChangeHandler);
 		};
 	}, [localeChangeHandler]);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -48,17 +48,30 @@ export default function UndoRedo({
 		step: 0,
 	});
 
+	let descriptionInputComponent;
+	let friendlyURLInputComponent;
+	let titleInputComponent;
+
+	Liferay.componentReady(
+		`${portletNamespace}${META_FIELD_NAMES.description}`
+	).then((component) => {
+		descriptionInputComponent = component;
+	});
+
+	Liferay.componentReady(
+		`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+	).then((component) => {
+		friendlyURLInputComponent = component;
+	});
+
+	Liferay.componentReady(
+		`${portletNamespace}${META_FIELD_NAMES.title}`
+	).then((component) => {
+		titleInputComponent = component;
+	});
+
 	const handleUndo = (newStep) => {
-		const descriptionInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.description}`
-		);
-		const friendlyURLInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
-		);
 		const nextStep = history[newStep];
-		const titleInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.title}`
-		);
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
 			const selectedLanguageIdInput = document.getElementById(
@@ -152,16 +165,7 @@ export default function UndoRedo({
 	};
 
 	const handleRedo = (newStep) => {
-		const descriptionInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.description}`
-		);
-		const friendlyURLInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
-		);
 		const nextStep = history[newStep];
-		const titleInputComponent = Liferay.component(
-			`${portletNamespace}${META_FIELD_NAMES.title}`
-		);
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
 			const selectedLanguageIdInput = document.getElementById(
@@ -250,20 +254,8 @@ export default function UndoRedo({
 				`${portletNamespace}defaultLanguageId`
 			);
 
-			const descriptionInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.description}`
-			);
-
-			const friendlyURLInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
-			);
-
 			const selectedLanguageIdInput = document.getElementById(
 				`${portletNamespace}languageId`
-			);
-
-			const titleInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.title}`
 			);
 
 			Promise.all([
@@ -312,7 +304,7 @@ export default function UndoRedo({
 				}
 			);
 		},
-		[history, portletNamespace, selectedLanguageId, step]
+		[descriptionInputComponent, friendlyURLInputComponent, history, portletNamespace, selectedLanguageId, step, titleInputComponent]
 	);
 
 	const resetStoreState = useCallback(
@@ -321,20 +313,8 @@ export default function UndoRedo({
 				`${portletNamespace}defaultLanguageId`
 			);
 
-			const descriptionInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.description}`
-			);
-
-			const friendlyURLInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
-			);
-
 			const selectedLanguageIdInput = document.getElementById(
 				`${portletNamespace}languageId`
-			);
-
-			const titleInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.title}`
 			);
 
 			Promise.all([
@@ -384,7 +364,7 @@ export default function UndoRedo({
 				}
 			);
 		},
-		[portletNamespace]
+		[descriptionInputComponent, friendlyURLInputComponent, portletNamespace, titleInputComponent]
 	);
 
 	const localeChangeHandler = useCallback(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -258,51 +258,39 @@ export default function UndoRedo({
 				`${portletNamespace}languageId`
 			);
 
-			Promise.all([
-				descriptionInputComponent,
-				titleInputComponent,
-				friendlyURLInputComponent,
-			]).then(
-				([
-					descriptionInputComponent,
-					titleInputComponent,
-					friendlyURLInputComponent,
-				]) => {
-					const newHistory = {
-						defaultLanguageId: defaultLanguageIdInput.value,
-						descriptionInputComponent:
-							descriptionInputComponent.getValue(
-								selectedLanguageId
-							),
-						descriptionTranslatedLanguages:
-							descriptionInputComponent
-								.get('translatedLanguages')
-								.values(),
-						friendlyURLInputComponent:
-							friendlyURLInputComponent.getValue(
-								selectedLanguageId
-							),
-						friendlyURLTranslatedLanguages:
-							friendlyURLInputComponent
-								.get('translatedLanguages')
-								.values(),
-						name: fieldName,
-						selectedLanguageId: selectedLanguageIdInput.value,
-						titleInputComponent:
-							titleInputComponent.getValue(selectedLanguageId),
-						titleTranslatedLanguages: titleInputComponent
-							.get('translatedLanguages')
-							.values(),
-					};
+			const newHistory = {
+				defaultLanguageId: defaultLanguageIdInput.value,
+				descriptionInputComponent:
+					descriptionInputComponent.getValue(
+						selectedLanguageId
+					),
+				descriptionTranslatedLanguages:
+					descriptionInputComponent
+						.get('translatedLanguages')
+						.values(),
+				friendlyURLInputComponent:
+					friendlyURLInputComponent.getValue(
+						selectedLanguageId
+					),
+				friendlyURLTranslatedLanguages:
+					friendlyURLInputComponent
+						.get('translatedLanguages')
+						.values(),
+				name: fieldName,
+				selectedLanguageId: selectedLanguageIdInput.value,
+				titleInputComponent:
+					titleInputComponent.getValue(selectedLanguageId),
+				titleTranslatedLanguages: titleInputComponent
+					.get('translatedLanguages')
+					.values(),
+			};
 
-					setState({
-						defaultLanguageId: defaultLanguageIdInput.value,
-						history: [...history.slice(0, step + 1), newHistory],
-						selectedLanguageId: selectedLanguageIdInput.value,
-						step: step + 1,
-					});
-				}
-			);
+			setState({
+				defaultLanguageId: defaultLanguageIdInput.value,
+				history: [...history.slice(0, step + 1), newHistory],
+				selectedLanguageId: selectedLanguageIdInput.value,
+				step: step + 1,
+			});
 		},
 		[descriptionInputComponent, friendlyURLInputComponent, history, portletNamespace, selectedLanguageId, step, titleInputComponent]
 	);
@@ -317,52 +305,40 @@ export default function UndoRedo({
 				`${portletNamespace}languageId`
 			);
 
-			Promise.all([
-				descriptionInputComponent,
-				titleInputComponent,
-				friendlyURLInputComponent,
-			]).then(
-				([
-					descriptionInputComponent,
-					titleInputComponent,
-					friendlyURLInputComponent,
-				]) => {
-					const newHistory = {
-						defaultLanguageId: defaultLanguageIdInput.value,
-						descriptionInputComponent:
-							descriptionInputComponent.getValue(
-								selectedLanguageIdInput.value
-							),
-						descriptionTranslatedLanguages:
-							descriptionInputComponent
-								.get('translatedLanguages')
-								.values(),
-						friendlyURLInputComponent:
-							friendlyURLInputComponent.getValue(
-								selectedLanguageIdInput.value
-							),
-						friendlyURLTranslatedLanguages:
-							friendlyURLInputComponent
-								.get('translatedLanguages')
-								.values(),
-						name: fieldName,
-						selectedLanguageId: selectedLanguageIdInput.value,
-						titleInputComponent: titleInputComponent.getValue(
-							selectedLanguageIdInput.value
-						),
-						titleTranslatedLanguages: titleInputComponent
-							.get('translatedLanguages')
-							.values(),
-					};
+			const newHistory = {
+				defaultLanguageId: defaultLanguageIdInput.value,
+				descriptionInputComponent:
+					descriptionInputComponent.getValue(
+						selectedLanguageIdInput.value
+					),
+				descriptionTranslatedLanguages:
+					descriptionInputComponent
+						.get('translatedLanguages')
+						.values(),
+				friendlyURLInputComponent:
+					friendlyURLInputComponent.getValue(
+						selectedLanguageIdInput.value
+					),
+				friendlyURLTranslatedLanguages:
+					friendlyURLInputComponent
+						.get('translatedLanguages')
+						.values(),
+				name: fieldName,
+				selectedLanguageId: selectedLanguageIdInput.value,
+				titleInputComponent: titleInputComponent.getValue(
+					selectedLanguageIdInput.value
+				),
+				titleTranslatedLanguages: titleInputComponent
+					.get('translatedLanguages')
+					.values(),
+			};
 
-					setState({
-						defaultLanguageId: defaultLanguageIdInput.value,
-						history: [newHistory],
-						selectedLanguageId: selectedLanguageIdInput.value,
-						step: 0,
-					});
-				}
-			);
+			setState({
+				defaultLanguageId: defaultLanguageIdInput.value,
+				history: [newHistory],
+				selectedLanguageId: selectedLanguageIdInput.value,
+				step: 0,
+			});
 		},
 		[descriptionInputComponent, friendlyURLInputComponent, portletNamespace, titleInputComponent]
 	);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -64,11 +64,11 @@ export default function UndoRedo({
 		friendlyURLInputComponent = component;
 	});
 
-	Liferay.componentReady(
-		`${portletNamespace}${META_FIELD_NAMES.title}`
-	).then((component) => {
-		titleInputComponent = component;
-	});
+	Liferay.componentReady(`${portletNamespace}${META_FIELD_NAMES.title}`).then(
+		(component) => {
+			titleInputComponent = component;
+		}
+	);
 
 	const handleUndo = () => {
 		const newStep = step - 1;
@@ -263,21 +263,15 @@ export default function UndoRedo({
 			const newHistory = {
 				defaultLanguageId: defaultLanguageIdInput.value,
 				descriptionInputComponent:
-					descriptionInputComponent.getValue(
-						selectedLanguageId
-					),
-				descriptionTranslatedLanguages:
-					descriptionInputComponent
-						.get('translatedLanguages')
-						.values(),
+					descriptionInputComponent.getValue(selectedLanguageId),
+				descriptionTranslatedLanguages: descriptionInputComponent
+					.get('translatedLanguages')
+					.values(),
 				friendlyURLInputComponent:
-					friendlyURLInputComponent.getValue(
-						selectedLanguageId
-					),
-				friendlyURLTranslatedLanguages:
-					friendlyURLInputComponent
-						.get('translatedLanguages')
-						.values(),
+					friendlyURLInputComponent.getValue(selectedLanguageId),
+				friendlyURLTranslatedLanguages: friendlyURLInputComponent
+					.get('translatedLanguages')
+					.values(),
 				name: fieldName,
 				selectedLanguageId: selectedLanguageIdInput.value,
 				titleInputComponent:
@@ -294,7 +288,15 @@ export default function UndoRedo({
 				step: step + 1,
 			});
 		},
-		[descriptionInputComponent, friendlyURLInputComponent, history, portletNamespace, selectedLanguageId, step, titleInputComponent]
+		[
+			descriptionInputComponent,
+			friendlyURLInputComponent,
+			history,
+			portletNamespace,
+			selectedLanguageId,
+			step,
+			titleInputComponent,
+		]
 	);
 
 	const resetStoreState = useCallback(
@@ -309,22 +311,18 @@ export default function UndoRedo({
 
 			const newHistory = {
 				defaultLanguageId: defaultLanguageIdInput.value,
-				descriptionInputComponent:
-					descriptionInputComponent.getValue(
-						selectedLanguageIdInput.value
-					),
-				descriptionTranslatedLanguages:
-					descriptionInputComponent
-						.get('translatedLanguages')
-						.values(),
-				friendlyURLInputComponent:
-					friendlyURLInputComponent.getValue(
-						selectedLanguageIdInput.value
-					),
-				friendlyURLTranslatedLanguages:
-					friendlyURLInputComponent
-						.get('translatedLanguages')
-						.values(),
+				descriptionInputComponent: descriptionInputComponent.getValue(
+					selectedLanguageIdInput.value
+				),
+				descriptionTranslatedLanguages: descriptionInputComponent
+					.get('translatedLanguages')
+					.values(),
+				friendlyURLInputComponent: friendlyURLInputComponent.getValue(
+					selectedLanguageIdInput.value
+				),
+				friendlyURLTranslatedLanguages: friendlyURLInputComponent
+					.get('translatedLanguages')
+					.values(),
 				name: fieldName,
 				selectedLanguageId: selectedLanguageIdInput.value,
 				titleInputComponent: titleInputComponent.getValue(
@@ -342,7 +340,12 @@ export default function UndoRedo({
 				step: 0,
 			});
 		},
-		[descriptionInputComponent, friendlyURLInputComponent, portletNamespace, titleInputComponent]
+		[
+			descriptionInputComponent,
+			friendlyURLInputComponent,
+			portletNamespace,
+			titleInputComponent,
+		]
 	);
 
 	const localeChangeHandler = useCallback(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -353,6 +353,25 @@ export default function UndoRedo({
 		[portletNamespace, resetStoreState]
 	);
 
+	const handleUpdateFriendlyURL = useCallback(
+		({friendlyURL}) => {
+			const newHistory = history.map((step) => {
+				if (step.titleInputValue) {
+					step.friendlyURLInputValue = friendlyURL;
+				}
+
+				return step;
+			});
+			setState((prevState) => {
+				return {
+					...prevState,
+					history: newHistory,
+				};
+			});
+		},
+		[history]
+	);
+
 	useEffect(() => {
 		Liferay.after('journal:localeChanged', localeChangeHandler);
 		Liferay.after(
@@ -376,6 +395,17 @@ export default function UndoRedo({
 			Liferay.detach('journal:storeState', handleStoreState);
 		};
 	}, [handleStoreState]);
+
+	useEffect(() => {
+		Liferay.on('journal:update-friendly-url', handleUpdateFriendlyURL);
+
+		return () => {
+			Liferay.detach(
+				'journal:update-friendly-url',
+				handleUpdateFriendlyURL
+			);
+		};
+	}, [handleUpdateFriendlyURL]);
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -113,16 +113,16 @@ export default function UndoRedo({
 				`${portletNamespace}${META_FIELD_NAMES.description}`
 			);
 
-			const titleInputComponent = Liferay.componentReady(
-				`${portletNamespace}${META_FIELD_NAMES.title}`
-			);
-
 			const friendlyURLInputComponent = Liferay.componentReady(
 				`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
 			);
 
 			const selectedLanguageIdInput = document.getElementById(
 				`${portletNamespace}languageId`
+			);
+
+			const titleInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.title}`
 			);
 
 			Promise.all([
@@ -141,14 +141,25 @@ export default function UndoRedo({
 							descriptionInputComponent.getValue(
 								selectedLanguageId
 							),
+						descriptionTranslatedLanguages:
+							descriptionInputComponent
+								.get('translatedLanguages')
+								.values(),
 						friendlyURLInputComponent:
 							friendlyURLInputComponent.getValue(
 								selectedLanguageId
 							),
+						friendlyURLTranslatedLanguages:
+							friendlyURLInputComponent
+								.get('translatedLanguages')
+								.values(),
 						name: fieldName,
 						selectedLanguageId: selectedLanguageIdInput.value,
 						titleInputComponent:
 							titleInputComponent.getValue(selectedLanguageId),
+						titleTranslatedLanguages: titleInputComponent
+							.get('translatedLanguages')
+							.values(),
 					};
 
 					setState({
@@ -201,15 +212,26 @@ export default function UndoRedo({
 							descriptionInputComponent.getValue(
 								selectedLanguageIdInput.value
 							),
+						descriptionTranslatedLanguages:
+							descriptionInputComponent
+								.get('translatedLanguages')
+								.values(),
 						friendlyURLInputComponent:
 							friendlyURLInputComponent.getValue(
 								selectedLanguageIdInput.value
 							),
+						friendlyURLTranslatedLanguages:
+							friendlyURLInputComponent
+								.get('translatedLanguages')
+								.values(),
 						name: fieldName,
 						selectedLanguageId: selectedLanguageIdInput.value,
 						titleInputComponent: titleInputComponent.getValue(
 							selectedLanguageIdInput.value
 						),
+						titleTranslatedLanguages: titleInputComponent
+							.get('translatedLanguages')
+							.values(),
 					};
 
 					setState({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -163,28 +163,117 @@ export default function UndoRedo({
 		[history, portletNamespace, selectedLanguageId, step]
 	);
 
+	const resetStoreState = useCallback(
+		({fieldName}) => {
+			const defaultLanguageIdInput = document.getElementById(
+				`${portletNamespace}defaultLanguageId`
+			);
+
+			const descriptionInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.description}`
+			);
+
+			const friendlyURLInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.friendlyURL}`
+			);
+
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			const titleInputComponent = Liferay.componentReady(
+				`${portletNamespace}${META_FIELD_NAMES.title}`
+			);
+
+			Promise.all([
+				descriptionInputComponent,
+				titleInputComponent,
+				friendlyURLInputComponent,
+			]).then(
+				([
+					descriptionInputComponent,
+					titleInputComponent,
+					friendlyURLInputComponent,
+				]) => {
+					const newHistory = {
+						defaultLanguageId: defaultLanguageIdInput.value,
+						descriptionInputComponent:
+							descriptionInputComponent.getValue(
+								selectedLanguageIdInput.value
+							),
+						friendlyURLInputComponent:
+							friendlyURLInputComponent.getValue(
+								selectedLanguageIdInput.value
+							),
+						name: fieldName,
+						selectedLanguageId: selectedLanguageIdInput.value,
+						titleInputComponent: titleInputComponent.getValue(
+							selectedLanguageIdInput.value
+						),
+					};
+
+					setState({
+						defaultLanguageId: defaultLanguageIdInput.value,
+						history: [newHistory],
+						selectedLanguageId: selectedLanguageIdInput.value,
+						step: 0,
+					});
+				}
+			);
+		},
+		[portletNamespace]
+	);
+
 	const localeChangeHandler = useCallback(
 		(event) => {
+			const fieldName = 'Locale Change';
 			const selectedLanguageId = event.item.getAttribute('data-value');
-
 			const selectedLanguageIdInput = document.getElementById(
 				`${portletNamespace}languageId`
 			);
 
 			selectedLanguageIdInput.value = selectedLanguageId;
 
-			Liferay.fire('journal:storeState', {fieldName: 'Locale Change'});
+			Liferay.fire('journal:storeState', {fieldName});
 		},
 		[portletNamespace]
 	);
 
+	const defaultLocaleChangeHandler = useCallback(
+		(event) => {
+			const defaultLanguageIdInput = document.getElementById(
+				`${portletNamespace}defaultLanguageId`
+			);
+			const fieldName = 'Reset';
+			const selectedLanguageId = event.item.getAttribute('data-value');
+			const selectedLanguageIdInput = document.getElementById(
+				`${portletNamespace}languageId`
+			);
+
+			defaultLanguageIdInput.value = selectedLanguageId;
+
+			selectedLanguageIdInput.value = selectedLanguageId;
+
+			resetStoreState({fieldName});
+		},
+		[portletNamespace, resetStoreState]
+	);
+
 	useEffect(() => {
 		Liferay.after('journal:localeChanged', localeChangeHandler);
+		Liferay.after(
+			'journal:defaultLocaleChanged',
+			defaultLocaleChangeHandler
+		);
 
 		return () => {
 			Liferay.detach('journal:localeChanged', localeChangeHandler);
+			Liferay.detach(
+				'journal:defaultLocaleChanged',
+				defaultLocaleChangeHandler
+			);
 		};
-	}, [localeChangeHandler]);
+	}, [defaultLocaleChangeHandler, localeChangeHandler]);
 
 	useEffect(() => {
 		Liferay.on('journal:storeState', handleStoreState);

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -183,7 +183,56 @@ autoSaveAsDraftTest(
 		);
 	}
 );
+autoSaveAsDraftTest(
+	'LPD-31072: Translation is removed when using Undo and restored when using Redo',
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		const translationButton = page.locator(
+			'[id="_com_liferay_journal_web_portlet_JournalPortlet__com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXMLMenu"]'
+		);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'Not translated into Catalan.',
+			}),
+			trigger: translationButton,
+		});
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		await clickAndExpectToBeVisible({
+			autoClick: false,
+			target: page.getByRole('menuitem', {
+				name: 'Translated into Catalan.',
+			}),
+			trigger: translationButton,
+		});
+
+		await journalEditArticlePage.undoButton.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: false,
+			target: page.getByRole('menuitem', {
+				name: 'Not translated into Catalan.',
+			}),
+			trigger: translationButton,
+		});
+
+		await journalEditArticlePage.redoButton.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: false,
+			target: page.getByRole('menuitem', {
+				name: 'Translated into Catalan.',
+			}),
+			trigger: translationButton,
+		});
+	}
+);
 autoSaveAsDraftTest(
 	'LPD-26863: Undo/Redo buttons work with metadata fields',
 	async ({journalEditArticlePage, site}) => {


### PR DESCRIPTION
This is a follow up of https://github.com/liferay-content-management/liferay-portal/pull/5714

I've tested the changes made in the previous PR and all looks good. I also implemented the suggestions and added another commit with another subtask. That is responsible of handling adding the FriendlyURL value to the already saved steps, when we get it from the backend after the first autosave. => [LPD-31071](https://liferay.atlassian.net/browse/LPD-31071)

# What is this trying to solve?

[LPD-26390](https://liferay.atlassian.net/browse/LPD-26390)
[LPD-31535](https://liferay.atlassian.net/browse/LPD-31535)
[LPD-31072](https://liferay.atlassian.net/browse/LPD-31072)
[LPD-31071](https://liferay.atlassian.net/browse/LPD-31071)


This PR is:

1. Introducing a new unique localechange event, that is fired from the language-selector. This was implemented as the original inputLocalized:localechanged event is fired in many different scenarios where a localechange actually did not happen.
2. Updated the UndoRedo state, to hold information about what language is translated in the metadatafields
3. With the translatedLanguages for the metafields we are removing and restoring translations when undoing or redoing a localizationChange
4. When the defaultLocale is changed we reset the available history steps, another subtask is opened to implement a warning for the user, that changing defaultLocale is resetting the available History steps.

# How can you verify that it works?

add to portal-ext:
`feature.flag.LPD-11228=true
feature.flag.LPD-15596=true`


-  Enable changable default language for web content
- Create a web content
- Fill the fields
- Change locale to ES
- Change the title
- Step back 2 times ( so you end up on the default locale)

**Expected**: When opening the language selector the ES locale is not translated

- Hit Redo 2 times ( so you are on the ES locale with the modified title)

**Expected** : When opening the language selector the ES locale is translated

- Change the default locale

**Expected** : You cannot use Undo or Redo as the history steps were beeing reset