### PR TITLE
LPD-35134 fix test: Icon menu should close when another menu opens

### DIFF
--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -8,53 +8,57 @@ import {expect, mergeTests} from '@playwright/test';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 
 export const test = mergeTests(isolatedSiteTest, loginTest(), wikiPagesTest);
 
-test('LPD-26435 Icon menu should close when another icon menu is open', async ({
-	page,
-	wikiPage,
-}) => {
-	await wikiPage.goto();
+test(
+	'Icon menu should close when another icon menu is open',
+	{
+		tag: '@LPD-26435',
+	},
+	async ({page, wikiPage}) => {
+		await wikiPage.goto();
 
-	await wikiPage.createNewWikiNode('Wiki Node Title');
+		await wikiPage.createNewWikiNode('Wiki Node Title');
 
-	await page.getByLabel('Order').waitFor();
-
-	const wikiNodeMenu = await page.locator(
-		'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
-	);
-
-	await test.step('Check menu gets closed', async () => {
-		await wikiNodeMenu.click();
-
-		const menuOne = await page.locator(
-			'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
+		const wikiNodeMenu = page.locator(
+			'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
 		);
 
-		await expect(menuOne).toBeVisible();
+		await test.step('Check menu gets closed', async () => {
+			const menuOne = page.locator(
+				'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
+			);
 
-		await page
-			.locator(
-				'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
-			)
-			.click();
+			await clickAndExpectToBeVisible({
+				autoClick: false,
+				target: menuOne,
+				trigger: wikiNodeMenu,
+			});
 
-		const menuTwo = await page.locator(
-			'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
-		);
+			await page
+				.locator(
+					'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
+				)
+				.click();
 
-		await expect(menuTwo).toBeVisible();
+			const menuTwo = page.locator(
+				'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
+			);
 
-		await expect(menuOne).toBeHidden();
-	});
+			await expect(menuTwo).toBeVisible();
 
-	await test.step('Wiki node is deleted', async () => {
-		await wikiNodeMenu.click();
+			await expect(menuOne).toBeHidden();
+		});
 
-		await page.getByRole('link', {name: 'Delete'}).click();
-	});
-});
+		await test.step('Wiki node is deleted', async () => {
+			await wikiNodeMenu.click();
+
+			await page.getByRole('link', {name: 'Delete'}).click();
+		});
+	}
+);
 
 test('LPD-28898 Image added via rich text editor on Wiki tool losing reference', async ({
 	page,

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -17,8 +17,8 @@ test(
 	{
 		tag: '@LPD-26435',
 	},
-	async ({page, wikiPage}) => {
-		await wikiPage.goto();
+	async ({page, site, wikiPage}) => {
+		await wikiPage.goto(site.friendlyUrlPath);
 
 		await wikiPage.createNewWikiNode('Wiki Node Title');
 
@@ -51,20 +51,15 @@ test(
 
 			await expect(menuOne).toBeHidden();
 		});
-
-		await test.step('Wiki node is deleted', async () => {
-			await wikiNodeMenu.click();
-
-			await page.getByRole('link', {name: 'Delete'}).click();
-		});
 	}
 );
 
 test('LPD-28898 Image added via rich text editor on Wiki tool losing reference', async ({
 	page,
+	site,
 	wikiPage,
 }) => {
-	await wikiPage.goto();
+	await wikiPage.goto(site.friendlyUrlPath);
 
 	await wikiPage.goToWikiNode('Main');
 
@@ -86,7 +81,7 @@ test('LPD-28898 Image added via rich text editor on Wiki tool losing reference',
 
 	await wikiPage.publishPage();
 
-	await wikiPage.goto();
+	await wikiPage.goto(site.friendlyUrlPath);
 
 	await wikiPage.goToWikiNode('Main');
 


### PR DESCRIPTION
Hi Team,
I would like to kindly ask to review my PR

Technikal task: https://liferay.atlassian.net/browse/LPD-35134 original issue: https://liferay.atlassian.net/browse/LPD-26435
 
Added clickAndExpectToBeVisible because it could not find the drop down menu, now it is waiting for that to be visible.

![image](https://github.com/user-attachments/assets/19870992-8593-497b-8d94-eddbc7db4e00)

Thanks!