### PR TITLE
LPD-35388 Control NPE

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/asset/model/test/DepotAssetRendererFactoryTest.java
@@ -127,6 +127,35 @@ public class DepotAssetRendererFactoryTest {
 	}
 
 	@Test
+	public void testGetAssetRendererJournalArticleWithInvalidGroup()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_depotEntry.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			Collections.emptyMap());
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setScopeGroupId(RandomTestUtil.randomLong());
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			AssetRendererFactory<JournalArticle> assetRendererFactory =
+				AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+					JournalArticle.class);
+
+			Assert.assertNull(
+				assetRendererFactory.getAssetRenderer(
+					journalArticle.getResourcePrimKey()));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
 	public void testGetAssetRendererJournalArticleWithRelatedGroup()
 		throws Exception {
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -88,6 +88,10 @@ public class DepotAssetRendererFactoryWrapper<T>
 
 		Group group = _getGroup();
 
+		if (group == null) {
+			return null;
+		}
+
 		if (ArrayUtil.contains(
 				_siteConnectedGroupGroupProvider.
 					getCurrentAndAncestorSiteAndDepotGroupIds(


### PR DESCRIPTION
This is a follow up to https://github.com/brianchandotcom/liferay-portal/pull/153944.

The reason for the changes is that service context might not have correct values, so a NPE is thrown. This corrects it and also adds the test to avoid future issues