### PR TITLE
LPD-33986 Exceptions in WC Structures page are not handled correctly

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -78,7 +78,7 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			_log.error(exception);
 
 			SessionErrors.add(
-				actionRequest, "importDataDefinitionErrorMessage");
+				actionRequest, "importDataDefinitionErrorMessage", exception);
 
 			hideDefaultErrorMessage(actionRequest);
 		}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -40,9 +40,6 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 
 	<liferay-ui:error embed="<%= false %>" key="importDataDefinitionErrorMessage">
 		<c:choose>
-			<c:when test="<%= errorException instanceof DataDefinitionValidationException %>">
-				<liferay-ui:message key="please-enter-a-valid-form-definition" />
-			</c:when>
 			<c:when test="<%= errorException instanceof DataDefinitionValidationException.MustNotDuplicateFieldName %>">
 
 				<%
@@ -73,8 +70,8 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 			<c:when test="<%= errorException instanceof DataDefinitionValidationException.MustSetValidName %>">
 				<liferay-ui:message key="please-enter-a-valid-name" />
 			</c:when>
-			<c:when test="<%= errorException instanceof DataLayoutValidationException %>">
-				<liferay-ui:message key="please-enter-a-valid-form-layout" />
+			<c:when test="<%= errorException instanceof DataDefinitionValidationException %>">
+				<liferay-ui:message key="please-enter-a-valid-form-definition" />
 			</c:when>
 			<c:when test="<%= errorException instanceof DataLayoutValidationException.MustNotDuplicateFieldName %>">
 
@@ -83,6 +80,9 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 				%>
 
 				<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(mndfn.getDuplicatedFieldNames(), StringPool.COMMA_AND_SPACE)) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
+			</c:when>
+			<c:when test="<%= errorException instanceof DataLayoutValidationException %>">
+				<liferay-ui:message key="please-enter-a-valid-form-layout" />
 			</c:when>
 			<c:when test="<%= errorException instanceof PrincipalException.MustHavePermission %>">
 				<liferay-ui:message key="you-do-not-have-the-required-permissions" />


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33986

1) Exceptions raised during the “Import and Override” action of a Structure produces an error page:

![image](https://github.com/user-attachments/assets/e1716f68-d43a-425c-b4f0-f4b60a08bca5)

2) Some exceptions have a specific message to show but a general one is shown instead (incorrect handling order)

# How am I fixing it?

1) I'm adding the exception object to the SessionError
2) Reording the handling of the exceptions in the JSP file

# How can you verify that it works?

Following steps in issue. TESTS ARE MISSING
