### PR TITLE
LPD-34699 Blog entry URL is not correct when a tag is selected in widget

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntryContentDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntryContentDisplayContext.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import javax.portlet.PortletRequest;
+
 /**
  * @author Roberto Díaz
  */
@@ -60,8 +62,8 @@ public class BlogsViewEntryContentDisplayContext {
 				"entryId", String.valueOf(entry.getEntryId()));
 		}
 
-		return PortletURLBuilder.createRenderURL(
-			_liferayPortletResponse
+		return PortletURLBuilder.createLiferayPortletURL(
+			_liferayPortletResponse, PortletRequest.RENDER_PHASE
 		).setMVCRenderCommandName(
 			"/blogs/view_entry"
 		).setRedirect(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-34699

The blog entry URL is not always correctly created. This problem was introduced in #5734 

# How am I fixing it?

I'm just using the correct URL creator method.

# How can you verify that it works?

Follow the steps in the issue or run `ant -f build-test.xml run-selenium-test -Dtest.class=TagsUseCase#AddMultipleTagsViaBlogs`

# Why doesn't this include any test?

A POSHI test already exists: `TagsUseCase#AddMultipleTagsViaBlogs`