### PR TITLE
LPD-27779 Add ctCollectionId to query filters

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/portal/upgrade/v7_4_x/test/UpgradeDLFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/portal/upgrade/v7_4_x/test/UpgradeDLFileEntryTest.java
@@ -1,0 +1,205 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.UpgradeDLFileEntry;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class UpgradeDLFileEntryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, UpgradeDLFileEntryTest.class.getSimpleName(), null);
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		DLFileEntry productionDLFileEntry;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			productionDLFileEntry = _dlFileEntryLocalService.addFileEntry(
+				StringUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), _group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				StringUtil.randomString(), StringUtil.randomString(),
+				StringUtil.randomString(), null, StringUtil.randomString(),
+				StringUtil.randomString(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+				null, null, new UnsyncByteArrayInputStream(new byte[0]), 0,
+				null, null, null,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		}
+
+		DLFileEntry ctCollectionDLFileEntry;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionDLFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+				productionDLFileEntry.getFileEntryId());
+
+			ctCollectionDLFileEntry =
+				_dlFileEntryLocalService.updateDLFileEntry(
+					ctCollectionDLFileEntry);
+
+			_unsetExternalReferenceCode(ctCollectionDLFileEntry);
+		}
+
+		_runUpgrade();
+
+		_multiVMPool.clear();
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			productionDLFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+				productionDLFileEntry.getFileEntryId());
+		}
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionDLFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+				ctCollectionDLFileEntry.getFileEntryId());
+		}
+
+		Assert.assertNotNull(
+			ctCollectionDLFileEntry.getExternalReferenceCode());
+		Assert.assertEquals(
+			String.valueOf(ctCollectionDLFileEntry.getFileEntryId()),
+			ctCollectionDLFileEntry.getExternalReferenceCode());
+
+		Assert.assertNotEquals(
+			productionDLFileEntry.getExternalReferenceCode(),
+			ctCollectionDLFileEntry.getExternalReferenceCode());
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = new UpgradeDLFileEntry() {
+
+			@Override
+			protected void alterTableAddColumn(
+					String tableName, String columnName, String columnType)
+				throws Exception {
+
+				if (tableName.equals("DLFileEntry") &&
+					columnName.equals("externalReferenceCode") &&
+					columnType.equals("VARCHAR(75)")) {
+
+					return;
+				}
+
+				super.alterTableAddColumn(tableName, columnName, columnType);
+			}
+
+			@Override
+			protected UpgradeStep[] getPostUpgradeSteps() {
+				return new UpgradeStep[0];
+			}
+
+			@Override
+			protected boolean hasColumn(String tableName, String columnName)
+				throws Exception {
+
+				if (tableName.equals("DLFileEntry") &&
+					columnName.equals("externalReferenceCode")) {
+
+					return false;
+				}
+
+				return super.hasColumn(tableName, columnName);
+			}
+
+		};
+
+		upgradeProcess.upgrade();
+	}
+
+	private void _unsetExternalReferenceCode(DLFileEntry dlFileEntry)
+		throws Exception {
+
+		Connection connection = DataAccess.getConnection();
+
+		Statement statement = connection.createStatement();
+
+		int rowCount = statement.executeUpdate(
+			StringBundler.concat(
+				"update DLFileEntry set externalReferenceCode = '' where ",
+				"ctCollectionId = ", dlFileEntry.getCtCollectionId(),
+				" and fileEntryId = ", dlFileEntry.getFileEntryId()));
+
+		Assert.assertEquals(1, rowCount);
+	}
+
+	@Inject
+	private static CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private CTCollection _ctCollection;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/portal/upgrade/v7_4_x/test/UpgradeDLFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/portal/upgrade/v7_4_x/test/UpgradeDLFileEntryTest.java
@@ -63,7 +63,7 @@ public class UpgradeDLFileEntryTest {
 
 	@Test
 	public void testUpgrade() throws Exception {
-		DLFileEntry productionDLFileEntry;
+		DLFileEntry productionDLFileEntry = null;
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
@@ -81,7 +81,7 @@ public class UpgradeDLFileEntryTest {
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 		}
 
-		DLFileEntry ctCollectionDLFileEntry;
+		DLFileEntry ctCollectionDLFileEntry = null;
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_3_0/StorageLinksUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_3_0/StorageLinksUpgradeProcess.java
@@ -31,6 +31,7 @@ public class StorageLinksUpgradeProcess extends UpgradeProcess {
 				connection.prepareStatement(
 					StringBundler.concat(
 						"select DDMStructureVersion.structureVersionId, ",
+						"DDMStorageLink.ctCollectionId, ",
 						"DDMStorageLink.storageLinkId from DDMStorageLink ",
 						"inner join DDMStructure on DDMStructure.structureId ",
 						"= DDMStorageLink.structureVersionId inner join ",
@@ -45,12 +46,13 @@ public class StorageLinksUpgradeProcess extends UpgradeProcess {
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update DDMStorageLink set structureVersionId = ? where " +
-						"storageLinkId = ?");
+						"ctCollectionId = ? and storageLinkId = ?");
 			ResultSet resultSet = selectPreparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
 				updatePreparedStatement.setLong(1, resultSet.getLong(1));
 				updatePreparedStatement.setLong(2, resultSet.getLong(2));
+				updatePreparedStatement.setLong(3, resultSet.getLong(3));
 
 				updatePreparedStatement.addBatch();
 			}
@@ -62,6 +64,7 @@ public class StorageLinksUpgradeProcess extends UpgradeProcess {
 				connection.prepareStatement(
 					StringBundler.concat(
 						"select DDMStructureVersion.structureId, ",
+						"DDMStorageLink.ctCollectionId, ",
 						"DDMStorageLink.storageLinkId from DDMStorageLink ",
 						"inner join DDMStructureVersion on ",
 						"DDMStructureVersion.structureVersionId = ",
@@ -71,12 +74,13 @@ public class StorageLinksUpgradeProcess extends UpgradeProcess {
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update DDMStorageLink set structureId = ? where " +
-						"storageLinkId = ?");
+						"ctCollectionId = ? and storageLinkId = ?");
 			ResultSet resultSet = selectPreparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
 				updatePreparedStatement.setLong(1, resultSet.getLong(1));
 				updatePreparedStatement.setLong(2, resultSet.getLong(2));
+				updatePreparedStatement.setLong(3, resultSet.getLong(3));
 
 				updatePreparedStatement.addBatch();
 			}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v3_3_0/test/StorageLinksUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v3_3_0/test/StorageLinksUpgradeProcessTest.java
@@ -70,7 +70,7 @@ public class StorageLinksUpgradeProcessTest {
 
 	@Test
 	public void testUpgrade() throws Exception {
-		DDMStructure productionDDMStructure;
+		DDMStructure productionDDMStructure = null;
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
@@ -92,7 +92,7 @@ public class StorageLinksUpgradeProcessTest {
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 		}
 
-		DDMStructure ctCollectionDDMStructure;
+		DDMStructure ctCollectionDDMStructure = null;
 
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
@@ -122,9 +122,6 @@ public class StorageLinksUpgradeProcessTest {
 
 		_multiVMPool.clear();
 
-		List<DDMStorageLink> ctCollectionDDMStorageLinks;
-		DDMStructureVersion ctCollectionDDMStructureVersion;
-
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					_ctCollection.getCtCollectionId())) {
@@ -133,39 +130,40 @@ public class StorageLinksUpgradeProcessTest {
 				_ddmStructureLocalService.fetchDDMStructure(
 					productionDDMStructure.getStructureId());
 
-			ctCollectionDDMStorageLinks =
+			List<DDMStorageLink> ctCollectionDDMStorageLinks =
 				_ddmStorageLinkLocalService.getStructureStorageLinks(
 					ctCollectionDDMStructure.getStructureId());
-
-			ctCollectionDDMStructureVersion =
+			DDMStructureVersion ctCollectionDDMStructureVersion =
 				ctCollectionDDMStructure.getStructureVersion();
+
+			List<Long> ddmStructureVersionIds = ListUtil.toList(
+				ctCollectionDDMStorageLinks,
+				DDMStorageLink::getStructureVersionId);
+
+			Assert.assertFalse(
+				ddmStructureVersionIds.toString(),
+				ListUtil.exists(
+					ddmStructureVersionIds,
+					ddmStructureVersionId -> ddmStructureVersionId == 0));
+			Assert.assertEquals(
+				ddmStructureVersionIds.toString(),
+				ddmStructureVersionIds.size(),
+				ListUtil.count(
+					ddmStructureVersionIds,
+					ddmStructureVersionId ->
+						ddmStructureVersionId ==
+							ctCollectionDDMStructureVersion.
+								getStructureVersionId()));
 		}
-
-		List<Long> ddmStructureVersionIds = ListUtil.toList(
-			ctCollectionDDMStorageLinks, DDMStorageLink::getStructureVersionId);
-
-		Assert.assertFalse(
-			ddmStructureVersionIds.toString(),
-			ListUtil.exists(
-				ddmStructureVersionIds,
-				ddmStructureVersionId -> ddmStructureVersionId == 0));
-		Assert.assertEquals(
-			ddmStructureVersionIds.toString(), ddmStructureVersionIds.size(),
-			ListUtil.count(
-				ddmStructureVersionIds,
-				ddmStructureVersionId ->
-					ddmStructureVersionId ==
-						ctCollectionDDMStructureVersion.
-							getStructureVersionId()));
 	}
 
 	private DDMForm _getDDMForm() {
 		DDMForm ddmForm = new DDMForm();
 
-		ddmForm.setDefaultLocale(LocaleUtil.US);
 		ddmForm.addAvailableLocale(LocaleUtil.US);
 		ddmForm.addDDMFormField(
 			new DDMFormField("field", DDMFormFieldTypeConstants.TEXT));
+		ddmForm.setDefaultLocale(LocaleUtil.US);
 
 		return ddmForm;
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v3_3_0/test/StorageLinksUpgradeProcessTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/upgrade/v3_3_0/test/StorageLinksUpgradeProcessTest.java
@@ -1,0 +1,211 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.internal.upgrade.v3_3_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStorageLink;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMStorageLinkLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.StorageType;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class StorageLinksUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, StorageLinksUpgradeProcessTest.class.getSimpleName(), null);
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		DDMStructure productionDDMStructure;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
+
+			productionDDMStructure = _ddmStructureLocalService.addStructure(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
+				_classNameLocalService.getClassNameId(JournalArticle.class),
+				StringUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.US, StringUtil.randomString()
+				).build(),
+				HashMapBuilder.put(
+					LocaleUtil.US, StringUtil.randomString()
+				).build(),
+				_getDDMForm(), _ddm.getDefaultDDMFormLayout(_getDDMForm()),
+				StorageType.DEFAULT.toString(),
+				DDMStructureConstants.TYPE_DEFAULT,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		}
+
+		DDMStructure ctCollectionDDMStructure;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionDDMStructure =
+				_ddmStructureLocalService.updateStructure(
+					TestPropsValues.getUserId(),
+					productionDDMStructure.getStructureId(), _getDDMForm(),
+					_ddm.getDefaultDDMFormLayout(_getDDMForm()),
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId()));
+
+			List<DDMStorageLink> ddmStorageLinks =
+				_ddmStorageLinkLocalService.getStructureStorageLinks(
+					ctCollectionDDMStructure.getStructureId());
+
+			for (DDMStorageLink ddmStorageLink : ddmStorageLinks) {
+				ddmStorageLink.setStructureVersionId(0);
+
+				_ddmStorageLinkLocalService.updateDDMStorageLink(
+					ddmStorageLink);
+			}
+		}
+
+		_runUpgrade();
+
+		_multiVMPool.clear();
+
+		List<DDMStorageLink> ctCollectionDDMStorageLinks;
+		DDMStructureVersion ctCollectionDDMStructureVersion;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			ctCollectionDDMStructure =
+				_ddmStructureLocalService.fetchDDMStructure(
+					productionDDMStructure.getStructureId());
+
+			ctCollectionDDMStorageLinks =
+				_ddmStorageLinkLocalService.getStructureStorageLinks(
+					ctCollectionDDMStructure.getStructureId());
+
+			ctCollectionDDMStructureVersion =
+				ctCollectionDDMStructure.getStructureVersion();
+		}
+
+		List<Long> ddmStructureVersionIds = ListUtil.toList(
+			ctCollectionDDMStorageLinks, DDMStorageLink::getStructureVersionId);
+
+		Assert.assertFalse(
+			ddmStructureVersionIds.toString(),
+			ListUtil.exists(
+				ddmStructureVersionIds,
+				ddmStructureVersionId -> ddmStructureVersionId == 0));
+		Assert.assertEquals(
+			ddmStructureVersionIds.toString(), ddmStructureVersionIds.size(),
+			ListUtil.count(
+				ddmStructureVersionIds,
+				ddmStructureVersionId ->
+					ddmStructureVersionId ==
+						ctCollectionDDMStructureVersion.
+							getStructureVersionId()));
+	}
+
+	private DDMForm _getDDMForm() {
+		DDMForm ddmForm = new DDMForm();
+
+		ddmForm.setDefaultLocale(LocaleUtil.US);
+		ddmForm.addAvailableLocale(LocaleUtil.US);
+		ddmForm.addDDMFormField(
+			new DDMFormField("field", DDMFormFieldTypeConstants.TEXT));
+
+		return ddmForm;
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.journal.internal.upgrade.v3_3_0." +
+				"StorageLinksUpgradeProcess");
+
+		upgradeProcess.upgrade();
+	}
+
+	@Inject
+	private static CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.journal.internal.upgrade.registry.JournalServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private CTCollection _ctCollection;
+
+	@Inject
+	private DDM _ddm;
+
+	@Inject
+	private DDMStorageLinkLocalService _ddmStorageLinkLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFileEntry.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFileEntry.java
@@ -40,7 +40,7 @@ public class UpgradeDLFileEntry extends UpgradeProcess {
 
 	private void _populateExternalReferenceCode() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select fileEntryId from DLFileEntry where " +
+				"select ctCollectionId, fileEntryId from DLFileEntry where " +
 					"externalReferenceCode is null or externalReferenceCode " +
 						"= ''");
 			ResultSet resultSet = preparedStatement1.executeQuery();
@@ -48,13 +48,18 @@ public class UpgradeDLFileEntry extends UpgradeProcess {
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update DLFileEntry set externalReferenceCode = ? where " +
-						"fileEntryId = ?")) {
+						"ctCollectionId = ? and fileEntryId = ?")) {
 
 			while (resultSet.next()) {
-				long fileEntryId = resultSet.getLong(1);
+				long ctCollectionId = resultSet.getLong(1);
+
+				long fileEntryId = resultSet.getLong(2);
 
 				preparedStatement2.setString(1, String.valueOf(fileEntryId));
-				preparedStatement2.setLong(2, fileEntryId);
+
+				preparedStatement2.setLong(2, ctCollectionId);
+
+				preparedStatement2.setLong(3, fileEntryId);
 
 				preparedStatement2.addBatch();
 			}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFileEntry.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDLFileEntry.java
@@ -51,14 +51,11 @@ public class UpgradeDLFileEntry extends UpgradeProcess {
 						"ctCollectionId = ? and fileEntryId = ?")) {
 
 			while (resultSet.next()) {
-				long ctCollectionId = resultSet.getLong(1);
-
 				long fileEntryId = resultSet.getLong(2);
 
 				preparedStatement2.setString(1, String.valueOf(fileEntryId));
 
-				preparedStatement2.setLong(2, ctCollectionId);
-
+				preparedStatement2.setLong(2, resultSet.getLong(1));
 				preparedStatement2.setLong(3, fileEntryId);
 
 				preparedStatement2.addBatch();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27779
https://liferay.atlassian.net/browse/LPD-27790

Some queries should restrict updates by ctCollectionId, but they're not taking that column into account.

# How am I fixing it?

By adding the ctCollectionId as an additional filter to the queries.

# How can you verify that it works?

This PR includes two integration tests, one per upgrade process.