### PR TITLE
LPD-32639 Fix flaky journal test

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -517,17 +517,19 @@ baseTest(
 
 		await journalPage.changeView('list');
 
-		await page.getByLabel(`Actions for ${title}`).waitFor();
-		await page.getByLabel(`Actions for ${title}`).click();
-
-		await page.getByRole('menuitem', {name: 'View History'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'View History'}),
+			trigger: page.getByLabel(`Actions for ${title}`),
+		});
 
 		await journalPage.changeView('cards');
 
-		await page.getByLabel(`More Actions`).waitFor();
-		await page.getByLabel(`More Actions`).click();
-
-		await page.getByRole('menuitem', {name: 'Compare to...'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Compare to...'}),
+			trigger: page.getByLabel(`More Actions`),
+		});
 
 		await expect(
 			page.getByRole('heading', {name: 'Compare Versions'})

--- a/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
@@ -133,11 +133,11 @@ export class JournalPage {
 	}
 
 	async changeView(viewName: string) {
-		await this.page
-			.getByLabel('Select View, Currently Selected: ')
-			.waitFor();
-		await this.page.getByLabel('Select View, Currently Selected: ').click();
-		await this.page.getByRole('menuitem', {name: viewName}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: viewName}),
+			trigger: this.page.getByLabel('Select View, Currently Selected: '),
+		});
 	}
 
 	async publishArticle() {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32639

We are fixing a flaky test

![image](https://github.com/user-attachments/assets/b7c75ddb-ae98-4389-9bab-af2d47feab6a)


# How am I fixing it?

Avoiding `.waitFor` and applying `.toPass` instead.

> [!NOTE]
> [clickAndExpectToBeVisible](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/utils/clickAndExpectToBeVisible.ts) use .toPass inside

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright -- test -g "LPD-31655"` to run the test

# Avoid flakiness by repeating 15 times

```sh
npm run playwright -- test -g "LPD-31655" --reporter list --repeat-each 15
```
![image](https://github.com/user-attachments/assets/0823d071-8551-47e5-b664-f8fd3b07876b)
