### PR TITLE
LPD-29742 Show categories in the blogs portlet entry urls (and ADP url as well)

### DIFF
--- a/modules/apps/blogs/blogs-web-test/build.gradle
+++ b/modules/apps/blogs/blogs-web-test/build.gradle
@@ -2,9 +2,11 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:trash:trash-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogsViewEntryContentDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogsViewEntryContentDisplayContextTest.java
@@ -1,0 +1,307 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.blogs.web.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.service.BlogsEntryService;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class BlogsViewEntryContentDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = _companyLocalService.getCompany(_group.getCompanyId());
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+	}
+
+	@Test
+	public void testGetViewEntryURLWithAssetDisplayPage() throws Exception {
+		BlogsEntry entry = _addBlogEntry(
+			"beta",
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_addAssetDisplayPage(entry);
+
+		String viewEntryURL = _getViewEntryURL(entry);
+
+		Assert.assertTrue(
+			viewEntryURL.endsWith(_ENTRY_ASSET_DISPLAY_PAGE_FRIENDLY_URL));
+	}
+
+	@FeatureFlags("LPD-11147")
+	@Test
+	public void testGetViewEntryURLWithAssetDisplayPageAndURLAssetCategory()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		_populateServiceContextWithCategory(serviceContext);
+
+		BlogsEntry entry = _addBlogEntry("beta", serviceContext);
+
+		_addAssetDisplayPage(entry);
+
+		String viewEntryURL = _getViewEntryURL(entry);
+
+		Assert.assertTrue(
+			viewEntryURL.endsWith(
+				_ENTRY_ASSET_DISPLAY_PAGE_CATEGORY_FRIENDLY_URL));
+	}
+
+	@Test
+	public void testGetViewEntryURLWithoutAssetDisplayPage() throws Exception {
+		BlogsEntry entry = _addBlogEntry(
+			"alpha",
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(
+			_ENTRY_WITHOUT_ASSET_DISPLAY_PAGE_FRIENDLY_URL,
+			_getViewEntryURL(entry));
+	}
+
+	@FeatureFlags("LPD-11147")
+	@Test
+	public void testGetViewEntryURLWithoutAssetDisplayPageAndWithURLAssetCategory()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		_populateServiceContextWithCategory(serviceContext);
+
+		BlogsEntry entry = _addBlogEntry("alpha", serviceContext);
+
+		Assert.assertEquals(
+			_ENTRY_WITHOUT_ASSET_DISPLAY_PAGE_FRIENDLY_URL,
+			_getViewEntryURL(entry));
+	}
+
+	private void _addAssetDisplayPage(BlogsEntry entry) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, serviceContext.getUserId(),
+				serviceContext.getScopeGroupId(), 0, "Blogs",
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
+				WorkflowConstants.STATUS_APPROVED, serviceContext);
+
+		serviceContext.setAttribute(
+			"assetDisplayPageId",
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
+
+		serviceContext.setAttribute(
+			"displayPageType", AssetDisplayPageConstants.TYPE_SPECIFIC);
+
+		_assetDisplayPageEntryFormProcessor.process(
+			BlogsEntry.class.getName(), entry.getEntryId(), serviceContext);
+	}
+
+	private BlogsEntry _addBlogEntry(
+			String title, ServiceContext serviceContext)
+		throws Exception {
+
+		return _blogsEntryService.addEntry(
+			title, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
+			new String[0], RandomTestUtil.randomString(), null, null,
+			serviceContext);
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(_company);
+		themeDisplay.setLayout(_layout);
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		portletDisplay.setPortletName(BlogsPortletKeys.BLOGS);
+
+		themeDisplay.setRealUser(TestPropsValues.getUser());
+		themeDisplay.setScopeGroupId(_layout.getGroupId());
+		themeDisplay.setSiteGroupId(_layout.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private String _getViewEntryURL(BlogsEntry entry) throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest(_getMockHttpServletRequest());
+
+		_mvcRenderCommand.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+
+		Object blogsViewEntryContentDisplayContext =
+			mockLiferayPortletRenderRequest.getAttribute(
+				"com.liferay.blogs.web.internal.display.context." +
+					"BlogsViewEntryContentDisplayContext");
+
+		return ReflectionTestUtil.invoke(
+			blogsViewEntryContentDisplayContext, "getViewEntryURL",
+			new Class<?>[] {BlogsEntry.class}, entry);
+	}
+
+	private void _populateServiceContextWithCategory(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(), null,
+				HashMapBuilder.put(
+					LocaleUtil.US, RandomTestUtil.randomString()
+				).build(),
+				null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				new ServiceContext());
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			HashMapBuilder.put(
+				LocaleUtil.US, "cat1"
+			).build(),
+			null, assetVocabulary.getVocabularyId(), null,
+			new ServiceContext());
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory.getCategoryId()});
+
+		serviceContext.setAttribute(
+			"friendlyURLAssetCategoryIds",
+			new long[] {assetCategory.getCategoryId()});
+	}
+
+	private static final String
+		_ENTRY_ASSET_DISPLAY_PAGE_CATEGORY_FRIENDLY_URL = "/b/cat1/beta";
+
+	private static final String _ENTRY_ASSET_DISPLAY_PAGE_FRIENDLY_URL =
+		"/b/beta";
+
+	private static final String _ENTRY_WITHOUT_ASSET_DISPLAY_PAGE_FRIENDLY_URL =
+		"http//localhost/test?param_mvcRenderCommandName=/blogs/view_entry;" +
+			"param_redirect=;param_urlTitle=alpha";
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetDisplayPageEntryFormProcessor
+		_assetDisplayPageEntryFormProcessor;
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject
+	private BlogsEntryService _blogsEntryService;
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.blogs.web.internal.portlet.action.ViewMVCRenderCommand"
+	)
+	private MVCRenderCommand _mvcRenderCommand;
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntryContentDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntryContentDisplayContext.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.blogs.web.internal.display.context;
+
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+
+/**
+ * @author Roberto Díaz
+ */
+public class BlogsViewEntryContentDisplayContext {
+
+	public BlogsViewEntryContentDisplayContext(
+		AssetDisplayPageFriendlyURLProvider assetDisplayPageFriendlyURLProvider,
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		_assetDisplayPageFriendlyURLProvider =
+			assetDisplayPageFriendlyURLProvider;
+		_liferayPortletRequest = liferayPortletRequest;
+		_liferayPortletResponse = liferayPortletResponse;
+
+		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public String getViewEntryURL(BlogsEntry entry) throws PortalException {
+		String friendlyURL =
+			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+				new InfoItemReference(
+					BlogsEntry.class.getName(),
+					new ClassPKInfoItemIdentifier(entry.getEntryId())),
+				_themeDisplay);
+
+		if (friendlyURL != null) {
+			return friendlyURL;
+		}
+
+		ObjectValuePair<String, String> objectValuePair = null;
+
+		if (Validator.isNotNull(entry.getUrlTitle())) {
+			objectValuePair = new ObjectValuePair<>(
+				"urlTitle", entry.getUrlTitle());
+		}
+		else {
+			objectValuePair = new ObjectValuePair<>(
+				"entryId", String.valueOf(entry.getEntryId()));
+		}
+
+		return PortletURLBuilder.createRenderURL(
+			_liferayPortletResponse
+		).setMVCRenderCommandName(
+			"/blogs/view_entry"
+		).setRedirect(
+			_themeDisplay.getURLCurrent()
+		).setParameter(
+			objectValuePair.getKey(), objectValuePair.getValue()
+		).buildString();
+	}
+
+	private final AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
+	private final LiferayPortletRequest _liferayPortletRequest;
+	private final LiferayPortletResponse _liferayPortletResponse;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -5,8 +5,10 @@
 
 package com.liferay.blogs.web.internal.portlet.action;
 
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.display.context.BlogsViewEntriesDisplayContext;
+import com.liferay.blogs.web.internal.display.context.BlogsViewEntryContentDisplayContext;
 import com.liferay.blogs.web.internal.display.context.BlogsViewImagesDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -45,6 +47,13 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		if (Objects.equals(
 				_getPortletId(renderRequest), BlogsPortletKeys.BLOGS)) {
 
+			renderRequest.setAttribute(
+				BlogsViewEntryContentDisplayContext.class.getName(),
+				new BlogsViewEntryContentDisplayContext(
+					_assetDisplayPageFriendlyURLProvider,
+					_portal.getLiferayPortletRequest(renderRequest),
+					_portal.getLiferayPortletResponse(renderResponse)));
+
 			return "/blogs/view.jsp";
 		}
 
@@ -69,6 +78,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		return portletDisplay.getPortletName();
 	}
+
+	@Reference
+	private AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
 
 	@Reference
 	private HtmlParser _htmlParser;

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<%@ page import="com.liferay.blogs.web.internal.display.context.BlogsViewEntryDisplayContext" %><%@
+<%@ page import="com.liferay.blogs.web.internal.display.context.BlogsViewEntryContentDisplayContext" %><%@
+page import="com.liferay.blogs.web.internal.display.context.BlogsViewEntryDisplayContext" %><%@
 page import="com.liferay.friendly.url.exception.FriendlyURLCategoryException" %>
 
 <%@ include file="/blogs/init-ext.jsp" %>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -13,24 +13,14 @@ SearchContainer<BaseModel<?>> searchContainer = (SearchContainer)request.getAttr
 BlogsEntry entry = (BlogsEntry)request.getAttribute("view_entry_content.jsp-entry");
 
 BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortletInstanceConfigurationUtil.getBlogsPortletInstanceConfiguration(themeDisplay);
+
+BlogsViewEntryContentDisplayContext blogsViewEntryContentDisplayContext = (BlogsViewEntryContentDisplayContext)request.getAttribute(BlogsViewEntryContentDisplayContext.class.getName());
+
+String viewEntryURL = blogsViewEntryContentDisplayContext.getViewEntryURL(entry);
 %>
 
 <c:choose>
 	<c:when test="<%= entry.isVisible() || (entry.getUserId() == user.getUserId()) || BlogsEntryPermission.contains(permissionChecker, entry, ActionKeys.UPDATE) %>">
-		<portlet:renderURL var="viewEntryURL">
-			<portlet:param name="mvcRenderCommandName" value="/blogs/view_entry" />
-			<portlet:param name="redirect" value='<%= ParamUtil.getString(request, "redirect", currentURL) %>' />
-
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(entry.getUrlTitle()) %>">
-					<portlet:param name="urlTitle" value="<%= entry.getUrlTitle() %>" />
-				</c:when>
-				<c:otherwise>
-					<portlet:param name="entryId" value="<%= String.valueOf(entry.getEntryId()) %>" />
-				</c:otherwise>
-			</c:choose>
-		</portlet:renderURL>
-
 		<div class="widget-mode-simple-entry">
 			<clay:content-row
 				cssClass="widget-topbar"


### PR DESCRIPTION
[LPD-29742 Show categories in the blogs portlet entry urls (and ADP url as well)# What is this trying to solve?](https://liferay.atlassian.net/browse/LPD-26660)

# How am I fixing it?

Adding a a new service context to get the right url in each case.

If the Blogs entry has an Asset Display Page, show the friendly url as "/b/{friendlyURL} (it could contain the categories if "LPD-11147" FF is activated, or the legacy Blogs entry portlet URL if not.

# How can you verify that it works?

Run the included automated tests added to `com.liferay.blogs.web.test.BlogsViewEntryContentDisplayContextTest`
