### PR TITLE
LPD-34334 Email body replacements not working correctly on Web Content Granted notifications

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6823,8 +6823,7 @@ public class JournalArticleLocalServiceImpl
 		_populateSubscriptionSender(
 			article,
 			JournalUtil.getJournalControlPanelLink(
-				article.getFolderId(), article.getGroupId(),
-				serviceContext.getLiferayPortletResponse()),
+				article.getFolderId(), article.getGroupId(), null),
 			action, fromAddress,
 			journalGroupServiceConfiguration.emailFromName(),
 			journalGroupServiceConfiguration, serviceContext,
@@ -6836,7 +6835,7 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setLocalizedContextAttribute(
 			"[$ARTICLE_CONTENT$]",
 			new EscapableLocalizableFunction(
-				locale -> _getArticleContent(article, locale, serviceContext)));
+				locale -> _getArticleContent(article, locale), false));
 		subscriptionSender.setLocalizedContextAttribute(
 			"[$ARTICLE_STATUS$]",
 			new EscapableLocalizableFunction(
@@ -7600,24 +7599,13 @@ public class JournalArticleLocalServiceImpl
 		return ddmFormValues;
 	}
 
-	private String _getArticleContent(
-		JournalArticle article, Locale locale, ServiceContext serviceContext) {
-
+	private String _getArticleContent(JournalArticle article, Locale locale) {
 		String articleContent = StringPool.BLANK;
 
 		try {
-			PortletRequestModel portletRequestModel = null;
-
-			if (!ExportImportThreadLocal.isImportInProcess()) {
-				portletRequestModel = new PortletRequestModel(
-					serviceContext.getLiferayPortletRequest(),
-					serviceContext.getLiferayPortletResponse());
-			}
-
 			JournalArticleDisplay articleDisplay = getArticleDisplay(
 				article, article.getDDMTemplateKey(), Constants.VIEW,
-				LocaleUtil.toLanguageId(locale), 1, portletRequestModel,
-				serviceContext.getThemeDisplay());
+				LocaleUtil.toLanguageId(locale), 1, null, null);
 
 			articleContent = articleDisplay.getContent();
 		}
@@ -7630,29 +7618,15 @@ public class JournalArticleLocalServiceImpl
 		return articleContent;
 	}
 
-	private String _getArticleDiffs(
-		JournalArticle article, Locale locale, ServiceContext serviceContext) {
-
+	private String _getArticleDiffs(JournalArticle article, Locale locale) {
 		JournalArticle previousApprovedArticle =
 			journalArticleLocalService.getPreviousApprovedArticle(article);
 
 		try {
-			PortletRequestModel portletRequestModel = null;
-
-			if (!ExportImportThreadLocal.isImportInProcess() &&
-				(serviceContext.getLiferayPortletRequest() != null) &&
-				(serviceContext.getLiferayPortletResponse() != null)) {
-
-				portletRequestModel = new PortletRequestModel(
-					serviceContext.getLiferayPortletRequest(),
-					serviceContext.getLiferayPortletResponse());
-			}
-
 			String articleDiffs = _journalHelper.diffHtml(
 				article.getGroupId(), article.getArticleId(),
 				previousApprovedArticle.getVersion(), article.getVersion(),
-				LocaleUtil.toLanguageId(locale), portletRequestModel,
-				serviceContext.getThemeDisplay());
+				LocaleUtil.toLanguageId(locale), null, null);
 
 			return _diffHtml.replaceStyles(articleDiffs);
 		}
@@ -8078,7 +8052,7 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setLocalizedContextAttribute(
 			"[$ARTICLE_DIFFS$]",
 			new EscapableLocalizableFunction(
-				locale -> _getArticleDiffs(article, locale, serviceContext)));
+				locale -> _getArticleDiffs(article, locale), false));
 		subscriptionSender.setLocalizedContextAttribute(
 			"[$ARTICLE_TITLE$]",
 			new EscapableLocalizableFunction(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -349,14 +348,11 @@ public class JournalSubscriptionLocalizedContentTest
 			journalArticle = _journalArticleLocalService.getLatestArticle(
 				journalArticle.getResourcePrimKey());
 
-			journalArticleDiffs = HtmlUtil.escape(
-				_diffHtml.replaceStyles(
-					_journalHelper.diffHtml(
-						journalArticle.getGroupId(),
-						journalArticle.getArticleId(),
-						previousJournalArticleVersion,
-						journalArticle.getVersion(), user.getLanguageId(), null,
-						themeDisplay)));
+			journalArticleDiffs = _diffHtml.replaceStyles(
+				_journalHelper.diffHtml(
+					journalArticle.getGroupId(), journalArticle.getArticleId(),
+					previousJournalArticleVersion, journalArticle.getVersion(),
+					user.getLanguageId(), null, themeDisplay));
 		}
 
 		JournalArticleDisplay journalArticleDisplay =


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34334

The replacements in WC notifications doesn't always work correctly. Bug introduced with LPD-32067.

# How am I fixing it?

The problem was that the lambda expression in setLocalizedContextAttributes was using request parameters, this is, data that it can be missing when the actual call is made. Fortunately, this info is not required.

# How can you verify that it works?

Follow the steps in issue or execute existing POSHI test WebContentWithUserNotifications#ViewGrantedEmailNotificationWithArticleDiffs

# Why doesn't this include any test?

The test already exists: WebContentWithUserNotifications#ViewGrantedEmailNotificationWithArticleDiffs