### PR TITLE
LPD-33787 Add new ci:test:content-management-playwright suite

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -68,6 +68,7 @@ ci.test.available.suites=\
     content-management-db-partition,\
     content-management-headless,\
     content-management-lxc,\
+    content-management-playwright,\
     content-management-upgrade,\
     content-page-review,\
     continuous-integration,\
@@ -283,6 +284,7 @@ ci.test.suite.description[content-management-acceptance]=Test Content Management
 ci.test.suite.description[content-management-db-partition]=Test Content Management functional tests with Database Partitioning.
 ci.test.suite.description[content-management-headless]=Test Content Management headless tests.
 ci.test.suite.description[content-management-lxc]=Content Management functional tests with Liferay Experience Cloud configurations.
+ci.test.suite.description[content-management-playwright]=Test Content Management playwright tests.
 ci.test.suite.description[content-management-upgrade]=Test Content Management upgrade tests.
 ci.test.suite.description[content-page-review]=Test Content Page Review (comments) tests.
 ci.test.suite.description[continuous-integration]=Test Continuous Integration tests.

--- a/test.properties
+++ b/test.properties
@@ -4336,7 +4336,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Content Management
     #
 
-    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=\
+    content-management-playwright-projects=\
         announcements-web,\
         blogs-web,\
         content-dashboard-web,\
@@ -4349,6 +4349,8 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         portlet-configuration-css-web,\
         questions-web,\
         wiki-web
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=${content-management-playwright-projects}
 
     test.batch.class.names.includes[content-management]=\
         **/adaptive-media-blogs-test/**/*Test.java,\
@@ -4707,6 +4709,17 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][content-management-headless]=\
         (portal.upstream == true) AND \
         (testray.main.component.name ~ "Content Management Headless")
+
+    #
+    # Content Management Playwright
+    #
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management-playwright]=${content-management-playwright-projects}
+
+    test.batch.dist.app.servers[content-management-playwright]=tomcat
+
+    test.batch.names[content-management-playwright]=\
+        playwright-js-tomcat90-mysql57-jdk8
 
     #
     # Content Management Upgrade


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33787

I added a new `ci:test:content-management-playwright` suite for run only Content Management team playwright tests.

# How am I fixing it?

Adding the new `content-management-playwright` suite

# How can you verify that it works?

Comment

```sh
ci:test:content-management-playwright
```

in the PR to launch the suite :D

# Why doesn't this include any test?

Because it is an infraestruccture change to launch our Content Management playwright tests