### PR TITLE
LPD-34653 Fix test failures in ContentPageReviewUpgrade#ViewContentPageReviewArchive

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
@@ -8,8 +8,6 @@ definition {
 
 		if (IsElementNotPresent(key_fragmentName = ${fragmentName}, locator1 = "PageEditor#FRAGMENT_SIDEBAR_COMMENT_SECTION_NAME")) {
 			PageEditor.clickConfigurableField(fragmentName = ${fragmentName});
-
-			PageEditor.gotoTab(tabName = "Browser");
 		}
 
 		AssertElementPresent(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidatePagesUpgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidatePagesUpgrade.macro
@@ -142,8 +142,6 @@ definition {
 
 		PageEditor.clickConfigurableField(fragmentName = "Static Text");
 
-		PageEditor.gotoTab(tabName = "Browser");
-
 		PageEditor.viewComment(fragmentComment = "This is a fragment comment");
 
 		PageEditor.viewCommentReply(
@@ -171,8 +169,6 @@ definition {
 		PageEditor.gotoTab(tabName = "Comments");
 
 		PageEditor.clickConfigurableField(fragmentName = "Static Text");
-
-		PageEditor.gotoTab(tabName = "Browser");
 
 		PageEditor.viewComment(fragmentComment = "This is a new fragment comment");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34653

Fix the following tests:

* LocalFile.ContentPageReviewUpgrade#ViewContentPageReviewArchive72101
* LocalFile.ContentPageReviewUpgrade#ViewContentPageReviewArchive73101

# How am I fixing it?

Removing the instruction `PageEditor.gotoTab(tabName = "Browser")`  incorrectly added in LPD-30896.

# How can you verify that it works?

Run:

* `ant -f build-test.xml run-selenium-test -Dtest.class=ContentPageReviewUpgrade#ViewContentPageReviewArchive72101`
* `ant -f build-test.xml run-selenium-test -Dtest.class=ContentPageReviewUpgrade#ViewContentPageReviewArchive73101`

Note: the associated data folder and db dump should be imported first.