### PR TITLE
LPD-32949 & LPD-26404 Permissions to be asked during publication and not when autosaving

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4950,6 +4950,19 @@ public class JournalArticleLocalServiceImpl
 
 		updateFriendlyURLs(article, urlTitleMap, serviceContext);
 
+		// Resources
+
+		if (serviceContext.isAddGroupPermissions() ||
+			serviceContext.isAddGuestPermissions()) {
+
+			addArticleResources(
+				article, serviceContext.isAddGroupPermissions(),
+				serviceContext.isAddGuestPermissions());
+		}
+		else {
+			addArticleResources(article, serviceContext.getModelPermissions());
+		}
+
 		// Asset
 
 		if (hasModifiedLatestApprovedVersion(groupId, articleId, version)) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditArticleDisplayContextTest.java
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.test.MockLiferayPortletContext;
+
+import javax.portlet.Portlet;
+import javax.portlet.RenderRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Gergely Szalay
+ */
+@RunWith(Arquillian.class)
+public class JournalEditArticleDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_user = TestPropsValues.getUser();
+	}
+
+	@FeatureFlags("LPD-11228")
+	@Test
+	public void testIsShowPublishModal() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		serviceContext.setCommand(Constants.ADD);
+		serviceContext.setLayoutFullURL("http://localhost");
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
+
+		RenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest(journalArticle);
+
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		mvcPortlet.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+
+		Object journalEditArticleDisplayContext =
+			mockLiferayPortletRenderRequest.getAttribute(
+				"com.liferay.journal.web.internal.display.context." +
+					"JournalEditArticleDisplayContext");
+
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				journalEditArticleDisplayContext, "_isShowPublishModal",
+				new Class<?>[0]));
+
+		journalArticle.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		JournalTestUtil.updateArticle(
+			journalArticle, RandomTestUtil.randomString());
+
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				journalEditArticleDisplayContext, "_isShowPublishModal",
+				new Class<?>[0]));
+	}
+
+	private MockLiferayPortletRenderRequest _getMockLiferayPortletRenderRequest(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.addParameter(
+			"articleId", journalArticle.getArticleId());
+		mockLiferayPortletRenderRequest.addParameter(
+			"resourcePrimKey",
+			String.valueOf(journalArticle.getResourcePrimKey()));
+
+		mockLiferayPortletRenderRequest.addParameter(
+			"mvcRenderCommandName", "/journal/edit_article");
+
+		String path = "/edit_article.jsp";
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			MVCRenderConstants.
+				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
+			new MockLiferayPortletContext(path));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_user));
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(_user);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockLiferayPortletRenderRequest.setParameter("mvcPath", path);
+
+		return mockLiferayPortletRenderRequest;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"
+	)
+	private Portlet _portlet;
+
+	private User _user;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1025,7 +1025,7 @@ public class JournalEditArticleDisplayContext {
 		return "save";
 	}
 
-	public Map<String, Object> getSaveButtonsContext() {
+	public Map<String, Object> getSaveButtonsContext() throws PortalException {
 		return HashMapBuilder.<String, Object>put(
 			"articleId", getArticleId()
 		).put(
@@ -1059,6 +1059,8 @@ public class JournalEditArticleDisplayContext {
 			() -> LanguageUtil.get(_httpServletRequest, getSaveButtonLabel())
 		).put(
 			"selectedLanguageId", getSelectedLanguageId()
+		).put(
+			"showPublishModal", _isShowPublishModal()
 		).put(
 			"timeZone", getTimeZoneName()
 		).put(
@@ -1657,6 +1659,35 @@ public class JournalEditArticleDisplayContext {
 			_httpServletRequest, "showHeader", true);
 
 		return _showHeader;
+	}
+
+	private boolean _isShowPublishModal() throws PortalException {
+		if (_article == null) {
+			return true;
+		}
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-11228")) {
+
+			if (Validator.isNotNull(_article.getArticleId())) {
+				return false;
+			}
+
+			return true;
+		}
+
+		JournalArticle oldestArticle =
+			JournalArticleLocalServiceUtil.getOldestArticle(
+				_article.getGroupId(), _article.getArticleId());
+
+		if ((oldestArticle == null) ||
+			((oldestArticle.getVersion() == _article.getVersion()) &&
+			 (oldestArticle.getStatus() == WorkflowConstants.STATUS_DRAFT))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isWorkflowEnabled() throws PortalException {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -230,12 +230,16 @@ export default function SaveButtons({
 						form={formId}
 						onClick={() => onClick('publish')}
 						symbolLeft="arrow-right-full"
-						type={articleId ? 'submit' : 'button'}
+						type={showPublishModal ? 'button' : 'submit'}
 					>
-						{!showPublishModal
+						{articleId
 							? workflowEnabled
 								? Liferay.Language.get('submit-for-workflow')
-								: Liferay.Language.get('publish')
+								: showPublishModal
+									? Liferay.Language.get(
+											'publish-with-permissions'
+										)
+									: Liferay.Language.get('publish')
 							: workflowEnabled
 								? Liferay.Language.get(
 										'submit-for-workflow-with-permissions'

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -69,7 +69,7 @@ export default function SaveButtons({
 		);
 
 		if (titleInputComponent?.getValue(defaultLanguageId)) {
-			if (!showPublishModal) {
+			if (articleId && !showPublishModal) {
 				handleButtonClick(action);
 			}
 			else {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -24,6 +24,7 @@ export default function SaveButtons({
 	publishButtonLabel,
 	saveButtonLabel,
 	selectedLanguageId,
+	showPublishModal,
 	timeZone,
 	workflowEnabled,
 }) {
@@ -68,7 +69,7 @@ export default function SaveButtons({
 		);
 
 		if (titleInputComponent?.getValue(defaultLanguageId)) {
-			if (articleId) {
+			if (!showPublishModal) {
 				handleButtonClick(action);
 			}
 			else {
@@ -231,7 +232,7 @@ export default function SaveButtons({
 						symbolLeft="arrow-right-full"
 						type={articleId ? 'submit' : 'button'}
 					>
-						{articleId
+						{!showPublishModal
 							? workflowEnabled
 								? Liferay.Language.get('submit-for-workflow')
 								: Liferay.Language.get('publish')

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -69,14 +69,14 @@ export default function PublishModal({
 					/>
 				) : null}
 
-				{!articleId || Liferay.FeatureFlags['LPD-11228'] ? (
+				{(!articleId || Liferay.FeatureFlags['LPD-11228']) && (
 					<div className="mt-3">
 						<PermissionsOptions
 							formId={formId}
 							permissionsURL={permissionsURL}
 						/>
 					</div>
-				) : null}
+				)}
 			</ClayModal.Body>
 
 			<ClayModal.Footer

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -69,14 +69,14 @@ export default function PublishModal({
 					/>
 				) : null}
 
-				{articleId ? null : (
+				{!articleId || Liferay.FeatureFlags['LPD-11228'] ? (
 					<div className="mt-3">
 						<PermissionsOptions
 							formId={formId}
 							permissionsURL={permissionsURL}
 						/>
 					</div>
-				)}
+				) : null}
 			</ClayModal.Body>
 
 			<ClayModal.Footer

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1354,8 +1354,11 @@ baseTest(
 	}
 );
 
-scheduleTest(
+autoSaveAsDraftTest(
 	'Create a web content selecting permissions in the modal',
+	{
+		tag: '@LPD-32949',
+	},
 	async ({journalEditArticlePage, journalPage, page, site}) => {
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
@@ -1378,6 +1381,10 @@ scheduleTest(
 		const title = getRandomString();
 
 		await journalEditArticlePage.fillTitle(title);
+
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,


### PR DESCRIPTION
LPD-32949 & LPD-26404 Permissions to be asked during publication and not when autosaving

# What is this trying to solve?

We want to set the article's permissions the first time we publish the article. So the first time we publish an article we should show the permissions modal.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-32949)
[Link to ticket](https://liferay.atlassian.net/browse/LPD-26404)

# How am I fixing it?

- We have added a property in **"JournalEditArticleDisplayContext.java"** called `showPublishModal` that controlles whether the article has been published or it's in draft.
- Then, from the frontend part, we have adapted the `showPublishModal` condition in order to show the modal the first time we publish the article. 
- Finally, this change needed a change in **"JournalArticleLocalServiceImpl.java** to add the permissions selected when updating the article, as with the autosave the `articleId` will be never null.

# How can I test it?

- Enable FF 'LPD-11228': true,
		'LPD-15596': true,
- Create a WC
- Fill the title 
- Wait for the Autosave indicator
- Click on Publish button
- Select Publish with Permissions
- Select some Permissions
- Publish the article
- Click on the article's kebab > Permissions
- See the permissions selected are enabled

https://github.com/user-attachments/assets/80de53ae-6485-421c-91e6-d2ba8735c6af