### PR TITLE
LPD-33570 web content publish bug

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -245,6 +245,25 @@ $productMenuWidth: 320px;
 			}
 		}
 
+		.edit-article-panel {
+			border-color: $gray-400;
+
+			.sheet-subtitle {
+				border-width: 0;
+				font-size: 1.25rem;
+				padding: 1.25rem;
+				padding-bottom: 0;
+				text-transform: none;
+
+				.lexicon-icon {
+					font-size: 1.25rem;
+					margin-top: 1rem;
+					position: relative;
+					right: 0.5rem;
+				}
+			}
+		}
+
 		.sidebar-body {
 			.collapse-icon {
 				border-bottom: 1px solid $light;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -403,6 +403,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 							<liferay-frontend:fieldset
 								collapsed="<%= false %>"
 								collapsible="<%= true %>"
+								cssClass="edit-article-panel"
 								label="fields"
 							>
 								<div class="c-px-2 panel-body">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -400,15 +400,15 @@ journalEditArticleDisplayContext.setViewAttributes();
 						</div>
 
 						<div id="<portlet:namespace />content">
-							<clay:panel
-								displayTitle='<%= LanguageUtil.get(request, "fields") %>'
-								displayType="block"
-								expanded="<%= true %>"
+							<liferay-frontend:fieldset
+								collapsed="<%= false %>"
+								collapsible="<%= true %>"
+								label="fields"
 							>
 								<div class="c-px-2 panel-body">
 									<%@ include file="/article_content.jspf" %>
 								</div>
-							</clay:panel>
+							</liferay-frontend:fieldset>
 						</div>
 
 						<div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -299,7 +299,9 @@ export default function SaveButtons({
 							publishModalVisible: false,
 						})
 					}
-					onPublishButtonClick={handleButtonClick}
+					onPublishButtonClick={() => {
+						handleButtonClick(ACTION_PUBLISH);
+					}}
 					permissionsURL={permissionsURL}
 					portletNamespace={portletNamespace}
 					timeZone={timeZone}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -14,6 +14,10 @@ import PublishModal from './modals/PublishModal';
 import removeAlert from './removeAlert';
 import showAlert from './showAlert';
 
+const ACTION_PUBLISH = 'publish';
+const ACTION_DRAFT = 'draft';
+const ACTION_SCHEDULE = 'schedule';
+
 export default function SaveButtons({
 	articleId: initialArticleId,
 	defaultLanguageId,
@@ -99,9 +103,9 @@ export default function SaveButtons({
 		);
 
 		if (
-			action === 'publish' ||
-			publishModalAction === 'publish' ||
-			publishModalAction === 'schedule'
+			action === ACTION_PUBLISH ||
+			publishModalAction === ACTION_PUBLISH ||
+			publishModalAction === ACTION_SCHEDULE
 		) {
 			workflowActionInput.value = Liferay.Workflow.ACTION_PUBLISH;
 		}
@@ -179,7 +183,7 @@ export default function SaveButtons({
 					className="mr-3"
 					displayType="secondary"
 					form={formId}
-					onClick={() => onClick('draft')}
+					onClick={() => onClick(ACTION_DRAFT)}
 					title={
 						articleId
 							? null
@@ -228,7 +232,7 @@ export default function SaveButtons({
 				<ClayDropDown.ItemList>
 					<ClayDropDown.Item
 						form={formId}
-						onClick={() => onClick('publish')}
+						onClick={() => onClick(ACTION_PUBLISH)}
 						symbolLeft="arrow-right-full"
 						type={showPublishModal ? 'button' : 'submit'}
 					>
@@ -258,7 +262,7 @@ export default function SaveButtons({
 								titleInputComponent?.getValue(defaultLanguageId)
 							) {
 								setPublishModalState({
-									publishModalAction: 'schedule',
+									publishModalAction: ACTION_SCHEDULE,
 									publishModalVisible: true,
 								});
 							}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -106,6 +106,7 @@ export default function PublishModal({
 								}
 								else {
 									onPublishButtonClick();
+									onClose();
 								}
 							}}
 							type={

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -93,6 +93,14 @@ const translationTest = mergeTests(
 	})
 );
 
+const translationAndAutosaveTest = mergeTests(
+	translationTest,
+	featureFlagsTest({
+		'LPD-11228': true,
+		'LPD-15596': true,
+	})
+);
+
 const privateContentIconTest = mergeTests(baseTest);
 
 autoSaveAsDraftTest(
@@ -1736,5 +1744,27 @@ scheduleTest(
 			articleDate,
 			{workflow: true}
 		);
+	}
+);
+
+translationAndAutosaveTest(
+	'Web Content is published when Feature Flags LPS-114700, LPD-11228 and LPD-15596 are active',
+	{
+		tag: '@LPD-33570',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = 'Web Content Title';
+
+		journalEditArticlePage.createAndPublishBasicArticle(articleTitle);
+
+		await expect(page.getByTitle(articleTitle)).toBeVisible();
+
+		await expect(
+			page.locator(
+				'[id="_com_liferay_journal_web_portlet_JournalPortlet_articles_1"] span.label-item'
+			)
+		).toHaveText('Approved');
 	}
 );

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -114,6 +114,14 @@ export class JournalEditArticlePage {
 		);
 	}
 
+	async createAndPublishBasicArticle(title?: string) {
+		const articleTitle = title || getRandomString();
+
+		await this.fillTitle(articleTitle);
+
+		await this.publishArticle();
+	}
+
 	async publishArticle() {
 		await clickAndExpectToBeVisible({
 			autoClick: true,


### PR DESCRIPTION
[Link to ticket. ](https://liferay.atlassian.net/browse/LPD-33570)

# What is the problem
When Feature Flag `LPS-114700` is enabled (can be done in Instance Settings), the Publish button for Web Content does not work, and user is not redirected to the main view. 

# How did I resolve it
For some reason, the taglib `<liferay-data-engine:data-layout-renderer>` was not being rendered properly inside a `<clay:panel>`. The submit event was not attached to the form (https://github.com/ambrinchaudhary/liferay-portal/blame/master/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js#L216C58-L216C58), and thus the `Liferay.fire('ddmFormSubmit')`, was never fired. 

I decided to change it for a `<liferay-frontend:fieldset>` and adjust the styles, as debugging inside Data Engine elements was going to require much more time. Look and feel is the same. Metadata section is a `<clay:panel>` but Fields is a `<liferay-frontend:fieldset>`
<img width="1100" alt="Screenshot 2024-08-19 at 17 04 35" src="https://github.com/user-attachments/assets/4b0cdef9-86ce-4c63-adc8-9b5f03263d68">



# How to test it
Follow the steps described in the issue, or run the test: 
`npm run playwright -- test -g 'Web Content is published' --reporter list`

```
Running 1 test using 1 worker

  ✓  1 [journal-web] › journal-web/journalArticle.spec.ts:1751:1 › Web Content is published when Feature Flags LPS-114700, LPD-11228 and LPD-15596 are active (32.8s)
```