### PR TITLE
LPD-34390 Internal Server Error when retrieving a structured content with localizable fields in a field group

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -87,13 +87,15 @@ public class ContentFieldUtil {
 						ddmFormFieldValue.getValue()));
 				setContentFieldValue_i18n(
 					() -> {
-						if (!dtoConverterContext.isAcceptAllLanguages()) {
+						Value value = ddmFormFieldValue.getValue();
+
+						if (!dtoConverterContext.isAcceptAllLanguages() ||
+							(value == null)) {
+
 							return null;
 						}
 
 						Map<String, ContentFieldValue> map = new HashMap<>();
-
-						Value value = ddmFormFieldValue.getValue();
 
 						Locale defaultLocale = value.getDefaultLocale();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -427,6 +427,10 @@ public class StructuredContentResourceTest
 		_testGetStructuredContentAssetLibrary();
 		_testGetStructuredContentWithAllTypesOfContentFields(false);
 		_testGetStructuredContentWithAllTypesOfContentFields(true);
+		_testGetStructuredContentWithAllTypesOfContentFieldsAndAcceptAllLanguagesHeader(
+			false);
+		_testGetStructuredContentWithAllTypesOfContentFieldsAndAcceptAllLanguagesHeader(
+			true);
 		_testGetStructuredContentWithDateExpired();
 		_testGetStructuredContentWithDateExpiredNeverExpire();
 		_testGetStructuredContentWithDifferentFolder();
@@ -1770,6 +1774,28 @@ public class StructuredContentResourceTest
 
 		StructuredContent getStructuredContent =
 			structuredContentResource.getStructuredContent(
+				postStructuredContent.getId());
+
+		assertEquals(postStructuredContent, getStructuredContent);
+		assertValid(getStructuredContent);
+	}
+
+	private void
+			_testGetStructuredContentWithAllTypesOfContentFieldsAndAcceptAllLanguagesHeader(
+				boolean localizable)
+		throws Exception {
+
+		StructuredContentResource acceptAllLanguagesStructuredContentResource =
+			_buildStructureContentResource(LocaleUtil.getDefault());
+
+		StructuredContent postStructuredContent =
+			acceptAllLanguagesStructuredContentResource.
+				postSiteStructuredContent(
+					testGroup.getGroupId(),
+					_randomCompleteStructuredContent(localizable));
+
+		StructuredContent getStructuredContent =
+			acceptAllLanguagesStructuredContentResource.getStructuredContent(
 				postStructuredContent.getId());
 
 		assertEquals(postStructuredContent, getStructuredContent);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -1214,6 +1214,11 @@ public class StructuredContentResourceTest
 			},
 			new ContentField() {
 				{
+					name = "Fieldset";
+				}
+			},
+			new ContentField() {
+				{
 					contentFieldValue = new ContentFieldValue() {
 						{
 							data = String.valueOf(RandomTestUtil.randomInt());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-complex-ddm-structure.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-complex-ddm-structure.json
@@ -287,7 +287,7 @@
 			"collapsible": false,
 			"ddmStructureId": "",
 			"ddmStructureLayoutId": "",
-			"fieldReference": "Fieldset39810423",
+			"fieldReference": "Fieldset",
 			"label": {
 				"en_US": "Fields Group"
 			},


### PR DESCRIPTION
Internal Server Error when retrieving a structured content with localizable fields in a field group

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-34390)

Avoid throwing a NPE when the value of a field is null

# How am I fixing it?

Control the NPE

# How can you verify that it works?

Follow the steps in the ticket or run the provided tests
