### PR TITLE
LPD-31633 Check if Item Selectors Browser Breadcrumb is updated 

### DIFF
--- a/modules/apps/item-selector/test.properties
+++ b/modules/apps/item-selector/test.properties
@@ -23,6 +23,8 @@
     # Relevant
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=item-selector-taglib
+
     modules.includes.required.test.batch.class.names.includes[modules-integration-mysql57-jdk8][relevant][item-selector-rule]=\
         apps/item-selector/**/*Test.java
 

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -116,6 +116,15 @@ export class DocumentLibraryPage {
 			trigger: this.page.getByRole('button', {exact: true, name: 'New'}),
 		});
 	}
+
+	async goToCreateNewFolder() {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Folder'}),
+			trigger: this.page.getByRole('button', {exact: true, name: 'New'}),
+		});
+	}
+
 	async openCreateAIImage() {
 		await this.openNewButton();
 

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -29,6 +29,7 @@ import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/conf
 import {config as frontendTaglibClayConfig} from './tests/frontend-taglib-clay/config';
 import {config as headlessBuilderImplConfig} from './tests/headless-builder-impl/config';
 import {config as headlessBuilderWebConfig} from './tests/headless-builder-web/config';
+import {config as itemSelectorTaglibConfig} from './tests/item-selector-taglib/config';
 import {config as journalWebConfig} from './tests/journal-web/config';
 import {config as knowledgeBaseWebConfig} from './tests/knowledge-base-web/config';
 import {config as layoutAdminWebConfig} from './tests/layout-admin-web/config';
@@ -99,6 +100,7 @@ export default defineConfig({
 		frontendTaglibClayConfig,
 		headlessBuilderImplConfig,
 		headlessBuilderWebConfig,
+		itemSelectorTaglibConfig,
 		jethr0Config,
 		journalWebConfig,
 		knowledgeBaseWebConfig,

--- a/modules/test/playwright/tests/item-selector-taglib/config.ts
+++ b/modules/test/playwright/tests/item-selector-taglib/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'item-selector-taglib',
+	testDir: 'tests/item-selector-taglib',
+};

--- a/modules/test/playwright/tests/item-selector-taglib/itemSelector.spec.ts
+++ b/modules/test/playwright/tests/item-selector-taglib/itemSelector.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+
+const baseTest = mergeTests(
+	documentLibraryPagesTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
+);
+
+baseTest(
+	'Check if Item Selectors Browser Breadcrumb is updated after change folder',
+	{
+		tag: '@LPD-31633',
+	},
+	async ({documentLibraryPage, journalEditArticlePage, page, site}) => {
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.goToCreateNewFolder();
+		const folderName = getRandomString();
+		await page.getByLabel('Name Required').fill(folderName);
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await page.getByLabel('Image', {exact: true}).click();
+
+		const iframeFolder = page
+			.frameLocator('iframe[title="Select Item"]')
+			.getByRole('link', {name: folderName});
+		await iframeFolder.click();
+		await expect(iframeFolder).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/item-selector-taglib/test.properties
+++ b/modules/test/playwright/tests/item-selector-taglib/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+testray.main.component.name=Item Selector

--- a/test.properties
+++ b/test.properties
@@ -4323,6 +4323,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         blogs-web,\
         content-dashboard-web,\
         document-library-web,\
+        item-selector-taglib,\
         journal-web,\
         knowledge-base-web,\
         locked-items-web,\


### PR DESCRIPTION
Hi, 
May I ask to review this PR? 

This is the playwright test for the issue:  https://liferay.atlassian.net/browse/LPS-174323

**Steps to reproduce**
1. Go to Content & Data > Document and Media, and Add Folder
2. Create a WC (or another content)
3. Select on image selector 
4. select the created folder of D&M
**Actual result**
Breadcrumb does not change

Task: https://liferay.atlassian.net/browse/LPD-31633