### PR TITLE
LPD-33279 upgrade ddmField and ddmFieldAttribute company id with value

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -40,6 +40,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.5.0
+Liferay-Require-SchemaVersion: 5.5.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -50,12 +50,14 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v5_2_1.WorkflowDefiniti
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_2_2.DLFileEntryDDMFormInstanceRecordUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_3_3.BrowserSnifferTemplateUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_4_5.DDMTemplateLinkUpgradeProcess;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.DDMFieldAttributeUpgradeProcess;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutSerializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesSerializer;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
 import com.liferay.dynamic.data.mapping.spi.converter.SPIDDMFormRuleConverter;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.dynamic.data.mapping.util.DDMDataDefinitionConverter;
@@ -576,6 +578,13 @@ public class DDMServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"5.5.0", "5.5.1",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.
+				DDMFieldUpgradeProcess(_ddmStructureVersionLocalService),
+			new DDMFieldAttributeUpgradeProcess(
+				_ddmStructureVersionLocalService));
 	}
 
 	@Activate
@@ -610,6 +619,9 @@ public class DDMServiceUpgradeStepRegistrator
 
 	@Reference
 	private DDMFormLayoutDeserializer _ddmFormLayoutDeserializer;
+
+	@Reference
+	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Alicia García
+ */
+public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
+
+	public DDMFieldAttributeUpgradeProcess(
+		DDMStructureVersionLocalService ddmStructureVersionLocalService) {
+
+		_ddmStructureVersionLocalService = ddmStructureVersionLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement selectPreparedStatement =
+				connection.prepareStatement(
+					SQLTransformer.transform(
+						StringBundler.concat(
+							"select DDMFieldAttribute.ctCollectionId, ",
+							"DDMFieldAttribute.fieldAttributeId, ",
+							"DDMFieldAttribute.fieldId, ",
+							"DDMField.structureVersionId from ",
+							"DDMFieldAttribute inner join DDMField on ",
+							"DDMFieldAttribute.fieldId = DDMField.fieldId ",
+							"where DDMFieldAttribute.companyId = 0")));
+			PreparedStatement updatePreparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMFieldAttribute set companyId = ? where " +
+						"ctCollectionId = ? and fieldAttributeId = ?")) {
+
+			ResultSet resultSet = selectPreparedStatement.executeQuery();
+
+			while (resultSet.next()) {
+				long structureVersionId = resultSet.getLong(
+					"structureVersionId");
+
+				DDMStructureVersion ddmStructureVersion =
+					_ddmStructureVersionLocalService.fetchDDMStructureVersion(
+						structureVersionId);
+
+				if (ddmStructureVersion == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"DDMStructureVersion not found for field ID " +
+								resultSet.getLong("fieldId"));
+					}
+				}
+				else {
+					updatePreparedStatement.setLong(
+						1, ddmStructureVersion.getCompanyId());
+
+					updatePreparedStatement.setLong(
+						2, resultSet.getLong("ctCollectionId"));
+					updatePreparedStatement.setLong(
+						3, resultSet.getLong("fieldAttributeId"));
+
+					updatePreparedStatement.addBatch();
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Change the company id value for field ",
+								"Attribute ID ",
+								resultSet.getLong("fieldAttributeId"),
+								" from 0 to ",
+								ddmStructureVersion.getCompanyId()));
+					}
+				}
+			}
+
+			updatePreparedStatement.executeBatch();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFieldAttributeUpgradeProcess.class);
+
+	private final DDMStructureVersionLocalService
+		_ddmStructureVersionLocalService;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Alicia García
+ */
+public class DDMFieldUpgradeProcess extends UpgradeProcess {
+
+	public DDMFieldUpgradeProcess(
+		DDMStructureVersionLocalService ddmStructureVersionLocalService) {
+
+		_ddmStructureVersionLocalService = ddmStructureVersionLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement selectPreparedStatement =
+				connection.prepareStatement(
+					SQLTransformer.transform(
+						"select ctCollectionId, fieldId, structureVersionId " +
+							"from DDMField where companyId = 0"));
+			PreparedStatement updatePreparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMField set companyId = ? where ctCollectionId " +
+						"= ? and fieldId = ?")) {
+
+			ResultSet resultSet = selectPreparedStatement.executeQuery();
+
+			while (resultSet.next()) {
+				long structureVersionId = resultSet.getLong(
+					"structureVersionId");
+
+				DDMStructureVersion ddmStructureVersion =
+					_ddmStructureVersionLocalService.fetchDDMStructureVersion(
+						structureVersionId);
+
+				if (ddmStructureVersion == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"DDMStructureVersion not found for field ID " +
+								resultSet.getLong("fieldId"));
+					}
+				}
+				else {
+					updatePreparedStatement.setLong(
+						1, ddmStructureVersion.getCompanyId());
+
+					updatePreparedStatement.setLong(
+						2, resultSet.getLong("ctCollectionId"));
+					updatePreparedStatement.setLong(
+						3, resultSet.getLong("fieldId"));
+
+					updatePreparedStatement.addBatch();
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Change the company id value for field ID ",
+								resultSet.getLong("fieldId"), " from 0 to ",
+								ddmStructureVersion.getCompanyId()));
+					}
+				}
+			}
+
+			updatePreparedStatement.executeBatch();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFieldUpgradeProcess.class);
+
+	private final DDMStructureVersionLocalService
+		_ddmStructureVersionLocalService;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMFieldAttribute;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.persistence.DDMFieldAttributePersistence;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DDMFieldAttributeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			TransactionalTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_originalCompanyId = CompanyThreadLocal.getCompanyId();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_ddmFieldLocalService.deleteDDMFormValues(_STORAGE_ID);
+
+		CompanyThreadLocal.setCompanyId(_originalCompanyId);
+	}
+
+	@Test
+	public void testClassUpgradeProcess() throws Exception {
+		_addDDMValues();
+
+		List<DDMFieldAttribute> ddmFieldAttributes =
+			_ddmFieldAttributePersistence.findByStorageId(_STORAGE_ID);
+
+		List<String> ddmFieldAttributeNames = new ArrayList<>(
+			ddmFieldAttributes.size());
+
+		for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+			ddmFieldAttributeNames.add(ddmFieldAttribute.getAttributeName());
+
+			Assert.assertEquals(0L, ddmFieldAttribute.getCompanyId());
+		}
+
+		_runUpgrade();
+
+		for (String ddmFieldAttributeName : ddmFieldAttributeNames) {
+			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
+				_STORAGE_ID, ddmFieldAttributeName);
+
+			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+				Assert.assertNotEquals(0L, ddmFieldAttribute.getCompanyId());
+			}
+		}
+	}
+
+	private void _addDDMValues() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			RandomTestUtil.randomString());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
+			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
+			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
+			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext());
+
+		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
+
+		ddmFormValues.setDefaultLocale(LocaleUtil.ENGLISH);
+
+		Set<Locale> availableLocales = new LinkedHashSet<>(
+			Arrays.asList(
+				LocaleUtil.CHINA, LocaleUtil.ENGLISH, LocaleUtil.SPAIN));
+
+		ddmFormValues.setAvailableLocales(availableLocales);
+
+		DDMFormFieldValue ddmFormFieldValue = new DDMFormFieldValue();
+
+		ddmFormFieldValue.setName("field1");
+		ddmFormFieldValue.setInstanceId(StringUtil.randomString(8));
+
+		Value value = new LocalizedValue(LocaleUtil.ENGLISH);
+
+		for (Locale locale : availableLocales) {
+			value.addString(locale, LocaleUtil.toLanguageId(locale) + " value");
+		}
+
+		ddmFormFieldValue.setValue(value);
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		_ddmFieldLocalService.updateDDMFormValues(
+			ddmStructure.getStructureId(), _STORAGE_ID, ddmFormValues);
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1." +
+			"DDMFieldAttributeUpgradeProcess";
+
+	private static final long _STORAGE_ID = 0;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMFieldAttributePersistence _ddmFieldAttributePersistence;
+
+	@Inject
+	private DDMFieldLocalService _ddmFieldLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private long _originalCompanyId;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMField;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DDMFieldUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_originalCompanyId = CompanyThreadLocal.getCompanyId();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_ddmFieldLocalService.deleteDDMFormValues(_STORAGE_ID);
+
+		CompanyThreadLocal.setCompanyId(_originalCompanyId);
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			RandomTestUtil.randomString());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
+			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
+			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
+			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext());
+
+		List<DDMStructureVersion> structureVersions =
+			_ddmStructureVersionLocalService.getStructureVersions(
+				ddmStructure.getStructureId());
+
+		DDMStructureVersion ddmStructureVersion = structureVersions.get(0);
+
+		DDMField ddmField = _addDDMField(
+			ddmStructureVersion.getStructureVersionId());
+
+		Assert.assertEquals(CompanyConstants.SYSTEM, ddmField.getCompanyId());
+
+		_runUpgrade();
+
+		ddmField = _ddmFieldLocalService.getDDMField(ddmField.getFieldId());
+
+		Assert.assertNotEquals(
+			CompanyConstants.SYSTEM, ddmField.getCompanyId());
+	}
+
+	private DDMField _addDDMField(long structureVersionId) {
+		DDMField ddmField = _ddmFieldLocalService.createDDMField(
+			_counterLocalService.increment());
+
+		ddmField.setParentFieldId(0);
+		ddmField.setStorageId(_STORAGE_ID);
+		ddmField.setStructureVersionId(structureVersionId);
+		ddmField.setFieldName(RandomTestUtil.randomString());
+		ddmField.setFieldType(DDMFormFieldTypeConstants.TEXT);
+		ddmField.setInstanceId(RandomTestUtil.randomString(8));
+		ddmField.setLocalizable(false);
+		ddmField.setPriority(RandomTestUtil.randomInt());
+
+		return _ddmFieldLocalService.addDDMField(ddmField);
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1." +
+			"DDMFieldUpgradeProcess";
+
+	private static final long _STORAGE_ID = 0;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMFieldLocalService _ddmFieldLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private long _originalCompanyId;
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -13,6 +13,7 @@ import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -22,6 +23,9 @@ import com.liferay.portal.kernel.util.Portal;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -57,41 +61,52 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		long originalCompanyId = CompanyThreadLocal.getCompanyId();
+
 		long classNameId = _classNameLocalService.getClassNameId(
 			JournalArticle.class);
 
-		processConcurrently(
-			"select id_, groupId, content, DDMStructureKey from " +
-				"JournalArticle where ctCollectionId = 0",
-			resultSet -> new Object[] {
-				resultSet.getLong("id_"), resultSet.getLong("groupId"),
-				resultSet.getString("content"),
-				resultSet.getString("DDMStructureKey")
-			},
-			values -> {
-				long id = (Long)values[0];
-				long groupId = (Long)values[1];
+		try {
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						"select id_, groupId, companyId, content, " +
+							"DDMStructureKey from JournalArticle where " +
+								"ctCollectionId = 0");
+				ResultSet resultSet = preparedStatement1.executeQuery()) {
 
-				String content = (String)values[2];
+				while (resultSet.next()) {
+					long id = resultSet.getLong("id_");
+					long groupId = resultSet.getLong("groupId");
 
-				String ddmStructureKey = (String)values[3];
+					CompanyThreadLocal.setCompanyId(
+						resultSet.getLong("companyId"));
 
-				DDMStructure ddmStructure =
-					_ddmStructureLocalService.getStructure(
-						_portal.getSiteGroupId(groupId), classNameId,
-						ddmStructureKey, true);
+					String content = resultSet.getString("content");
 
-				content = _convertFieldNames(content);
+					String ddmStructureKey = resultSet.getString(
+						"DDMStructureKey");
 
-				DDMFormValues ddmFormValues =
-					_fieldsToDDMFormValuesConverter.convert(
-						ddmStructure,
-						_journalConverter.getDDMFields(ddmStructure, content));
+					DDMStructure ddmStructure =
+						_ddmStructureLocalService.getStructure(
+							_portal.getSiteGroupId(groupId), classNameId,
+							ddmStructureKey, true);
 
-				_ddmFieldLocalService.updateDDMFormValues(
-					ddmStructure.getStructureId(), id, ddmFormValues);
-			},
-			null);
+					content = _convertFieldNames(content);
+
+					DDMFormValues ddmFormValues =
+						_fieldsToDDMFormValuesConverter.convert(
+							ddmStructure,
+							_journalConverter.getDDMFields(
+								ddmStructure, content));
+
+					_ddmFieldLocalService.updateDDMFormValues(
+						ddmStructure.getStructureId(), id, ddmFormValues);
+				}
+			}
+		}
+		finally {
+			CompanyThreadLocal.setCompanyId(originalCompanyId);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
LPD-33279 JournalArticleDDMFieldsUpgradeProcess does not fill correctly the companyId Of the ddmFields and ddmFieldAttribute

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33279

`On the com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess` if needed, the company id on the creation of the `ddmField` and `ddmFieldAttribute` is obtained from the `CompanyThreadLocal.getCompanyId()` but because is a upgrade this value is 0.

# How am I fixing it?

On the `com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess` we should fill with the company data from the database.
And because the database can have data with values filled with 0 on `ddmField` and `ddmFieldAttribute`, we should create upgrades for each table with a process to fill this values with the values from the ddmStructure.

# How can you verify that it works?

For the new upgrades: Run the included automated tests.


# Why doesn't this include any test for the JournalArticleDDMFieldsUpgradeProcess?

I don't know how to reproduce it without the client data, **in addition** the failing upgrade is on a datatable version that have **2 columns** that master does not have.



# Commits


- **LPD-33279 populate the CompanyThreadLocal companyId value with the data from the query. We can not use the processConcurrently because the CompanyThreadLocal does not allow the modification on it.**
- **LPD-33279 create upgrade to fill the incorrect data that can be generated by error**
- **LPD-33279 register the new upgrades**
- **LPD-33279 add test to check the new upgrades**
