### PR TITLE
LPD-34156

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
@@ -6,7 +6,11 @@
 package com.liferay.journal.web.internal.layout.display.page.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
@@ -67,6 +71,40 @@ public class JournalArticleLayoutDisplayPageProviderTest {
 	@After
 	public void tearDown() throws Exception {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProviderJournalArticleWithExpiredArticleVersionInfoItemReference()
+		throws Exception {
+
+		JournalArticle originalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalTestUtil.updateArticle(originalArticle);
+
+		JournalTestUtil.expireArticle(
+			originalArticle.getGroupId(), originalArticle,
+			originalArticle.getVersion());
+
+		AssetRendererFactory<?> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+				JournalArticle.class);
+
+		AssetEntry assetEntry = assetRendererFactory.getAssetEntry(
+			JournalArticle.class.getName(),
+			originalArticle.getResourcePrimKey());
+
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+			new ClassPKInfoItemIdentifier(assetEntry.getClassPK());
+
+		classPKInfoItemIdentifier.setVersion(
+			String.valueOf(originalArticle.getVersion()));
+
+		Assert.assertNull(
+			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				new InfoItemReference(
+					assetEntry.getClassName(), classPKInfoItemIdentifier)));
 	}
 
 	@Test

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -64,6 +64,12 @@ public class JournalArticleLayoutDisplayPageProvider
 		JournalArticle article = journalArticleLocalService.fetchLatestArticle(
 			classPKInfoItemIdentifier.getClassPK());
 
+		if (classPKInfoItemIdentifier.getVersion() != null) {
+			article = journalArticleLocalService.fetchArticle(
+				article.getGroupId(), article.getArticleId(),
+				Double.valueOf(classPKInfoItemIdentifier.getVersion()));
+		}
+
 		if (!_isShow(article)) {
 			return null;
 		}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -811,11 +811,16 @@ public class JournalArticleActionDropdownItemsProvider {
 		if (AssetDisplayPageUtil.hasAssetDisplayPage(
 				_themeDisplay.getScopeGroupId(), assetEntry)) {
 
+			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+				new ClassPKInfoItemIdentifier(assetEntry.getClassPK());
+
+			classPKInfoItemIdentifier.setVersion(
+				String.valueOf(_article.getVersion()));
+
 			String previewURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					new InfoItemReference(
-						assetEntry.getClassName(),
-						new ClassPKInfoItemIdentifier(assetEntry.getClassPK())),
+						assetEntry.getClassName(), classPKInfoItemIdentifier),
 					_themeDisplay);
 
 			previewURL = HttpComponentsUtil.addParameter(


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-34156

### How am I fixing it?
The preview button is added based on the article's status. This logic was used in the article history as well, but the article version was not considered so all the article versions preview button in the history was generated based on the latest article status. I fixed it by using the already existing version field inside the classPKInfoItemIdentifier.

### How can you verify that it works?

To test run:
`gw testIntegration --tests JournalArticleLayoutDisplayPageProviderTest'`

Or manually test based on the LPD steps
