### PR TITLE
LPD-33020 Fix failing test SharingDLViewFileVersionDisplayContextTest

### DIFF
--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
@@ -155,6 +155,8 @@ public class SharingDLViewFileVersionDisplayContextTest {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		portletDisplay.setPortletName(DLPortletKeys.DOCUMENT_LIBRARY_ADMIN);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32020

# How am I fixing it?

Add local to it does not fail the test. See : https://testray.liferay.com/#/project/34754/routines/34756/build/50831307/case-result/50898127/history?filter=%7B%22testrayRoutineIds%22%3A%5B34756%5D%7D&filterSchema=buildResultsHistory

# How can you verify that it works?

Execute test