### PR TITLE
LPD-34389 Fix test JournalArticleLocalServiceTest.testUpdateArticleByNonownerUser

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -1705,6 +1705,9 @@ public class JournalArticleLocalServiceTest {
 				_group.getCompanyId(), _group.getGroupId(),
 				nonownerPermissionChecker.getUserId());
 
+			serviceContext.setAddGroupPermissions(false);
+			serviceContext.setAddGuestPermissions(false);
+
 			Double originalArticleVersion = journalArticle.getVersion();
 
 			journalArticle = _journalArticleLocalService.updateArticle(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34389

Fix test `JournalArticleLocalServiceTest.testUpdateArticleByNonownerUser`

# How am I fixing it?

Avoid non-owner user permissions overwriting by disabling ServiceContext `AddGroupPermissions` and `AddGuestPermissions`

# How can you verify that it works?

Run test `JournalArticleLocalServiceTest.testUpdateArticleByNonownerUser`
