### PR TITLE
LPD-34191 Upgrade DDMField and DDMFieldAttribut company id when is 0

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -40,6 +40,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.5.0
+Liferay-Require-SchemaVersion: 5.5.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -50,6 +50,7 @@ import com.liferay.dynamic.data.mapping.internal.upgrade.v5_2_1.WorkflowDefiniti
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_2_2.DLFileEntryDDMFormInstanceRecordUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_3_3.BrowserSnifferTemplateUpgradeProcess;
 import com.liferay.dynamic.data.mapping.internal.upgrade.v5_4_5.DDMTemplateLinkUpgradeProcess;
+import com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.DDMFieldAttributeUpgradeProcess;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutSerializer;
@@ -576,6 +577,12 @@ public class DDMServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"5.5.0", "5.5.1",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.
+				DDMFieldUpgradeProcess(),
+			new DDMFieldAttributeUpgradeProcess());
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Alicia García
+ */
+public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		processConcurrently(
+			SQLTransformer.transform(
+				StringBundler.concat(
+					"select DDMFieldAttribute.ctCollectionId, ",
+					"DDMFieldAttribute.fieldAttributeId, ",
+					"DDMStructureVersion.companyId from DDMStructureVersion ",
+					"inner join DDMField on ",
+					"DDMStructureVersion.ctCollectionId = ",
+					"DDMField.ctCollectionId and ",
+					"DDMStructureVersion.structureVersionId = ",
+					"DDMField.structureVersionId inner join DDMFieldAttribute ",
+					"on DDMFieldAttribute.ctCollectionId = ",
+					"DDMField.ctCollectionId and DDMFieldAttribute.fieldId = ",
+					"DDMField.fieldId where DDMFieldAttribute.companyId = 0")),
+			"update DDMFieldAttribute set companyId = ? where ctCollectionId " +
+				"= ? and fieldAttributeId = ?",
+			resultSet -> new Object[] {
+				resultSet.getLong("ctCollectionId"),
+				resultSet.getLong("fieldAttributeId"),
+				resultSet.getLong("companyId")
+			},
+			(values, preparedStatement) -> {
+				long companyId = (Long)values[2];
+				long fieldAttributeId = (Long)values[1];
+
+				preparedStatement.setLong(1, companyId);
+
+				preparedStatement.setLong(2, (Long)values[0]);
+				preparedStatement.setLong(3, fieldAttributeId);
+
+				preparedStatement.executeUpdate();
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Change the company id value for field Attribute ",
+							"Id ", fieldAttributeId, " from 0 to ", companyId));
+				}
+			},
+			"Unable to update company id 0 of DDMFieldAttribute ");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFieldAttributeUpgradeProcess.class);
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Alicia García
+ */
+public class DDMFieldUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		processConcurrently(
+			SQLTransformer.transform(
+				StringBundler.concat(
+					"select DDMField.ctCollectionId, DDMField.fieldId, ",
+					"DDMStructureVersion.companyId from DDMStructureVersion ",
+					"inner join DDMField on ",
+					"DDMStructureVersion.ctCollectionId = ",
+					"DDMField.ctCollectionId and ",
+					"DDMStructureVersion.structureVersionId = ",
+					"DDMField.structureVersionId where DDMField.companyId = ",
+					"0")),
+			"update DDMField set companyId = ? where ctCollectionId = ? and " +
+				"fieldId = ?",
+			resultSet -> new Object[] {
+				resultSet.getLong("ctCollectionId"),
+				resultSet.getLong("fieldId"), resultSet.getLong("companyId")
+			},
+			(values, preparedStatement) -> {
+				long companyId = (Long)values[2];
+				long fieldId = (Long)values[1];
+
+				preparedStatement.setLong(1, companyId);
+
+				preparedStatement.setLong(2, (Long)values[0]);
+				preparedStatement.setLong(3, fieldId);
+
+				preparedStatement.executeUpdate();
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Change the company id value for field ID ",
+							fieldId, " from 0 to ", companyId));
+				}
+			},
+			"Unable to update company id 0 of DDMField ");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFieldUpgradeProcess.class);
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -15,7 +15,6 @@ import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
-import com.liferay.dynamic.data.mapping.service.persistence.DDMFieldAttributePersistence;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
@@ -40,12 +39,9 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.test.rule.TransactionalTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -69,10 +65,7 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE,
-			TransactionalTestRule.INSTANCE);
+		new LiferayIntegrationTestRule();
 
 	@Before
 	public void setUp() throws Exception {
@@ -94,22 +87,21 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	public void testClassUpgradeProcess() throws Exception {
 		_addDDMFormValues();
 
-		List<DDMFieldAttribute> ddmFieldAttributes =
-			_ddmFieldAttributePersistence.findByStorageId(_STORAGE_ID);
+		List<DDMFieldAttribute> ddmFieldAttributes;
 
-		List<String> ddmFieldAttributeNames = new ArrayList<>(
-			ddmFieldAttributes.size());
+		for (String ddmFieldAttributeName : _ddmFieldAttributeNames) {
+			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
+				_STORAGE_ID, ddmFieldAttributeName);
 
-		for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
-			ddmFieldAttributeNames.add(ddmFieldAttribute.getAttributeName());
-
-			Assert.assertEquals(
-				CompanyConstants.SYSTEM, ddmFieldAttribute.getCompanyId());
+			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+				Assert.assertEquals(
+					CompanyConstants.SYSTEM, ddmFieldAttribute.getCompanyId());
+			}
 		}
 
 		_runUpgrade();
 
-		for (String ddmFieldAttributeName : ddmFieldAttributeNames) {
+		for (String ddmFieldAttributeName : _ddmFieldAttributeNames) {
 			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
 				_STORAGE_ID, ddmFieldAttributeName);
 
@@ -181,6 +173,9 @@ public class DDMFieldAttributeUpgradeProcessTest {
 
 	private static final long _STORAGE_ID = 0;
 
+	private static final List<String> _ddmFieldAttributeNames = Arrays.asList(
+		"availableLanguageIds", "defaultLanguageId");
+
 	@Inject(
 		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
 	)
@@ -188,9 +183,6 @@ public class DDMFieldAttributeUpgradeProcessTest {
 
 	@Inject
 	private DDM _ddm;
-
-	@Inject
-	private DDMFieldAttributePersistence _ddmFieldAttributePersistence;
 
 	@Inject
 	private DDMFieldLocalService _ddmFieldLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -1,0 +1,212 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMFieldAttribute;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.persistence.DDMFieldAttributePersistence;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DDMFieldAttributeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			TransactionalTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_originalCompanyId = CompanyThreadLocal.getCompanyId();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_ddmFieldLocalService.deleteDDMFormValues(_STORAGE_ID);
+
+		CompanyThreadLocal.setCompanyId(_originalCompanyId);
+	}
+
+	@Test
+	public void testClassUpgradeProcess() throws Exception {
+		_addDDMFormValues();
+
+		List<DDMFieldAttribute> ddmFieldAttributes =
+			_ddmFieldAttributePersistence.findByStorageId(_STORAGE_ID);
+
+		List<String> ddmFieldAttributeNames = new ArrayList<>(
+			ddmFieldAttributes.size());
+
+		for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+			ddmFieldAttributeNames.add(ddmFieldAttribute.getAttributeName());
+
+			Assert.assertEquals(
+				CompanyConstants.SYSTEM, ddmFieldAttribute.getCompanyId());
+		}
+
+		_runUpgrade();
+
+		for (String ddmFieldAttributeName : ddmFieldAttributeNames) {
+			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
+				_STORAGE_ID, ddmFieldAttributeName);
+
+			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+				Assert.assertEquals(
+					_group.getCompanyId(), ddmFieldAttribute.getCompanyId());
+			}
+		}
+	}
+
+	private void _addDDMFormValues() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			RandomTestUtil.randomString());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
+			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
+			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
+			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext());
+
+		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
+
+		ddmFormValues.setDefaultLocale(LocaleUtil.ENGLISH);
+
+		Set<Locale> availableLocales = new LinkedHashSet<>(
+			Arrays.asList(
+				LocaleUtil.CHINA, LocaleUtil.ENGLISH, LocaleUtil.SPAIN));
+
+		ddmFormValues.setAvailableLocales(availableLocales);
+
+		DDMFormFieldValue ddmFormFieldValue = new DDMFormFieldValue();
+
+		ddmFormFieldValue.setName("field1");
+		ddmFormFieldValue.setInstanceId(StringUtil.randomString(8));
+
+		Value value = new LocalizedValue(LocaleUtil.ENGLISH);
+
+		for (Locale locale : availableLocales) {
+			value.addString(locale, LocaleUtil.toLanguageId(locale) + " value");
+		}
+
+		ddmFormFieldValue.setValue(value);
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		_ddmFieldLocalService.updateDDMFormValues(
+			ddmStructure.getStructureId(), _STORAGE_ID, ddmFormValues);
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1." +
+			"DDMFieldAttributeUpgradeProcess";
+
+	private static final long _STORAGE_ID = 0;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMFieldAttributePersistence _ddmFieldAttributePersistence;
+
+	@Inject
+	private DDMFieldLocalService _ddmFieldLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private long _originalCompanyId;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -87,29 +87,11 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	public void testClassUpgradeProcess() throws Exception {
 		_addDDMFormValues();
 
-		List<DDMFieldAttribute> ddmFieldAttributes;
-
-		for (String ddmFieldAttributeName : _ddmFieldAttributeNames) {
-			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
-				_STORAGE_ID, ddmFieldAttributeName);
-
-			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
-				Assert.assertEquals(
-					CompanyConstants.SYSTEM, ddmFieldAttribute.getCompanyId());
-			}
-		}
+		_assertCompanyId(CompanyConstants.SYSTEM);
 
 		_runUpgrade();
 
-		for (String ddmFieldAttributeName : _ddmFieldAttributeNames) {
-			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
-				_STORAGE_ID, ddmFieldAttributeName);
-
-			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
-				Assert.assertEquals(
-					_group.getCompanyId(), ddmFieldAttribute.getCompanyId());
-			}
-		}
+		_assertCompanyId(_group.getCompanyId());
 	}
 
 	private void _addDDMFormValues() throws Exception {
@@ -151,6 +133,20 @@ public class DDMFieldAttributeUpgradeProcessTest {
 
 		_ddmFieldLocalService.updateDDMFormValues(
 			ddmStructure.getStructureId(), _STORAGE_ID, ddmFormValues);
+	}
+
+	private void _assertCompanyId(long companyId) {
+		List<DDMFieldAttribute> ddmFieldAttributes;
+
+		for (String ddmFieldAttributeName : _ddmFieldAttributeNames) {
+			ddmFieldAttributes = _ddmFieldLocalService.getDDMFieldAttributes(
+				_STORAGE_ID, ddmFieldAttributeName);
+
+			for (DDMFieldAttribute ddmFieldAttribute : ddmFieldAttributes) {
+				Assert.assertEquals(
+					companyId, ddmFieldAttribute.getCompanyId());
+			}
+		}
 	}
 
 	private void _runUpgrade() throws Exception {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMField;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DDMFieldUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_originalCompanyId = CompanyThreadLocal.getCompanyId();
+
+		CompanyThreadLocal.setCompanyId(CompanyConstants.SYSTEM);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_ddmFieldLocalService.deleteDDMFormValues(_STORAGE_ID);
+
+		CompanyThreadLocal.setCompanyId(_originalCompanyId);
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			RandomTestUtil.randomString());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
+			TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
+			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
+			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
+			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
+			ServiceContextTestUtil.getServiceContext());
+
+		List<DDMStructureVersion> structureVersions =
+			_ddmStructureVersionLocalService.getStructureVersions(
+				ddmStructure.getStructureId());
+
+		DDMStructureVersion ddmStructureVersion = structureVersions.get(0);
+
+		DDMField ddmField = _addDDMField(
+			ddmStructureVersion.getStructureVersionId());
+
+		Assert.assertEquals(CompanyConstants.SYSTEM, ddmField.getCompanyId());
+
+		_runUpgrade();
+
+		ddmField = _ddmFieldLocalService.getDDMField(ddmField.getFieldId());
+
+		Assert.assertEquals(
+			ddmStructureVersion.getCompanyId(), ddmField.getCompanyId());
+	}
+
+	private DDMField _addDDMField(long structureVersionId) {
+		DDMField ddmField = _ddmFieldLocalService.createDDMField(
+			_counterLocalService.increment());
+
+		ddmField.setParentFieldId(0);
+		ddmField.setStorageId(_STORAGE_ID);
+		ddmField.setStructureVersionId(structureVersionId);
+		ddmField.setFieldName(RandomTestUtil.randomString());
+		ddmField.setFieldType(DDMFormFieldTypeConstants.TEXT);
+		ddmField.setInstanceId(RandomTestUtil.randomString(8));
+		ddmField.setLocalizable(false);
+		ddmField.setPriority(RandomTestUtil.randomInt());
+
+		return _ddmFieldLocalService.addDDMField(ddmField);
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1." +
+			"DDMFieldUpgradeProcess";
+
+	private static final long _STORAGE_ID = 0;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMFieldLocalService _ddmFieldLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private long _originalCompanyId;
+
+}


### PR DESCRIPTION
LPD-34191 After JournalArticleDDMFieldsUpgradeProcess DDMField and DDMFieldAttributes has a 0 on the field companyId

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34191

`On the com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess` if needed, the company id on the creation of the `ddmField` and `ddmFieldAttribute` is obtained from the `CompanyThreadLocal.getCompanyId()` but because is a upgrade this value is 0.

# How am I fixing it?

On the `com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgradeProcess` we should fill with the company data from the database.
And because the database can have data with values filled with 0 on `ddmField` and `ddmFieldAttribute`, 

We create upgrades for each table with a process to fill this values with the values from the ddmStructure.

# How can you verify that it works?

Run the included automated tests.


# Commits

- **LPD-34191 create upgrade to fill the incorrect data that can be generated by error**
- **LPD-34191 register the new upgrades**
- **LPD-34191 add test to check the new upgrades**
