### PR TITLE
LPD-34452 Fix test ContentPageReview#CanViewCommentOnDifferentExperience

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/Comments/ContentPageReview.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/Comments/ContentPageReview.testcase
@@ -580,6 +580,8 @@ definition {
 
 		PageEditor.removeFragment(fragmentName = "Title");
 
+		PageEditor.gotoTab(tabName = "Comments");
+
 		PageEditor.viewComment();
 
 		ContentPagesNavigator.openEditContentPage(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34452

Fix the POSHI test `ContentPageReview#CanViewCommentOnDifferentExperience`

# How am I fixing it?

I'm adding a navigation to the "Comments" tab before checking that there are no comments.
Before it was working because the removal of a fragment (previous instruction `PageEditor.removeFragment`) didn't change the currently selected tab. The LPD-30896 introduced a navigation to the "Browser" tab while removing the fragment (in my opinion this is not correct but it affects many places so it's difficult to safely revert).

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=ContentPageReview#CanViewCommentOnDifferentExperience`