### PR TITLE
LPD-34197 Message Boards does not translate the answer language key

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/change/tracking/spi/display/MBMessageCTDisplayRenderer.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/change/tracking/spi/display/MBMessageCTDisplayRenderer.java
@@ -135,7 +135,7 @@ public class MBMessageCTDisplayRenderer
 		).display(
 			"last-modified", mbMessage.getModifiedDate()
 		).display(
-			"answer", mbMessage.isAnswer()
+			"answer[noun]", mbMessage.isAnswer()
 		).display(
 			"number-of-attachments", mbMessage.getAttachmentsFileEntriesCount()
 		).display(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
@@ -175,7 +175,7 @@
 				<div>
 					<%= threadAnswersCount %>
 
-					<liferay-ui:message key='<%= (threadAnswersCount == 1) ? "answer" : "answers" %>' />
+					<liferay-ui:message key='<%= (threadAnswersCount == 1) ? "answer[noun]" : "answers" %>' />
 				</div>
 			</c:if>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
@@ -237,7 +237,7 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 								<div>
 									<%= threadAnswersCount %>
 
-									<liferay-ui:message key='<%= (threadAnswersCount == 1) ? "answer" : "answers" %>' />
+									<liferay-ui:message key='<%= (threadAnswersCount == 1) ? "answer[noun]" : "answers" %>' />
 								</div>
 							</c:if>
 


### PR DESCRIPTION
# What is this trying to solve?
[LPD-34197](https://liferay.atlassian.net/browse/LPD-34197)
`answer` language key no longer exists, so when its called, only `answer` is rendered in every language.

# How am I fixing it?
Replace the language key references with the correct ones.

# How can you verify that it works?
Follow the steps described in [LPD-34197](https://liferay.atlassian.net/browse/LPD-34197)

# Why doesn't this include any test?
Fixing typos in language keys

Cheers,
Balázs
