### PR TITLE
LPD-35003 Translation Portlet Redirect not being escaped

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/ExportTranslationDisplayContext.java
@@ -163,7 +163,7 @@ public class ExportTranslationDisplayContext {
 		).put(
 			"pathModule", PortalUtil.getPathModule()
 		).put(
-			"redirectURL", getRedirect()
+			"redirectURL", PortalUtil.escapeRedirect(getRedirect())
 		).build();
 	}
 

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -222,7 +223,7 @@ public class TranslateDisplayContext {
 		return HashMapBuilder.<String, Object>put(
 			"additionalFields",
 			HashMapBuilder.<String, Object>put(
-				"redirect", ParamUtil.getString(_httpServletRequest, "redirect")
+				"redirect", _getRedirect()
 			).put(
 				"sourceLanguageId", getSourceLanguageId()
 			).put(
@@ -254,7 +255,7 @@ public class TranslateDisplayContext {
 			"publishButtonLabel",
 			LanguageUtil.get(_httpServletRequest, getPublishButtonLabel())
 		).put(
-			"redirectURL", ParamUtil.getString(_httpServletRequest, "redirect")
+			"redirectURL", _getRedirect()
 		).put(
 			"saveButtonDisabled", isSaveButtonDisabled()
 		).put(
@@ -540,6 +541,17 @@ public class TranslateDisplayContext {
 		return editorConfiguration.getData();
 	}
 
+	private String _getRedirect() {
+		if (Validator.isNotNull(_redirect)) {
+			return _redirect;
+		}
+
+		_redirect = PortalUtil.escapeRedirect(
+			ParamUtil.getString(_httpServletRequest, "redirect"));
+
+		return _redirect;
+	}
+
 	private TranslationEntry _getTranslationEntry() {
 		if (_translationEntry != null) {
 			return _translationEntry;
@@ -571,6 +583,7 @@ public class TranslateDisplayContext {
 	private final InfoForm _infoForm;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final Object _object;
+	private String _redirect;
 	private final long _segmentsExperienceId;
 	private final InfoItemFieldValues _sourceInfoItemFieldValues;
 	private final String _sourceLanguageId;

--- a/modules/apps/translation/translation-web/src/test/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContextTest.java
+++ b/modules/apps/translation/translation-web/src/test/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContextTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.translation.web.internal.display.context;
+
+import com.liferay.info.form.InfoForm;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.language.LanguageImpl;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+import com.liferay.translation.info.field.TranslationInfoFieldChecker;
+
+import java.util.ArrayList;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class TranslateDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_setUpLanguageUtil();
+		_setUpPortalUtil();
+	}
+
+	@Test
+	public void testRedirect() {
+		String redirect = _getRedirect("javascript:alert(document.domain)");
+
+		Assert.assertNull(redirect);
+
+		redirect = _getRedirect("/myexample1.png");
+
+		Assert.assertEquals("/myexample1.png", redirect);
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, Mockito.mock(ThemeDisplay.class));
+
+		return mockHttpServletRequest;
+	}
+
+	private String _getRedirect(String value) {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter("redirect", value);
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+
+		TranslateDisplayContext translateDisplayContext =
+			new TranslateDisplayContext(
+				new ArrayList<>(), new ArrayList<>(), () -> true,
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				Mockito.mock(InfoForm.class), mockLiferayPortletActionRequest,
+				new MockLiferayPortletRenderResponse(), null,
+				RandomTestUtil.randomLong(),
+				Mockito.mock(InfoItemFieldValues.class),
+				LanguageUtil.getLanguageId(LocaleUtil.ENGLISH),
+				Mockito.mock(InfoItemFieldValues.class),
+				LanguageUtil.getLanguageId(LocaleUtil.SPAIN),
+				Mockito.mock(TranslationInfoFieldChecker.class));
+
+		Assert.assertNotNull(translateDisplayContext);
+
+		return ReflectionTestUtil.invoke(
+			translateDisplayContext, "_getRedirect", new Class<?>[0]);
+	}
+
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(new LanguageImpl());
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+	}
+
+}


### PR DESCRIPTION
- **LPD-35003 Escape the redirects that we are passing to frontend components**
- **LPD-35003 Adds test**

Translation Portlet Redirect not being escaped

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-35003)

Redirect param is not being escaped when passing to the frontend component

# How am I fixing it?

Escaping it before passing it to the frontend component

# How can you verify that it works?

Follow the steps on the ticket or execute the unit test

