### PR TITLE
LPD-32067 language mixed in wc notification

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -166,6 +166,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -6816,52 +6817,27 @@ public class JournalArticleLocalServiceImpl
 			journalGroupServiceConfiguration, serviceContext,
 			subscriptionSender);
 
-		String articleContent = StringPool.BLANK;
-
-		try {
-			PortletRequestModel portletRequestModel = null;
-
-			if (!ExportImportThreadLocal.isImportInProcess()) {
-				portletRequestModel = new PortletRequestModel(
-					serviceContext.getLiferayPortletRequest(),
-					serviceContext.getLiferayPortletResponse());
-			}
-
-			JournalArticleDisplay articleDisplay = getArticleDisplay(
-				article, article.getDDMTemplateKey(), Constants.VIEW,
-				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), 1,
-				portletRequestModel, serviceContext.getThemeDisplay());
-
-			articleContent = articleDisplay.getContent();
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
-
-		subscriptionSender.setContextAttribute(
-			"[$ARTICLE_CONTENT$]", articleContent, false);
-
-		String folderName = StringPool.BLANK;
-
-		if (folder != null) {
-			folderName = folder.getName();
-		}
-		else if (article.getFolderId() ==
-					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-
-			folderName = _language.get(LocaleUtil.getSiteDefault(), "home");
-		}
-
-		subscriptionSender.setContextAttributes(
-			"[$FOLDER_NAME$]", folderName, "[$ARTICLE_STATUS$]",
-			_language.get(
-				LocaleUtil.getSiteDefault(),
-				WorkflowConstants.getStatusLabel(article.getStatus())));
 		subscriptionSender.setCurrentUserId(userId);
 		subscriptionSender.setEntryTitle(
 			article.getTitle(serviceContext.getLanguageId()));
+		subscriptionSender.setLocalizedContextAttribute(
+			"[$ARTICLE_CONTENT$]",
+			new EscapableLocalizableFunction(
+				locale -> _getArticleContent(article, locale, serviceContext)));
+		subscriptionSender.setLocalizedContextAttribute(
+			"[$ARTICLE_STATUS$]",
+			new EscapableLocalizableFunction(
+				locale -> _language.get(
+					locale,
+					WorkflowConstants.getStatusLabel(article.getStatus()))));
+
+		JournalFolder folderCopy = folder;
+
+		subscriptionSender.setLocalizedContextAttribute(
+			"[$FOLDER_NAME$]",
+			new EscapableLocalizableFunction(
+				locale -> _getFolderName(article, locale, folderCopy)));
+
 		subscriptionSender.setNotificationType(_getNotificationType(action));
 		subscriptionSender.setReplyToAddress(fromAddress);
 
@@ -7611,11 +7587,41 @@ public class JournalArticleLocalServiceImpl
 		return ddmFormValues;
 	}
 
-	private String _getArticleDiffs(
-		JournalArticle article, ServiceContext serviceContext) {
+	private String _getArticleContent(
+		JournalArticle article, Locale locale, ServiceContext serviceContext) {
 
-		JournalArticle previousApprovedArticle = getPreviousApprovedArticle(
-			article);
+		String articleContent = StringPool.BLANK;
+
+		try {
+			PortletRequestModel portletRequestModel = null;
+
+			if (!ExportImportThreadLocal.isImportInProcess()) {
+				portletRequestModel = new PortletRequestModel(
+					serviceContext.getLiferayPortletRequest(),
+					serviceContext.getLiferayPortletResponse());
+			}
+
+			JournalArticleDisplay articleDisplay = getArticleDisplay(
+				article, article.getDDMTemplateKey(), Constants.VIEW,
+				LocaleUtil.toLanguageId(locale), 1, portletRequestModel,
+				serviceContext.getThemeDisplay());
+
+			articleContent = articleDisplay.getContent();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return articleContent;
+	}
+
+	private String _getArticleDiffs(
+		JournalArticle article, Locale locale, ServiceContext serviceContext) {
+
+		JournalArticle previousApprovedArticle =
+			journalArticleLocalService.getPreviousApprovedArticle(article);
 
 		try {
 			PortletRequestModel portletRequestModel = null;
@@ -7632,8 +7638,8 @@ public class JournalArticleLocalServiceImpl
 			String articleDiffs = _journalHelper.diffHtml(
 				article.getGroupId(), article.getArticleId(),
 				previousApprovedArticle.getVersion(), article.getVersion(),
-				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
-				portletRequestModel, serviceContext.getThemeDisplay());
+				LocaleUtil.toLanguageId(locale), portletRequestModel,
+				serviceContext.getThemeDisplay());
 
 			return _diffHtml.replaceStyles(articleDiffs);
 		}
@@ -7691,6 +7697,23 @@ public class JournalArticleLocalServiceImpl
 
 			return null;
 		}
+	}
+
+	private String _getFolderName(
+		JournalArticle article, Locale locale, JournalFolder folder) {
+
+		String folderName = StringPool.BLANK;
+
+		if (folder != null) {
+			folderName = folder.getName();
+		}
+		else if (article.getFolderId() ==
+					JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+
+			folderName = _language.get(locale, "home");
+		}
+
+		return folderName;
 	}
 
 	private Map<Locale, String> _getLocalizedBodyMap(
@@ -8029,12 +8052,8 @@ public class JournalArticleLocalServiceImpl
 		ServiceContext serviceContext, SubscriptionSender subscriptionSender) {
 
 		subscriptionSender.setClassName(article.getModelClassName());
-		subscriptionSender.setContextAttribute(
-			"[$ARTICLE_DIFFS$]", _getArticleDiffs(article, serviceContext),
-			false);
 		subscriptionSender.setContextAttributes(
-			"[$ARTICLE_ID$]", article.getArticleId(), "[$ARTICLE_TITLE$]",
-			article.getTitle(serviceContext.getLanguageId()), "[$ARTICLE_URL$]",
+			"[$ARTICLE_ID$]", article.getArticleId(), "[$ARTICLE_URL$]",
 			articleURL, "[$ARTICLE_VERSION$]", article.getVersion());
 		subscriptionSender.setContextCreatorUserPrefix("ARTICLE");
 		subscriptionSender.setCreatorUserId(article.getUserId());
@@ -8043,6 +8062,14 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setHtmlFormat(true);
 		subscriptionSender.setLocalizedBodyMap(
 			_getLocalizedBodyMap(emailType, journalGroupServiceConfiguration));
+		subscriptionSender.setLocalizedContextAttribute(
+			"[$ARTICLE_DIFFS$]",
+			new EscapableLocalizableFunction(
+				locale -> _getArticleDiffs(article, locale, serviceContext)));
+		subscriptionSender.setLocalizedContextAttribute(
+			"[$ARTICLE_TITLE$]",
+			new EscapableLocalizableFunction(
+				locale -> article.getTitle(LocaleUtil.toLanguageId(locale))));
 		subscriptionSender.setLocalizedSubjectMap(
 			_getLocalizedSubjectMap(
 				emailType, journalGroupServiceConfiguration));

--- a/modules/apps/journal/journal-test-util/bnd.bnd
+++ b/modules/apps/journal/journal-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Test Utilities
 Bundle-SymbolicName: com.liferay.journal.test.util
-Bundle-Version: 13.1.1
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.journal.test.util,\
 	com.liferay.journal.test.util.search

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -987,6 +987,21 @@ public class JournalTestUtil {
 
 	public static JournalArticle updateArticle(
 			long userId, JournalArticle article, Map<Locale, String> titleMap,
+			Map<Locale, String> contentMap, Locale defaultLocale,
+			boolean workflowEnabled, boolean approved,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent(
+			contentMap, LocaleUtil.toLanguageId(defaultLocale));
+
+		return updateArticle(
+			userId, article, titleMap, content, null, workflowEnabled, approved,
+			serviceContext);
+	}
+
+	public static JournalArticle updateArticle(
+			long userId, JournalArticle article, Map<Locale, String> titleMap,
 			String content, boolean workflowEnabled, boolean approved,
 			ServiceContext serviceContext)
 		throws Exception {

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -386,7 +387,9 @@ public class JournalTestUtil {
 
 		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
 			ddmGroupId, ddmStructure.getStructureId(),
-			PortalUtil.getClassNameId(JournalArticle.class));
+			PortalUtil.getClassNameId(JournalArticle.class),
+			TemplateConstants.LANG_TYPE_FTL, "${name.getData()}",
+			LocaleUtil.getSiteDefault());
 
 		boolean neverExpire = true;
 

--- a/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
+++ b/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/journal/journal-test/build.gradle
+++ b/modules/apps/journal/journal-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-test-util")
+	testIntegrationImplementation project(":apps:diff:diff-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -24,6 +24,9 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.subscription.test.util.BaseSubscriptionLocalizedContentTestCase;
 
+import java.util.Locale;
+import java.util.Map;
+
 import javax.portlet.PortletPreferences;
 
 import org.junit.ClassRule;
@@ -89,19 +92,21 @@ public class JournalSubscriptionLocalizedContentTest
 
 	@Override
 	protected void setBaseModelSubscriptionBodyPreferences(
-			String bodyPreferenceName)
+			Map<Locale, String> localizedContents, String bodyPreferenceName)
 		throws Exception {
 
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.getStrictPortletSetup(
 				layout, getServiceName());
 
-		LocalizationUtil.setPreferencesValue(
-			portletPreferences, bodyPreferenceName,
-			LocaleUtil.toLanguageId(LocaleUtil.GERMANY), GERMAN_BODY);
-		LocalizationUtil.setPreferencesValue(
-			portletPreferences, bodyPreferenceName,
-			LocaleUtil.toLanguageId(LocaleUtil.SPAIN), SPANISH_BODY);
+		for (Map.Entry<Locale, String> localizedContent :
+				localizedContents.entrySet()) {
+
+			LocalizationUtil.setPreferencesValue(
+				portletPreferences, bodyPreferenceName,
+				LocaleUtil.toLanguageId(localizedContent.getKey()),
+				localizedContent.getValue());
+		}
 
 		PortletPreferencesLocalServiceUtil.updatePreferences(
 			group.getGroupId(), PortletKeys.PREFS_OWNER_TYPE_GROUP,

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -88,8 +87,8 @@ public class JournalSubscriptionLocalizedContentTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		group.setName("Test Site", LocaleUtil.getDefault());
-		group.setName("Sitio de Pruebas", LocaleUtil.SPAIN);
+		group.setName("Test Site in English", LocaleUtil.getDefault());
+		group.setName("Sitio de Pruebas en español", LocaleUtil.SPAIN);
 
 		group = _groupLocalService.updateGroup(group);
 	}
@@ -182,9 +181,9 @@ public class JournalSubscriptionLocalizedContentTest
 			).build(),
 			null,
 			HashMapBuilder.put(
-				LocaleUtil.getDefault(), "Content"
+				LocaleUtil.getDefault(), "Content in English"
 			).put(
-				LocaleUtil.SPAIN, "Contenido"
+				LocaleUtil.SPAIN, "Contenido en español"
 			).build(),
 			LocaleUtil.getDefault(), false, true, serviceContext);
 
@@ -268,9 +267,9 @@ public class JournalSubscriptionLocalizedContentTest
 				LocaleUtil.SPAIN, "Título Nuevo"
 			).build(),
 			HashMapBuilder.put(
-				LocaleUtil.getDefault(), "New Content"
+				LocaleUtil.getDefault(), "New content in English"
 			).put(
-				LocaleUtil.SPAIN, "Contenido Nuevo"
+				LocaleUtil.SPAIN, "Contenido nuevo en español"
 			).build(),
 			LocaleUtil.getDefault(), false, true, serviceContext);
 	}
@@ -315,7 +314,7 @@ public class JournalSubscriptionLocalizedContentTest
 					user.getLocale(),
 					WorkflowConstants.getStatusLabel(
 						journalArticle.getStatus())),
-				HtmlUtil.escape(journalArticle.getTitle(user.getLanguageId())),
+				journalArticle.getTitle(user.getLanguageId()),
 				_language.get(user.getLocale(), "home"),
 				_portal.getPortletTitle(
 					JournalPortletKeys.JOURNAL, user.getLanguageId()),

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -364,6 +364,7 @@ public class JournalSubscriptionLocalizedContentTest
 		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
 		themeDisplay.setLookAndFeel(
 			layoutSet.getTheme(), layoutSet.getColorScheme());
+		themeDisplay.setRealUser(user);
 		themeDisplay.setRequest(_getHttpServletRequest(themeDisplay));
 		themeDisplay.setResponse(new MockHttpServletResponse());
 		themeDisplay.setScopeGroupId(group.getGroupId());

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -108,16 +108,12 @@ public class JournalSubscriptionLocalizedContentTest
 
 		addSubscriptionContainerModel(getDefaultContainerModelId());
 
-		_themeDisplay = _getThemeDisplay(creatorUser);
-
 		long journalArticlePrimaryKey = addBaseModel(
 			creatorUser.getUserId(), getDefaultContainerModelId());
 
 		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
 
 		MailMessage mailMessage = MailServiceTestUtil.getLastMailMessage();
-
-		_themeDisplay.setUser(user);
 
 		Assert.assertEquals(
 			_getExpectedMailBody(
@@ -138,8 +134,6 @@ public class JournalSubscriptionLocalizedContentTest
 			).build(),
 			getSubscriptionUpdatedBodyPreferenceName());
 
-		_themeDisplay = _getThemeDisplay(creatorUser);
-
 		long journalArticlePrimaryKey = addBaseModel(
 			creatorUser.getUserId(), getDefaultContainerModelId());
 
@@ -150,8 +144,6 @@ public class JournalSubscriptionLocalizedContentTest
 		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
 
 		MailMessage mailMessage = MailServiceTestUtil.getLastMailMessage();
-
-		_themeDisplay.setUser(user);
 
 		Assert.assertEquals(
 			_getExpectedMailBody(
@@ -167,9 +159,9 @@ public class JournalSubscriptionLocalizedContentTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), userId);
 
-		if (_themeDisplay != null) {
-			serviceContext.setRequest(_themeDisplay.getRequest());
-		}
+		ThemeDisplay themeDisplay = _getThemeDisplay(creatorUser);
+
+		serviceContext.setRequest(themeDisplay.getRequest());
 
 		JournalArticle article = JournalTestUtil.addArticle(
 			group.getGroupId(), containerModelId,
@@ -255,9 +247,9 @@ public class JournalSubscriptionLocalizedContentTest
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), userId);
 
-		if (_themeDisplay != null) {
-			serviceContext.setRequest(_themeDisplay.getRequest());
-		}
+		ThemeDisplay themeDisplay = _getThemeDisplay(creatorUser);
+
+		serviceContext.setRequest(themeDisplay.getRequest());
 
 		JournalTestUtil.updateArticle(
 			userId, _journalArticleLocalService.getArticle(baseModelId),
@@ -282,6 +274,7 @@ public class JournalSubscriptionLocalizedContentTest
 			journalArticlePrimaryKey);
 
 		String journalArticleDiffs = "";
+		ThemeDisplay themeDisplay = _getThemeDisplay(user);
 
 		if (_EMAIL_ARTICLE_UPDATED_BODY.equals(emailArticleBody)) {
 			double previousJournalArticleVersion = journalArticle.getVersion();
@@ -293,13 +286,13 @@ public class JournalSubscriptionLocalizedContentTest
 				_journalHelper.diffHtml(
 					journalArticle.getGroupId(), journalArticle.getArticleId(),
 					previousJournalArticleVersion, journalArticle.getVersion(),
-					user.getLanguageId(), null, _themeDisplay));
+					user.getLanguageId(), null, themeDisplay));
 		}
 
 		JournalArticleDisplay journalArticleDisplay =
 			_journalArticleLocalService.getArticleDisplay(
 				group.getGroupId(), journalArticle.getArticleId(),
-				Constants.VIEW, user.getLanguageId(), _themeDisplay);
+				Constants.VIEW, user.getLanguageId(), themeDisplay);
 
 		return StringUtil.replace(
 			emailArticleBody,
@@ -403,8 +396,6 @@ public class JournalSubscriptionLocalizedContentTest
 
 	@Inject
 	private Portal _portal;
-
-	private ThemeDisplay _themeDisplay;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.subscriptions.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.diff.DiffHtml;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
@@ -14,6 +15,7 @@ import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.journal.util.JournalHelper;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -119,7 +121,42 @@ public class JournalSubscriptionLocalizedContentTest
 		_themeDisplay.setUser(user);
 
 		Assert.assertEquals(
-			_getExpectedMailBody(journalArticlePrimaryKey),
+			_getExpectedMailBody(
+				_EMAIL_ARTICLE_ADDED_BODY, journalArticlePrimaryKey),
+			mailMessage.getBody());
+	}
+
+	@Test
+	public void testSubscriptionLocalizedContentWithMacrosWhenUpdatingBaseModel()
+		throws Exception {
+
+		user = _userLocalService.updateLanguageId(
+			user.getUserId(), _language.getLanguageId(LocaleUtil.SPAIN));
+
+		setBaseModelSubscriptionBodyPreferences(
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, _EMAIL_ARTICLE_UPDATED_BODY
+			).build(),
+			getSubscriptionUpdatedBodyPreferenceName());
+
+		_themeDisplay = _getThemeDisplay(creatorUser);
+
+		long journalArticlePrimaryKey = addBaseModel(
+			creatorUser.getUserId(), getDefaultContainerModelId());
+
+		addSubscriptionContainerModel(getDefaultContainerModelId());
+
+		updateBaseModel(creatorUser.getUserId(), journalArticlePrimaryKey);
+
+		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+
+		MailMessage mailMessage = MailServiceTestUtil.getLastMailMessage();
+
+		_themeDisplay.setUser(user);
+
+		Assert.assertEquals(
+			_getExpectedMailBody(
+				_EMAIL_ARTICLE_UPDATED_BODY, journalArticlePrimaryKey),
 			mailMessage.getBody());
 	}
 
@@ -141,15 +178,11 @@ public class JournalSubscriptionLocalizedContentTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "Title"
 			).put(
-				LocaleUtil.GERMANY, "Titel"
-			).put(
 				LocaleUtil.SPAIN, "Título"
 			).build(),
 			null,
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), "Content"
-			).put(
-				LocaleUtil.GERMANY, "Inhalte"
 			).put(
 				LocaleUtil.SPAIN, "Contenido"
 			).build(),
@@ -219,15 +252,50 @@ public class JournalSubscriptionLocalizedContentTest
 	protected void updateBaseModel(long userId, long baseModelId)
 		throws Exception {
 
-		JournalTestUtil.updateArticleWithWorkflow(
-			userId, _journalArticleLocalService.getArticle(baseModelId), true);
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), userId);
+
+		if (_themeDisplay != null) {
+			serviceContext.setRequest(_themeDisplay.getRequest());
+		}
+
+		JournalTestUtil.updateArticle(
+			userId, _journalArticleLocalService.getArticle(baseModelId),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "New Title"
+			).put(
+				LocaleUtil.SPAIN, "Título Nuevo"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "New Content"
+			).put(
+				LocaleUtil.SPAIN, "Contenido Nuevo"
+			).build(),
+			LocaleUtil.getDefault(), false, true, serviceContext);
 	}
 
-	private String _getExpectedMailBody(long journalArticlePrimaryKey)
+	private String _getExpectedMailBody(
+			String emailArticleBody, long journalArticlePrimaryKey)
 		throws Exception {
 
 		JournalArticle journalArticle = _journalArticleLocalService.getArticle(
 			journalArticlePrimaryKey);
+
+		String journalArticleDiffs = "";
+
+		if (_EMAIL_ARTICLE_UPDATED_BODY.equals(emailArticleBody)) {
+			double previousJournalArticleVersion = journalArticle.getVersion();
+
+			journalArticle = _journalArticleLocalService.getLatestArticle(
+				journalArticle.getResourcePrimKey());
+
+			journalArticleDiffs = _diffHtml.replaceStyles(
+				_journalHelper.diffHtml(
+					journalArticle.getGroupId(), journalArticle.getArticleId(),
+					previousJournalArticleVersion, journalArticle.getVersion(),
+					user.getLanguageId(), null, _themeDisplay));
+		}
 
 		JournalArticleDisplay journalArticleDisplay =
 			_journalArticleLocalService.getArticleDisplay(
@@ -235,14 +303,14 @@ public class JournalSubscriptionLocalizedContentTest
 				Constants.VIEW, user.getLanguageId(), _themeDisplay);
 
 		return StringUtil.replace(
-			_EMAIL_ARTICLE_ADDED_BODY,
+			emailArticleBody,
 			new String[] {
-				"[$ARTICLE_CONTENT$]", "[$ARTICLE_STATUS$]",
-				"[$ARTICLE_TITLE$]", "[$FOLDER_NAME$]", "[$PORTLET_TITLE$]",
-				"[$SITE_NAME$]"
+				"[$ARTICLE_CONTENT$]", "[$ARTICLE_DIFFS$]",
+				"[$ARTICLE_STATUS$]", "[$ARTICLE_TITLE$]", "[$FOLDER_NAME$]",
+				"[$PORTLET_TITLE$]", "[$SITE_NAME$]"
 			},
 			new String[] {
-				journalArticleDisplay.getContent(),
+				journalArticleDisplay.getContent(), journalArticleDiffs,
 				_language.get(
 					user.getLocale(),
 					WorkflowConstants.getStatusLabel(
@@ -311,14 +379,24 @@ public class JournalSubscriptionLocalizedContentTest
 		"[$PORTLET_TITLE$]: [$SITE_NAME$]: [$FOLDER_NAME$]: " +
 			"[$ARTICLE_TITLE$]: [$ARTICLE_STATUS$]: [$ARTICLE_CONTENT$]";
 
+	private static final String _EMAIL_ARTICLE_UPDATED_BODY =
+		"[$PORTLET_TITLE$]: [$SITE_NAME$]: [$FOLDER_NAME$]: " +
+			"[$ARTICLE_TITLE$]: [$ARTICLE_STATUS$]: [$ARTICLE_DIFFS$]";
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DiffHtml _diffHtml;
 
 	@Inject
 	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private JournalHelper _journalHelper;
 
 	@Inject
 	private Language _language;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -8,12 +8,10 @@ package com.liferay.journal.subscriptions.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalConstants;
-import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalService;
-import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -109,33 +107,19 @@ public class JournalSubscriptionLocalizedContentTest
 
 		addSubscriptionContainerModel(getDefaultContainerModelId());
 
-		ThemeDisplay themeDisplay = _getThemeDisplay(creatorUser);
+		_themeDisplay = _getThemeDisplay(creatorUser);
 
-		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			group.getGroupId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), "Title"
-			).put(
-				LocaleUtil.SPAIN, "Título"
-			).build(),
-			null,
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), "Content"
-			).put(
-				LocaleUtil.SPAIN, "Contenido"
-			).build(),
-			null, LocaleUtil.getDefault(), null, true, true,
-			_getServiceContext(themeDisplay.getRequest()));
+		long journalArticlePrimaryKey = addBaseModel(
+			creatorUser.getUserId(), getDefaultContainerModelId());
 
 		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
 
 		MailMessage mailMessage = MailServiceTestUtil.getLastMailMessage();
 
-		themeDisplay.setUser(user);
+		_themeDisplay.setUser(user);
 
 		Assert.assertEquals(
-			_getExpectedMailBody(journalArticle, themeDisplay),
+			_getExpectedMailBody(journalArticlePrimaryKey),
 			mailMessage.getBody());
 	}
 
@@ -143,10 +127,35 @@ public class JournalSubscriptionLocalizedContentTest
 	protected long addBaseModel(long userId, long containerModelId)
 		throws Exception {
 
-		JournalArticle article = JournalTestUtil.addArticle(
-			userId, group.getGroupId(), containerModelId);
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), userId);
 
-		return article.getResourcePrimKey();
+		if (_themeDisplay != null) {
+			serviceContext.setRequest(_themeDisplay.getRequest());
+		}
+
+		JournalArticle article = JournalTestUtil.addArticle(
+			group.getGroupId(), containerModelId,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "Title"
+			).put(
+				LocaleUtil.GERMANY, "Titel"
+			).put(
+				LocaleUtil.SPAIN, "Título"
+			).build(),
+			null,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "Content"
+			).put(
+				LocaleUtil.GERMANY, "Inhalte"
+			).put(
+				LocaleUtil.SPAIN, "Contenido"
+			).build(),
+			LocaleUtil.getDefault(), false, true, serviceContext);
+
+		return article.getPrimaryKey();
 	}
 
 	@Override
@@ -210,27 +219,20 @@ public class JournalSubscriptionLocalizedContentTest
 	protected void updateBaseModel(long userId, long baseModelId)
 		throws Exception {
 
-		JournalArticle article =
-			JournalArticleLocalServiceUtil.getLatestArticle(baseModelId);
-
-		JournalTestUtil.updateArticleWithWorkflow(userId, article, true);
+		JournalTestUtil.updateArticleWithWorkflow(
+			userId, _journalArticleLocalService.getArticle(baseModelId), true);
 	}
 
-	private String _getArticleContent(
-			JournalArticle journalArticle, ThemeDisplay themeDisplay)
+	private String _getExpectedMailBody(long journalArticlePrimaryKey)
 		throws Exception {
+
+		JournalArticle journalArticle = _journalArticleLocalService.getArticle(
+			journalArticlePrimaryKey);
 
 		JournalArticleDisplay journalArticleDisplay =
 			_journalArticleLocalService.getArticleDisplay(
 				group.getGroupId(), journalArticle.getArticleId(),
-				Constants.VIEW, user.getLanguageId(), themeDisplay);
-
-		return journalArticleDisplay.getContent();
-	}
-
-	private String _getExpectedMailBody(
-			JournalArticle journalArticle, ThemeDisplay themeDisplay)
-		throws Exception {
+				Constants.VIEW, user.getLanguageId(), _themeDisplay);
 
 		return StringUtil.replace(
 			_EMAIL_ARTICLE_ADDED_BODY,
@@ -240,7 +242,7 @@ public class JournalSubscriptionLocalizedContentTest
 				"[$SITE_NAME$]"
 			},
 			new String[] {
-				_getArticleContent(journalArticle, themeDisplay),
+				journalArticleDisplay.getContent(),
 				_language.get(
 					user.getLocale(),
 					WorkflowConstants.getStatusLabel(
@@ -274,19 +276,6 @@ public class JournalSubscriptionLocalizedContentTest
 		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
 
 		return httpServletRequest;
-	}
-
-	private ServiceContext _getServiceContext(
-			HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				group.getGroupId(), creatorUser.getUserId());
-
-		serviceContext.setRequest(httpServletRequest);
-
-		return serviceContext;
 	}
 
 	private ThemeDisplay _getThemeDisplay(User user) throws Exception {
@@ -336,6 +325,8 @@ public class JournalSubscriptionLocalizedContentTest
 
 	@Inject
 	private Portal _portal;
+
+	private ThemeDisplay _themeDisplay;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -6,20 +6,48 @@
 package com.liferay.journal.subscriptions.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.mail.MailMessage;
+import com.liferay.portal.test.mail.MailServiceTestUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.subscription.test.util.BaseSubscriptionLocalizedContentTestCase;
@@ -29,9 +57,17 @@ import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Zsolt Berentey
@@ -46,6 +82,62 @@ public class JournalSubscriptionLocalizedContentTest
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(), SynchronousMailTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		group.setName("Test Site", LocaleUtil.getDefault());
+		group.setName("Sitio de Pruebas", LocaleUtil.SPAIN);
+
+		group = _groupLocalService.updateGroup(group);
+	}
+
+	@Test
+	public void testSubscriptionLocalizedContentWithMacrosWhenAddingBaseModel()
+		throws Exception {
+
+		user = _userLocalService.updateLanguageId(
+			user.getUserId(), _language.getLanguageId(LocaleUtil.SPAIN));
+
+		setBaseModelSubscriptionBodyPreferences(
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, _EMAIL_ARTICLE_ADDED_BODY
+			).build(),
+			getSubscriptionAddedBodyPreferenceName());
+
+		addSubscriptionContainerModel(getDefaultContainerModelId());
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(creatorUser);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			group.getGroupId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "Title"
+			).put(
+				LocaleUtil.SPAIN, "Título"
+			).build(),
+			null,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "Content"
+			).put(
+				LocaleUtil.SPAIN, "Contenido"
+			).build(),
+			null, LocaleUtil.getDefault(), null, true, true,
+			_getServiceContext(themeDisplay.getRequest()));
+
+		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+
+		MailMessage mailMessage = MailServiceTestUtil.getLastMailMessage();
+
+		themeDisplay.setUser(user);
+
+		Assert.assertEquals(
+			_getExpectedMailBody(journalArticle, themeDisplay),
+			mailMessage.getBody());
+	}
 
 	@Override
 	protected long addBaseModel(long userId, long containerModelId)
@@ -123,5 +215,129 @@ public class JournalSubscriptionLocalizedContentTest
 
 		JournalTestUtil.updateArticleWithWorkflow(userId, article, true);
 	}
+
+	private String _getArticleContent(
+			JournalArticle journalArticle, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		JournalArticleDisplay journalArticleDisplay =
+			_journalArticleLocalService.getArticleDisplay(
+				group.getGroupId(), journalArticle.getArticleId(),
+				Constants.VIEW, user.getLanguageId(), themeDisplay);
+
+		return journalArticleDisplay.getContent();
+	}
+
+	private String _getExpectedMailBody(
+			JournalArticle journalArticle, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		return StringUtil.replace(
+			_EMAIL_ARTICLE_ADDED_BODY,
+			new String[] {
+				"[$ARTICLE_CONTENT$]", "[$ARTICLE_STATUS$]",
+				"[$ARTICLE_TITLE$]", "[$FOLDER_NAME$]", "[$PORTLET_TITLE$]",
+				"[$SITE_NAME$]"
+			},
+			new String[] {
+				_getArticleContent(journalArticle, themeDisplay),
+				_language.get(
+					user.getLocale(),
+					WorkflowConstants.getStatusLabel(
+						journalArticle.getStatus())),
+				HtmlUtil.escape(journalArticle.getTitle(user.getLanguageId())),
+				_language.get(user.getLocale(), "home"),
+				_portal.getPortletTitle(
+					JournalPortletKeys.JOURNAL, user.getLanguageId()),
+				group.getDescriptiveName(user.getLocale())
+			});
+	}
+
+	private HttpServletRequest _getHttpServletRequest(
+		ThemeDisplay themeDisplay) {
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		MockLiferayResourceRequest mockPortletRequest =
+			new MockLiferayResourceRequest();
+
+		mockPortletRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, httpServletRequest);
+
+		httpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST, mockPortletRequest);
+
+		httpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletActionResponse());
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return httpServletRequest;
+	}
+
+	private ServiceContext _getServiceContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), creatorUser.getUserId());
+
+		serviceContext.setRequest(httpServletRequest);
+
+		return serviceContext;
+	}
+
+	private ThemeDisplay _getThemeDisplay(User user) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(group.getCompanyId()));
+
+		themeDisplay.setLanguageId(group.getDefaultLanguageId());
+
+		themeDisplay.setLayout(layout);
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		themeDisplay.setLayoutSet(layoutSet);
+
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
+		themeDisplay.setLookAndFeel(
+			layoutSet.getTheme(), layoutSet.getColorScheme());
+		themeDisplay.setRequest(_getHttpServletRequest(themeDisplay));
+		themeDisplay.setResponse(new MockHttpServletResponse());
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setSiteGroupId(group.getGroupId());
+		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
+		themeDisplay.setUser(user);
+
+		return themeDisplay;
+	}
+
+	private static final String _EMAIL_ARTICLE_ADDED_BODY =
+		"[$PORTLET_TITLE$]: [$SITE_NAME$]: [$FOLDER_NAME$]: " +
+			"[$ARTICLE_TITLE$]: [$ARTICLE_STATUS$]: [$ARTICLE_CONTENT$]";
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private Language _language;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -16,6 +16,9 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalHelper;
+import com.liferay.mail.kernel.model.Account;
+import com.liferay.mail.kernel.service.MailService;
+import com.liferay.mail.kernel.service.MailServiceUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -27,6 +30,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -35,6 +39,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -54,10 +59,14 @@ import com.liferay.subscription.test.util.BaseSubscriptionLocalizedContentTestCa
 import java.util.Locale;
 import java.util.Map;
 
+import javax.mail.Session;
+import javax.mail.internet.InternetHeaders;
+
 import javax.portlet.PortletPreferences;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -91,6 +100,20 @@ public class JournalSubscriptionLocalizedContentTest
 		group.setName("Sitio de Pruebas en español", LocaleUtil.SPAIN);
 
 		group = _groupLocalService.updateGroup(group);
+
+		_mailService = MailServiceUtil.getService();
+
+		ReflectionTestUtil.setFieldValue(
+			MailServiceUtil.class, "_mailService", _geMailService());
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			MailServiceUtil.class, "_mailService", _mailService);
+
+		super.tearDown();
 	}
 
 	@Test
@@ -266,6 +289,50 @@ public class JournalSubscriptionLocalizedContentTest
 			LocaleUtil.getDefault(), false, true, serviceContext);
 	}
 
+	private MailService _geMailService() {
+		return new MailService() {
+
+			@Override
+			public void clearSession() {
+				_mailService.clearSession();
+			}
+
+			@Override
+			public void clearSession(long companyId) {
+				_mailService.clearSession(companyId);
+			}
+
+			@Override
+			public Session getSession() {
+				return _mailService.getSession();
+			}
+
+			@Override
+			public Session getSession(Account account) {
+				return _mailService.getSession(account);
+			}
+
+			@Override
+			public Session getSession(long companyId) {
+				return _mailService.getSession(companyId);
+			}
+
+			@Override
+			public void sendEmail(
+				com.liferay.mail.kernel.model.MailMessage mailMessage) {
+
+				InternetHeaders internetHeaders = new InternetHeaders();
+
+				internetHeaders.setHeader("Content-Transfer-Encoding", "8bit");
+
+				mailMessage.setInternetHeaders(internetHeaders);
+
+				_mailService.sendEmail(mailMessage);
+			}
+
+		};
+	}
+
 	private String _getExpectedMailBody(
 			String emailArticleBody, long journalArticlePrimaryKey)
 		throws Exception {
@@ -282,11 +349,14 @@ public class JournalSubscriptionLocalizedContentTest
 			journalArticle = _journalArticleLocalService.getLatestArticle(
 				journalArticle.getResourcePrimKey());
 
-			journalArticleDiffs = _diffHtml.replaceStyles(
-				_journalHelper.diffHtml(
-					journalArticle.getGroupId(), journalArticle.getArticleId(),
-					previousJournalArticleVersion, journalArticle.getVersion(),
-					user.getLanguageId(), null, themeDisplay));
+			journalArticleDiffs = HtmlUtil.escape(
+				_diffHtml.replaceStyles(
+					_journalHelper.diffHtml(
+						journalArticle.getGroupId(),
+						journalArticle.getArticleId(),
+						previousJournalArticleVersion,
+						journalArticle.getVersion(), user.getLanguageId(), null,
+						themeDisplay)));
 		}
 
 		JournalArticleDisplay journalArticleDisplay =
@@ -393,6 +463,8 @@ public class JournalSubscriptionLocalizedContentTest
 
 	@Inject
 	private Language _language;
+
+	private MailService _mailService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/subscription/subscription-test-util/bnd.bnd
+++ b/modules/apps/subscription/subscription-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Subscription Test Utilities
 Bundle-SymbolicName: com.liferay.subscription.test.util
-Bundle-Version: 3.0.9
+Bundle-Version: 4.0.0
 Export-Package: com.liferay.subscription.test.util

--- a/modules/apps/subscription/subscription-test-util/src/main/java/com/liferay/subscription/test/util/BaseSubscriptionLocalizedContentTestCase.java
+++ b/modules/apps/subscription/subscription-test-util/src/main/java/com/liferay/subscription/test/util/BaseSubscriptionLocalizedContentTestCase.java
@@ -21,7 +21,6 @@ import com.liferay.portal.test.mail.MailMessage;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
 import com.liferay.portal.test.rule.Inject;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -55,13 +54,13 @@ public abstract class BaseSubscriptionLocalizedContentTestCase
 	public void testSubscriptionLocalizedContentWhenAddingBaseModel()
 		throws Exception {
 
-		Map<Locale, String> previousLocalizedContents = HashMapBuilder.putAll(
-			localizedContents
-		).build();
-
-		_initializeLocale(LocaleUtil.GERMANY, GERMAN_BODY);
+		user = _userLocalService.updateLanguageId(
+			user.getUserId(), LocaleUtil.toLanguageId(LocaleUtil.GERMANY));
 
 		setBaseModelSubscriptionBodyPreferences(
+			HashMapBuilder.put(
+				LocaleUtil.GERMANY, GERMAN_BODY
+			).build(),
 			getSubscriptionAddedBodyPreferenceName());
 
 		addSubscriptionContainerModel(getDefaultContainerModelId());
@@ -72,21 +71,19 @@ public abstract class BaseSubscriptionLocalizedContentTestCase
 			"Body", GERMAN_BODY);
 
 		Assert.assertEquals(messages.toString(), 1, messages.size());
-
-		localizedContents = previousLocalizedContents;
 	}
 
 	@Test
 	public void testSubscriptionLocalizedContentWhenUpdatingBaseModel()
 		throws Exception {
 
-		Map<Locale, String> previousLocalizedContents = HashMapBuilder.putAll(
-			localizedContents
-		).build();
-
-		_initializeLocale(LocaleUtil.SPAIN, SPANISH_BODY);
+		user = _userLocalService.updateLanguageId(
+			user.getUserId(), LocaleUtil.toLanguageId(LocaleUtil.SPAIN));
 
 		setBaseModelSubscriptionBodyPreferences(
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, SPANISH_BODY
+			).build(),
 			getSubscriptionUpdatedBodyPreferenceName());
 
 		long baseModelId = addBaseModel(
@@ -100,8 +97,6 @@ public abstract class BaseSubscriptionLocalizedContentTestCase
 			"Body", SPANISH_BODY);
 
 		Assert.assertEquals(messages.toString(), 1, messages.size());
-
-		localizedContents = previousLocalizedContents;
 	}
 
 	protected abstract void addSubscriptionContainerModel(long containerModelId)
@@ -122,7 +117,7 @@ public abstract class BaseSubscriptionLocalizedContentTestCase
 	protected abstract String getSubscriptionUpdatedBodyPreferenceName();
 
 	protected void setBaseModelSubscriptionBodyPreferences(
-			String bodyPreferenceName)
+			Map<Locale, String> localizedContents, String bodyPreferenceName)
 		throws Exception {
 
 		Settings settings = FallbackKeysSettingsUtil.getSettings(
@@ -151,15 +146,6 @@ public abstract class BaseSubscriptionLocalizedContentTestCase
 
 	protected Locale defaultLocale;
 	protected Layout layout;
-	protected Map<Locale, String> localizedContents = new HashMap<>();
-
-	private void _initializeLocale(Locale locale, String body) {
-		user.setLanguageId(locale.toString());
-
-		user = _userLocalService.updateUser(user);
-
-		localizedContents.put(locale, body);
-	}
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/subscription/subscription-test-util/src/main/resources/com/liferay/subscription/test/util/packageinfo
+++ b/modules/apps/subscription/subscription-test-util/src/main/resources/com/liferay/subscription/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java
@@ -346,9 +346,10 @@ public class SubscriptionSender implements Serializable {
 		}
 
 		if (groupId > 0) {
-			Group group = GroupLocalServiceUtil.getGroup(groupId);
-
-			setContextAttribute("[$SITE_NAME$]", group.getDescriptiveName());
+			setLocalizedContextAttribute(
+				"[$SITE_NAME$]",
+				new EscapableLocalizableFunction(
+					locale -> _getGroupDescriptiveName(groupId, locale)));
 		}
 
 		if ((creatorUserId > 0) &&
@@ -1109,6 +1110,21 @@ public class SubscriptionSender implements Serializable {
 
 		return StringBundler.concat(
 			key.substring(0, i), StringPool.PIPE, escapeMode, "$]");
+	}
+
+	private String _getGroupDescriptiveName(long groupId, Locale locale) {
+		try {
+			Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+			return group.getDescriptiveName(locale);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return StringPool.BLANK;
 	}
 
 	private <T> List<Hook<T>> _getHooks(Hook.Event<T> event) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32067

The content of email notifications when Web Content is aded or updated, do not use the destination user language for macros such as [$ARTICLE_CONTENT$]

# How am I fixing it?

I'm using the method `setLocalizedContextAttribute` instead of `setContextAttribute` when adding the value of the macros to the `subscriptionSender` object.

# How can you verify that it works?

Follow the steps of the issue and/or execute the new tests created in class `JournalSubscriptionLocalizedContentTest`.