### PR TITLE
LPD-35730 Fix A non-localizabled field is disabled in journalArticle.spec.ts

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1042,7 +1042,10 @@ translationTest(
 );
 
 translationTest(
-	'LPD-19627: A non-localizabled field is disabled when another translation language is selected',
+	'A non-localizabled field is disabled when another translation language is selected',
+	{
+		tag: 'LPD-19627',
+	},
 	async ({apiHelpers, journalEditArticlePage, page, site}) => {
 		const nonLocalizableFieldName = 'Text1234';
 		const structureName = 'Structure 1';
@@ -1072,11 +1075,15 @@ translationTest(
 			trigger: translationButton,
 		});
 
-		await expect(
-			page.getByRole('textbox', {
-				name: nonLocalizableFieldName,
-			})
-		).toBeDisabled();
+		const textBox = page.getByRole('textbox', {
+			name: nonLocalizableFieldName,
+		});
+
+		if (await textBox.isHidden()) {
+			await page.getByRole('link', {name: 'Fields'}).click();
+		}
+
+		await expect(textBox).toBeDisabled();
 	}
 );
 


### PR DESCRIPTION
Hi,
May I ask to review this PR?

This is for https://liferay.atlassian.net/browse/LPD-35730, story: LPD-19627

test name: A non-localized field is disabled when another translation language is selected

Solution: looks like a new Metadata and fields section was introduced since, added to open Fields section if the Field is not visible

Thank you in advance!