### PR TITLE
LPD-35468 GetCount should be consistent with Get method

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
@@ -23,6 +23,7 @@ import com.liferay.taglib.util.IncludeTag;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
@@ -90,15 +91,15 @@ public class GroupSelectorTag extends IncludeTag {
 	}
 
 	private List<Group> _getGroups(HttpServletRequest httpServletRequest) {
-		String groupType = _getGroupType(httpServletRequest);
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
 		Group group = _getGroup(themeDisplay);
 
-		if (_isScopeGroupType(httpServletRequest) && groupType.equals("site")) {
+		if (_isScopeGroupType(httpServletRequest) &&
+			Objects.equals(_getGroupType(httpServletRequest), "site")) {
+
 			_groups = new ArrayList<>();
 
 			if (!group.isCompany()) {
@@ -121,7 +122,7 @@ public class GroupSelectorTag extends IncludeTag {
 
 		GroupItemSelectorProvider groupItemSelectorProvider =
 			GroupItemSelectorProviderRegistryUtil.getGroupItemSelectorProvider(
-				groupType);
+				_getGroupType(httpServletRequest));
 
 		if (groupItemSelectorProvider == null) {
 			_groups = Collections.emptyList();
@@ -155,15 +156,15 @@ public class GroupSelectorTag extends IncludeTag {
 	}
 
 	private int _getGroupsCount(HttpServletRequest httpServletRequest) {
-		String groupType = _getGroupType(httpServletRequest);
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
 		Group group = _getGroup(themeDisplay);
 
-		if (_isScopeGroupType(httpServletRequest) && groupType.equals("site")) {
+		if (_isScopeGroupType(httpServletRequest) &&
+			Objects.equals(_getGroupType(httpServletRequest), "site")) {
+
 			if (group.isCompany()) {
 				_groupsCount = 1;
 			}
@@ -176,7 +177,7 @@ public class GroupSelectorTag extends IncludeTag {
 
 		GroupItemSelectorProvider groupSelectorProvider =
 			GroupItemSelectorProviderRegistryUtil.getGroupItemSelectorProvider(
-				groupType);
+				_getGroupType(httpServletRequest));
 
 		if (groupSelectorProvider == null) {
 			_groupsCount = 0;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
@@ -155,13 +155,15 @@ public class GroupSelectorTag extends IncludeTag {
 	}
 
 	private int _getGroupsCount(HttpServletRequest httpServletRequest) {
+		String groupType = _getGroupType(httpServletRequest);
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
 		Group group = _getGroup(themeDisplay);
 
-		if (_isScopeGroupType(httpServletRequest)) {
+		if (_isScopeGroupType(httpServletRequest) && groupType.equals("site")) {
 			if (group.isCompany()) {
 				_groupsCount = 1;
 			}
@@ -174,7 +176,7 @@ public class GroupSelectorTag extends IncludeTag {
 
 		GroupItemSelectorProvider groupSelectorProvider =
 			GroupItemSelectorProviderRegistryUtil.getGroupItemSelectorProvider(
-				_getGroupType(httpServletRequest));
+				groupType);
 
 		if (groupSelectorProvider == null) {
 			_groupsCount = 0;

--- a/modules/apps/item-selector/item-selector-test/build.gradle
+++ b/modules/apps/item-selector/item-selector-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-api")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-criteria-api")

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/GroupSelectorTagTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/taglib/test/GroupSelectorTagTest.java
@@ -6,19 +6,29 @@
 package com.liferay.item.selector.test.taglib.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.item.selector.taglib.servlet.taglib.GroupSelectorTag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -35,6 +45,7 @@ import org.springframework.mock.web.MockPageContext;
 
 /**
  * @author Cristina González
+ * @author Roberto Díaz
  */
 @RunWith(Arquillian.class)
 public class GroupSelectorTagTest {
@@ -45,6 +56,64 @@ public class GroupSelectorTagTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetDepotGroupsWithDepotGroupTypeWhenPagination()
+		throws Exception {
+
+		_addDepotEntries(PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA + 1);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, getThemeDisplay());
+		mockHttpServletRequest.addParameter("groupType", "depot");
+
+		GroupSelectorTag groupSelectorTag = _getGroupSelectorTag(
+			mockHttpServletRequest);
+
+		groupSelectorTag.doEndTag();
+
+		List<Group> groups = (List<Group>)mockHttpServletRequest.getAttribute(
+			"liferay-item-selector:group-selector:groups");
+
+		Assert.assertEquals(
+			groups.toString(), PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA,
+			groups.size());
+
+		Assert.assertEquals(
+			PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA + 1,
+			mockHttpServletRequest.getAttribute(
+				"liferay-item-selector:group-selector:groupsCount"));
+	}
+
+	@Test
+	public void testGetGroupsCountWithDepotGroupType() throws Exception {
+		_addDepotEntries(3);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, getThemeDisplay());
+		mockHttpServletRequest.addParameter("groupType", "depot");
+
+		GroupSelectorTag groupSelectorTag = _getGroupSelectorTag(
+			mockHttpServletRequest);
+
+		groupSelectorTag.doEndTag();
+
+		List<Group> groups = (List<Group>)mockHttpServletRequest.getAttribute(
+			"liferay-item-selector:group-selector:groups");
+
+		Assert.assertEquals(groups.toString(), 3, groups.size());
+
+		Assert.assertEquals(
+			groups.size(),
+			mockHttpServletRequest.getAttribute(
+				"liferay-item-selector:group-selector:groupsCount"));
+	}
 
 	@Test
 	public void testGetGroupsCountWithoutGroupType() throws Exception {
@@ -194,6 +263,22 @@ public class GroupSelectorTagTest {
 		return themeDisplay;
 	}
 
+	private void _addDepotEntries(int count) throws Exception {
+		for (int i = 0; i < count; i++) {
+			DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				ServiceContextTestUtil.getServiceContext());
+
+			_depotEntries.add(depotEntry);
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), TestPropsValues.getGroupId());
+		}
+	}
+
 	private GroupSelectorTag _getGroupSelectorTag(
 		HttpServletRequest httpServletRequest) {
 
@@ -207,5 +292,14 @@ public class GroupSelectorTagTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35468

Currenty the iterator doesn't appear in all the cases when browsing the Asset Libraries

# How am I fixing it?

Making consistent all the conditions in the get and count methods

# How can you verify that it works?

Run the included automated tests in `com.liferay.item.selector.test.taglib.test.GroupSelectorTagTest`