### PR TITLE
LPD-35008 Fixing tests in ContentTemplateResourceTest

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentTemplateResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentTemplateResourceTest.java
@@ -35,7 +35,6 @@ import java.io.InputStream;
 
 import java.util.Collections;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,12 +44,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ContentTemplateResourceTest
 	extends BaseContentTemplateResourceTestCase {
-
-	@Ignore
-	@Override
-	@Test
-	public void testGetAssetLibraryContentTemplatesPageWithFilterStringEquals() {
-	}
 
 	@Override
 	@Test
@@ -74,12 +67,6 @@ public class ContentTemplateResourceTest
 						contentTemplate2, entityField.getName(), 1);
 				}
 			});
-	}
-
-	@Ignore
-	@Override
-	@Test
-	public void testGetSiteContentTemplatesPageWithFilterStringEquals() {
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35008

These two tests are ignored on file `ContentTemplateResourceTest` so they are always marked as `UNTESTED` in Testray

* testGetAssetLibraryContentTemplatesPageWithFilterStringEquals
* testGetSiteContentTemplatesPageWithFilterStringEquals

# How am I fixing it?

Remove `Ignore` annotation on working tests because these tests are working correctly, at least locally.

# How can you verify that it works?

Run `gw tI --tests "ContentTemplateResourceTest.testGet*ContentTemplatesPageWithFilterStringEquals"` in folder `modules/apps/headless/headless-delivery/headless-delivery-test`

