### PR TITLE
LPD-35436 Fix POSHI test QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
@@ -194,10 +194,17 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro assertCanonicalURL(category = null, title = null) {
+	macro assertCanonicalURL(category = null, directNavigation = null, title = null) {
 		var html = '''<link href="''';
 		var html2 = '''" rel="canonical" data-react-helmet="true">''';
-		var portalURL = "${portalURL}/web/guest";
+
+		if (${directNavigation} == "true") {
+			var portalURL = ${portalURL};
+		}
+		else {
+			var portalURL = "${portalURL}/web/guest";
+		}
+
 		var pageName = StringUtil.lowerCase(${pageName});
 
 		var pageNameURL = StringUtil.replace(${pageName}, " ", "-");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -1300,6 +1300,7 @@ definition {
 		task ("Then a he can see the question title on url as 'question-1'") {
 			Questions.assertCanonicalURL(
 				category = "category",
+				directNavigation = "true",
 				pageName = "Questions Page",
 				portalURL = ${portalURL},
 				title = "question-1");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35436

I'm fixing the POSHI test `QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions`

# How am I fixing it?

After solving [LPD-30186 Fixing expected URL](https://github.com/liferay/liferay-portal/commit/64ae080f2d4914179fe081eb9eddfce3f82d7716) it started failing in a case where there is a direct navigation instead of a navigation through UI clicks. I'm now managing this case.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions`