### PR TITLE
LPD-32586 Images not honouring file permissions when they are served from Adaptive Media

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -47,7 +48,9 @@ public class AMImageContentTransformerTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImpl.java
@@ -24,6 +24,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -55,15 +60,26 @@ public class MediaQueryProviderImpl implements MediaQueryProvider {
 				_amImageConfigurationHelper.getAMImageConfigurationEntries(
 					fileEntry.getCompanyId()),
 				amImageConfigurationEntry -> {
-					AdaptiveMedia<AMProcessor<FileVersion>> adaptiveMedia =
-						_getAdaptiveMediaFromConfigurationEntry(
-							fileEntry, amImageConfigurationEntry);
+					try {
+						AdaptiveMedia<AMProcessor<FileVersion>> adaptiveMedia =
+							_getAdaptiveMediaFromConfigurationEntry(
+								fileEntry, amImageConfigurationEntry);
 
-					if (_getWidth(adaptiveMedia) <= 0) {
+						if (_getWidth(adaptiveMedia) <= 0) {
+							return null;
+						}
+
+						return adaptiveMedia;
+					}
+					catch (PrincipalException.MustHavePermission
+								principalException) {
+
+						if (_log.isWarnEnabled()) {
+							_log.warn(principalException);
+						}
+
 						return null;
 					}
-
-					return adaptiveMedia;
 				});
 
 		adaptiveMedias.sort(_comparator);
@@ -115,9 +131,18 @@ public class MediaQueryProviderImpl implements MediaQueryProvider {
 	}
 
 	private AdaptiveMedia<AMProcessor<FileVersion>>
-		_getAdaptiveMediaFromConfigurationEntry(
-			FileEntry fileEntry,
-			AMImageConfigurationEntry amImageConfigurationEntry) {
+			_getAdaptiveMediaFromConfigurationEntry(
+				FileEntry fileEntry,
+				AMImageConfigurationEntry amImageConfigurationEntry)
+		throws PortalException {
+
+		ModelResourcePermission<?> fileEntryModelResourcePermission =
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				FileEntry.class.getName());
+
+		fileEntryModelResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(),
+			fileEntry.getFileEntryId(), ActionKeys.DOWNLOAD);
 
 		AdaptiveMedia<AMProcessor<FileVersion>> adaptiveMedia =
 			_findAdaptiveMedia(fileEntry, amImageConfigurationEntry);

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
@@ -22,10 +22,16 @@ import com.liferay.adaptive.media.image.url.AMImageURLFactory;
 import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.net.URI;
@@ -37,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -44,6 +51,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Alejandro Tardín
@@ -84,8 +94,19 @@ public class MediaQueryProviderImplTest {
 			_mediaQueryProviderImpl, "_amImageURLFactory", _amImageURLFactory);
 	}
 
+	@After
+	public void tearDown() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+
+			_serviceRegistration = null;
+		}
+	}
+
 	@Test
 	public void testCreatesAMediaQuery() throws Exception {
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry("uuid", 800, 1989, "adaptiveURL"));
 
@@ -107,6 +128,8 @@ public class MediaQueryProviderImplTest {
 
 	@Test
 	public void testCreatesSeveralMediaQueries() throws Exception {
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid1", 800, 1986, "adaptiveURL1"),
@@ -142,6 +165,8 @@ public class MediaQueryProviderImplTest {
 
 	@Test
 	public void testCreatesSeveralMediaQueriesSortedByWidth() throws Exception {
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid2", 800, 1989, "adaptiveURL2"),
@@ -177,6 +202,8 @@ public class MediaQueryProviderImplTest {
 
 	@Test
 	public void testFiltersOutAdaptiveMediasWithNoWidth() throws Exception {
+		_configureFileEntryPermission(true);
+
 		int auto = 0;
 
 		_addConfigs(
@@ -198,6 +225,8 @@ public class MediaQueryProviderImplTest {
 
 	@Test
 	public void testHDMediaQueriesApplies() throws Exception {
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid1", 450, 800, "http://small.adaptive.com"),
@@ -251,6 +280,8 @@ public class MediaQueryProviderImplTest {
 	public void testHDMediaQueryAppliesWhenHeightHas1PXLessThanExpected()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid1", 450, 800, "http://small.adaptive.com"),
@@ -291,6 +322,8 @@ public class MediaQueryProviderImplTest {
 	public void testHDMediaQueryAppliesWhenHeightHas1PXMoreThanExpected()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid1", 450, 800, "http://small.adaptive.com"),
@@ -330,6 +363,8 @@ public class MediaQueryProviderImplTest {
 	@Test
 	public void testHDMediaQueryAppliesWhenWidthHas1PXLessThanExpected()
 		throws Exception {
+
+		_configureFileEntryPermission(true);
 
 		_addConfigs(
 			_createAMImageConfigurationEntry(
@@ -376,6 +411,8 @@ public class MediaQueryProviderImplTest {
 	public void testHDMediaQueryAppliesWhenWidthHas1PXMoreThanExpected()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid", 450, 800, "http://small.adaptive.com"),
@@ -416,6 +453,8 @@ public class MediaQueryProviderImplTest {
 	public void testHDMediaQueryNotAppliesWhenHeightHas2PXLessThanExpected()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid", 450, 800, "http://small.adaptive.com"),
@@ -453,6 +492,8 @@ public class MediaQueryProviderImplTest {
 	@Test
 	public void testHDMediaQueryNotAppliesWhenHeightHas2PXMoreThanExpected()
 		throws Exception {
+
+		_configureFileEntryPermission(true);
 
 		_addConfigs(
 			_createAMImageConfigurationEntry(
@@ -492,6 +533,8 @@ public class MediaQueryProviderImplTest {
 	public void testHDMediaQueryNotAppliesWhenWidthHas2PXLessThanExpected()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs(
 			_createAMImageConfigurationEntry(
 				"uuid", 450, 800, "http://small.adaptive.com"),
@@ -529,6 +572,8 @@ public class MediaQueryProviderImplTest {
 	@Test
 	public void testHDMediaQueryNotAppliesWhenWidthHas2PXMoreThanExpected()
 		throws Exception {
+
+		_configureFileEntryPermission(true);
 
 		_addConfigs(
 			_createAMImageConfigurationEntry(
@@ -568,6 +613,8 @@ public class MediaQueryProviderImplTest {
 	public void testReturnsNoMediaQueriesIfThereAreNoConfigs()
 		throws Exception {
 
+		_configureFileEntryPermission(true);
+
 		_addConfigs();
 
 		List<MediaQuery> mediaQueries = _mediaQueryProviderImpl.getMediaQueries(
@@ -579,6 +626,8 @@ public class MediaQueryProviderImplTest {
 	@Test
 	public void testUsesTheValuesFromConfigIfNoAdaptiveMediasArePresent()
 		throws Exception {
+
+		_configureFileEntryPermission(true);
 
 		int auto = 0;
 
@@ -601,6 +650,8 @@ public class MediaQueryProviderImplTest {
 	@Test
 	public void testUsesTheValuesFromTheAdaptiveMediasIfPresent()
 		throws Exception {
+
+		_configureFileEntryPermission(true);
 
 		int auto = 0;
 
@@ -628,6 +679,67 @@ public class MediaQueryProviderImplTest {
 		_assertMediaQuery(mediaQueries.get(1), "wautoURL", 169, 506);
 		_assertMediaQuery(mediaQueries.get(2), "hautoURL", 506, 600);
 		_assertMediaQuery(mediaQueries.get(3), "normalURL", 600, 750);
+	}
+
+	public class MockModelResourcePermission
+		implements ModelResourcePermission<FileEntry> {
+
+		public MockModelResourcePermission(boolean downloadPermission) {
+			_downloadPermission = downloadPermission;
+		}
+
+		@Override
+		public void check(
+				PermissionChecker permissionChecker, FileEntry model,
+				String actionId)
+			throws PortalException {
+
+			if (!_downloadPermission) {
+				throw new PrincipalException.MustHavePermission(0L, actionId);
+			}
+		}
+
+		@Override
+		public void check(
+				PermissionChecker permissionChecker, long primaryKey,
+				String actionId)
+			throws PortalException {
+
+			if (!_downloadPermission) {
+				throw new PrincipalException.MustHavePermission(0L, actionId);
+			}
+		}
+
+		@Override
+		public boolean contains(
+				PermissionChecker permissionChecker, FileEntry model,
+				String actionId)
+			throws PortalException {
+
+			return false;
+		}
+
+		@Override
+		public boolean contains(
+				PermissionChecker permissionChecker, long primaryKey,
+				String actionId)
+			throws PortalException {
+
+			return false;
+		}
+
+		@Override
+		public String getModelName() {
+			return null;
+		}
+
+		@Override
+		public PortletResourcePermission getPortletResourcePermission() {
+			return null;
+		}
+
+		private final boolean _downloadPermission;
+
 	}
 
 	private void _addAdaptiveMedias(
@@ -718,6 +830,17 @@ public class MediaQueryProviderImplTest {
 		_assertCondition(conditions.get(1), "min-width", minWidth + "px");
 	}
 
+	private void _configureFileEntryPermission(boolean downloadPermission) {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ModelResourcePermission.class,
+			new MockModelResourcePermission(downloadPermission),
+			MapUtil.singletonDictionary(
+				"model.class.name",
+				"com.liferay.portal.kernel.repository.model.FileEntry"));
+	}
+
 	private AdaptiveMedia<AMProcessor<FileVersion>> _createAdaptiveMedia(
 			String amImageConfigurationEntryUuid, int height, int width,
 			String url)
@@ -793,6 +916,8 @@ public class MediaQueryProviderImplTest {
 	}
 
 	private static final long _COMPANY_ID = 1L;
+
+	private static ServiceRegistration<?> _serviceRegistration;
 
 	private final AMImageConfigurationHelper _amImageConfigurationHelper =
 		Mockito.mock(AMImageConfigurationHelper.class);

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
@@ -624,6 +624,24 @@ public class MediaQueryProviderImplTest {
 	}
 
 	@Test
+	public void testReturnsNoMediaQueriesIfThereAreNoDownloadPermission()
+		throws Exception {
+
+		_configureFileEntryPermission(false);
+
+		_addConfigs(
+			_createAMImageConfigurationEntry(
+				"uuid", 450, 800, "http://small.adaptive.com"),
+			_createAMImageConfigurationEntry(
+				"uuid", 900, 1601, "http://small.hd.adaptive.com"));
+
+		List<MediaQuery> mediaQueries = _mediaQueryProviderImpl.getMediaQueries(
+			_fileEntry);
+
+		Assert.assertEquals(mediaQueries.toString(), 0, mediaQueries.size());
+	}
+
+	@Test
 	public void testUsesTheValuesFromConfigIfNoAdaptiveMediasArePresent()
 		throws Exception {
 


### PR DESCRIPTION
LPD-32586 Images not honouring file permissions when they are served from Adaptive Media

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32586

If you can not see the image, it's reasonable that you cannot see the adaptive media image. So the permissions to see it (https://learn.liferay.com/web/guest/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/managing-document-access/documents-and-media-permissions-reference) must be checked.

# How am I fixing it?

Checking the DOWNLOAD permission to get the adaptive media image, and if not pressent, do no show it.

# How can you verify that it works?

Steps to Reproduce
1) Add a new image and uncheck the Download permission for Guest users.
2) Edit home page and add the image on it
3) Open the page in an incognito window (not logged in) and check the result:
4) Minimize the browser window to a smaller width than the maximum defined in the adaptive media resolutions (you can see it by inspecting the element through the developer tools), so this way is served by AM.
5) The image should not be shown


Run the included automated tests.


# Commits

- **LPD-32586 check DOWNLOAD permission to know if we can see the file and return the adaptive media**
- **LPD-32586 fix test**
- **LPD-32586 add test to check that if no download permission there is no adaptive media returned**
