### PR TITLE
LPD-30186 Investigate Poshi test failures for QuestionsEntry related to CanonicalURL 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -1225,6 +1225,10 @@ definition {
 				questionTabField = "Questions",
 				questionTitle = "Question");
 
+			var pageSource = selenium.getHtmlSource();
+
+			echo("## * Page Source: ${pageSource}");
+
 			Questions.assertCanonicalURL(
 				category = "category",
 				pageName = "questions-page",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30186

A text is not found in the page source in CI, while it works correctly in local.

# How am I fixing it?

I'm adding debug info to try to find the problem.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURL`
