### PR TITLE
LPD-32874 Add resource command for autosave

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
@@ -1,0 +1,347 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
+
+import java.io.ByteArrayOutputStream;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class AutoSaveArticleMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testServeResource() throws Exception {
+		JSONObject jsonObject = _serveResource(
+			_getMockLiferayResourceRequest());
+
+		Assert.assertTrue(jsonObject.getBoolean("success"));
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchArticle(
+				_group.getGroupId(), jsonObject.getString("articleId"));
+
+		Assert.assertNotNull(journalArticle);
+
+		Assert.assertNotNull("title", jsonObject.getString("friendlyURL"));
+
+		Date modifiedDate = journalArticle.getModifiedDate();
+
+		Assert.assertNotNull(modifiedDate);
+		Assert.assertEquals(
+			modifiedDate.getTime(), jsonObject.getLong("modifiedDate"));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, journalArticle.getStatus());
+
+		Assert.assertEquals("1", jsonObject.getString("version"));
+
+		jsonObject = _serveResource(
+			_getMockLiferayResourceRequest(
+				journalArticle.getArticleId(),
+				journalArticle.getFriendlyURLMap()));
+
+		Assert.assertTrue(jsonObject.getBoolean("success"));
+
+		journalArticle = _journalArticleLocalService.fetchArticle(
+			_group.getGroupId(), jsonObject.getString("articleId"));
+
+		Assert.assertFalse(jsonObject.has("friendlyURL"));
+
+		modifiedDate = journalArticle.getModifiedDate();
+
+		Assert.assertNotNull(modifiedDate);
+		Assert.assertEquals(
+			modifiedDate.getTime(), jsonObject.getLong("modifiedDate"));
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, journalArticle.getStatus());
+
+		Assert.assertEquals("1", jsonObject.getString("version"));
+	}
+
+	@Test
+	public void testServeResourceWithErrors() throws Exception {
+		JSONObject jsonObject = _serveResource(
+			_getMockLiferayResourceRequest());
+
+		Assert.assertTrue(jsonObject.getBoolean("success"));
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchArticle(
+				_group.getGroupId(), jsonObject.getString("articleId"));
+
+		jsonObject = _serveResource(
+			_getMockLiferayResourceRequest(
+				journalArticle.getArticleId(), Collections.emptyMap()));
+
+		Assert.assertFalse(jsonObject.getBoolean("success"));
+		Assert.assertEquals(
+			_language.get(
+				_portal.getSiteDefaultLocale(_group),
+				"you-must-define-a-friendly-url-for-the-default-language"),
+			jsonObject.getString("errorMessage"));
+	}
+
+	private MockMultipartHttpServletRequest
+		_createMockMultipartHttpServletRequest() {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+		mockMultipartHttpServletRequest.setContentType(
+			StringBundler.concat(
+				MediaType.MULTIPART_FORM_DATA_VALUE,
+				"; boundary=WebKitFormBoundary", StringUtil.randomString()));
+
+		return mockMultipartHttpServletRequest;
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest()
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			_createMockMultipartHttpServletRequest();
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest(mockMultipartHttpServletRequest);
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.CURRENT_URL, "http://localhost:8080");
+
+		mockMultipartHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				_portletLocalService.getPortletById(JournalPortletKeys.JOURNAL),
+				null));
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			_getThemeDisplay(mockMultipartHttpServletRequest));
+
+		mockLiferayResourceRequest.setParameter(
+			"autoArticleId", StringPool.TRUE);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+			_group.getGroupId(), _portal.getClassNameId(JournalArticle.class),
+			"BASIC-WEB-CONTENT", true);
+
+		mockLiferayResourceRequest.setParameter(
+			"ddmStructureId", String.valueOf(ddmStructure.getStructureId()));
+
+		mockLiferayResourceRequest.setParameter(
+			"ddmTemplateKey", "BASIC-WEB-CONTENT");
+		mockLiferayResourceRequest.setParameter(
+			"descriptionMapAsXML_en_US", "description");
+		mockLiferayResourceRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockLiferayResourceRequest.setParameter("titleMapAsXML_en_US", "title");
+		mockLiferayResourceRequest.setParameter(
+			"workflowAction", String.valueOf(WorkflowConstants.STATUS_DRAFT));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
+			String articleId, Map<Locale, String> friendlyURLMap)
+		throws Exception {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			_getMockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setParameter("articleId", articleId);
+
+		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
+			Locale locale = entry.getKey();
+
+			mockLiferayResourceRequest.setParameter(
+				"friendlyURL_" + locale.toString(), entry.getValue());
+		}
+
+		mockLiferayResourceRequest.setParameter("version", "1");
+
+		return mockLiferayResourceRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(
+			MockMultipartHttpServletRequest mockMultipartHttpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		mockMultipartHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
+
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setRequest(mockMultipartHttpServletRequest);
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private JSONObject _serveResource(
+			MockLiferayResourceRequest mockLiferayResourceRequest)
+		throws Exception {
+
+		try {
+			MockLiferayResourceResponse mockLiferayResourceResponse =
+				new MockLiferayResourceResponse();
+
+			_setUpUploadPortletRequest(mockLiferayResourceRequest);
+
+			_mvcResourceCommand.serveResource(
+				mockLiferayResourceRequest, mockLiferayResourceResponse);
+
+			ByteArrayOutputStream byteArrayOutputStream =
+				(ByteArrayOutputStream)
+					mockLiferayResourceResponse.getPortletOutputStream();
+
+			return JSONFactoryUtil.createJSONObject(
+				byteArrayOutputStream.toString());
+		}
+		finally {
+			if (_mvcResourceCommandPortal != null) {
+				ReflectionTestUtil.setFieldValue(
+					_mvcResourceCommand, "_portal", _mvcResourceCommandPortal);
+			}
+		}
+	}
+
+	private void _setUpUploadPortletRequest(
+		MockLiferayResourceRequest mockLiferayResourceRequest) {
+
+		_mvcResourceCommandPortal = ReflectionTestUtil.getFieldValue(
+			_mvcResourceCommand, "_portal");
+
+		ReflectionTestUtil.setFieldValue(
+			_mvcResourceCommand, "_portal",
+			ProxyUtil.newProxyInstance(
+				AutoSaveArticleMVCResourceCommandTest.class.getClassLoader(),
+				new Class<?>[] {Portal.class},
+				(proxy, method, args) -> {
+					if (Objects.equals(
+							method.getName(), "getUploadPortletRequest")) {
+
+						LiferayPortletRequest liferayPortletRequest =
+							_portal.getLiferayPortletRequest(
+								mockLiferayResourceRequest);
+
+						return UploadTestUtil.createUploadPortletRequest(
+							_portal.getUploadServletRequest(
+								liferayPortletRequest.getHttpServletRequest()),
+							liferayPortletRequest,
+							_portal.getPortletNamespace(
+								liferayPortletRequest.getPortletName()));
+					}
+
+					return method.invoke(_portal, args);
+				}));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private Language _language;
+
+	@Inject(filter = "mvc.command.name=/journal/auto_save_article")
+	private MVCResourceCommand _mvcResourceCommand;
+
+	private Portal _mvcResourceCommandPortal;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
@@ -104,7 +104,7 @@ public class AutoSaveArticleMVCResourceCommandTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, journalArticle.getStatus());
 
-		Assert.assertEquals("1", jsonObject.getString("version"));
+		Assert.assertEquals("1.0", jsonObject.getString("version"));
 
 		jsonObject = _serveResource(
 			_getMockLiferayResourceRequest(
@@ -127,7 +127,7 @@ public class AutoSaveArticleMVCResourceCommandTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, journalArticle.getStatus());
 
-		Assert.assertEquals("1", jsonObject.getString("version"));
+		Assert.assertEquals("1.0", jsonObject.getString("version"));
 	}
 
 	@Test
@@ -229,7 +229,7 @@ public class AutoSaveArticleMVCResourceCommandTest {
 				"friendlyURL_" + locale.toString(), entry.getValue());
 		}
 
-		mockLiferayResourceRequest.setParameter("version", "1");
+		mockLiferayResourceRequest.setParameter("version", "1.0");
 
 		return mockLiferayResourceRequest;
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateArticleMVCResourceCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateArticleMVCResourceCommandTest.java
@@ -1,0 +1,315 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class UpdateArticleMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testServeResource() throws Exception {
+		_processAction(_getMockLiferayPortletActionRequest());
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchArticleByUrlTitle(
+				_group.getGroupId(), "title");
+
+		Assert.assertNotNull(journalArticle);
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, journalArticle.getStatus());
+		Assert.assertEquals(1.0, journalArticle.getVersion(), 0.01);
+
+		_processAction(
+			_getMockLiferayPortletActionRequest(
+				journalArticle.getArticleId(),
+				journalArticle.getFriendlyURLMap()));
+
+		journalArticle = _journalArticleLocalService.fetchArticleByUrlTitle(
+			_group.getGroupId(), "title");
+
+		Assert.assertNotNull(journalArticle);
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, journalArticle.getStatus());
+		Assert.assertEquals(1.1, journalArticle.getVersion(), 0.01);
+	}
+
+	@Test
+	public void testServeResourceWithErrors() throws Exception {
+		_processAction(_getMockLiferayPortletActionRequest());
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.fetchArticleByUrlTitle(
+				_group.getGroupId(), "title");
+
+		Assert.assertNotNull(journalArticle);
+
+		expectedException.expect(PortletException.class);
+
+		_processAction(
+			_getMockLiferayPortletActionRequest(
+				journalArticle.getArticleId(), Collections.emptyMap()));
+	}
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private MockMultipartHttpServletRequest
+		_createMockMultipartHttpServletRequest() {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+		mockMultipartHttpServletRequest.setContentType(
+			StringBundler.concat(
+				MediaType.MULTIPART_FORM_DATA_VALUE,
+				"; boundary=WebKitFormBoundary", StringUtil.randomString()));
+
+		return mockMultipartHttpServletRequest;
+	}
+
+	private MockLiferayPortletActionRequest
+			_getMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			_createMockMultipartHttpServletRequest();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest(
+				mockMultipartHttpServletRequest);
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.CURRENT_URL, "http://localhost:8080");
+
+		mockMultipartHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				_portletLocalService.getPortletById(JournalPortletKeys.JOURNAL),
+				null));
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			_getThemeDisplay(mockMultipartHttpServletRequest));
+
+		mockLiferayPortletActionRequest.setParameter(
+			ActionRequest.ACTION_NAME, "/journal/add_article");
+		mockLiferayPortletActionRequest.setParameter(
+			"autoArticleId", StringPool.TRUE);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+			_group.getGroupId(), _portal.getClassNameId(JournalArticle.class),
+			"BASIC-WEB-CONTENT", true);
+
+		mockLiferayPortletActionRequest.setParameter(
+			"ddmStructureId", String.valueOf(ddmStructure.getStructureId()));
+
+		mockLiferayPortletActionRequest.setParameter(
+			"ddmTemplateKey", "BASIC-WEB-CONTENT");
+		mockLiferayPortletActionRequest.setParameter(
+			"descriptionMapAsXML_en_US", "description");
+		mockLiferayPortletActionRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockLiferayPortletActionRequest.setParameter(
+			"titleMapAsXML_en_US", "title");
+		mockLiferayPortletActionRequest.setParameter(
+			"workflowAction", String.valueOf(WorkflowConstants.STATUS_PENDING));
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+			String articleId, Map<Locale, String> friendlyURLMap)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			ActionRequest.ACTION_NAME, "/journal/update_article");
+		mockLiferayPortletActionRequest.setParameter("articleId", articleId);
+
+		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
+			Locale locale = entry.getKey();
+
+			mockLiferayPortletActionRequest.setParameter(
+				"friendlyURL_" + locale.toString(), entry.getValue());
+		}
+
+		mockLiferayPortletActionRequest.setParameter("version", "1.0");
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(
+			MockMultipartHttpServletRequest mockMultipartHttpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		mockMultipartHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
+
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setRequest(mockMultipartHttpServletRequest);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private void _processAction(
+			MockLiferayPortletActionRequest mockLiferayPortletActionRequest)
+		throws Exception {
+
+		try {
+			_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+
+			_mvcActionCommand.processAction(
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+		}
+		finally {
+			if (_mvcActionCommandPortal != null) {
+				ReflectionTestUtil.setFieldValue(
+					_mvcActionCommand, "_portal", _mvcActionCommandPortal);
+			}
+		}
+	}
+
+	private void _setUpUploadPortletRequest(
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
+
+		_mvcActionCommandPortal = ReflectionTestUtil.getFieldValue(
+			_mvcActionCommand, "_portal");
+
+		ReflectionTestUtil.setFieldValue(
+			_mvcActionCommand, "_portal",
+			ProxyUtil.newProxyInstance(
+				UpdateArticleMVCResourceCommandTest.class.getClassLoader(),
+				new Class<?>[] {Portal.class},
+				(proxy, method, args) -> {
+					if (Objects.equals(
+							method.getName(), "getUploadPortletRequest")) {
+
+						LiferayPortletRequest liferayPortletRequest =
+							_portal.getLiferayPortletRequest(
+								mockLiferayPortletActionRequest);
+
+						return UploadTestUtil.createUploadPortletRequest(
+							_portal.getUploadServletRequest(
+								liferayPortletRequest.getHttpServletRequest()),
+							liferayPortletRequest,
+							_portal.getPortletNamespace(
+								liferayPortletRequest.getPortletName()));
+					}
+
+					return method.invoke(_portal, args);
+				}));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject(filter = "mvc.command.name=/journal/add_article")
+	private MVCActionCommand _mvcActionCommand;
+
+	private Portal _mvcActionCommandPortal;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -32,6 +32,7 @@ import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCriterion;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
@@ -104,6 +105,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 
+import javax.portlet.MimeResponse;
+import javax.portlet.PortletRequest;
 import javax.portlet.RenderResponse;
 
 import javax.servlet.http.HttpServletRequest;
@@ -400,7 +403,9 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"autoSaveDraftURL",
 			ResourceURLBuilder.createResourceURL(
-				_liferayPortletResponse
+				_liferayPortletResponse.createLiferayPortletURL(
+					JournalPortletKeys.JOURNAL, PortletRequest.RESOURCE_PHASE,
+					MimeResponse.Copy.PUBLIC)
 			).setResourceID(
 				"/journal/auto_save_article"
 			).buildString()

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
@@ -396,6 +397,13 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"autoSaveDraftEnabled",
 			FeatureFlagManagerUtil.isEnabled("LPD-11228")
+		).put(
+			"autoSaveDraftURL",
+			ResourceURLBuilder.createResourceURL(
+				_liferayPortletResponse
+			).setResourceID(
+				"/journal/auto_save_article"
+			).buildString()
 		).put(
 			"availableLocales", _getAvailableLanguageIds()
 		).put(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
@@ -132,6 +132,10 @@ public class AutoSaveArticleMVCResourceCommand extends BaseMVCResourceCommand {
 							article.getDefaultLanguageId()));
 				}
 			).put(
+				"modifiedDate",
+				article.getModifiedDate(
+				).getTime()
+			).put(
 				"success", true
 			).put(
 				"version", String.valueOf(article.getVersion())

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
@@ -1,0 +1,154 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action;
+
+import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
+import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.journal.util.JournalConverter;
+import com.liferay.journal.util.JournalHelper;
+import com.liferay.journal.web.internal.util.JournalArticleUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Locale;
+import java.util.Map;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"mvc.command.name=/journal/auto_save_article"
+	},
+	service = MVCResourceCommand.class
+)
+public class AutoSaveArticleMVCResourceCommand extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONObject jsonObject;
+
+		try {
+			UploadPortletRequest uploadPortletRequest =
+				_portal.getUploadPortletRequest(resourceRequest);
+
+			String articleId = ParamUtil.getString(
+				uploadPortletRequest, "articleId");
+
+			JournalArticle journalArticle =
+				_journalArticleLocalService.fetchArticle(
+					ParamUtil.getLong(uploadPortletRequest, "groupId"),
+					articleId);
+
+			String actionName = "/journal/add_article";
+
+			if (journalArticle != null) {
+				actionName = "/journal/update_article";
+			}
+
+			JournalArticle article = JournalArticleUtil.addOrUpdateArticle(
+				actionName, _assetDisplayPageEntryFormProcessor,
+				_ddmFormValuesFactory, _ddmFormValuesToFieldsConverter,
+				_ddmStructureLocalService, _journalArticleService,
+				_journalConverter, _journalHelper, _localization, _portal,
+				resourceRequest);
+
+			jsonObject = JSONUtil.put(
+				"articleId", article.getArticleId()
+			).put(
+				"friendlyURL",
+				() -> {
+					if (Validator.isNotNull(articleId)) {
+						return null;
+					}
+
+					Map<Locale, String> friendlyURLMap =
+						article.getFriendlyURLMap();
+
+					return friendlyURLMap.get(
+						LocaleUtil.fromLanguageId(
+							article.getDefaultLanguageId()));
+				}
+			).put(
+				"success", true
+			).put(
+				"version", String.valueOf(article.getVersion())
+			);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.error("Unable to perform action", exception);
+			}
+
+			jsonObject = JSONUtil.put("success", false);
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AutoSaveArticleMVCResourceCommand.class);
+
+	@Reference
+	private AssetDisplayPageEntryFormProcessor
+		_assetDisplayPageEntryFormProcessor;
+
+	@Reference
+	private DDMFormValuesFactory _ddmFormValuesFactory;
+
+	@Reference
+	private DDMFormValuesToFieldsConverter _ddmFormValuesToFieldsConverter;
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Reference
+	private JournalArticleService _journalArticleService;
+
+	@Reference
+	private JournalConverter _journalConverter;
+
+	@Reference
+	private JournalHelper _journalHelper;
+
+	@Reference
+	private Localization _localization;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AutoSaveArticleMVCResourceCommand.java
@@ -1,40 +1,72 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.journal.web.internal.portlet.action;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
+import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
+import com.liferay.document.library.kernel.exception.FileSizeException;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.dynamic.data.mapping.exception.NoSuchStructureException;
+import com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException;
+import com.liferay.dynamic.data.mapping.exception.StorageFieldRequiredException;
 import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
+import com.liferay.exportimport.kernel.exception.ExportImportContentValidationException;
+import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.exception.ArticleContentException;
+import com.liferay.journal.exception.ArticleContentSizeException;
+import com.liferay.journal.exception.ArticleFriendlyURLException;
+import com.liferay.journal.exception.ArticleIdException;
+import com.liferay.journal.exception.ArticleTitleException;
+import com.liferay.journal.exception.ArticleVersionException;
+import com.liferay.journal.exception.DuplicateArticleIdException;
+import com.liferay.journal.exception.InvalidDDMStructureException;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.model.JournalArticleLocalization;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.util.JournalHelper;
 import com.liferay.journal.web.internal.util.JournalArticleUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.LocaleException;
+import com.liferay.portal.kernel.exception.NoSuchImageException;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.upload.FileItem;
+import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -110,11 +142,231 @@ public class AutoSaveArticleMVCResourceCommand extends BaseMVCResourceCommand {
 				_log.error("Unable to perform action", exception);
 			}
 
-			jsonObject = JSONUtil.put("success", false);
+			jsonObject = JSONUtil.put(
+				"errorMessage", _getErrorMessage(exception, resourceRequest)
+			).put(
+				"success", false
+			);
 		}
 
 		JSONPortletResponseUtil.writeJSON(
 			resourceRequest, resourceResponse, jsonObject);
+	}
+
+	private String _getErrorMessage(
+		Exception exception, ResourceRequest resourceRequest) {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			resourceRequest);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (exception instanceof ArticleContentException) {
+			return _language.get(
+				httpServletRequest, "please-enter-valid-content");
+		}
+		else if (exception instanceof ArticleContentSizeException) {
+			return _language.get(
+				httpServletRequest,
+				"you-have-exceeded-the-maximum-web-content-size-allowed");
+		}
+		else if (exception instanceof ArticleFriendlyURLException) {
+			return _language.get(
+				httpServletRequest,
+				"you-must-define-a-friendly-url-for-the-default-language");
+		}
+		else if (exception instanceof ArticleIdException) {
+			return _language.get(httpServletRequest, "please-enter-a-valid-id");
+		}
+		else if (exception instanceof ArticleTitleException) {
+			return _language.format(
+				httpServletRequest,
+				"please-enter-a-valid-title-for-the-default-language-x",
+				LocaleUtil.toW3cLanguageId(
+					ParamUtil.getString(
+						httpServletRequest, "defaultLanguageId")));
+		}
+		else if (exception instanceof
+					ArticleTitleException.MustNotExceedMaximumLength) {
+
+			return _language.format(
+				httpServletRequest,
+				"please-enter-a-title-with-fewer-than-x-characters",
+				ModelHintsUtil.getMaxLength(
+					JournalArticleLocalization.class.getName(), "title"));
+		}
+		else if (exception instanceof ArticleVersionException) {
+			return _language.get(
+				httpServletRequest,
+				"another-user-has-made-changes-since-you-started-editing");
+		}
+		else if (exception instanceof DuplicateArticleIdException) {
+			return _language.get(
+				httpServletRequest, "please-enter-a-unique-id");
+		}
+		else if (exception instanceof DuplicateFileEntryException) {
+			return _language.get(
+				httpServletRequest, "a-file-with-that-name-already-exists");
+		}
+		else if (exception instanceof ExportImportContentValidationException) {
+			ExportImportContentValidationException
+				exportImportContentValidationException =
+					(ExportImportContentValidationException)exception;
+
+			if (exportImportContentValidationException.getType() ==
+					ExportImportContentValidationException.ARTICLE_NOT_FOUND) {
+
+				return _language.get(
+					httpServletRequest,
+					"unable-to-validate-referenced-web-content-article");
+			}
+			else if (exportImportContentValidationException.getType() ==
+						ExportImportContentValidationException.
+							FILE_ENTRY_NOT_FOUND) {
+
+				return _language.format(
+					httpServletRequest,
+					"unable-to-validate-referenced-document-because-it-" +
+						"cannot-be-found-with-the-following-parameters-x-" +
+							"when-analyzing-link-x",
+					new String[] {
+						MapUtil.toString(
+							exportImportContentValidationException.
+								getDlReferenceParameters()),
+						exportImportContentValidationException.getDlReference()
+					});
+			}
+			else if (exportImportContentValidationException.getType() ==
+						ExportImportContentValidationException.
+							JOURNAL_FEED_NOT_FOUND) {
+
+				return _language.format(
+					httpServletRequest,
+					"unable-to-validate-referenced-journal-feed-because-it-" +
+						"cannot-be-found-with-url-x",
+					exportImportContentValidationException.
+						getJournalArticleFeedURL());
+			}
+			else if (exportImportContentValidationException.getType() ==
+						ExportImportContentValidationException.
+							LAYOUT_GROUP_NOT_FOUND) {
+
+				return _language.format(
+					httpServletRequest,
+					"unable-to-validate-referenced-page-with-url-x-because-" +
+						"the-page-group-with-url-x-cannot-be-found",
+					new String[] {
+						exportImportContentValidationException.getLayoutURL(),
+						exportImportContentValidationException.
+							getGroupFriendlyURL()
+					});
+			}
+			else if (exportImportContentValidationException.getType() ==
+						ExportImportContentValidationException.
+							LAYOUT_NOT_FOUND) {
+
+				return _language.format(
+					httpServletRequest,
+					"unable-to-validate-referenced-page-because-it-cannot-be-" +
+						"found-with-the-following-parameters-x",
+					MapUtil.toString(
+						exportImportContentValidationException.
+							getLayoutReferenceParameters()));
+			}
+			else if (exportImportContentValidationException.getType() ==
+						ExportImportContentValidationException.
+							LAYOUT_WITH_URL_NOT_FOUND) {
+
+				return _language.format(
+					httpServletRequest,
+					"unable-to-validate-referenced-page-because-it-cannot-be-" +
+						"found-with-url-x",
+					exportImportContentValidationException.getLayoutURL());
+			}
+		}
+		else if (exception instanceof FileSizeException) {
+			FileSizeException fileSizeException = (FileSizeException)exception;
+
+			return _language.format(
+				httpServletRequest,
+				"please-enter-a-file-with-a-valid-file-size-no-larger-than-x",
+				_language.formatStorageSize(
+					fileSizeException.getMaxSize(), themeDisplay.getLocale()),
+				false);
+		}
+		else if (exception instanceof InvalidDDMStructureException) {
+			return _language.get(
+				httpServletRequest,
+				"the-structure-you-selected-is-not-valid-for-this-folder");
+		}
+		else if (exception instanceof LiferayFileItemException) {
+			return _language.format(
+				httpServletRequest,
+				"please-enter-valid-content-with-valid-content-size-no-" +
+					"larger-than-x",
+				_language.formatStorageSize(
+					FileItem.THRESHOLD_SIZE, themeDisplay.getLocale()),
+				false);
+		}
+		else if (exception instanceof LocaleException) {
+			LocaleException localeException = (LocaleException)exception;
+
+			if (localeException.getType() == LocaleException.TYPE_CONTENT) {
+				return _language.format(
+					httpServletRequest,
+					"the-default-language-x-does-not-match-the-portal's-" +
+						"available-languages-x",
+					new String[] {
+						StringUtil.merge(
+							localeException.getSourceAvailableLanguageIds(),
+							StringPool.COMMA_AND_SPACE),
+						StringUtil.merge(
+							localeException.getTargetAvailableLanguageIds(),
+							StringPool.COMMA_AND_SPACE)
+					});
+			}
+		}
+		else if (exception instanceof NoSuchFileEntryException) {
+			return _language.get(
+				httpServletRequest,
+				"the-content-references-a-missing-file-entry");
+		}
+		else if (exception instanceof NoSuchImageException) {
+			return _language.get(
+				httpServletRequest, "please-select-an-existing-small-image");
+		}
+		else if (exception instanceof NoSuchLayoutException) {
+			NoSuchLayoutException noSuchLayoutException =
+				(NoSuchLayoutException)exception;
+
+			if (Objects.equals(
+					noSuchLayoutException.getMessage(),
+					JournalArticleConstants.DISPLAY_PAGE)) {
+
+				return _language.get(
+					httpServletRequest,
+					"please-select-an-existing-display-page-template");
+			}
+
+			return _language.get(
+				httpServletRequest, "the-content-references-a-missing-page");
+		}
+		else if (exception instanceof NoSuchStructureException) {
+			return _language.get(
+				httpServletRequest, "please-select-an-existing-structure");
+		}
+		else if (exception instanceof NoSuchTemplateException) {
+			return _language.get(
+				httpServletRequest, "please-select-an-existing-template");
+		}
+		else if (exception instanceof StorageFieldRequiredException) {
+			return _language.get(
+				httpServletRequest, "please-fill-out-all-required-fields");
+		}
+
+		return _language.get(
+			httpServletRequest, "an-unexpected-error-occurred");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -144,6 +396,9 @@ public class AutoSaveArticleMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private JournalHelper _journalHelper;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private Localization _localization;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -461,8 +461,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private String _getSaveAndContinueRedirect(
-		String actionName, ActionRequest actionRequest, JournalArticle article,
-		String redirect) {
+		ActionRequest actionRequest, JournalArticle article, String redirect) {
 
 		return PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(
@@ -478,21 +477,6 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			"articleId", article.getArticleId()
 		).setParameter(
 			"folderId", article.getFolderId()
-		).setParameter(
-			"friendlyURL",
-			() -> {
-				if (!FeatureFlagManagerUtil.isEnabled("LPD-11228") ||
-					!Objects.equals(actionName, "/journal/add_article")) {
-
-					return null;
-				}
-
-				Map<Locale, String> friendlyURLMap =
-					article.getFriendlyURLMap();
-
-				return friendlyURLMap.get(
-					LocaleUtil.fromLanguageId(article.getDefaultLanguageId()));
-			}
 		).setParameter(
 			"groupId", article.getGroupId()
 		).setParameter(
@@ -569,7 +553,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			(workflowAction == WorkflowConstants.ACTION_SAVE_DRAFT)) {
 
 			redirect = _getSaveAndContinueRedirect(
-				actionName, actionRequest, article, redirect);
+				actionRequest, article, redirect);
 		}
 		else {
 			redirect = _portal.escapeRedirect(redirect);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -5,17 +5,12 @@
 
 package com.liferay.journal.web.internal.portlet.action;
 
-import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
-import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
-import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.exception.ArticleContentSizeException;
 import com.liferay.journal.model.JournalArticle;
@@ -24,6 +19,7 @@ import com.liferay.journal.service.JournalArticleService;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.util.JournalHelper;
 import com.liferay.journal.web.internal.asset.model.JournalArticleAssetRenderer;
+import com.liferay.journal.web.internal.util.JournalArticleUtil;
 import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.petra.string.StringBundler;
@@ -31,10 +27,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -58,19 +51,14 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.util.PropsValues;
-
-import java.io.File;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -127,268 +115,35 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			throw new PortalException(throwable);
 		}
 
-		UploadPortletRequest uploadPortletRequest =
-			_portal.getUploadPortletRequest(actionRequest);
-
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Updating article " +
-					MapUtil.toString(uploadPortletRequest.getParameterMap()));
-		}
-
 		String actionName = ParamUtil.getString(
 			actionRequest, ActionRequest.ACTION_NAME);
 
+		UploadPortletRequest uploadPortletRequest =
+			_portal.getUploadPortletRequest(actionRequest);
+
 		long groupId = ParamUtil.getLong(uploadPortletRequest, "groupId");
 
-		long folderId = ParamUtil.getLong(uploadPortletRequest, "folderId");
-
-		long newFolderId = ParamUtil.getLong(
-			uploadPortletRequest, "newFolderId");
-
-		if (newFolderId > 0) {
-			folderId = newFolderId;
-		}
-
-		String articleId = ParamUtil.getString(
-			uploadPortletRequest, "articleId");
-
-		Map<Locale, String> titleMap = _localization.getLocalizationMap(
-			actionRequest, "titleMapAsXML");
-
-		long ddmStructureId = ParamUtil.getLong(
-			uploadPortletRequest, "ddmStructureId");
-
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
-			ddmStructureId);
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			JournalArticle.class.getName(), uploadPortletRequest);
-
-		DDMFormValues ddmFormValues = _ddmFormValuesFactory.create(
-			actionRequest, ddmStructure.getDDMForm());
-
-		Fields fields = _ddmFormValuesToFieldsConverter.convert(
-			ddmStructure, ddmFormValues);
-
-		String content = _journalConverter.getContent(
-			ddmStructure, fields, groupId);
-
-		Map<Locale, String> descriptionMap = _localization.getLocalizationMap(
-			actionRequest, "descriptionMapAsXML");
-		Map<Locale, String> friendlyURLMap = _localization.getLocalizationMap(
-			actionRequest, "friendlyURL");
-
-		String ddmTemplateKey = ParamUtil.getString(
-			uploadPortletRequest, "ddmTemplateKey");
-		int displayPageType = ParamUtil.getInteger(
-			uploadPortletRequest, "displayPageType");
-
-		String layoutUuid = ParamUtil.getString(
-			uploadPortletRequest, "layoutUuid");
-
-		JournalArticle latestArticle = _journalArticleService.fetchArticle(
-			groupId, articleId);
-
-		if ((displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) ||
-			(displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC)) {
-
-			Layout targetLayout = _journalHelper.getArticleLayout(
-				layoutUuid, groupId);
-
-			if ((displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) &&
-				(targetLayout == null) && (latestArticle != null) &&
-				Validator.isNotNull(latestArticle.getLayoutUuid())) {
-
-				Layout latestTargetLayout = _journalHelper.getArticleLayout(
-					latestArticle.getLayoutUuid(), groupId);
-
-				if (latestTargetLayout == null) {
-					layoutUuid = latestArticle.getLayoutUuid();
-				}
-			}
-			else if ((displayPageType ==
-						AssetDisplayPageConstants.TYPE_DEFAULT) ||
-					 (targetLayout == null)) {
-
-				layoutUuid = null;
-			}
-		}
-		else {
-			layoutUuid = null;
-		}
-
-		int displayDateMonth = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateMonth");
-		int displayDateDay = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateDay");
-		int displayDateYear = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateYear");
-		int displayDateHour = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateHour");
-		int displayDateMinute = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateMinute");
-		int displayDateAmPm = ParamUtil.getInteger(
-			uploadPortletRequest, "displayDateAmPm");
-
-		if (displayDateAmPm == Calendar.PM) {
-			displayDateHour += 12;
-		}
-
-		int expirationDateMonth = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateMonth");
-		int expirationDateDay = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateDay");
-		int expirationDateYear = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateYear");
-		int expirationDateHour = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateHour");
-		int expirationDateMinute = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateMinute");
-		int expirationDateAmPm = ParamUtil.getInteger(
-			uploadPortletRequest, "expirationDateAmPm");
-
-		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire", expirationDateYear == 0);
-
-		if (!PropsValues.SCHEDULER_ENABLED) {
-			neverExpire = true;
-		}
-
-		if (expirationDateAmPm == Calendar.PM) {
-			expirationDateHour += 12;
-		}
-
-		int reviewDateMonth = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateMonth");
-		int reviewDateDay = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateDay");
-		int reviewDateYear = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateYear");
-		int reviewDateHour = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateHour");
-		int reviewDateMinute = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateMinute");
-		int reviewDateAmPm = ParamUtil.getInteger(
-			uploadPortletRequest, "reviewDateAmPm");
-
-		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview", reviewDateYear == 0);
-
-		if (!PropsValues.SCHEDULER_ENABLED) {
-			neverReview = true;
-		}
-
-		if (reviewDateAmPm == Calendar.PM) {
-			reviewDateHour += 12;
-		}
-
-		boolean indexable = ParamUtil.getBoolean(
-			uploadPortletRequest, "indexable");
-
-		int smallImageSource = ParamUtil.getInteger(
-			uploadPortletRequest, "smallImageSource",
-			JournalArticleConstants.SMALL_IMAGE_SOURCE_NONE);
-
-		boolean smallImage = false;
-
-		if (smallImageSource !=
-				JournalArticleConstants.SMALL_IMAGE_SOURCE_NONE) {
-
-			smallImage = true;
-		}
-
-		long smallImageId = 0;
-		String smallImageURL = StringPool.BLANK;
-		File smallFile = null;
-
-		if (smallImageSource ==
-				JournalArticleConstants.
-					SMALL_IMAGE_SOURCE_DOCUMENTS_AND_MEDIA) {
-
-			smallImageId = ParamUtil.getLong(
-				uploadPortletRequest, "smallImageId");
-		}
-		else if (smallImageSource ==
-					JournalArticleConstants.SMALL_IMAGE_SOURCE_URL) {
-
-			smallImageURL = ParamUtil.getString(
-				uploadPortletRequest, "smallImageURL");
-		}
-		else if (smallImageSource ==
-					JournalArticleConstants.SMALL_IMAGE_SOURCE_USER_COMPUTER) {
-
-			smallFile = uploadPortletRequest.getFile("smallFile");
-
-			if (((smallFile == null) || (smallFile.length() == 0)) &&
-				(latestArticle != null)) {
-
-				smallImageId = latestArticle.getSmallImageId();
-			}
-		}
-
-		String articleURL = ParamUtil.getString(
-			uploadPortletRequest, "articleURL");
-
-		serviceContext.setAttribute(
-			"updateAutoTags",
-			ParamUtil.getBoolean(actionRequest, "updateAutoTags"));
-
-		JournalArticle article = null;
 		String oldUrlTitle = StringPool.BLANK;
 
-		if (actionName.equals("/journal/add_article")) {
+		String tempOldUrlTitle = StringPool.BLANK;
 
-			// Add article
+		if (!actionName.equals("/journal/add_article")) {
+			JournalArticle article = _journalArticleService.getArticle(
+				groupId, ParamUtil.getString(uploadPortletRequest, "articleId"),
+				ParamUtil.getDouble(uploadPortletRequest, "version"));
 
-			long classNameId = ParamUtil.getLong(
-				uploadPortletRequest, "classNameId");
-			long classPK = ParamUtil.getLong(uploadPortletRequest, "classPK");
-			boolean autoArticleId = ParamUtil.getBoolean(
-				uploadPortletRequest, "autoArticleId");
-
-			article = _journalArticleService.addArticle(
-				null, groupId, folderId, classNameId, classPK, articleId,
-				autoArticleId, titleMap, descriptionMap, friendlyURLMap,
-				content, ddmStructureId, ddmTemplateKey, layoutUuid,
-				displayDateMonth, displayDateDay, displayDateYear,
-				displayDateHour, displayDateMinute, expirationDateMonth,
-				expirationDateDay, expirationDateYear, expirationDateHour,
-				expirationDateMinute, neverExpire, reviewDateMonth,
-				reviewDateDay, reviewDateYear, reviewDateHour, reviewDateMinute,
-				neverReview, indexable, smallImage, smallImageId,
-				smallImageSource, smallImageURL, smallFile, null, articleURL,
-				serviceContext);
+			tempOldUrlTitle = article.getUrlTitle();
 		}
-		else {
 
-			// Update article
+		JournalArticle article = JournalArticleUtil.addOrUpdateArticle(
+			actionName, _assetDisplayPageEntryFormProcessor,
+			_ddmFormValuesFactory, _ddmFormValuesToFieldsConverter,
+			_ddmStructureLocalService, _journalArticleService,
+			_journalConverter, _journalHelper, _localization, _portal,
+			actionRequest);
 
-			double version = ParamUtil.getDouble(
-				uploadPortletRequest, "version");
-
-			article = _journalArticleService.getArticle(
-				groupId, articleId, version);
-
-			String tempOldUrlTitle = article.getUrlTitle();
-
-			if (actionName.equals("/journal/update_article")) {
-				article = _journalArticleService.updateArticle(
-					groupId, folderId, articleId, version, titleMap,
-					descriptionMap, friendlyURLMap, content, ddmTemplateKey,
-					layoutUuid, displayDateMonth, displayDateDay,
-					displayDateYear, displayDateHour, displayDateMinute,
-					expirationDateMonth, expirationDateDay, expirationDateYear,
-					expirationDateHour, expirationDateMinute, neverExpire,
-					reviewDateMonth, reviewDateDay, reviewDateYear,
-					reviewDateHour, reviewDateMinute, neverReview, indexable,
-					smallImage, smallImageId, smallImageSource, smallImageURL,
-					smallFile, null, articleURL, serviceContext);
-			}
-
-			if (!tempOldUrlTitle.equals(article.getUrlTitle())) {
-				oldUrlTitle = tempOldUrlTitle;
-			}
+		if (!tempOldUrlTitle.equals(article.getUrlTitle())) {
+			oldUrlTitle = tempOldUrlTitle;
 		}
 
 		// Journal content
@@ -423,6 +178,14 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			}
 
 			if (assetEntry != null) {
+				ServiceContext serviceContext =
+					ServiceContextFactory.getInstance(
+						JournalArticle.class.getName(), uploadPortletRequest);
+
+				serviceContext.setAttribute(
+					"updateAutoTags",
+					ParamUtil.getBoolean(actionRequest, "updateAutoTags"));
+
 				_updateLayoutClassedModelUsage(
 					groupId,
 					_portal.getClassNameId(JournalArticle.class.getName()),
@@ -432,10 +195,6 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		// Asset display page
-
-		_assetDisplayPageEntryFormProcessor.process(
-			JournalArticle.class.getName(), article.getResourcePrimKey(),
-			actionRequest);
 
 		int workflowAction = ParamUtil.getInteger(
 			actionRequest, "workflowAction", WorkflowConstants.ACTION_PUBLISH);
@@ -463,9 +222,17 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 					User user = themeDisplay.getUser();
 
 					Date displayDate = _portal.getDate(
-						displayDateMonth, displayDateDay, displayDateYear,
-						displayDateHour, displayDateMinute, user.getTimeZone(),
-						null);
+						ParamUtil.getInteger(
+							uploadPortletRequest, "displayDateMonth"),
+						ParamUtil.getInteger(
+							uploadPortletRequest, "displayDateDay"),
+						ParamUtil.getInteger(
+							uploadPortletRequest, "displayDateYear"),
+						ParamUtil.getInteger(
+							uploadPortletRequest, "displayDateHour"),
+						ParamUtil.getInteger(
+							uploadPortletRequest, "displayDateMinute"),
+						user.getTimeZone(), null);
 
 					if (displayDate != null) {
 						MultiSessionMessages.add(
@@ -507,6 +274,9 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			actionRequest);
+
+		Map<Locale, String> friendlyURLMap = _localization.getLocalizationMap(
+			actionRequest, "friendlyURL");
 
 		Map<String, String> friendlyURLWarningMessages =
 			_getFriendlyURLWarningMessages(
@@ -862,9 +632,6 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			groupId, classNameId, classPK, StringPool.BLANK, portletResource,
 			_portal.getClassNameId(Portlet.class), plid, serviceContext);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		UpdateArticleMVCActionCommand.class);
 
 	@Reference
 	private AssetDisplayPageEntryFormProcessor

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -12,7 +12,6 @@ import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
 import com.liferay.journal.constants.JournalPortletKeys;
-import com.liferay.journal.exception.ArticleContentSizeException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleService;
@@ -24,7 +23,6 @@ import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -41,8 +39,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.upload.LiferayFileItemException;
-import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -94,26 +90,6 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 	protected void doProcessAction(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
-
-		UploadException uploadException =
-			(UploadException)actionRequest.getAttribute(
-				WebKeys.UPLOAD_EXCEPTION);
-
-		if (uploadException != null) {
-			Throwable throwable = uploadException.getCause();
-
-			if (uploadException.isExceededLiferayFileItemSizeLimit()) {
-				throw new LiferayFileItemException(throwable);
-			}
-
-			if (uploadException.isExceededFileSizeLimit() ||
-				uploadException.isExceededUploadRequestSizeLimit()) {
-
-				throw new ArticleContentSizeException(throwable);
-			}
-
-			throw new PortalException(throwable);
-		}
 
 		String actionName = ParamUtil.getString(
 			actionRequest, ActionRequest.ACTION_NAME);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
@@ -14,22 +14,27 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
 import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.exception.ArticleContentSizeException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.util.JournalHelper;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.upload.LiferayFileItemException;
+import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -57,6 +62,26 @@ public class JournalArticleUtil {
 			Localization localization, Portal portal,
 			PortletRequest portletRequest)
 		throws Exception {
+
+		UploadException uploadException =
+			(UploadException)portletRequest.getAttribute(
+				WebKeys.UPLOAD_EXCEPTION);
+
+		if (uploadException != null) {
+			Throwable throwable = uploadException.getCause();
+
+			if (uploadException.isExceededLiferayFileItemSizeLimit()) {
+				throw new LiferayFileItemException(throwable);
+			}
+
+			if (uploadException.isExceededFileSizeLimit() ||
+				uploadException.isExceededUploadRequestSizeLimit()) {
+
+				throw new ArticleContentSizeException(throwable);
+			}
+
+			throw new PortalException(throwable);
+		}
 
 		UploadPortletRequest uploadPortletRequest =
 			portal.getUploadPortletRequest(portletRequest);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
@@ -1,0 +1,325 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.util;
+
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.portlet.AssetDisplayPageEntryFormProcessor;
+import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.journal.util.JournalConverter;
+import com.liferay.journal.util.JournalHelper;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+public class JournalArticleUtil {
+
+	public static JournalArticle addOrUpdateArticle(
+			String actionName,
+			AssetDisplayPageEntryFormProcessor
+				assetDisplayPageEntryFormProcessor,
+			DDMFormValuesFactory ddmFormValuesFactory,
+			DDMFormValuesToFieldsConverter ddmFormValuesToFieldsConverter,
+			DDMStructureLocalService ddmStructureLocalService,
+			JournalArticleService journalArticleService,
+			JournalConverter journalConverter, JournalHelper journalHelper,
+			Localization localization, Portal portal,
+			PortletRequest portletRequest)
+		throws Exception {
+
+		UploadPortletRequest uploadPortletRequest =
+			portal.getUploadPortletRequest(portletRequest);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Updating article " +
+					MapUtil.toString(uploadPortletRequest.getParameterMap()));
+		}
+
+		long groupId = ParamUtil.getLong(uploadPortletRequest, "groupId");
+
+		long folderId = ParamUtil.getLong(uploadPortletRequest, "folderId");
+
+		long newFolderId = ParamUtil.getLong(
+			uploadPortletRequest, "newFolderId");
+
+		if (newFolderId > 0) {
+			folderId = newFolderId;
+		}
+
+		String articleId = ParamUtil.getString(
+			uploadPortletRequest, "articleId");
+
+		Map<Locale, String> titleMap = localization.getLocalizationMap(
+			portletRequest, "titleMapAsXML");
+
+		long ddmStructureId = ParamUtil.getLong(
+			uploadPortletRequest, "ddmStructureId");
+
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
+			ddmStructureId);
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			JournalArticle.class.getName(), uploadPortletRequest);
+
+		DDMFormValues ddmFormValues = ddmFormValuesFactory.create(
+			portletRequest, ddmStructure.getDDMForm());
+
+		Fields fields = ddmFormValuesToFieldsConverter.convert(
+			ddmStructure, ddmFormValues);
+
+		String content = journalConverter.getContent(
+			ddmStructure, fields, groupId);
+
+		Map<Locale, String> descriptionMap = localization.getLocalizationMap(
+			portletRequest, "descriptionMapAsXML");
+		Map<Locale, String> friendlyURLMap = localization.getLocalizationMap(
+			portletRequest, "friendlyURL");
+
+		String ddmTemplateKey = ParamUtil.getString(
+			uploadPortletRequest, "ddmTemplateKey");
+		int displayPageType = ParamUtil.getInteger(
+			uploadPortletRequest, "displayPageType");
+
+		String layoutUuid = ParamUtil.getString(
+			uploadPortletRequest, "layoutUuid");
+
+		JournalArticle latestArticle = journalArticleService.fetchArticle(
+			groupId, articleId);
+
+		if ((displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) ||
+			(displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC)) {
+
+			Layout targetLayout = journalHelper.getArticleLayout(
+				layoutUuid, groupId);
+
+			if ((displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) &&
+				(targetLayout == null) && (latestArticle != null) &&
+				Validator.isNotNull(latestArticle.getLayoutUuid())) {
+
+				Layout latestTargetLayout = journalHelper.getArticleLayout(
+					latestArticle.getLayoutUuid(), groupId);
+
+				if (latestTargetLayout == null) {
+					layoutUuid = latestArticle.getLayoutUuid();
+				}
+			}
+			else if ((displayPageType ==
+						AssetDisplayPageConstants.TYPE_DEFAULT) ||
+					 (targetLayout == null)) {
+
+				layoutUuid = null;
+			}
+		}
+		else {
+			layoutUuid = null;
+		}
+
+		int displayDateMonth = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateMonth");
+		int displayDateDay = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateDay");
+		int displayDateYear = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateYear");
+		int displayDateHour = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateHour");
+		int displayDateMinute = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateMinute");
+		int displayDateAmPm = ParamUtil.getInteger(
+			uploadPortletRequest, "displayDateAmPm");
+
+		if (displayDateAmPm == Calendar.PM) {
+			displayDateHour += 12;
+		}
+
+		int expirationDateMonth = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateMonth");
+		int expirationDateDay = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateDay");
+		int expirationDateYear = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateYear");
+		int expirationDateHour = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateHour");
+		int expirationDateMinute = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateMinute");
+		int expirationDateAmPm = ParamUtil.getInteger(
+			uploadPortletRequest, "expirationDateAmPm");
+
+		boolean neverExpire = ParamUtil.getBoolean(
+			uploadPortletRequest, "neverExpire", expirationDateYear == 0);
+
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			neverExpire = true;
+		}
+
+		if (expirationDateAmPm == Calendar.PM) {
+			expirationDateHour += 12;
+		}
+
+		int reviewDateMonth = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateMonth");
+		int reviewDateDay = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateDay");
+		int reviewDateYear = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateYear");
+		int reviewDateHour = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateHour");
+		int reviewDateMinute = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateMinute");
+		int reviewDateAmPm = ParamUtil.getInteger(
+			uploadPortletRequest, "reviewDateAmPm");
+
+		boolean neverReview = ParamUtil.getBoolean(
+			uploadPortletRequest, "neverReview", reviewDateYear == 0);
+
+		if (!PropsValues.SCHEDULER_ENABLED) {
+			neverReview = true;
+		}
+
+		if (reviewDateAmPm == Calendar.PM) {
+			reviewDateHour += 12;
+		}
+
+		boolean indexable = ParamUtil.getBoolean(
+			uploadPortletRequest, "indexable");
+
+		int smallImageSource = ParamUtil.getInteger(
+			uploadPortletRequest, "smallImageSource",
+			JournalArticleConstants.SMALL_IMAGE_SOURCE_NONE);
+
+		boolean smallImage = false;
+
+		if (smallImageSource !=
+				JournalArticleConstants.SMALL_IMAGE_SOURCE_NONE) {
+
+			smallImage = true;
+		}
+
+		long smallImageId = 0;
+		String smallImageURL = StringPool.BLANK;
+		File smallFile = null;
+
+		if (smallImageSource ==
+				JournalArticleConstants.
+					SMALL_IMAGE_SOURCE_DOCUMENTS_AND_MEDIA) {
+
+			smallImageId = ParamUtil.getLong(
+				uploadPortletRequest, "smallImageId");
+		}
+		else if (smallImageSource ==
+					JournalArticleConstants.SMALL_IMAGE_SOURCE_URL) {
+
+			smallImageURL = ParamUtil.getString(
+				uploadPortletRequest, "smallImageURL");
+		}
+		else if (smallImageSource ==
+					JournalArticleConstants.SMALL_IMAGE_SOURCE_USER_COMPUTER) {
+
+			smallFile = uploadPortletRequest.getFile("smallFile");
+
+			if (((smallFile == null) || (smallFile.length() == 0)) &&
+				(latestArticle != null)) {
+
+				smallImageId = latestArticle.getSmallImageId();
+			}
+		}
+
+		String articleURL = ParamUtil.getString(
+			uploadPortletRequest, "articleURL");
+
+		serviceContext.setAttribute(
+			"updateAutoTags",
+			ParamUtil.getBoolean(portletRequest, "updateAutoTags"));
+
+		JournalArticle article = null;
+
+		if (actionName.equals("/journal/add_article")) {
+
+			// Add article
+
+			long classNameId = ParamUtil.getLong(
+				uploadPortletRequest, "classNameId");
+			long classPK = ParamUtil.getLong(uploadPortletRequest, "classPK");
+			boolean autoArticleId = ParamUtil.getBoolean(
+				uploadPortletRequest, "autoArticleId");
+
+			article = journalArticleService.addArticle(
+				null, groupId, folderId, classNameId, classPK, articleId,
+				autoArticleId, titleMap, descriptionMap, friendlyURLMap,
+				content, ddmStructureId, ddmTemplateKey, layoutUuid,
+				displayDateMonth, displayDateDay, displayDateYear,
+				displayDateHour, displayDateMinute, expirationDateMonth,
+				expirationDateDay, expirationDateYear, expirationDateHour,
+				expirationDateMinute, neverExpire, reviewDateMonth,
+				reviewDateDay, reviewDateYear, reviewDateHour, reviewDateMinute,
+				neverReview, indexable, smallImage, smallImageId,
+				smallImageSource, smallImageURL, smallFile, null, articleURL,
+				serviceContext);
+		}
+		else {
+
+			// Update article
+
+			double version = ParamUtil.getDouble(
+				uploadPortletRequest, "version");
+
+			article = journalArticleService.getArticle(
+				groupId, articleId, version);
+
+			if (actionName.equals("/journal/update_article")) {
+				article = journalArticleService.updateArticle(
+					groupId, folderId, articleId, version, titleMap,
+					descriptionMap, friendlyURLMap, content, ddmTemplateKey,
+					layoutUuid, displayDateMonth, displayDateDay,
+					displayDateYear, displayDateHour, displayDateMinute,
+					expirationDateMonth, expirationDateDay, expirationDateYear,
+					expirationDateHour, expirationDateMinute, neverExpire,
+					reviewDateMonth, reviewDateDay, reviewDateYear,
+					reviewDateHour, reviewDateMinute, neverReview, indexable,
+					smallImage, smallImageId, smallImageSource, smallImageURL,
+					smallFile, null, articleURL, serviceContext);
+			}
+		}
+
+		assetDisplayPageEntryFormProcessor.process(
+			JournalArticle.class.getName(), article.getResourcePrimKey(),
+			portletRequest);
+
+		return article;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleUtil.class);
+
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -54,17 +54,42 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	<b><liferay-ui:message key="structure" /></b>: <%= HtmlUtil.escape(ddmStructure.getName(locale)) %>
 </p>
 
-<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
-	<p class="article-version-status">
-		<b><liferay-ui:message key="version" /></b>: <%= article.getVersion() %>
+<c:choose>
+	<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
+		<p class="article-version-status <%= (article != null) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />articleVersionStatusWrapper">
+			<b><liferay-ui:message key="version" /></b>: <span id="<portlet:namespace />displayedVersion"><%= (article != null) ? article.getVersion() : "" %></span>
 
-		<clay:label
-			cssClass="ml-2 text-uppercase"
-			displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
-			label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
-		/>
-	</p>
-</c:if>
+			<c:if test="<%= article != null %>">
+				<clay:label
+					cssClass="ml-2 text-uppercase"
+					displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
+					id='<%= liferayPortletResponse.getNamespace() + "statusLabel" %>'
+					label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
+				/>
+			</c:if>
+
+			<clay:label
+				cssClass="hide ml-2 text-uppercase"
+				displayType="secondary"
+				id='<%= liferayPortletResponse.getNamespace() + "statusDraftLabel" %>'
+				label="<%= WorkflowConstants.LABEL_DRAFT %>"
+			/>
+		</p>
+	</c:when>
+	<c:otherwise>
+		<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
+			<p class="article-version-status">
+				<b><liferay-ui:message key="version" /></b>: <%= article.getVersion() %>
+
+				<clay:label
+					cssClass="ml-2 text-uppercase"
+					displayType="<%= WorkflowConstants.getStatusStyle(article.getStatus()) %>"
+					label="<%= WorkflowConstants.getStatusLabel(article.getStatus()) %>"
+				/>
+			</p>
+		</c:if>
+	</c:otherwise>
+</c:choose>
 
 <c:choose>
 	<c:when test="<%= !journalWebConfiguration.journalArticleForceAutogenerateId() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
@@ -101,11 +126,20 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		<aui:input name="newArticleId" type="hidden" />
 		<aui:input name="autoArticleId" type="hidden" value="<%= true %>" />
 
-		<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
-			<p class="article-id">
-				<b><liferay-ui:message key="id" /></b>: <%= article.getArticleId() %>
-			</p>
-		</c:if>
+		<c:choose>
+			<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
+				<p class="article-id <%= (article != null) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />articleIdWrapper">
+					<b><liferay-ui:message key="id" /></b>: <span id="<portlet:namespace />displayedArticleId"><%= (article != null) ? article.getArticleId() : "" %></span>
+				</p>
+			</c:when>
+			<c:otherwise>
+				<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
+					<p class="article-id">
+						<b><liferay-ui:message key="id" /></b>: <%= article.getArticleId() %>
+					</p>
+				</c:if>
+			</c:otherwise>
+		</c:choose>
 	</c:otherwise>
 </c:choose>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -374,37 +374,72 @@ export default function _JournalPortlet({
 				return response.json();
 			})
 			.then((data) => {
-				if (!articleId && data.success) {
-					articleId = data.articleId;
-					document.getElementById(
-						`${namespace}articleId`
-					).value = articleId;
+				if (data.success) {
+					if (!articleId) {
+						articleId = data.articleId;
+						document.getElementById(`${namespace}articleId`).value =
+							articleId;
 
-					Liferay.fire('asyncFormSubmission', {articleId});
+						Liferay.fire('asyncFormSubmission', {articleId});
 
-					const friendlyUrlInputComponent = Liferay.component(
-						`${namespace}friendlyURL`
+						const friendlyUrlInputComponent = Liferay.component(
+							`${namespace}friendlyURL`
+						);
+
+						if (!friendlyUrlInputComponent.getValue()) {
+							const friendlyURL = data.friendlyURL;
+							friendlyUrlInputComponent.updateInputLanguage(
+								friendlyURL,
+								defaultLanguageId
+							);
+							friendlyUrlInputComponent.updateInput(friendlyURL);
+
+							Liferay.fire('journal:update-friendly-url', {
+								friendlyURL,
+							});
+						}
+					}
+
+					const articleIdWrapper = document.getElementById(
+						`${namespace}articleIdWrapper`
+					);
+					const articleVersionInput = document.getElementById(
+						`${namespace}version`
+					);
+					const articleVersionStatusWrapper = document.getElementById(
+						`${namespace}articleVersionStatusWrapper`
+					);
+					const displayedArticleId = document.getElementById(
+						`${namespace}displayedArticleId`
+					);
+					const displayedVersion = document.getElementById(
+						`${namespace}displayedVersion`
+					);
+					const statusDraftLabel = document.getElementById(
+						`${namespace}statusDraftLabel`
+					);
+					const statusLabel = document.getElementById(
+						`${namespace}statusLabel`
 					);
 
-					if (!friendlyUrlInputComponent.getValue()) {
-						const friendlyURL =
-							data.friendlyURL;
-						friendlyUrlInputComponent.updateInputLanguage(
-							friendlyURL,
-							defaultLanguageId
-						);
-						friendlyUrlInputComponent.updateInput(
-							friendlyURL
-						);
-
-						Liferay.fire('journal:update-friendly-url', {
-							friendlyURL,
-						});
+					if (statusLabel) {
+						statusLabel.classList.add('hide');
 					}
+
+					articleVersionStatusWrapper.classList.remove('hide');
+					statusDraftLabel.classList.remove('hide');
+
+					articleVersionInput.value = data.version;
+					displayedVersion.innerHTML = data.version;
+
+					articleIdWrapper.classList.remove('hide');
+					displayedArticleId.innerHTML = articleId;
 				}
+
 				formDateInput.value = data.modifiedDate;
 				lockHolder.lock?.unlock();
-			}).catch((error) => {
+			})
+			.catch((error) => {
 				console.error(error);
 				lockHolder.lock?.unlock(true);
 			});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -492,7 +492,8 @@ export default function _JournalPortlet({
 						redirectOnSave: false,
 						showErrors: true,
 					});
-				}
+				},
+				namespace
 			)
 		);
 	}
@@ -516,7 +517,8 @@ function attachFormChangeListener(
 	form,
 	accentChangeEvent,
 	acceptMutationRecord,
-	callback
+	callback,
+	namespace
 ) {
 	const handleChange = debounce(() => {
 		callback();
@@ -525,7 +527,10 @@ function attachFormChangeListener(
 	const mutationObserver = new MutationObserver((mutationRecords) => {
 		const observedMutationRecords = mutationRecords
 			.filter((mutationRecord) => {
-				if (mutationRecord.type === 'attributes') {
+				if (mutationRecord.target.id === `${namespace}formDate`) {
+					return;
+				}
+				else if (mutationRecord.type === 'attributes') {
 					return (
 						mutationRecord.oldValue !== null &&
 						mutationRecord.target.value.trim() !==

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -21,6 +21,7 @@ const AUTO_SAVE_DELAY = 1500;
 export default function _JournalPortlet({
 	articleId: initialArticleId,
 	autoSaveDraftEnabled,
+	autoSaveDraftURL,
 	availableLocales: initialAvailableLocales,
 	classNameId,
 	contentTitle,
@@ -361,7 +362,7 @@ export default function _JournalPortlet({
 			formDateInput.value = Date.now().toString();
 		}
 
-		return fetch(formElement.action, {
+		return fetch(autoSaveDraftURL, {
 			body: new FormData(formElement),
 			method: formElement.method,
 		})
@@ -373,47 +374,41 @@ export default function _JournalPortlet({
 							: window.location.href
 					);
 				}
-				else {
-					if (!articleId && response.url) {
-						const articleIdKey = `${namespace}articleId`;
-						const friendlyURLKey = `${namespace}friendlyURL`;
-						const url = new URL(response.url);
 
-						if (url.searchParams.has(articleIdKey)) {
-							articleId = url.searchParams.get(articleIdKey);
-							document.getElementById(
-								`${namespace}articleId`
-							).value = articleId;
-
-							Liferay.fire('asyncFormSubmission', {articleId});
-						}
-
-						if (url.searchParams.has(friendlyURLKey)) {
-							const friendlyUrlInputComponent = Liferay.component(
-								`${namespace}friendlyURL`
-							);
-
-							if (!friendlyUrlInputComponent.getValue()) {
-								const friendlyURL =
-									url.searchParams.get(friendlyURLKey);
-								friendlyUrlInputComponent.updateInputLanguage(
-									friendlyURL,
-									defaultLanguageId
-								);
-								friendlyUrlInputComponent.updateInput(
-									friendlyURL
-								);
-
-								Liferay.fire('journal:update-friendly-url', {
-									friendlyURL,
-								});
-							}
-						}
-					}
-					lockHolder.lock?.unlock();
-				}
+				return response.json();
 			})
-			.catch((error) => {
+			.then((data) => {
+				if (!articleId && data.success) {
+					articleId = data.articleId;
+					document.getElementById(
+						`${namespace}articleId`
+					).value = articleId;
+
+					Liferay.fire('asyncFormSubmission', {articleId});
+
+					const friendlyUrlInputComponent = Liferay.component(
+						`${namespace}friendlyURL`
+					);
+
+					if (!friendlyUrlInputComponent.getValue()) {
+						const friendlyURL =
+							data.friendlyURL;
+						friendlyUrlInputComponent.updateInputLanguage(
+							friendlyURL,
+							defaultLanguageId
+						);
+						friendlyUrlInputComponent.updateInput(
+							friendlyURL
+						);
+
+						Liferay.fire('journal:update-friendly-url', {
+							friendlyURL,
+						});
+					}
+
+				}
+				lockHolder.lock?.unlock();
+			}).catch((error) => {
 				console.error(error);
 				lockHolder.lock?.unlock(true);
 			});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -219,7 +219,7 @@ export default function _JournalPortlet({
 
 			availableLocalesInput.value = availableLocales;
 
-			if (autoSaveDraftEnabled) {
+			if (autoSaveDraftEnabled && !redirectOnSave) {
 				Liferay.componentReady(`${namespace}dataEngineLayoutRenderer`)
 					.then((dataEngineLayoutRenderer) => {
 						const dataEngineLayoutRendererRef =

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -358,10 +358,6 @@ export default function _JournalPortlet({
 		formElement,
 		{redirectOnSave} = {redirectOnSave: false}
 	) => {
-		if (autoSaveDraftEnabled) {
-			formDateInput.value = Date.now().toString();
-		}
-
 		return fetch(autoSaveDraftURL, {
 			body: new FormData(formElement),
 			method: formElement.method,
@@ -405,8 +401,8 @@ export default function _JournalPortlet({
 							friendlyURL,
 						});
 					}
-
 				}
+				formDateInput.value = data.modifiedDate;
 				lockHolder.lock?.unlock();
 			}).catch((error) => {
 				console.error(error);

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1459,6 +1459,57 @@ autoSaveAsDraftTest(
 	}
 );
 
+autoSaveAsDraftTest(
+	'Web Content version, status and ID are shown and updated after auto save',
+	{
+		tag: '@LPD-32874',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await expect(
+			journalEditArticlePage.changesSavedIndicator
+		).toBeVisible();
+
+		await expect(page.getByText('1.0')).toBeVisible();
+
+		await expect(page.getByText('Draft', {exact: true})).toBeVisible();
+
+		await expect(page.getByText('ID', {exact: true})).toBeVisible();
+
+		await journalEditArticlePage.publishArticle();
+
+		await page.getByLabel(`Actions for ${title}`).waitFor();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				exact: true,
+				name: 'Edit',
+			}),
+			trigger: page.getByLabel(`Actions for ${title}`, {
+				exact: true,
+			}),
+		});
+
+		await expect(async () => {
+			await journalEditArticlePage.fillTitle(getRandomString());
+
+			await expect(
+				journalEditArticlePage.changesSavedIndicator
+			).toBeVisible();
+		}).toPass();
+
+		await expect(page.getByText('1.1')).toBeVisible();
+
+		await expect(page.getByText('Draft', {exact: true})).toBeVisible();
+	}
+);
+
 scheduleTest(
 	'Change permission of a web content in edition mode',
 	async ({journalEditArticlePage, journalPage, page, site}) => {


### PR DESCRIPTION
LPD-32874 Add resource command for autosave

# What is this trying to solve?

- Add resource command for autosave feature to better performance and manage errors.
- It solves a bug: Before this fix, we coulnd't publish a Web Content when editing it as autosave does not update the version of the article.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-32874)

# How am I fixing it?

- @Mikellorza Added a Resource Command to retrieve the data we need to update for the article after teh autosave.
- Then, I added some steps to update teh article version, status and ID after autosaving.

# How can I test it?

- Enable FF 'LPD-11228': true,
		'LPD-15596': true,
- Create a WC
- Fill the title 
- Wait for the Autosave indicator
- Assert version, draft and article ID appears
- Publish WC
- Edit the WC
- Make some chnage in the title
- Assert version changes and draft status label appears

https://github.com/user-attachments/assets/bc0dc524-378a-4daa-a14a-705d77af67c8

