### PR TITLE
LPD-35436 Fix POSHI test QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Questions.macro
@@ -194,17 +194,10 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro assertCanonicalURL(category = null, directNavigation = null, title = null) {
+	macro assertCanonicalURL(category = null, title = null) {
 		var html = '''<link href="''';
 		var html2 = '''" rel="canonical" data-react-helmet="true">''';
-
-		if (${directNavigation} == "true") {
-			var portalURL = ${portalURL};
-		}
-		else {
-			var portalURL = "${portalURL}/web/guest";
-		}
-
+		var portalURL = "${portalURL}/web/guest";
 		var pageName = StringUtil.lowerCase(${pageName});
 
 		var pageNameURL = StringUtil.replace(${pageName}, " ", "-");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -1294,7 +1294,7 @@ definition {
 		}
 
 		task ("When an anonymous user goes to the most recently created question's detail page") {
-			Navigator.openSpecificURL(url = "${portalURL}/questions-page/questions/category/question-1");
+			Navigator.openSpecificURL(url = "${portalURL}/web/guest/questions-page/questions/category/question-1");
 		}
 
 		task ("Then a he can see the question title on url as 'question-1'") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntry.testcase
@@ -1300,7 +1300,6 @@ definition {
 		task ("Then a he can see the question title on url as 'question-1'") {
 			Questions.assertCanonicalURL(
 				category = "category",
-				directNavigation = "true",
 				pageName = "Questions Page",
 				portalURL = ${portalURL},
 				title = "question-1");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35436

I'm fixing the POSHI test QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions

# How am I fixing it?

This is the second PR after #5824 to try to fix the test. 

The previous PR #5824 was not useful. I was wrong on what is not working. The problem seems the direct navigation itself, not the Canonical URL after the navigation. If you check the [Poshi Report](https://ff7e8b066e784cdc0752b46a9ae6ac3d8b6877dc685a781836a551f-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2024-09%2Ftest-1-36%2Ftest-portal-testsuite-upstream(master)%2F2046%2Ffunctional-tomcat90-mysql57-jdk8%2F35%2F7%2FLocalFile.QuestionsEntry_CanViewCanonicalURLForDuplicatedQuestions%2Findex.html.gz?jk=AXZI6Jz8mEGxU3mhNTcqNgT5F2Iq63mPLmXDOk-iSzDAzsZDMT36vKs8FFPL7ywLUIsnOLw5rOg0vlMUG6-9AHLe0ROfcju127j0tvxDBUPpbIu13aDKsXXTX-7Njl5ue7F6lhGTlHvVU_L9_lHfs67Rc-HoybQTFnudu9HMXW5GM9SPX9ryAJ3U06LpS5MSvAE8LLMmlq8ql1_EHctUZc6jIzAJUsCcNVLJnmbC3rf1bYE-8oC4aD7-du_KWCiOA4RpToxEFZhDvCpn0sLkogBfQ3ONVnZgG03JRILSYdvlIcQy7SoRU1VGcrnNyo1SveQnv47RQFiT5AeY7I8UbwBAHmf2441VB-UI0F21CO17Vko0NuVE0AAJxDnqYii0K_yFkBATYS-PBjI-IzhZVdwa0EzODMHVtJDhnNbTKkZb2l-9e01mjdHwuOlj09ORxxS99hXN7Pvy4-EpYyAEvmgqOat5dwVyCi1O6s4UzAUfT1l7Je1P_aOkc5T5KulYjE1rau0lic9_mCZ07YPzXL9q_gmrpVVyBqWzuP6yd3DgnpUqHEwri2aJEmtI-WjFlgLyrFd_9Bgs6tKnH-rkGYZuSgK6hBE1cIaNBPOrkW7TtZMFS6oPgVK_1FziVMmHqQ0vFverkvsb1Ppcxlo2WicQSBaIfljkfmA2TPFU-8aIp8WvvN2_VUTYCQT5sCdzw7TGqwwzJKwMPTcMuk_mjaGp5zde4A6frPsqO47stxnh0tX3ju1w9_3m-F7ghDicscwPFWXz--2yOG5cvSGXFUoln5Q6K9mAmZW8hC_xaxaXjW8Rpek8DpEQB3jjzY-43WUNHfsUkGrQ-VcyUsN8u-oxgr4-Jh7W3Rx2zV4g47Ohf0v70KXiuvaCwxCOVn3xYOS3mwHn6o9ThVVQ-kiFi8Z_pA2208YFcg4wBEnVbdDlRsFmNIsYCcmDM396j6kk8PDI1E-p5dYtUJgYEgqeDTmVTTyNLF2sZbSjcy7pO2If_U44LfxR2f3xh-qOU6uu5lUJvkAbpglgVmGXigFMnkD_MyVvSq51TvcSGSXJbGm2gcMFLAIjzJCL1OwwbumB-TSd_W9Ijfp79o0HXOpFxjUXDnZX6f5Aks3WzxbWh60oH4GVoZrfU6tOFlA0qwCDcHpvC4V3dZIx2wTZuYWQmbCRV-JX4ASvprvCnxkbZbMScLug0bfaWljzhaQOYLdDUccxf99jTWZfCCH64L_J0iTJ62qyBg6jtUMMuPR4ge8qquQv8elKvCMMsYNe9z93r4BAQYxG9UNK6OgHAs8rAwuxc8fC40nQp8CxW09NUNzRko2FN-7tEyaE6rjKIEUVs81CfeaERBnDw3IWzUiJXYHCIXb_6SZQF_XZfy9JbdZ5Pg&isca=1) you can see in the error screenshots that the navigation to the question info didn’t succeed.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanViewCanonicalURLForDuplicatedQuestions`