### PR TITLE
LPD-34114 Cannot see scheduled Blog in Blog's Widget

### DIFF
--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntriesDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntriesDisplayContextTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.blogs.web.test;
+package com.liferay.blogs.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.blogs.web.test;
+package com.liferay.blogs.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/portlet/action/test/EditEntryMVCActionCommandTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/portlet/action/test/EditEntryMVCActionCommandTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.blogs.web.test;
+package com.liferay.blogs.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.exception.NoSuchEntryException;

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogsViewEntryContentDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/test/BlogsViewEntryContentDisplayContextTest.java
@@ -25,7 +25,6 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -50,6 +49,12 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import javax.portlet.Portlet;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -179,16 +184,24 @@ public class BlogsViewEntryContentDisplayContextTest {
 			serviceContext);
 	}
 
-	private MockHttpServletRequest _getMockHttpServletRequest()
+	private MockLiferayPortletRenderRequest
+			_getMockLiferayPortletRenderRequest()
 		throws Exception {
 
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new TestMockLiferayPortletRenderRequest(
+				new MockHttpServletRequest());
 
-		mockHttpServletRequest.setAttribute(
+		mockLiferayPortletRenderRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, _getThemeDisplay());
 
-		return mockHttpServletRequest;
+		ReflectionTestUtil.invoke(
+			_portlet, "doDispatch",
+			new Class<?>[] {RenderRequest.class, RenderResponse.class},
+			mockLiferayPortletRenderRequest,
+			new TestMockLiferayPortletRenderResponse());
+
+		return mockLiferayPortletRenderRequest;
 	}
 
 	private ThemeDisplay _getThemeDisplay() throws Exception {
@@ -213,11 +226,7 @@ public class BlogsViewEntryContentDisplayContextTest {
 
 	private String _getViewEntryURL(BlogsEntry entry) throws Exception {
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			new MockLiferayPortletRenderRequest(_getMockHttpServletRequest());
-
-		_mvcRenderCommand.render(
-			mockLiferayPortletRenderRequest,
-			new MockLiferayPortletRenderResponse());
+			_getMockLiferayPortletRenderRequest();
 
 		Object blogsViewEntryContentDisplayContext =
 			mockLiferayPortletRenderRequest.getAttribute(
@@ -299,8 +308,38 @@ public class BlogsViewEntryContentDisplayContextTest {
 		_layoutPageTemplateEntryLocalService;
 
 	@Inject(
-		filter = "component.name=com.liferay.blogs.web.internal.portlet.action.ViewMVCRenderCommand"
+		filter = "component.name=com.liferay.blogs.web.internal.portlet.BlogsPortlet"
 	)
-	private MVCRenderCommand _mvcRenderCommand;
+	private Portlet _portlet;
+
+	private static class TestMockLiferayPortletRenderRequest
+		extends MockLiferayPortletRenderRequest {
+
+		public TestMockLiferayPortletRenderRequest(
+			HttpServletRequest httpServletRequest) {
+
+			_httpServletRequest = httpServletRequest;
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			super.setAttribute(name, value);
+
+			_httpServletRequest.setAttribute(name, value);
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+
+	}
+
+	private static class TestMockLiferayPortletRenderResponse
+		extends MockLiferayPortletRenderResponse {
+
+		@Override
+		public String getNamespace() {
+			return BlogsPortletKeys.BLOGS;
+		}
+
+	}
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/BlogsPortlet.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/BlogsPortlet.java
@@ -6,9 +6,12 @@
 package com.liferay.blogs.web.internal.portlet;
 
 import com.liferay.asset.constants.AssetWebKeys;
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.blogs.web.internal.display.context.BlogsViewEntryContentDisplayContext;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.trash.TrashHelper;
 import com.liferay.trash.util.TrashWebKeys;
 
@@ -69,8 +72,30 @@ public class BlogsPortlet extends BaseBlogsPortlet {
 		super.render(renderRequest, renderResponse);
 	}
 
+	@Override
+	protected void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		renderRequest.setAttribute(
+			BlogsViewEntryContentDisplayContext.class.getName(),
+			new BlogsViewEntryContentDisplayContext(
+				_assetDisplayPageFriendlyURLProvider,
+				_portal.getLiferayPortletRequest(renderRequest),
+				_portal.getLiferayPortletResponse(renderResponse)));
+
+		super.doDispatch(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider;
+
 	@Reference
 	private AssetHelper _assetHelper;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.blogs.web)(&(release.schema.version>=1.2.0)(!(release.schema.version>=2.0.0))))"

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -5,10 +5,8 @@
 
 package com.liferay.blogs.web.internal.portlet.action;
 
-import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.blogs.web.internal.display.context.BlogsViewEntriesDisplayContext;
-import com.liferay.blogs.web.internal.display.context.BlogsViewEntryContentDisplayContext;
 import com.liferay.blogs.web.internal.display.context.BlogsViewImagesDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -47,13 +45,6 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		if (Objects.equals(
 				_getPortletId(renderRequest), BlogsPortletKeys.BLOGS)) {
 
-			renderRequest.setAttribute(
-				BlogsViewEntryContentDisplayContext.class.getName(),
-				new BlogsViewEntryContentDisplayContext(
-					_assetDisplayPageFriendlyURLProvider,
-					_portal.getLiferayPortletRequest(renderRequest),
-					_portal.getLiferayPortletResponse(renderResponse)));
-
 			return "/blogs/view.jsp";
 		}
 
@@ -78,10 +69,6 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		return portletDisplay.getPortletName();
 	}
-
-	@Reference
-	private AssetDisplayPageFriendlyURLProvider
-		_assetDisplayPageFriendlyURLProvider;
 
 	@Reference
 	private HtmlParser _htmlParser;


### PR DESCRIPTION
Cannot see scheduled Blog in Blog's Widget

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-34114)

Accessing scheduled blogs is throwing a NPE

# How am I fixing it?

Move the point where we add the display context so that it's available in other views

# How can you verify that it works?

Follow the steps in the ticket

