### PR TITLE
LPD-32951 Journal Autosave - reorder elements

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -145,7 +145,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 					<div class="c-gap-3 form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 						<c:choose>
 							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
-								<div class="align-items-center d-none mx-3 small text-danger" id="<portlet:namespace />lockErrorIndicator">
+								<div class="align-items-center d-none small text-danger" id="<portlet:namespace />lockErrorIndicator">
 									<liferay-ui:message key="alert-helper-error" />
 
 									<clay:icon
@@ -154,20 +154,21 @@ journalEditArticleDisplayContext.setViewAttributes();
 									/>
 								</div>
 
-								<div class="align-items-center d-none mx-3 small" id="<portlet:namespace />savingChangesIndicator">
+								<div class="align-items-center d-none small" id="<portlet:namespace />savingChangesIndicator">
 									<liferay-ui:message key="saving" />
 
 									<span aria-hidden="true" class="d-inline-block loading-animation loading-animation-sm ml-2 my-0"></span>
 								</div>
 
-								<div class="align-items-center d-none mx-3 small text-success" id="<portlet:namespace />changesSavedIndicator">
+								<div class="align-items-center d-none small text-success" id="<portlet:namespace />changesSavedIndicator">
 									<liferay-ui:message key="saved" />
 
 									<clay:icon
-										cssClass="ml-2"
+										cssClass="ml-2 mt-0"
 										symbol="check-circle"
 									/>
 								</div>
+
 								<div>
 									<react:component
 										module="{UndoRedo} from journal-web"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -145,21 +145,6 @@ journalEditArticleDisplayContext.setViewAttributes();
 					<div class="c-gap-3 form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 						<c:choose>
 							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
-								<div>
-									<react:component
-										module="{UndoRedo} from journal-web"
-										props='<%=
-											HashMapBuilder.<String, Object>put(
-												"initialDefaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
-											).put(
-												"initialFields", journalEditArticleDisplayContext.getFieldMap()
-											).put(
-												"languageId", journalEditArticleDisplayContext.getSelectedLanguageId()
-											).build()
-										%>'
-									/>
-								</div>
-
 								<div class="align-items-center d-none mx-3 small text-danger" id="<portlet:namespace />lockErrorIndicator">
 									<liferay-ui:message key="alert-helper-error" />
 
@@ -181,6 +166,20 @@ journalEditArticleDisplayContext.setViewAttributes();
 									<clay:icon
 										cssClass="ml-2"
 										symbol="check-circle"
+									/>
+								</div>
+								<div>
+									<react:component
+										module="{UndoRedo} from journal-web"
+										props='<%=
+											HashMapBuilder.<String, Object>put(
+												"initialDefaultLanguageId", journalEditArticleDisplayContext.getDefaultArticleLanguageId()
+											).put(
+												"initialFields", journalEditArticleDisplayContext.getFieldMap()
+											).put(
+												"languageId", journalEditArticleDisplayContext.getSelectedLanguageId()
+											).build()
+										%>'
 									/>
 								</div>
 							</c:when>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-32951)

### Motivation 
After speaking with design and reviewing Figmas, we decided that messages should be put before the UndoRedo buttons

**Before PR:** 

<img width="985" alt="Screenshot 2024-08-22 at 12 35 59" src="https://github.com/user-attachments/assets/537b620c-34d5-4eed-b1b5-6f49170873a4">

**After PR:** 
 
<img width="988" alt="Screenshot 2024-08-22 at 12 34 17" src="https://github.com/user-attachments/assets/dffbc4aa-34d4-4906-be6b-50752133fc78">

Test will be added in subtask https://liferay.atlassian.net/browse/LPD-31063
