### PR TITLE
LPD-33568 Wrap scale command to escape parentheses

### DIFF
--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
@@ -66,7 +66,7 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 					_getVideoBitRate(videoProperties, containerType)),
 				"-vf",
 				String.format(
-					"scale=min(%d\\,iw):-2",
+					"\"scale=min(%d\\,iw):-2\"",
 					GetterUtil.getInteger(
 						PropsValues.DL_FILE_ENTRY_PREVIEW_VIDEO_WIDTH)),
 				"-r",


### PR DESCRIPTION
# What is this trying to solve?
[LPD-33568](https://liferay.atlassian.net/browse/LPD-33568)
Linux based OS' can't parse the ffmpeg command generated by Liferay

# How am I fixing it?
Based on https://trac.ffmpeg.org/wiki/Scaling we can wrap scale commands in quotes to escape the text in it

# How can you verify that it works?
Run [DLVideoFFMPEGVideoConverterTest.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-video-test/src/testIntegration/java/com/liferay/document/library/video/converter/test/DLVideoFFMPEGVideoConverterTest.java )

# Why doesn't this include any test?
There are already tests that cover this, it is hard to tell why it is not failing. Could be that the CI OS does not have an issue with this.

Cheers,
Balázs