### PR TITLE
LPD-32481 Add Order by Relevance option to the DL search in DPContext

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -243,6 +243,10 @@ public class DLAdminDisplayContext {
 		String orderByCol = ParamUtil.getString(
 			_httpServletRequest, "orderByCol");
 
+		if (Objects.equals(orderByCol, "relevance")) {
+			return "relevance";
+		}
+
 		if (orderByCol.equals("downloads") && (getFileEntryTypeId() >= 0)) {
 			orderByCol = "modifiedDate";
 		}
@@ -269,6 +273,10 @@ public class DLAdminDisplayContext {
 
 		if (isNavigationRecent()) {
 			return "desc";
+		}
+
+		if (Objects.equals(getOrderByCol(), "relevance")) {
+			return "asc";
 		}
 
 		String orderByType = ParamUtil.getString(
@@ -1128,6 +1136,9 @@ public class DLAdminDisplayContext {
 		else if (Objects.equals(orderByCol, "modifiedDate")) {
 			fieldName = Field.MODIFIED_DATE;
 			type = Sort.LONG_TYPE;
+		}
+		else if (Objects.equals(orderByCol, "relevance")) {
+			type = Sort.SCORE_TYPE;
 		}
 		else if (Objects.equals(orderByCol, "size")) {
 			type = Sort.LONG_TYPE;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -379,6 +379,10 @@ public class DLAdminManagementToolbarDisplayContext
 
 	@Override
 	public String getSortingOrder() {
+		if (Objects.equals(getOrderByCol(), "relevance")) {
+			return null;
+		}
+
 		return _dlAdminDisplayContext.getOrderByType();
 	}
 
@@ -946,11 +950,18 @@ public class DLAdminManagementToolbarDisplayContext
 		).put(
 			"modifiedDate", "modified-date"
 		).put(
+			"relevance",
+			() -> {
+				if (_isSearch()) {
+					return "relevance";
+				}
+
+				return null;
+			}
+		).put(
 			"size", "size"
 		).put(
 			"title", "name"
-		).put(
-			"relevance", "relevance"
 		).build();
 
 		return new DropdownItemList() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -949,6 +949,8 @@ public class DLAdminManagementToolbarDisplayContext
 			"size", "size"
 		).put(
 			"title", "name"
+		).put(
+			"relevance", "relevance"
 		).build();
 
 		return new DropdownItemList() {

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -87,8 +87,11 @@ export class DocumentLibraryEditFilePage {
 		await waitForSuccessAlert(this.page);
 	}
 
-	async publishNewBasicFileEntry(title: string) {
-		await this.goto();
+	async publishNewBasicFileEntry(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
 
 		await this.titleSelector.fill(title);
 

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -9,9 +9,12 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 
 export class DocumentLibraryPage {
-	readonly optionsMenu: Locator;
-	readonly page: Page;
 	readonly exportImportOptionsMenuItem: Locator;
+	readonly optionsMenu: Locator;
+	readonly orderMenu: Locator;
+	readonly page: Page;
+	readonly searchButton: Locator;
+	readonly searchInput: Locator;
 
 	constructor(page: Page) {
 		this.exportImportOptionsMenuItem = page.getByRole('menuitem', {
@@ -20,7 +23,14 @@ export class DocumentLibraryPage {
 		this.optionsMenu = page
 			.getByTestId('headerOptions')
 			.getByLabel('Options');
+		this.orderMenu = page.getByLabel('Order');
 		this.page = page;
+		this.searchButton = page.getByRole('button', {
+			name: 'Search for',
+		});
+		this.searchInput = page.getByRole('searchbox', {
+			name: 'Search for:',
+		});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -138,5 +148,16 @@ export class DocumentLibraryPage {
 		await this.optionsMenu
 			.and(this.page.locator('[aria-haspopup]'))
 			.click();
+	}
+	async orderBy(name: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name}),
+			trigger: this.orderMenu,
+		});
+	}
+	async searchInDL(query: string) {
+		await this.searchInput.fill(query);
+		await this.searchButton.click();
 	}
 }

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -41,6 +41,41 @@ export const testFeatureFlagsEnabled = mergeTests(
 export const testUploadMultipleFieldsWithCustomDocumentType =
 	mergeTests(baseTest);
 
+baseTest(
+	'Check order by Relevance in Search of DL',
+	{
+		tag: '@LPD-32481',
+	},
+	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			'test',
+			site.friendlyUrlPath
+		);
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			getRandomString(),
+			site.friendlyUrlPath
+		);
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			getRandomString(),
+			site.friendlyUrlPath
+		);
+		await documentLibraryPage.orderMenu.click();
+		await expect(
+			page.getByRole('menuitem', {name: 'Relevance'})
+		).not.toBeVisible();
+
+		await page.reload();
+
+		await documentLibraryPage.searchInDL('test');
+
+		await documentLibraryPage.orderBy('relevance');
+
+		await expect(
+			page.locator('dd.list-group-item[data-title="test"]')
+		).toHaveAttribute('id', /_entries_1$/);
+	}
+);
+
 testFeatureFlagsEnabled(
 	'LPD-16658 Show a success message after scheduling a new file',
 	async ({documentLibraryEditFilePage, documentLibraryPage, page}) => {


### PR DESCRIPTION
Hi,
May I ask to review this PR?

This is for https://liferay.atlassian.net/browse/LPD-32481.

**As a** content creator,

**I want** my document search results to be ordered by relevance,

**So that** the most pertinent results appear first.

**Requirements:**

New Ordering Option: Introduce a new option in the ordering selector for documents & media labeled “Relevance.” This option should appear the last one on the list.

Ordering by Relevance: When the “Relevance” option is selected, search results should be ordered with the most relevant results appearing first. The ascending/descending option should not appear.

Thanks in Advance!