### PR TITLE
LPD-31578 Make page reload after posting a comment so the workflow actions are updated correctly

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -155,7 +155,14 @@ export default function Comments({
 		}
 
 		if (refreshPage) {
-			window.location.reload();
+			openToast({
+				message: Liferay.Language.get(
+					'your-request-completed-successfully'
+				),
+				type: 'success',
+			});
+
+			setTimeout(() => window.location.reload(), 1000);
 		}
 		else {
 			const data = Liferay.Util.ns(namespace, {
@@ -352,7 +359,7 @@ export default function Comments({
 		hideEl(formId);
 	};
 
-	window[`${randomNamespace}postReply`] = function (i) {
+	window[`${randomNamespace}postReply`] = function (i, refreshPage = false) {
 		const editorInstance =
 			window[`${namespace}${randomNamespace}postReplyBody${i}`];
 
@@ -384,7 +391,7 @@ export default function Comments({
 			});
 		}
 		else {
-			sendMessage(form);
+			sendMessage(form, refreshPage);
 
 			editorInstance.dispose();
 		}

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -146,7 +146,7 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 												/>
 
 												<aui:button-row>
-													<aui:button cssClass="btn-comment btn-sm" disabled="<%= true %>" id="postReplyButton0" onClick='<%= randomNamespace + "postReply(0);" %>' primary="<%= true %>" value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
+													<aui:button cssClass="btn-comment btn-sm" disabled="<%= true %>" id="postReplyButton0" onClick='<%= randomNamespace + "postReply(0, true);" %>' primary="<%= true %>" value='<%= themeDisplay.isSignedIn() ? "reply" : "reply-as" %>' />
 												</aui:button-row>
 											</clay:content-col>
 										</clay:content-row>

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -3,37 +3,64 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {WorkflowTasksPage} from './WorkflowTasksPage';
 
 export class WorkflowTaskDetailsPage {
 	readonly approveMenuItem: Locator;
-	readonly assignee: FrameLocator;
+	readonly assignToMeMenuItem: Locator;
 	readonly assignToMenuItem: Locator;
-	readonly doneAssigneeButton: Locator;
+	readonly assigneeDoneButton: Locator;
+	readonly cancelButton: Locator;
+	readonly commentsButton: Locator;
 	readonly doneButton: Locator;
 	readonly page: Page;
+	readonly rejectMenuItem: Locator;
+	readonly replyButtom: Locator;
 	readonly reviewActionMenu: Locator;
 	readonly reviewComment: Locator;
+	readonly workflowCommentsTextbox: Locator;
 	readonly workflowTasksPage: WorkflowTasksPage;
 
 	constructor(page: Page) {
 		this.approveMenuItem = page.getByRole('menuitem', {name: 'approve'});
+		this.assignToMeMenuItem = page.getByRole('link', {
+			name: 'Assign to Me',
+		});
 		this.assignToMenuItem = page.getByRole('link', {name: 'Assign to...'});
-		this.doneAssigneeButton = page
+		this.assigneeDoneButton = page
 			.frameLocator(
 				'iframe[name="_com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet_assignToDialog_iframe_"]'
 			)
 			.getByRole('button', {name: 'Done'});
+		this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+		this.commentsButton = page.getByRole('button', {name: 'Comments'});
 		this.doneButton = page.getByRole('button', {name: 'Done'});
+		this.page = page;
+		this.rejectMenuItem = page.getByRole('menuitem', {name: 'reject'});
+		this.replyButtom = page.getByRole('button', {name: 'Reply'});
 		this.reviewActionMenu = page.locator(
 			'[id="_com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet_kldx___menu"]'
 		);
 		this.reviewComment = page.getByRole('textbox', {name: 'Comment'});
-		this.page = page;
+		this.workflowCommentsTextbox = page
+			.frameLocator('iframe')
+			.getByRole('textbox');
 		this.workflowTasksPage = new WorkflowTasksPage(page);
+	}
+
+	async addComment(comment: string) {
+		await this.commentsButton.click();
+		await this.workflowCommentsTextbox.fill(comment);
+		await this.replyButtom.click();
+	}
+
+	async clickAssigneeDoneButton() {
+		await this.assigneeDoneButton.click();
+
+		await waitForSuccessAlert(this.page);
 	}
 
 	async clickDoneButton() {
@@ -46,6 +73,14 @@ export class WorkflowTaskDetailsPage {
 		await this.workflowTasksPage.goto();
 
 		await this.selectAsset(assetTitle);
+	}
+
+	async goToMyRolesTab() {
+		await this.workflowTasksPage.goto();
+
+		await this.page
+			.getByRole('link', {name: 'Assigned to My Roles'})
+			.click();
 	}
 
 	async selectAsset(assetTitle: string) {

--- a/modules/test/playwright/tests/portal-workflow-task-web/assignments.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/assignments.spec.ts
@@ -147,7 +147,7 @@ test('send user back to my workflow tasks page after assign another user to revi
 
 	await workflowTaskDetailsPage.selectAssignee(user2.id.toString());
 
-	await workflowTaskDetailsPage.doneAssigneeButton.click();
+	await workflowTaskDetailsPage.assigneeDoneButton.click();
 
 	await expect(workflowTasksPage.assignedToMyRolesLink).toBeVisible();
 });

--- a/modules/test/playwright/tests/portal-workflow-task-web/comments.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/comments.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {notificationPagesTest} from '../../fixtures/notificationPagesTest';
+import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import {blogsPagesTest} from '../../tests/blogs-web/fixtures/blogsPagesTest';
+import {getRandomInt} from '../../utils/getRandomInt';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	blogsPagesTest,
+	loginTest(),
+	notificationPagesTest,
+	workflowPagesTest
+);
+
+let assetType: string;
+let blogTitle: string;
+let workflowDefinitionName: string;
+
+test.afterEach(async ({blogsPage, configurationTabPage}) => {
+	if (assetType && workflowDefinitionName) {
+		await configurationTabPage.goTo();
+
+		await configurationTabPage.unassignWorkflowFromAssetType(assetType);
+	}
+
+	if (blogTitle) {
+		await blogsPage.goto();
+		await blogsPage.deleteAllBlogEntries();
+	}
+
+	assetType = null;
+	blogTitle = null;
+	workflowDefinitionName = null;
+});
+
+test('approve or reject modal appear even after doing a comment on the comments section', async ({
+	blogsEditBlogEntryPage,
+	blogsPage,
+	configurationTabPage,
+	page,
+	workflowTaskDetailsPage,
+}) => {
+	await configurationTabPage.goTo();
+
+	workflowDefinitionName = 'Single Approver';
+
+	assetType = 'Blogs Entry';
+
+	await configurationTabPage.assignWorkflowToAssetType(
+		workflowDefinitionName,
+		assetType
+	);
+
+	await blogsPage.goto();
+
+	await blogsPage.goToCreateBlogEntry();
+
+	blogTitle = 'Blog Title' + getRandomInt();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: 'Blog content.',
+		submitToWorkflow: true,
+		title: blogTitle,
+	});
+
+	await workflowTaskDetailsPage.goToMyRolesTab();
+
+	await workflowTaskDetailsPage.selectAsset(blogTitle);
+
+	await page.waitForLoadState('networkidle');
+
+	await workflowTaskDetailsPage.reviewActionMenu.click();
+
+	await workflowTaskDetailsPage.assignToMeMenuItem.click();
+
+	await workflowTaskDetailsPage.assigneeDoneButton.click();
+
+	await workflowTaskDetailsPage.addComment('This is a comment');
+
+	await workflowTaskDetailsPage.reviewActionMenu.click();
+
+	await workflowTaskDetailsPage.approveMenuItem.click();
+
+	await expect(page.getByRole('heading', {name: 'Approve'})).toBeVisible();
+
+	await workflowTaskDetailsPage.cancelButton.click();
+
+	await workflowTaskDetailsPage.reviewActionMenu.click();
+
+	await workflowTaskDetailsPage.rejectMenuItem.click();
+
+	await expect(page.getByRole('heading', {name: 'Reject'})).toBeVisible();
+});


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-31578

hi everyone!

this is a follow up PR where i fix the same bug as this [previous PR](https://github.com/liferay-workflow/liferay-portal/pull/1205) but now on master instead of the 7.3; it also has a new test to cover the scenario from the bug.

the PR was already [approved by bpm team](https://github.com/liferay-workflow/liferay-portal/pull/1205), so could you please review this commit related to comments: 3ca0234711d7bc431ad1fbe8208adcd35da9949a

really appreciate all the help on this, thanks a lot! :cherry_blossom: 