### PR TITLE
LPD-35438 Change label when submitting for workflow

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -238,7 +238,13 @@ export default function SaveButtons({
 					>
 						{articleId
 							? workflowEnabled
-								? Liferay.Language.get('submit-for-workflow')
+								? showPublishModal
+									? Liferay.Language.get(
+											'submit-for-workflow-with-permissions'
+										)
+									: Liferay.Language.get(
+											'submit-for-workflow'
+										)
 								: showPublishModal
 									? Liferay.Language.get(
 											'publish-with-permissions'

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -72,6 +72,19 @@ describe('SaveButtons', () => {
 		expect(screen.getByText('save article')).toBeInTheDocument();
 	});
 
+	it('submit for workflow with permissions when publishing for the first time', () => {
+		renderComponent({
+			...DEFAULT_PROPS,
+			articleId: '2611',
+			showPublishModal: true,
+			workflowEnabled: true,
+		});
+
+		expect(
+			screen.getByText('submit-for-workflow-with-permissions')
+		).toBeInTheDocument();
+	});
+
 	it('Do not open modal for all buttons when there is an articleId', () => {
 		renderComponent({
 			...DEFAULT_PROPS,


### PR DESCRIPTION
LPD-35438 Change label when submitting for workflow

# What is this trying to solve?

- Change label "Submit for workflow" with "Submit for workflow with permissions" when we publish a web content for the first time as when we publish is "Publish with permissions" 

[Link to ticket](https://liferay.atlassian.net/browse/LPD-35438)

# How am I fixing it?

- Change the label and create the test

# How can I test it?

- Go to Configuration > Workflow > Web content article > SIngle approver
- Go to Content & Data > Web Content > Click on Submit for workflow
- See  "Submit for workflow with permissions" 
![image](https://github.com/user-attachments/assets/c5418947-5ba6-4d01-b958-49a0991ea9bc)
