### PR TITLE
LPD-35348 Error Viewing Web Content Using Page Break

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
@@ -54,9 +54,6 @@ public class AssetFullContentDisplayContext {
 	}
 
 	public PortletURL getPaginationURL() {
-		JournalArticleDisplay journalArticleDisplay =
-			getJournalArticleDisplay();
-
 		String pageRedirect = ParamUtil.getString(
 			_httpServletRequest, "redirect");
 
@@ -71,6 +68,9 @@ public class AssetFullContentDisplayContext {
 		if (portletURL == null) {
 			return null;
 		}
+
+		JournalArticleDisplay journalArticleDisplay =
+			getJournalArticleDisplay();
 
 		return PortletURLBuilder.create(
 			portletURL

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class AssetFullContentDisplayContext {
+
+	public AssetFullContentDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest = httpServletRequest;
+	}
+
+	public JournalArticleDisplay getJournalArticleDisplay() {
+		if (_journalArticleDisplay != null) {
+			return _journalArticleDisplay;
+		}
+
+		_journalArticleDisplay =
+			(JournalArticleDisplay)_httpServletRequest.getAttribute(
+				WebKeys.JOURNAL_ARTICLE_DISPLAY);
+
+		return _journalArticleDisplay;
+	}
+
+	public PortletURL getPaginationURL(String currentURL) {
+		JournalArticleDisplay journalArticleDisplay =
+			getJournalArticleDisplay();
+
+		String pageRedirect = ParamUtil.getString(
+			_httpServletRequest, "redirect");
+
+		if (Validator.isNull(pageRedirect)) {
+			pageRedirect = currentURL;
+		}
+
+		return PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				_httpServletRequest, JournalPortletKeys.JOURNAL,
+				PortletRequest.RENDER_PHASE)
+		).setMVCPath(
+			"/view_content.jsp"
+		).setRedirect(
+			pageRedirect
+		).setParameter(
+			"cur", ParamUtil.getInteger(_httpServletRequest, "cur")
+		).setParameter(
+			"groupId", journalArticleDisplay.getGroupId()
+		).setParameter(
+			"type",
+			() -> {
+				AssetRendererFactory<?> assetRendererFactory =
+					_getAssetRendererFactory();
+
+				return assetRendererFactory.getType();
+			}
+		).setParameter(
+			"urlTitle", journalArticleDisplay.getUrlTitle()
+		).buildPortletURL();
+	}
+
+	private AssetRendererFactory<?> _getAssetRendererFactory() {
+		if (_assetRendererFactory != null) {
+			return _assetRendererFactory;
+		}
+
+		_assetRendererFactory =
+			(AssetRendererFactory<?>)_httpServletRequest.getAttribute(
+				WebKeys.ASSET_RENDERER_FACTORY);
+
+		return _assetRendererFactory;
+	}
+
+	private AssetRendererFactory<?> _assetRendererFactory;
+	private final HttpServletRequest _httpServletRequest;
+	private JournalArticleDisplay _journalArticleDisplay;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
@@ -7,8 +7,10 @@ package com.liferay.journal.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
@@ -16,6 +18,8 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Objects;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
@@ -33,10 +37,8 @@ public class AssetFullContentDisplayContext {
 		LiferayPortletResponse liferayPortletResponse) {
 
 		_httpServletRequest = httpServletRequest;
+		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
-
-		_currentURLObj = PortletURLUtil.getCurrent(
-			liferayPortletRequest, liferayPortletResponse);
 	}
 
 	public JournalArticleDisplay getJournalArticleDisplay() {
@@ -58,12 +60,20 @@ public class AssetFullContentDisplayContext {
 		String pageRedirect = ParamUtil.getString(
 			_httpServletRequest, "redirect");
 
-		if (Validator.isNull(pageRedirect)) {
+		PortletURL currentURLObj = _getCurrentURLObj();
+
+		if (Validator.isNull(pageRedirect) && (currentURLObj != null)) {
 			pageRedirect = _currentURLObj.toString();
 		}
 
+		PortletURL portletURL = _getPortletURL();
+
+		if (portletURL == null) {
+			return null;
+		}
+
 		return PortletURLBuilder.create(
-			_getPortletURL()
+			portletURL
 		).setMVCPath(
 			"/view_content.jsp"
 		).setRedirect(
@@ -99,7 +109,39 @@ public class AssetFullContentDisplayContext {
 		return _assetRendererFactory;
 	}
 
+	private PortletURL _getCurrentURLObj() {
+		if ((_liferayPortletRequest == null) ||
+			(_liferayPortletResponse == null)) {
+
+			return null;
+		}
+
+		Portlet portlet = _liferayPortletResponse.getPortlet();
+
+		if (Objects.equals(
+				portlet.getPortletId(),
+				ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET)) {
+
+			return null;
+		}
+
+		if (_currentURLObj != null) {
+			return _currentURLObj;
+		}
+
+		_currentURLObj = PortletURLUtil.getCurrent(
+			_liferayPortletRequest, _liferayPortletResponse);
+
+		return _currentURLObj;
+	}
+
 	private PortletURL _getPortletURL() {
+		PortletURL portletURL = _getCurrentURLObj();
+
+		if (portletURL == null) {
+			return null;
+		}
+
 		try {
 			return PortletURLUtil.clone(
 				_currentURLObj, _liferayPortletResponse);
@@ -121,9 +163,10 @@ public class AssetFullContentDisplayContext {
 		AssetFullContentDisplayContext.class);
 
 	private AssetRendererFactory<?> _assetRendererFactory;
-	private final PortletURL _currentURLObj;
+	private PortletURL _currentURLObj;
 	private final HttpServletRequest _httpServletRequest;
 	private JournalArticleDisplay _journalArticleDisplay;
+	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/AssetFullContentDisplayContext.java
@@ -6,15 +6,18 @@
 package com.liferay.journal.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetRendererFactory;
-import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import javax.portlet.PortletRequest;
+import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,9 +28,15 @@ import javax.servlet.http.HttpServletRequest;
 public class AssetFullContentDisplayContext {
 
 	public AssetFullContentDisplayContext(
-		HttpServletRequest httpServletRequest) {
+		HttpServletRequest httpServletRequest,
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
 
 		_httpServletRequest = httpServletRequest;
+		_liferayPortletResponse = liferayPortletResponse;
+
+		_currentURLObj = PortletURLUtil.getCurrent(
+			liferayPortletRequest, liferayPortletResponse);
 	}
 
 	public JournalArticleDisplay getJournalArticleDisplay() {
@@ -42,7 +51,7 @@ public class AssetFullContentDisplayContext {
 		return _journalArticleDisplay;
 	}
 
-	public PortletURL getPaginationURL(String currentURL) {
+	public PortletURL getPaginationURL() {
 		JournalArticleDisplay journalArticleDisplay =
 			getJournalArticleDisplay();
 
@@ -50,13 +59,11 @@ public class AssetFullContentDisplayContext {
 			_httpServletRequest, "redirect");
 
 		if (Validator.isNull(pageRedirect)) {
-			pageRedirect = currentURL;
+			pageRedirect = _currentURLObj.toString();
 		}
 
 		return PortletURLBuilder.create(
-			PortalUtil.getControlPanelPortletURL(
-				_httpServletRequest, JournalPortletKeys.JOURNAL,
-				PortletRequest.RENDER_PHASE)
+			_getPortletURL()
 		).setMVCPath(
 			"/view_content.jsp"
 		).setRedirect(
@@ -65,6 +72,8 @@ public class AssetFullContentDisplayContext {
 			"cur", ParamUtil.getInteger(_httpServletRequest, "cur")
 		).setParameter(
 			"groupId", journalArticleDisplay.getGroupId()
+		).setParameter(
+			"page", (String)null
 		).setParameter(
 			"type",
 			() -> {
@@ -90,8 +99,31 @@ public class AssetFullContentDisplayContext {
 		return _assetRendererFactory;
 	}
 
+	private PortletURL _getPortletURL() {
+		try {
+			return PortletURLUtil.clone(
+				_currentURLObj, _liferayPortletResponse);
+		}
+		catch (PortletException portletException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portletException);
+			}
+
+			return PortletURLBuilder.createRenderURL(
+				_liferayPortletResponse
+			).setParameters(
+				_currentURLObj.getParameterMap()
+			).buildPortletURL();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetFullContentDisplayContext.class);
+
 	private AssetRendererFactory<?> _assetRendererFactory;
+	private final PortletURL _currentURLObj;
 	private final HttpServletRequest _httpServletRequest;
 	private JournalArticleDisplay _journalArticleDisplay;
+	private final LiferayPortletResponse _liferayPortletResponse;
 
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -10,38 +10,12 @@
 <liferay-util:dynamic-include key="com.liferay.journal.web#/asset/full_content.jsp#pre" />
 
 <%
-AssetRendererFactory<?> assetRendererFactory = (AssetRendererFactory<?>)request.getAttribute(WebKeys.ASSET_RENDERER_FACTORY);
-
-JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribute(WebKeys.JOURNAL_ARTICLE_DISPLAY);
-
-String pageRedirect = ParamUtil.getString(request, "redirect");
-
-if (Validator.isNull(pageRedirect)) {
-	pageRedirect = currentURL;
-}
-
-int cur = ParamUtil.getInteger(request, "cur");
+AssetFullContentDisplayContext assetFullContentDisplayContext = new AssetFullContentDisplayContext(request);
 %>
 
 <liferay-journal:journal-article-display
-	articleDisplay="<%= articleDisplay %>"
-	paginationURL='<%=
-		PortletURLBuilder.create(
-			PortalUtil.getControlPanelPortletURL(request, JournalPortletKeys.JOURNAL, PortletRequest.RENDER_PHASE)
-		).setMVCPath(
-			"/view_content.jsp"
-		).setRedirect(
-			pageRedirect
-		).setParameter(
-			"cur", cur
-		).setParameter(
-			"groupId", articleDisplay.getGroupId()
-		).setParameter(
-			"type", assetRendererFactory.getType()
-		).setParameter(
-			"urlTitle", articleDisplay.getUrlTitle()
-		).buildPortletURL()
-	%>'
+	articleDisplay="<%= assetFullContentDisplayContext.getJournalArticleDisplay() %>"
+	paginationURL="<%= assetFullContentDisplayContext.getPaginationURL(currentURL) %>"
 />
 
 <liferay-util:dynamic-include key="com.liferay.journal.web#/asset/full_content.jsp#post" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -10,12 +10,12 @@
 <liferay-util:dynamic-include key="com.liferay.journal.web#/asset/full_content.jsp#pre" />
 
 <%
-AssetFullContentDisplayContext assetFullContentDisplayContext = new AssetFullContentDisplayContext(request);
+AssetFullContentDisplayContext assetFullContentDisplayContext = new AssetFullContentDisplayContext(request, liferayPortletRequest, liferayPortletResponse);
 %>
 
 <liferay-journal:journal-article-display
 	articleDisplay="<%= assetFullContentDisplayContext.getJournalArticleDisplay() %>"
-	paginationURL="<%= assetFullContentDisplayContext.getPaginationURL(currentURL) %>"
+	paginationURL="<%= assetFullContentDisplayContext.getPaginationURL() %>"
 />
 
 <liferay-util:dynamic-include key="com.liferay.journal.web#/asset/full_content.jsp#post" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -16,24 +16,18 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.asset.kernel.model.AssetRendererFactory" %><%@
-page import="com.liferay.asset.util.AssetHelper" %><%@
-page import="com.liferay.journal.constants.JournalPortletKeys" %><%@
+<%@ page import="com.liferay.asset.util.AssetHelper" %><%@
 page import="com.liferay.journal.model.JournalArticleDisplay" %><%@
 page import="com.liferay.journal.model.JournalFolder" %><%@
 page import="com.liferay.journal.service.JournalArticleServiceUtil" %><%@
 page import="com.liferay.journal.service.JournalFolderServiceUtil" %><%@
+page import="com.liferay.journal.web.internal.display.context.AssetFullContentDisplayContext" %><%@
 page import="com.liferay.journal.web.internal.display.context.JournalDisplayContext" %><%@
-page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
-
-<%@ page import="javax.portlet.PortletRequest" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -10,6 +10,8 @@ import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest'
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageViewModePagesTest} from '../../fixtures/pageViewModePagesTest';
+import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
@@ -46,6 +48,8 @@ const baseTest = mergeTests(
 	isolatedSiteTest,
 	journalPagesTest,
 	loginTest(),
+	pageViewModePagesTest,
+	pagesAdminPagesTest,
 	workflowPagesTest
 );
 
@@ -1389,6 +1393,80 @@ baseTest(
 		expect(modifiedStructure.dataDefinitionFields[0].defaultValue).toEqual({
 			en_US: `${content}`,
 		});
+	}
+);
+
+baseTest(
+	'Can paginate Web Content in an Asset Publisher',
+	{
+		tag: '@LPD-35348',
+	},
+	async ({
+		journalEditArticlePage,
+		journalPage,
+		page,
+		pagesAdminPage,
+		site,
+		widgetPagePage,
+	}) => {
+		await journalPage.goto(site.friendlyUrlPath);
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await journalEditArticlePage.fillContent('page1 @page_break@ page2');
+
+		await journalEditArticlePage.publishButton.click();
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was created successfully.`
+		);
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+
+		const name = getRandomString();
+		await pagesAdminPage.addWidgetPage({name});
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+		await page.getByLabel(name, {exact: true}).click();
+
+		await widgetPagePage.addPortlet('Asset Publisher');
+		await page
+			.locator('.portlet-asset-publisher')
+			.first()
+			.getByLabel('Options')
+			.click();
+		await page
+			.getByRole('menuitem', {exact: true, name: 'Configuration'})
+			.click();
+		const configurationFrame = page.frameLocator(
+			'iframe[id="modalIframe"]'
+		);
+		await configurationFrame
+			.getByRole('tab', {name: 'Asset Selection'})
+			.click();
+		await configurationFrame.getByText('Dynamic').click();
+		await configurationFrame.getByRole('button', {name: 'Save'}).click();
+		await configurationFrame
+			.getByRole('tab', {name: 'Display Settings'})
+			.click();
+		await configurationFrame.getByLabel('Display Template').click();
+		await configurationFrame
+			.getByRole('option', {name: 'Full Content'})
+			.click();
+		await configurationFrame.getByRole('button', {name: 'Save'}).click();
+		await page.getByLabel('close', {exact: true}).click();
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+		await page.getByLabel(name, {exact: true}).click();
+
+		await page.getByLabel('Go to page, 2').click();
+
+		await expect(page.getByText('page2')).toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1450,7 +1450,7 @@ baseTest(
 			.getByRole('tab', {name: 'Asset Selection'})
 			.click();
 		await configurationFrame.getByText('Dynamic').click();
-		await configurationFrame.getByRole('button', {name: 'Save'}).click();
+		await configurationFrame.getByLabel('close').click();
 		await configurationFrame
 			.getByRole('tab', {name: 'Display Settings'})
 			.click();

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -150,7 +150,7 @@ export class JournalEditArticlePage {
 
 	async fillContent(content: string) {
 		await this.journalPage.articleContentTextBox.fill(content);
-		await this.journalPage.articleContentTextBox.press('Backspace');
+		await this.journalPage.articleContentTextBox.press('Enter');
 	}
 
 	async fillFriendlyURL(friendlyURL: string) {


### PR DESCRIPTION
Error Viewing Web Content Using Page Break

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-35348)

When the web content has a @page_break@ special work, an error will be thrown when paginating to another page in an asset publisher or as workflow

# How am I fixing it?

The fix for LPS-168601 changed the way the URL for the paginator was built. It assumed that the jsp responsible to render it was in journal portlet, but the asset render uses asset publisher to render it, thus failing. The fix is basically to take the current URL where the asset is being rendered and use it. Also, to control when and how we render the pagination.

It has been disabled mainly for collections, since it will brake navigation in edit mode, and it will throw excepions in view mode sinde no portlet is involved.

# How can you verify that it works?

Follow the steps in the ticket or run the provided playwright test
