### PR TITLE
LPD-33132 Posting a Document to Forums

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
@@ -413,7 +413,7 @@ public class EditMessageMVCActionCommand extends BaseMVCActionCommand {
 			WebKeys.THEME_DISPLAY);
 
 		String[] selectedFileNames = ParamUtil.getParameterValues(
-			actionRequest, "selectUploadedFile");
+			actionRequest, "selectUploadedFile", new String[0], false);
 
 		List<FileEntry> tempFileEntries = new ArrayList<>(
 			selectedFileNames.length);


### PR DESCRIPTION
Coming from https://github.com/liferay-content-management/liferay-portal/pull/5737 and resending again because I forgot a change about getting the parameter from the request as you can see in the commit.

https://liferay.atlassian.net/browse/LPD-33132
# What is this trying to solve?

Allow to upload files with comma when we are creating a thread on message board.

# How am I fixing it?

Using another parameter to know the filenames associated with thread instead of the used one.

# How can I test it?

Run included functional test.


https://github.com/user-attachments/assets/32423aac-cb4f-4c5d-99f1-bdf84f442237

