### PR TITLE
LPD-35434 Categorization is empty in content dashboard info panel

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -29,9 +29,9 @@ const TABS_1 = {
 };
 
 const TABS_2 = {
-	categorization: 2,
+	categorization: 1,
 	details: 0,
-	performance: 1,
+	performance: 2,
 	version: 3,
 };
 
@@ -199,21 +199,6 @@ const SidebarPanelInfoView = ({
 							{Liferay.Language.get('details')}
 						</ClayTabs.Item>
 
-						{!!Liferay.FeatureFlags['LPD-28830'] && (
-							<ClayTabs.Item
-								active={activeTabKeyValue === TABS.performance}
-								className="flex-shrink-0"
-								innerProps={{
-									'aria-controls': 'performance',
-								}}
-								onClick={() =>
-									setActiveTabKeyValue(TABS.performance)
-								}
-							>
-								{Liferay.Language.get('performance')}
-							</ClayTabs.Item>
-						)}
-
 						{hasCategorization && (
 							<ClayTabs.Item
 								active={
@@ -228,6 +213,21 @@ const SidebarPanelInfoView = ({
 								}
 							>
 								{Liferay.Language.get('categorization')}
+							</ClayTabs.Item>
+						)}
+
+						{!!Liferay.FeatureFlags['LPD-28830'] && (
+							<ClayTabs.Item
+								active={activeTabKeyValue === TABS.performance}
+								className="flex-shrink-0"
+								innerProps={{
+									'aria-controls': 'performance',
+								}}
+								onClick={() =>
+									setActiveTabKeyValue(TABS.performance)
+								}
+							>
+								{Liferay.Language.get('performance')}
 							</ClayTabs.Item>
 						)}
 
@@ -279,7 +279,7 @@ const SidebarPanelInfoView = ({
 				<div>
 					<ClayTabs.Content activeIndex={activeTabKeyValue} fade>
 						<ClayTabs.TabPane
-							aria-labelledby={`tab-${TABS.details + 1}`}
+							aria-labelledby={`tab-${TABS.details}`}
 							className="flex-shrink-0"
 						>
 							<DetailsContent
@@ -297,38 +297,34 @@ const SidebarPanelInfoView = ({
 							/>
 						</ClayTabs.TabPane>
 
-						{!!Liferay.FeatureFlags['LPD-28830'] &&
-							showTabs &&
-							activeTabKeyValue === TABS.performance && (
-								<ClayTabs.TabPane
-									aria-labelledby={`tab-${TABS.performance + 1}`}
-									className="flex-shrink-0"
-								>
-									<AnalyticsReports
-										contentPerformanceDataFetchURL={
-											contentPerformanceDataFetchURL
-										}
-									/>
-								</ClayTabs.TabPane>
-							)}
-
-						{hasCategorization &&
-							showTabs &&
-							activeTabKeyValue === TABS.categorization && (
-								<ClayTabs.TabPane
-									aria-labelledby={`tab-${TABS.categorization + 1}`}
-									className="flex-shrink-0"
-								>
-									<Categorization
-										tags={tags}
-										vocabularies={vocabularies}
-									/>
-								</ClayTabs.TabPane>
-							)}
-
-						{showTabs && activeTabKeyValue === TABS.version && (
+						{hasCategorization && showTabs && (
 							<ClayTabs.TabPane
-								aria-labelledby={`tab-${TABS.version + 1}`}
+								aria-labelledby={`tab-${TABS.categorization}`}
+								className="flex-shrink-0"
+							>
+								<Categorization
+									tags={tags}
+									vocabularies={vocabularies}
+								/>
+							</ClayTabs.TabPane>
+						)}
+
+						{!!Liferay.FeatureFlags['LPD-28830'] && showTabs && (
+							<ClayTabs.TabPane
+								aria-labelledby={`tab-${TABS.performance}`}
+								className="flex-shrink-0"
+							>
+								<AnalyticsReports
+									contentPerformanceDataFetchURL={
+										contentPerformanceDataFetchURL
+									}
+								/>
+							</ClayTabs.TabPane>
+						)}
+
+						{showTabs && (
+							<ClayTabs.TabPane
+								aria-labelledby={`tab-${TABS.version}`}
 								className="flex-shrink-0"
 							>
 								<VersionsContent

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -227,7 +227,7 @@ exports[`SidebarPanelInfoView renders 1`] = `
             class="tab-content"
           >
             <div
-              aria-labelledby="tab-1"
+              aria-labelledby="tab-0"
               class="tab-pane active fade show flex-shrink-0"
               role="tabpanel"
               tabindex="0"
@@ -598,6 +598,937 @@ exports[`SidebarPanelInfoView renders 1`] = `
                   </div>
                 </div>
               </div>
+            </div>
+            <div
+              aria-labelledby="tab-1"
+              class="tab-pane fade flex-shrink-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <div
+                class="panel c-mb-1 panel-unstyled"
+              >
+                <button
+                  aria-controls="clay-id-3"
+                  aria-expanded="true"
+                  class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                  type="button"
+                >
+                  <div>
+                    <div
+                      class="autofit-row"
+                    >
+                      <div
+                        class="align-self-center panel-title autofit-col autofit-col-expand"
+                      >
+                        <span
+                          aria-label="view public-categories"
+                        >
+                          public-categories
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    class="collapse-icon-closed"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-right"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="collapse-icon-open"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-down"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-down"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <div
+                  aria-labelledby="clay-id-3"
+                  class="panel-collapse"
+                  id="clay-id-3"
+                  role="region"
+                >
+                  <div
+                    class="panel-body"
+                  >
+                    <div>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        AA Another Fake vocabulary (Liferay)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Fake 6
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Clothes (Demo Site)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 6
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Clothe 7
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Developers (Liferay)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Backend
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Data Scientist
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Design
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Devops
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Frontend
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            QA
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Travel (Demo Site)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 6
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Travel 7
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        ZZ Fake vocabulary (Liferay)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Fake 6
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        AA Another Global Random Vocabulary (Global)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Another Global Random 6
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Foods (Global)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Chinese
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Indian
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Italian
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Mexican
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Spanish
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Thai
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Topic (Global)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 6
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Topic 7
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        ZZ Global Random Vocabulary (Global)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Global Random 6
+                          </span>
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="panel c-mb-1 panel-unstyled"
+              >
+                <button
+                  aria-controls="clay-id-4"
+                  aria-expanded="true"
+                  class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                  type="button"
+                >
+                  <div>
+                    <div
+                      class="autofit-row"
+                    >
+                      <div
+                        class="align-self-center panel-title autofit-col autofit-col-expand"
+                      >
+                        <span
+                          aria-label="view internal-categories"
+                        >
+                          internal-categories
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    class="collapse-icon-closed"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-right"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="collapse-icon-open"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-down"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-down"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <div
+                  aria-labelledby="clay-id-4"
+                  class="panel-collapse"
+                  id="clay-id-4"
+                  role="region"
+                >
+                  <div
+                    class="panel-body"
+                  >
+                    <div>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Internal categorization (Liferay)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Internal 6
+                          </span>
+                        </span>
+                      </p>
+                      <div
+                        class="c-mb-2 font-weight-semi-bold h5 vocabulary"
+                      >
+                        Private Stuff (Demo Site)
+                      </div>
+                      <p>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 1
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 2
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 3
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 4
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 5
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 6
+                          </span>
+                        </span>
+                        <span
+                          class="label c-mr-2 label-lg label-secondary"
+                        >
+                          <span
+                            class="label-item label-item-expand"
+                          >
+                            Private Stuff 7
+                          </span>
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="panel c-mb-1 panel-unstyled"
+              >
+                <button
+                  aria-controls="clay-id-5"
+                  aria-expanded="true"
+                  class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                  type="button"
+                >
+                  <div>
+                    <div
+                      class="autofit-row"
+                    >
+                      <div
+                        class="align-self-center panel-title autofit-col autofit-col-expand"
+                      >
+                        <span
+                          aria-label="view tags"
+                        >
+                          tags
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    class="collapse-icon-closed"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-right"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-right"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="collapse-icon-open"
+                  >
+                    <svg
+                      class="lexicon-icon lexicon-icon-angle-down"
+                      role="presentation"
+                    >
+                      <use
+                        href="#angle-down"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <div
+                  aria-labelledby="clay-id-5"
+                  class="panel-collapse"
+                  id="clay-id-5"
+                  role="region"
+                >
+                  <div
+                    class="panel-body"
+                  >
+                    <p>
+                      <span
+                        class="label c-mb-2 c-mr-2 label-lg label-secondary"
+                      >
+                        <span
+                          class="label-item label-item-expand"
+                        >
+                          tag1
+                        </span>
+                      </span>
+                      <span
+                        class="label c-mb-2 c-mr-2 label-lg label-secondary"
+                      >
+                        <span
+                          class="label-item label-item-expand"
+                        >
+                          tag2
+                        </span>
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-labelledby="tab-2"
+              class="tab-pane fade flex-shrink-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <ul
+                class="list-group sidebar-list-group"
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# What is this trying to solve?

[LPD-34375](https://liferay.atlassian.net/browse/LPD-35434)

The order of the tabpanes are very important for the clay tabcomponent and we cannot have an effect on the indexes thru conditional statements as it will have an unwanted effect on the render of the tabs and their active state.

# How am I fixing it?

I made sure we use the same indexes for the tabs when we set `feature.flag.LPD-28830=true`

# How can you verify that it works?

Follow ticket description => [LPD-34375](https://liferay.atlassian.net/browse/LPD-35434)

# Why doesn't this include any test?
There are already tests that were failing due to this bug and they are sufficient to test this usecase. There is no need to modify or extend the tests.
Failing test => [LPD-35431](https://liferay.atlassian.net/browse/LPD-35431)


\cc  @interaminense  as this bug was introduced by [LPD-33169](https://liferay.atlassian.net/browse/LPD-33169) and I changed the order of the tab panels. If this change goes against the requirement of your story, you can render two different tab and tabplane conditionnaly as well.