### PR TITLE
LPD-32890 Journal UndoRedo - Add all steps to the history dropdown

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -35,6 +35,9 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 	}, [defaultLanguageId, dispatch]);
 
 	useEffect(() => {
+		const goToHandler = ({step}) => {
+			dispatch({step, type: EVENT_TYPES.HISTORY.GOTO});
+		};
 		const handleStoreState = () => {
 			dispatch({type: EVENT_TYPES.HISTORY.ADD});
 		};
@@ -45,11 +48,13 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 			dispatch({type: EVENT_TYPES.HISTORY.NEXT});
 		};
 
+		Liferay.on('journal:goto', goToHandler);
 		Liferay.on('journal:undo', undoHandler);
 		Liferay.on('journal:redo', redoHandler);
 		Liferay.on('journal:storeState', handleStoreState);
 
 		return () => {
+			Liferay.detach('journal:goto', goToHandler);
 			Liferay.detach('journal:undo', undoHandler);
 			Liferay.detach('journal:redo', redoHandler);
 			Liferay.detach('journal:storeState', handleStoreState);

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
@@ -39,6 +39,16 @@ export default function historyReducer(state, action) {
 					edited: true,
 				},
 			};
+		case EVENT_TYPES.HISTORY.GOTO:
+			setTimeout(() => Liferay.fire('ddm:restoreState'), 100);
+
+			return {
+				...state.history.steps[action.step],
+				history: {
+					...state.history,
+					currentStep: action.step,
+				},
+			};
 		case EVENT_TYPES.HISTORY.NEXT:
 			setTimeout(() => Liferay.fire('ddm:restoreState'), 100);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -505,6 +505,9 @@ export default function UndoRedo({
 						disabled={step <= 0}
 						onClick={() => {
 							handleUndo(0);
+							Liferay.fire('journal:goto', {
+								step: 0,
+							});
 							setActive(false);
 						}}
 					>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -13,6 +13,13 @@ const META_FIELD_NAMES = {
 	title: 'titleMapAsXML',
 };
 
+const METADATA_FIELD_NAME_HISTORY = {
+	[`${META_FIELD_NAMES.description}Editor`]:
+		Liferay.Language.get('description'),
+	[META_FIELD_NAMES.friendlyURL]: Liferay.Language.get('friendly-url'),
+	[META_FIELD_NAMES.title]: Liferay.Language.get('title'),
+};
+
 export default function UndoRedo({
 	initialDefaultLanguageId,
 	initialFields,
@@ -457,6 +464,37 @@ export default function UndoRedo({
 				}
 			>
 				<ClayDropDown.ItemList>
+					{history
+						.map((item, index) => {
+							return (
+								index > 0 && (
+									<ClayDropDown.Item
+										disabled={step === index}
+										key={index}
+										onClick={() => {
+											if (index < step) {
+												handleUndo(index);
+											}
+											else {
+												handleRedo(index);
+											}
+											setActive(false);
+										}}
+										symbolRight={
+											step === index ? 'check' : ''
+										}
+									>
+										{Liferay.Language.get('edit')}{' '}
+
+										{METADATA_FIELD_NAME_HISTORY[
+											item.name
+										] || item.name}
+									</ClayDropDown.Item>
+								)
+							);
+						})
+						.reverse()}
+
 					<ClayDropDown.Divider />
 
 					<ClayDropDown.Item

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -501,6 +501,7 @@ export default function UndoRedo({
 						disabled={step <= 0}
 						onClick={() => {
 							handleUndo(0);
+							setActive(false);
 						}}
 					>
 						{Liferay.Language.get('undo-all')}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -477,6 +477,11 @@ export default function UndoRedo({
 											else {
 												handleRedo(index);
 											}
+
+											Liferay.fire('journal:goto', {
+												step: index,
+											});
+
 											setActive(false);
 										}}
 										symbolRight={

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -144,8 +144,7 @@ export default function UndoRedo({
 		updateMetadataFields(nextStep, newStep);
 	};
 
-	const handleRedo = () => {
-		const newStep = step + 1;
+	const handleRedo = (newStep) => {
 		const nextStep = history[newStep];
 
 		if (nextStep.selectedLanguageId !== selectedLanguageId) {
@@ -439,7 +438,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:redo');
-					handleRedo();
+					handleRedo(step + 1);
 				}}
 				size="sm"
 				symbol="redo"


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-32890)


Some screenshots while tested with data engine fields: 

Moved to step 3: 
<img width="997" alt="Screenshot 2024-08-21 at 13 34 48" src="https://github.com/user-attachments/assets/e71b8570-d1c4-4729-a3a3-21a36f5f1fff">

Back to the last step:
<img width="993" alt="Screenshot 2024-08-21 at 13 35 11" src="https://github.com/user-attachments/assets/c6022cb1-f517-441c-bb61-4df943133523">

**Note:**
Test will be added in a different subtask https://liferay.atlassian.net/browse/LPD-31063 once the rest of the task are completed
