### PR TITLE
LPD-34567 Permissions for new Web Content are not saved.

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -106,7 +106,6 @@ export default function PublishModal({
 								}
 								else {
 									onPublishButtonClick();
-									onClose();
 								}
 							}}
 							type={


### PR DESCRIPTION
LPD-34567 Permissions for new Web Content are not saved.

# What is this trying to solve?

- Save the permissions when publish web content the first time

[Link to ticket](https://liferay.atlassian.net/browse/LPD-34567)

# How can I test it?

- Follow steps in the bug

**NOTE**: This bug is covered by this test https://github.com/liferay/liferay-portal/blob/e0b6fada5915153b15eedcbce2197944798d7305/modules/test/playwright/tests/journal-web/journalArticle.spec.ts#L1419