### PR TITLE
LPD-32979 | Web content description is missing from table view

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -112,6 +112,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -1203,6 +1204,11 @@ public class JournalDisplayContext {
 			ResourceConstants.SCOPE_INDIVIDUAL,
 			String.valueOf(journalArticle.getResourcePrimKey()),
 			_guestRole.getRoleId(), ActionKeys.VIEW);
+	}
+
+	public boolean hasHighlightedDDMStructure() {
+		return ListUtil.isNotEmpty(
+			DDMStructureUtil.getHighlightedDDMStructures(_themeDisplay));
 	}
 
 	public boolean hasResults() throws PortalException {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -239,6 +239,14 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							</div>
 						</liferay-ui:search-container-column-text>
 
+						<c:if test="<%= !journalDisplayContext.hasHighlightedDDMStructure() %>">
+							<liferay-ui:search-container-column-text
+								cssClass="table-cell-expand table-cell-minw-200 text-truncate"
+								name="description"
+								value="<%= StringUtil.shorten(HtmlUtil.stripHtml(curArticle.getDescription(locale)), 200) %>"
+							/>
+						</c:if>
+
 						<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
 							<liferay-ui:search-container-column-text
 								cssClass="table-cell-expand-smallest table-cell-minw-200"

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -409,6 +409,57 @@ baseTest(
 );
 
 baseTest(
+	'LPD-32979: Ensure the presence of the Description column when needed',
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		page.on('dialog', (dialog) => dialog.accept());
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await page.getByText('Content', {exact: true}).waitFor();
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await page.getByLabel('Select View, Currently').click();
+
+		await page.getByRole('menuitem', {name: 'Table'}).click();
+
+		await expect(
+			page.getByRole('cell', {name: 'Description'})
+		).toBeVisible();
+
+		await page
+			.getByTestId('headerOptions')
+			.getByLabel('Options')
+			.and(page.locator('[aria-haspopup]'))
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Configuration'}).click();
+
+		await page.getByLabel('Select Highlighted Structures').click();
+
+		const dialogFrame = page.frameLocator(
+			'iframe[title="Select Structures"]'
+		);
+
+		await dialogFrame.getByLabel('Basic Web Content Global').click();
+
+		await page.getByRole('button', {name: 'Add'}).click();
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await page.getByText('Success:You have successfully').waitFor();
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await expect(page.getByRole('cell', {name: 'Description'})).toHaveCount(
+			0
+		);
+	}
+);
+
+baseTest(
 	'LPD-15248 Move folder to another folder via management toolbar',
 	async ({apiHelpers, journalPage, page, site}) => {
 		const childFolder = await apiHelpers.jsonWebServicesJournal.addFolder({


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-32979

### How am I fixing it?

Originally the description field was removed from the table view when the highlighted structure feature was released. I fix the issue by adding back the description field with the correct conditions. 
for the conditions see: 
https://liferay.slack.com/archives/CLD39UKM5/p1722243460258949

### How can you verify that it works?

To test run:
`npm run playwright -- test -g 'LPD-32979'`
