### PR TITLE
LPD-33707 if instance id of the node is not null, set the text content to random string to prevent duplicate or null data

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -120,6 +121,12 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 			Node node = nodeList.item(i);
 
 			NamedNodeMap namedNodeMap = node.getAttributes();
+
+			Node instanceIdNode = namedNodeMap.getNamedItem("instance-id");
+
+			if (instanceIdNode != null) {
+				instanceIdNode.setTextContent(StringUtil.randomString());
+			}
 
 			Node nameNode = namedNodeMap.getNamedItem("name");
 


### PR DESCRIPTION
LPD-33707 Duplicate Entries for IX_1BB20E75 in DDMField when instance id is null

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33707

On the com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess, depending on the data of the database, the instance-id is null or empty or repeated giving 2 errors, a NPE and the IX_1BB20E75 .

# How am I fixing it?

If the field is not null and is repeated, the IX_1BB20E75 error can happen.
When the values is empty, the `instanceToFieldIdMap.get(ddmFieldInfo._parentInstanceId)` or `instanceToFieldIdMap.get(ddmFieldAttributeInfo._ddmFieldInfo._instanceId)` was throwing a NPE and was masked as a index failure by the batch. 

So set the text content to random string to prevent duplicate or null data solves this.



# How can you verify that it works?

The way to verify this is to reproduce the steps on https://liferay.atlassian.net/browse/LPP-55173


# Why doesn't this include any test?

without the client data and the upgrade from 6.2, I don't know how to reproduce it, **in addition** the failing upgrade is on a database version whose table have **2 columns** that master does not have.

