### PR TITLE
LPD-35388 Asset publishers show assets after site/asset library is disconnected

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/validator/CardinalityAssetEntryValidator.java
@@ -100,7 +100,9 @@ public class CardinalityAssetEntryValidator implements AssetEntryValidator {
 				AssetRenderer<?> assetRenderer =
 					assetRendererFactory.getAssetRenderer(classPK);
 
-				if (!assetRenderer.isCategorizable(groupId)) {
+				if ((assetRenderer == null) ||
+					!assetRenderer.isCategorizable(groupId)) {
+
 					return false;
 				}
 			}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherViewContentDisplayContext.java
@@ -181,6 +181,13 @@ public class AssetPublisherViewContentDisplayContext {
 				_assetRenderer = _assetRendererFactory.getAssetRenderer(
 					getGroupId(), _getURLTitle());
 
+				if (_assetRenderer == null) {
+					SessionErrors.add(
+						_renderRequest, NoSuchModelException.class.getName());
+
+					return;
+				}
+
 				_assetEntry = _assetRendererFactory.getAssetEntry(
 					_assetRendererFactory.getClassName(),
 					_assetRenderer.getClassPK());

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java
@@ -238,6 +238,16 @@ public class AssetLinksTag extends IncludeTag {
 				assetRendererFactory.getAssetRenderer(
 					assetLinkEntry.getClassPK());
 
+			if (assetRenderer == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"No asset renderer found for classPK " +
+							assetLinkEntry.getClassPK());
+				}
+
+				continue;
+			}
+
 			if (!assetRenderer.hasViewPermission(
 					themeDisplay.getPermissionChecker()) ||
 				!(assetLinkEntry.isVisible() ||

--- a/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/asset/model/CommentAssetRenderer.java
+++ b/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/asset/model/CommentAssetRenderer.java
@@ -198,6 +198,10 @@ public class CommentAssetRenderer
 		AssetRenderer<?> assetRenderer = assetRendererFactory.getAssetRenderer(
 			_workflowableComment.getClassPK());
 
+		if (assetRenderer == null) {
+			return null;
+		}
+
 		return assetRenderer.getURLViewInContext(
 			liferayPortletRequest, liferayPortletResponse, noSuchEntryRedirect);
 	}
@@ -217,6 +221,10 @@ public class CommentAssetRenderer
 
 		AssetRenderer<?> assetRenderer = assetRendererFactory.getAssetRenderer(
 			_workflowableComment.getClassPK());
+
+		if (assetRenderer == null) {
+			return null;
+		}
 
 		return assetRenderer.getURLViewInContext(
 			themeDisplay, noSuchEntryRedirect);

--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:item-selector:item-selector-api")
 	testIntegrationImplementation project(":apps:item-selector:item-selector-criteria-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
+	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.web.internal.asset.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class DepotAssetRendererFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "name"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), "description"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetAssetRendererDLFileEntryWithRelatedGroup()
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(_getServiceContext());
+
+		try {
+			DepotEntryGroupRel depotEntryGroupRel =
+				_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+					_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+			DLFileEntry dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), _depotEntry.getGroupId(),
+				_depotEntry.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomString() + ".txt",
+				MimeTypesUtil.getExtensionContentType("txt"),
+				StringUtil.randomString(), null, StringPool.BLANK,
+				StringPool.BLANK,
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+				null, null, new UnsyncByteArrayInputStream(bytes), bytes.length,
+				null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					_depotEntry.getGroupId()));
+
+			AssetRendererFactory<DLFileEntry> assetRendererFactory =
+				AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+					DLFileEntry.class);
+
+			AssetRenderer<DLFileEntry> assetRenderer =
+				assetRendererFactory.getAssetRenderer(
+					dlFileEntry.getPrimaryKey());
+
+			Assert.assertNotNull(assetRenderer);
+
+			_depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(
+				depotEntryGroupRel);
+
+			assetRenderer = assetRendererFactory.getAssetRenderer(
+				dlFileEntry.getPrimaryKey());
+
+			Assert.assertNull(assetRenderer);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testGetAssetRendererJournalArticleWithRelatedGroup()
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(_getServiceContext());
+
+		try {
+			DepotEntryGroupRel depotEntryGroupRel =
+				_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+					_depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			JournalArticle journalArticle = JournalTestUtil.addArticle(
+				_depotEntry.getGroupId(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				Collections.emptyMap());
+
+			AssetRendererFactory<JournalArticle> assetRendererFactory =
+				AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+					JournalArticle.class);
+
+			AssetRenderer<JournalArticle> assetRenderer =
+				assetRendererFactory.getAssetRenderer(
+					journalArticle.getResourcePrimKey());
+
+			Assert.assertNotNull(assetRenderer);
+
+			_depotEntryGroupRelLocalService.deleteDepotEntryGroupRel(
+				depotEntryGroupRel);
+
+			assetRenderer = assetRendererFactory.getAssetRenderer(
+				journalArticle.getResourcePrimKey());
+
+			Assert.assertNull(assetRenderer);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	private ServiceContext _getServiceContext() throws Exception {
+		User user = TestPropsValues.getUser();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group, user.getUserId());
+
+		serviceContext.setLanguageId(LocaleUtil.toLanguageId(user.getLocale()));
+
+		return serviceContext;
+	}
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryCustomizer.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryCustomizer.java
@@ -7,6 +7,7 @@ package com.liferay.depot.web.internal.asset.model;
 
 import com.liferay.asset.kernel.AssetRendererFactoryCustomizer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.web.internal.application.controller.DepotApplicationController;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -27,7 +28,8 @@ public class DepotAssetRendererFactoryCustomizer
 
 		return new DepotAssetRendererFactoryWrapper<>(
 			assetRendererFactory, _depotApplicationController,
-			_depotEntryLocalService, _groupLocalService);
+			_depotEntryLocalService, _groupLocalService,
+			_siteConnectedGroupGroupProvider);
 	}
 
 	@Reference
@@ -38,5 +40,8 @@ public class DepotAssetRendererFactoryCustomizer
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;
 
 }

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -10,6 +10,7 @@ import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.util.AssetRendererFactoryWrapper;
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.web.internal.application.controller.DepotApplicationController;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 
 import java.util.Locale;
@@ -38,12 +40,14 @@ public class DepotAssetRendererFactoryWrapper<T>
 		AssetRendererFactory<T> assetRendererFactory,
 		DepotApplicationController depotApplicationController,
 		DepotEntryLocalService depotEntryLocalService,
-		GroupLocalService groupLocalService) {
+		GroupLocalService groupLocalService,
+		SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider) {
 
 		_assetRendererFactory = assetRendererFactory;
 		_depotApplicationController = depotApplicationController;
 		_depotEntryLocalService = depotEntryLocalService;
 		_groupLocalService = groupLocalService;
+		_siteConnectedGroupGroupProvider = siteConnectedGroupGroupProvider;
 	}
 
 	@Override
@@ -67,7 +71,33 @@ public class DepotAssetRendererFactoryWrapper<T>
 	public AssetRenderer<T> getAssetRenderer(long classPK)
 		throws PortalException {
 
-		return _assetRendererFactory.getAssetRenderer(classPK);
+		AssetRenderer<T> assetRenderer = _assetRendererFactory.getAssetRenderer(
+			classPK);
+
+		if (assetRenderer == null) {
+			return null;
+		}
+
+		long groupId = assetRenderer.getGroupId();
+
+		Group assetRendererGroup = _groupLocalService.fetchGroup(groupId);
+
+		if ((assetRendererGroup == null) || !assetRendererGroup.isDepot()) {
+			return assetRenderer;
+		}
+
+		Group group = _getGroup();
+
+		if (ArrayUtil.contains(
+				_siteConnectedGroupGroupProvider.
+					getCurrentAndAncestorSiteAndDepotGroupIds(
+						group.getGroupId()),
+				groupId)) {
+
+			return assetRenderer;
+		}
+
+		return null;
 	}
 
 	@Override
@@ -268,5 +298,7 @@ public class DepotAssetRendererFactoryWrapper<T>
 	private final DepotApplicationController _depotApplicationController;
 	private final DepotEntryLocalService _depotEntryLocalService;
 	private final GroupLocalService _groupLocalService;
+	private final SiteConnectedGroupGroupProvider
+		_siteConnectedGroupGroupProvider;
 
 }

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/FileEntryInfoItemItemSelectorReturnTypeResolver.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/FileEntryInfoItemItemSelectorReturnTypeResolver.java
@@ -92,6 +92,10 @@ public class FileEntryInfoItemItemSelectorReturnTypeResolver
 				assetRendererFactory.getAssetRenderer(
 					fileEntry.getFileEntryId());
 
+			if (assetRenderer == null) {
+				return null;
+			}
+
 			AssetEntry assetEntry = assetRendererFactory.getAssetEntry(
 				DLFileEntryConstants.getClassName(),
 				assetRenderer.getClassPK());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/layout/display/page/FileEntryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/layout/display/page/FileEntryLayoutDisplayPageObjectProvider.java
@@ -110,6 +110,10 @@ public class FileEntryLayoutDisplayPageObjectProvider
 				assetRendererFactory.getAssetRenderer(
 					fileEntry.getFileEntryId());
 
+			if (assetRenderer == null) {
+				return null;
+			}
+
 			return assetRendererFactory.getAssetEntry(
 				DLFileEntryConstants.getClassName(),
 				assetRenderer.getClassPK());

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/social/DLFileEntryActivityInterpreter.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/social/DLFileEntryActivityInterpreter.java
@@ -65,14 +65,22 @@ public class DLFileEntryActivityInterpreter
 			}
 		}
 
-		StringBundler sb = new StringBundler(3);
-
 		AssetRendererFactory<?> assetRendererFactory =
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				DLFileEntry.class.getName());
 
+		if (assetRendererFactory == null) {
+			return StringPool.BLANK;
+		}
+
 		AssetRenderer<?> assetRenderer = assetRendererFactory.getAssetRenderer(
 			fileEntry.getFileEntryId());
+
+		if (assetRenderer == null) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(3);
 
 		String fileEntryLink = assetRenderer.getURLDownload(
 			serviceContext.getThemeDisplay());

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
@@ -193,9 +193,17 @@ public class JournalContentConfigurationAction
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
 				JournalArticle.class);
 
+		if (articleAssetRendererFactory == null) {
+			return StringPool.BLANK;
+		}
+
 		AssetRenderer<JournalArticle> articleAssetRenderer =
 			articleAssetRendererFactory.getAssetRenderer(
 				assetEntry.getClassPK());
+
+		if (articleAssetRenderer == null) {
+			return StringPool.BLANK;
+		}
 
 		JournalArticle article = articleAssetRenderer.getAssetObject();
 

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -132,53 +132,60 @@ if (journalContentDisplayContext.isShowArticle()) {
 						AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRenderer(article.getResourcePrimKey());
 						%>
 
-						<liferay-util:buffer
-							var="scheduledOrNotApprovedMessage"
-						>
-							<c:choose>
-								<c:when test="<%= article.isScheduled() %>">
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(article.getTitle(locale)), dateTimeFormat.format(article.getDisplayDate())} %>" key="x-is-scheduled-and-will-be-displayed-on-x" />
-								</c:when>
-								<c:otherwise>
-									<liferay-ui:message arguments="<%= HtmlUtil.escape(article.getTitle(locale)) %>" key="x-is-not-approved" />
-								</c:otherwise>
-							</c:choose>
-						</liferay-util:buffer>
+						<c:if test="<%= assetRenderer != null %>">
+							<liferay-util:buffer
+								var="scheduledOrNotApprovedMessage"
+							>
+								<c:choose>
+									<c:when test="<%= article.isScheduled() %>">
+										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(article.getTitle(locale)), dateTimeFormat.format(article.getDisplayDate())} %>" key="x-is-scheduled-and-will-be-displayed-on-x" />
+									</c:when>
+									<c:otherwise>
+										<liferay-ui:message arguments="<%= HtmlUtil.escape(article.getTitle(locale)) %>" key="x-is-not-approved" />
+									</c:otherwise>
+								</c:choose>
+							</liferay-util:buffer>
 
-						<clay:alert
-							defaultTitleDisabled="<%= true %>"
-							displayType="warning"
-						>
-							<c:choose>
-								<c:when test="<%= assetRenderer.hasEditPermission(permissionChecker) %>">
-									<a href="<%= assetRenderer.getURLEdit(liferayPortletRequest, liferayPortletResponse, WindowState.NORMAL, currentURLObj) %>">
+							<clay:alert
+								defaultTitleDisabled="<%= true %>"
+								displayType="warning"
+							>
+								<c:choose>
+									<c:when test="<%= assetRenderer.hasEditPermission(permissionChecker) %>">
+										<a href="<%= assetRenderer.getURLEdit(liferayPortletRequest, liferayPortletResponse, WindowState.NORMAL, currentURLObj) %>">
+											<%= scheduledOrNotApprovedMessage %>
+										</a>
+									</c:when>
+									<c:otherwise>
 										<%= scheduledOrNotApprovedMessage %>
-									</a>
-								</c:when>
-								<c:otherwise>
-									<%= scheduledOrNotApprovedMessage %>
-								</c:otherwise>
-							</c:choose>
-						</clay:alert>
+									</c:otherwise>
+								</c:choose>
+							</clay:alert>
+						</c:if>
 					</c:when>
 					<c:when test="<%= articleDisplay != null %>">
 
 						<%
 						AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRenderer(article.getResourcePrimKey());
-
-						Map<String, Object> data = HashMapBuilder.<String, Object>put(
-							"fragments-editor-item-id", PortalUtil.getClassNameId(JournalArticle.class) + "-" + assetRenderer.getClassPK()
-						).put(
-							"fragments-editor-item-type", "fragments-editor-mapped-item"
-						).build();
 						%>
 
-						<div class="<%= journalContentDisplayContext.isPreview() ? "p-1 preview-asset-entry" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
-							<liferay-journal:journal-article-display
-								articleDisplay="<%= articleDisplay %>"
-								paginationURL="<%= renderResponse.createRenderURL() %>"
-							/>
-						</div>
+						<c:if test="<%= assetRenderer != null %>">
+
+							<%
+							Map<String, Object> data = HashMapBuilder.<String, Object>put(
+								"fragments-editor-item-id", PortalUtil.getClassNameId(JournalArticle.class) + "-" + assetRenderer.getClassPK()
+							).put(
+								"fragments-editor-item-type", "fragments-editor-mapped-item"
+							).build();
+							%>
+
+							<div class="<%= journalContentDisplayContext.isPreview() ? "p-1 preview-asset-entry" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
+								<liferay-journal:journal-article-display
+									articleDisplay="<%= articleDisplay %>"
+									paginationURL="<%= renderResponse.createRenderURL() %>"
+								/>
+							</div>
+						</c:if>
 					</c:when>
 				</c:choose>
 			</c:when>

--- a/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/servlet/taglib/ui/FileEntrySharingEntryDropdownItemContributor.java
+++ b/modules/apps/sharing/sharing-document-library/src/main/java/com/liferay/sharing/document/library/internal/servlet/taglib/ui/FileEntrySharingEntryDropdownItemContributor.java
@@ -63,6 +63,10 @@ public class FileEntrySharingEntryDropdownItemContributor
 			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
 				sharingEntry.getClassName());
 
+		if (assetRendererFactory == null) {
+			return null;
+		}
+
 		return assetRendererFactory.getAssetRenderer(sharingEntry.getClassPK());
 	}
 


### PR DESCRIPTION
LPD-35388 Asset publishers show assets after site/asset library is disconnected


resent with changes on tests name after : https://github.com/brianchandotcom/liferay-portal/pull/153944#issuecomment-2332910644



# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35388

When a object from an asset library is shown on an asset publisher we should check if the site/asset library is connected or not

# How am I fixing it?

On the DepotAssetRendererFactoryWrapper check if the asset entry is from a asset library, and if the group we are showing it is connected or not to it

# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-35388 if asset Renderer Group is depot check if is connected to show it**
- **LPD-35388 check NPE**
- **LPD-35388 add test to check that the asset renderer of the entry of the asset library returns null when the site and depot are not connected**

//cc @jkappler 