### PR TITLE
LPD-32574 Change of property dl.file.indexing.max.size isn't considered when reindexing

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -321,11 +321,19 @@ public class DLFileEntryModelDocumentContributor
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(), _getIndexVersionLabel(dlFileEntry))) {
 
-			return StreamUtil.toString(
+			String string = StreamUtil.toString(
 				_dlStore.getFileAsStream(
 					dlFileEntry.getCompanyId(),
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
 					_getIndexVersionLabel(dlFileEntry)));
+
+			if (string.length() <= PropsValues.DL_FILE_INDEXING_MAX_SIZE) {
+				return string;
+			}
+
+			_dlStore.deleteFile(
+				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
+				dlFileEntry.getName(), _getIndexVersionLabel(dlFileEntry));
 		}
 
 		InputStream inputStream = _getInputStream(dlFileEntry);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/spi/model/index/contributor/DLFileEntryModelDocumentContributor.java
@@ -316,16 +316,18 @@ public class DLFileEntryModelDocumentContributor
 	private String _extractText(DLFileEntry dlFileEntry)
 		throws IOException, PortalException {
 
+		String indexVersionLabel = _getIndexVersionLabel(dlFileEntry);
+
 		if (_dlIndexerConfiguration.cacheTextExtraction() &&
 			_dlStore.hasFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), _getIndexVersionLabel(dlFileEntry))) {
+				dlFileEntry.getName(), indexVersionLabel)) {
 
 			String string = StreamUtil.toString(
 				_dlStore.getFileAsStream(
 					dlFileEntry.getCompanyId(),
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName(),
-					_getIndexVersionLabel(dlFileEntry)));
+					indexVersionLabel));
 
 			if (string.length() <= PropsValues.DL_FILE_INDEXING_MAX_SIZE) {
 				return string;
@@ -333,7 +335,7 @@ public class DLFileEntryModelDocumentContributor
 
 			_dlStore.deleteFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
-				dlFileEntry.getName(), _getIndexVersionLabel(dlFileEntry));
+				dlFileEntry.getName(), indexVersionLabel);
 		}
 
 		InputStream inputStream = _getInputStream(dlFileEntry);
@@ -353,7 +355,7 @@ public class DLFileEntryModelDocumentContributor
 					dlFileEntry.getCompanyId(),
 					dlFileEntry.getDataRepositoryId(), dlFileEntry.getName()
 				).versionLabel(
-					_getIndexVersionLabel(dlFileEntry)
+					indexVersionLabel
 				).build(),
 				text.getBytes(StandardCharsets.UTF_8));
 		}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/index/contributor/test/DLFileEntryModelDocumentContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/index/contributor/test/DLFileEntryModelDocumentContributorTest.java
@@ -43,12 +43,11 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -115,7 +114,7 @@ public class DLFileEntryModelDocumentContributorTest {
 			Assert.assertNotEquals(
 				"overriden",
 				document.get(
-					PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+					_portal.getSiteDefaultLocale(dlFileEntry.getGroupId()),
 					Field.CONTENT));
 		}
 	}
@@ -146,7 +145,7 @@ public class DLFileEntryModelDocumentContributorTest {
 			Assert.assertEquals(
 				"overriden",
 				document.get(
-					PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+					_portal.getSiteDefaultLocale(dlFileEntry.getGroupId()),
 					Field.CONTENT));
 		}
 	}
@@ -209,7 +208,7 @@ public class DLFileEntryModelDocumentContributorTest {
 				document, dlFileEntry);
 
 			String content = document.get(
-				PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+				_portal.getSiteDefaultLocale(dlFileEntry.getGroupId()),
 				Field.CONTENT);
 
 			Assert.assertEquals(
@@ -223,7 +222,7 @@ public class DLFileEntryModelDocumentContributorTest {
 					document, dlFileEntry);
 
 				content = document.get(
-					PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+					_portal.getSiteDefaultLocale(dlFileEntry.getGroupId()),
 					Field.CONTENT);
 
 				Assert.assertEquals(100, content.length());
@@ -430,7 +429,7 @@ public class DLFileEntryModelDocumentContributorTest {
 		throws Exception {
 
 		DLFileEntry dlFileEntry = _addDLFileEntry(
-			ContentTypes.IMAGE_PNG, FileUtil.getBytes(getClass(), fileName));
+			ContentTypes.IMAGE_PNG, _file.getBytes(getClass(), fileName));
 
 		FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
 
@@ -499,6 +498,9 @@ public class DLFileEntryModelDocumentContributorTest {
 
 	@Inject
 	private DLStore _dlStore;
+
+	@Inject
+	private File _file;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/index/contributor/test/DLFileEntryModelDocumentContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/search/spi/model/index/contributor/test/DLFileEntryModelDocumentContributorTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -57,6 +58,7 @@ import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContri
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
 
@@ -146,6 +148,86 @@ public class DLFileEntryModelDocumentContributorTest {
 				document.get(
 					PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
 					Field.CONTENT));
+		}
+	}
+
+	@Test
+	public void testCachedTextExtractionWithDLFileIndexingMaxSizeAndCacheExtraction()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				_getConfigurationTemporarySwapper(true)) {
+
+			String fileContent = StringUtil.randomString(
+				PropsValues.DL_FILE_INDEXING_MAX_SIZE + 1);
+
+			DLFileEntry dlFileEntry = _addDLFileEntry(
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				fileContent.getBytes(StandardCharsets.UTF_8));
+
+			Document document = new DocumentImpl();
+
+			_dlFileEntryModelDocumentContributor.contribute(
+				document, dlFileEntry);
+
+			String content = _getFileAsString(dlFileEntry);
+
+			Assert.assertEquals(
+				PropsValues.DL_FILE_INDEXING_MAX_SIZE, content.length());
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"DL_FILE_INDEXING_MAX_SIZE", 100)) {
+
+				_dlFileEntryModelDocumentContributor.contribute(
+					document, dlFileEntry);
+
+				content = _getFileAsString(dlFileEntry);
+
+				Assert.assertEquals(100, content.length());
+			}
+		}
+	}
+
+	@Test
+	public void testCachedTextExtractionWithDLFileIndexingMaxSizeAndNoCacheExtraction()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				_getConfigurationTemporarySwapper(false)) {
+
+			String fileContent = StringUtil.randomString(
+				PropsValues.DL_FILE_INDEXING_MAX_SIZE + 1);
+
+			DLFileEntry dlFileEntry = _addDLFileEntry(
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				fileContent.getBytes(StandardCharsets.UTF_8));
+
+			Document document = new DocumentImpl();
+
+			_dlFileEntryModelDocumentContributor.contribute(
+				document, dlFileEntry);
+
+			String content = document.get(
+				PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+				Field.CONTENT);
+
+			Assert.assertEquals(
+				PropsValues.DL_FILE_INDEXING_MAX_SIZE, content.length());
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"DL_FILE_INDEXING_MAX_SIZE", 100)) {
+
+				_dlFileEntryModelDocumentContributor.contribute(
+					document, dlFileEntry);
+
+				content = document.get(
+					PortalUtil.getSiteDefaultLocale(dlFileEntry.getGroupId()),
+					Field.CONTENT);
+
+				Assert.assertEquals(100, content.length());
+			}
 		}
 	}
 


### PR DESCRIPTION
Change of property dl.file.indexing.max.size isn't considered when reindexing

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-32574)

dl.file.indexing.max.size is used to control the size of text extraction, but it's not being taken into account during reindex after it being changed

# How am I fixing it?

Check the size of the indexed content, and if it's higher than the property, delete the file and recalculate again

# How can you verify that it works?

Follow the steps in the ticket or run the integration tests