### PR TITLE
LPD-35077 Allow importing documents into imported folders

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 49.14.1
+Bundle-Version: 49.15.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
@@ -623,6 +623,56 @@ public class Document implements Serializable {
 	private Supplier<String> _descriptionSupplier;
 
 	@Schema(
+		description = "The external reference code of the `DocumentFolder` where this document is stored."
+	)
+	public String getDocumentFolderExternalReferenceCode() {
+		if (_documentFolderExternalReferenceCodeSupplier != null) {
+			documentFolderExternalReferenceCode =
+				_documentFolderExternalReferenceCodeSupplier.get();
+
+			_documentFolderExternalReferenceCodeSupplier = null;
+		}
+
+		return documentFolderExternalReferenceCode;
+	}
+
+	public void setDocumentFolderExternalReferenceCode(
+		String documentFolderExternalReferenceCode) {
+
+		this.documentFolderExternalReferenceCode =
+			documentFolderExternalReferenceCode;
+
+		_documentFolderExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDocumentFolderExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			documentFolderExternalReferenceCodeUnsafeSupplier) {
+
+		_documentFolderExternalReferenceCodeSupplier = () -> {
+			try {
+				return documentFolderExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The external reference code of the `DocumentFolder` where this document is stored."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String documentFolderExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _documentFolderExternalReferenceCodeSupplier;
+
+	@Schema(
 		description = "The ID of the `DocumentFolder` where this document is stored."
 	)
 	public Long getDocumentFolderId() {
@@ -1638,6 +1688,23 @@ public class Document implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		String documentFolderExternalReferenceCode =
+			getDocumentFolderExternalReferenceCode();
+
+		if (documentFolderExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentFolderExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(documentFolderExternalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 31.32.0
+version 31.33.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Document.java
@@ -302,6 +302,32 @@ public class Document implements Cloneable, Serializable {
 
 	protected String description;
 
+	public String getDocumentFolderExternalReferenceCode() {
+		return documentFolderExternalReferenceCode;
+	}
+
+	public void setDocumentFolderExternalReferenceCode(
+		String documentFolderExternalReferenceCode) {
+
+		this.documentFolderExternalReferenceCode =
+			documentFolderExternalReferenceCode;
+	}
+
+	public void setDocumentFolderExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			documentFolderExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			documentFolderExternalReferenceCode =
+				documentFolderExternalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String documentFolderExternalReferenceCode;
+
 	public Long getDocumentFolderId() {
 		return documentFolderId;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
@@ -241,6 +241,21 @@ public class DocumentSerDes {
 			sb.append("\"");
 		}
 
+		if (document.getDocumentFolderExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentFolderExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(document.getDocumentFolderExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (document.getDocumentFolderId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -627,6 +642,16 @@ public class DocumentSerDes {
 			map.put("description", String.valueOf(document.getDescription()));
 		}
 
+		if (document.getDocumentFolderExternalReferenceCode() == null) {
+			map.put("documentFolderExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"documentFolderExternalReferenceCode",
+				String.valueOf(
+					document.getDocumentFolderExternalReferenceCode()));
+		}
+
 		if (document.getDocumentFolderId() == null) {
 			map.put("documentFolderId", null);
 		}
@@ -827,6 +852,12 @@ public class DocumentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"documentFolderExternalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "documentFolderId")) {
 				return false;
 			}
@@ -989,6 +1020,15 @@ public class DocumentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "description")) {
 				if (jsonParserFieldValue != null) {
 					document.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"documentFolderExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					document.setDocumentFolderExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "documentFolderId")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1340,6 +1340,10 @@ components:
                     description:
                         The document's description.
                     type: string
+                documentFolderExternalReferenceCode:
+                    description:
+                        The external reference code of the `DocumentFolder` where this document is stored.
+                    type: string
                 documentFolderId:
                     description:
                         The ID of the `DocumentFolder` where this document is stored.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -166,6 +167,17 @@ public class DocumentDTOConverter
 				}
 
 				setDescription(fileEntry::getDescription);
+				setDocumentFolderExternalReferenceCode(
+					() -> {
+						if (fileEntry.getFolderId() > 0) {
+							Folder folder = _dlAppService.getFolder(
+								fileEntry.getFolderId());
+
+							return folder.getExternalReferenceCode();
+						}
+
+						return null;
+					});
 				setDocumentFolderId(fileEntry::getFolderId);
 				setDocumentType(
 					() -> _toDocumentType(dtoConverterContext, fileVersion));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1200,7 +1200,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryDocumentByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderExternalReferenceCode, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the asset library's document by external reference code."
@@ -1293,7 +1293,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderExternalReferenceCode, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the document.")
 	public Document document(@GraphQLName("documentId") Long documentId)
@@ -1397,7 +1397,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, adaptedImages, aggregateRating, assetLibraryKey, contentUrl, contentValue, creator, customFields, dateCreated, dateExpired, dateModified, datePublished, description, documentFolderExternalReferenceCode, documentFolderId, documentType, encodingFormat, externalReferenceCode, fileExtension, fileName, friendlyUrlPath, id, keywords, numberOfComments, relatedContents, renderedContents, siteId, sizeInBytes, taxonomyCategoryBriefs, taxonomyCategoryIds, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the site's document by external reference code."

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -552,6 +552,18 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			externalReferenceCode = document.getExternalReferenceCode();
 		}
 
+		if ((document != null) &&
+			(document.getDocumentFolderExternalReferenceCode() != null)) {
+
+			Folder folder =
+				_dlAppLocalService.fetchFolderByExternalReferenceCode(
+					document.getDocumentFolderExternalReferenceCode(), groupId);
+
+			if (folder != null) {
+				documentFolderId = folder.getFolderId();
+			}
+		}
+
 		if (documentFolderId == null) {
 			if (document != null) {
 				documentFolderId = document.getDocumentFolderId();
@@ -918,11 +930,26 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		Long folderId = null;
 
-		if ((document != null) && (document.getDocumentFolderId() != null) &&
-			(document.getDocumentFolderId() !=
-				existingFileEntry.getFolderId())) {
+		if (document != null) {
+			String documentFolderExternalReferenceCode =
+				document.getDocumentFolderExternalReferenceCode();
 
-			folderId = document.getDocumentFolderId();
+			if (documentFolderExternalReferenceCode != null) {
+				Folder folder =
+					_dlAppLocalService.fetchFolderByExternalReferenceCode(
+						documentFolderExternalReferenceCode,
+						existingFileEntry.getGroupId());
+
+				if (folder != null) {
+					folderId = folder.getFolderId();
+				}
+			}
+			else if ((document.getDocumentFolderId() != null) &&
+					 (document.getDocumentFolderId() !=
+						 existingFileEntry.getFolderId())) {
+
+				folderId = document.getDocumentFolderId();
+			}
 		}
 
 		if (folderId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -192,6 +192,7 @@ public abstract class BaseDocumentResourceTestCase {
 		document.setContentUrl(regex);
 		document.setContentValue(regex);
 		document.setDescription(regex);
+		document.setDocumentFolderExternalReferenceCode(regex);
 		document.setEncodingFormat(regex);
 		document.setExternalReferenceCode(regex);
 		document.setFileExtension(regex);
@@ -209,6 +210,8 @@ public abstract class BaseDocumentResourceTestCase {
 		Assert.assertEquals(regex, document.getContentUrl());
 		Assert.assertEquals(regex, document.getContentValue());
 		Assert.assertEquals(regex, document.getDescription());
+		Assert.assertEquals(
+			regex, document.getDocumentFolderExternalReferenceCode());
 		Assert.assertEquals(regex, document.getEncodingFormat());
 		Assert.assertEquals(regex, document.getExternalReferenceCode());
 		Assert.assertEquals(regex, document.getFileExtension());
@@ -3319,6 +3322,17 @@ public abstract class BaseDocumentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"documentFolderExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (document.getDocumentFolderExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("documentFolderId", additionalAssertFieldName)) {
 				if (document.getDocumentFolderId() == null) {
 					valid = false;
@@ -3771,6 +3785,20 @@ public abstract class BaseDocumentResourceTestCase {
 				if (!Objects.deepEquals(
 						document1.getDescription(),
 						document2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"documentFolderExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						document1.getDocumentFolderExternalReferenceCode(),
+						document2.getDocumentFolderExternalReferenceCode())) {
 
 					return false;
 				}
@@ -4498,6 +4526,52 @@ public abstract class BaseDocumentResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("documentFolderExternalReferenceCode")) {
+			Object object = document.getDocumentFolderExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("documentFolderId")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -4896,6 +4970,8 @@ public abstract class BaseDocumentResourceTestCase {
 				dateModified = RandomTestUtil.nextDate();
 				datePublished = RandomTestUtil.nextDate();
 				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				documentFolderExternalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				documentFolderId = RandomTestUtil.randomLong();
 				encodingFormat = StringUtil.toLowerCase(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -237,7 +237,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	public void testPutSiteDocumentByExternalReferenceCode() throws Exception {
 		super.testPutSiteDocumentByExternalReferenceCode();
 
-		DLFolder dlFolder = _dlFolderLocalService.addFolder(
+		DLFolder dlFolder1 = _dlFolderLocalService.addFolder(
 			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
 			testGroup.getGroupId(), false,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -246,7 +246,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 		Document randomDocument = randomDocument();
 
-		randomDocument.setDocumentFolderId(dlFolder.getFolderId());
+		randomDocument.setDocumentFolderId(dlFolder1.getFolderId());
 
 		Document putDocument =
 			documentResource.putSiteDocumentByExternalReferenceCode(
@@ -255,7 +255,24 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 				getMultipartFiles());
 
 		Assert.assertEquals(
-			(Long)dlFolder.getFolderId(), putDocument.getDocumentFolderId());
+			(Long)dlFolder1.getFolderId(), putDocument.getDocumentFolderId());
+
+		DLFolder dlFolder2 = _dlFolderLocalService.addFolder(
+			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
+			testGroup.getGroupId(), false,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId()));
+
+		putDocument.setDocumentFolderExternalReferenceCode(
+			dlFolder2.getExternalReferenceCode());
+
+		putDocument = documentResource.putSiteDocumentByExternalReferenceCode(
+			putDocument.getSiteId(), putDocument.getExternalReferenceCode(),
+			putDocument, getMultipartFiles());
+
+		Assert.assertEquals(
+			(Long)dlFolder2.getFolderId(), putDocument.getDocumentFolderId());
 	}
 
 	@Override


### PR DESCRIPTION
# Motivation

We are developing this user [story](https://liferay.atlassian.net/browse/LPD-29348) where the aim is to improve the export/import experience 
of object entries with attachment fields.

One of the acceptance criterias (AC5) of the story is:

> Given a successful import of an object entry with a previously missing attached file,
> 
> When the missing attached file is subsequently imported,
> 
> Then the system must establish the correct relationship between the object entry and the imported attached file.

In the cases where documents are in folders. We could not find a way to export and import the folders and documents as they were before, using the rest endpoints. Because the document only referenced the id of the its folder.

# Solution

In order to properly meet and test the criteria mentioned above, we added the folder ERC to the document DTO. And also added logic that takes the ERC into account when adding or updating a document, ensuring that it is created or moved to the corresponding folder if it exists.