### PR TITLE
LPD-33791 Empty Radio fields in Web Content give Internal Server Error when requested through headless

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -485,6 +485,10 @@ public class ContentFieldUtil {
 				LocalizedValue selectedOptionLabelLocalizedValue =
 					ddmFormFieldOptions.getOptionLabels(valueString);
 
+				if (selectedOptionLabelLocalizedValue == null) {
+					return new ContentFieldValue();
+				}
+
 				return new ContentFieldValue() {
 					{
 						setData(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -41,6 +41,7 @@ import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.problem.Problem;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentResource;
+import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
@@ -431,6 +432,7 @@ public class StructuredContentResourceTest
 		_testGetStructuredContentWithDifferentFolder();
 		_testGetStructuredContentWithDifferentLocale();
 		_testGetStructuredContentWithDifferentTimeZone();
+		_testGetStructuredContentWithRadioField();
 		_testGetStructuredContentWithRoleAdministrator();
 		_testGetStructuredContentWithRoleOwner();
 		_testGetStructuredContentWithRoleRegularUser();
@@ -1912,6 +1914,27 @@ public class StructuredContentResourceTest
 		finally {
 			_userLocalService.deleteUser(user);
 		}
+	}
+
+	private void _testGetStructuredContentWithRadioField() throws Exception {
+		DDMStructure ddmStructure = _addDDMStructure(
+			testGroup, "test-ddm-structure-radio.json");
+
+		JournalArticle journalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0,
+				_read("test-journal-article-radio.xml"),
+				ddmStructure.getStructureKey(), null, LocaleUtil.US, null,
+				ServiceContextTestUtil.getServiceContext(
+					testCompany.getCompanyId(), testGroup.getGroupId(),
+					TestPropsValues.getUserId()));
+
+		StructuredContent structuredContent =
+			structuredContentResource.getStructuredContent(
+				journalArticle.getResourcePrimKey());
+
+		Assert.assertNotNull(structuredContent.getContentStructureId());
 	}
 
 	private void _testGetStructuredContentWithRoleAdministrator()

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-radio.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-radio.json
@@ -1,0 +1,56 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fields": [
+		{
+			"dataType": "string",
+			"fieldNamespace": "",
+			"fieldReference": "SingleSelection",
+			"indexType": "keyword",
+			"inline": true,
+			"label": {
+				"en_US": "Single Selection"
+			},
+			"localizable": "[#LOCALIZABLE#]",
+			"name": "SingleSelection90775749",
+			"nativeField": false,
+			"options": [
+				{
+					"label": {
+						"en_US": "Option1"
+					},
+					"reference": "",
+					"value": "Option1"
+				},
+				{
+					"label": {
+						"en_US": "Option2"
+					},
+					"reference": "",
+					"value": "Option2"
+				},
+				{
+					"label": {
+						"en_US": "Option3"
+					},
+					"reference": "",
+					"value": "Option3"
+				}
+			],
+			"predefinedValue": {
+				"en_US": "[]"
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"type": "radio",
+			"visibilityExpression": ""
+		}
+	]
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-radio.xml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-radio.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="SingleSelection" index-type="keyword" instance-id="gTvjpM5x" name="SingleSelection" type="radio">
+		<dynamic-content language-id="en_US"><![CDATA[[]]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
# What is this trying to solve?
[LPD-33791](https://liferay.atlassian.net/browse/LPD-33791)

Web contents created with a radio selector without a selected option cause NPE during headless calls

# How am I fixing it?
By returning an empty ContentFieldValue

# How can you verify that it works?
`cd modules/apps/headless/headless-delivery/headless-delivery-test/`
`gw testIntegration --tests StructuredContentResourceTest.testGetStructuredContent`


Cheers,
Balázs