### PR TITLE
LPD-30186 Fix Poshi test failures for QuestionsEntry related to CanonicalURL

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
@@ -197,7 +197,7 @@ definition {
 	macro assertCanonicalURL(category = null, title = null) {
 		var html = '''<link href="''';
 		var html2 = '''" rel="canonical" data-react-helmet="true">''';
-		var portalURL = ${portalURL};
+		var portalURL = "${portalURL}/web/guest";
 		var pageName = StringUtil.lowerCase(${pageName});
 
 		var pageNameURL = StringUtil.replace(${pageName}, " ", "-");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -1225,10 +1225,6 @@ definition {
 				questionTabField = "Questions",
 				questionTitle = "Question");
 
-			var pageSource = selenium.getHtmlSource();
-
-			echo("## * Page Source: ${pageSource}");
-
 			Questions.assertCanonicalURL(
 				category = "category",
 				pageName = "questions-page",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-30186

The canonical URL in CI for questions pages is different  from the expected one.

# How am I fixing it?

I've added `/web/guest` to the URL path in function `Questions.assertCanonicalURL`, similarly to what the function `Pages.assertCanonicalURL` already has.

# How can you verify that it works?

I'm not able to reproduce it locally, however I'm quite sure it works in CI:

* `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURLWithSpecialCharacters`
* `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions`
* `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURL`