### PR TITLE
LPD-35856 Use the keywords if they do exist

### DIFF
--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-web-api")
+	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:site:site-memberships-api")
 	testIntegrationImplementation project(":apps:staging:staging-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotAdminGroupSearchProviderTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/web/internal/util/test/DepotAdminGroupSearchProviderTest.java
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.web.internal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.search.GroupSearch;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+public class DepotAdminGroupSearchProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_company = _companyLocalService.getCompany(_group.getCompanyId());
+
+		_depotAdminGroupSearchProvider = _getDepotAdminGroupSearchProvider();
+
+		_addDepotEntries();
+	}
+
+	@Test
+	public void testGetGroupSearch() throws Exception {
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		_assertDepotEntries(
+			_DEPOT_ENTRY_NAMES.length,
+			ReflectionTestUtil.invoke(
+				_depotAdminGroupSearchProvider, "getGroupSearch",
+				new Class<?>[] {
+					GroupItemSelectorCriterion.class, PortletRequest.class,
+					PortletURL.class
+				},
+				groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+				new MockLiferayPortletURL()));
+	}
+
+	@Test
+	public void testGetGroupSearchWithKeywords() throws Exception {
+		GroupItemSelectorCriterion groupItemSelectorCriterion =
+			new GroupItemSelectorCriterion();
+
+		groupItemSelectorCriterion.setIncludeAllVisibleGroups(false);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		mockLiferayPortletActionRequest.setParameter("keywords", "depot");
+
+		_assertDepotEntries(
+			3,
+			ReflectionTestUtil.invoke(
+				_depotAdminGroupSearchProvider, "getGroupSearch",
+				new Class<?>[] {
+					GroupItemSelectorCriterion.class, PortletRequest.class,
+					PortletURL.class
+				},
+				groupItemSelectorCriterion, mockLiferayPortletActionRequest,
+				new MockLiferayPortletURL()));
+	}
+
+	private void _addDepotEntries() throws Exception {
+		for (String name : _DEPOT_ENTRY_NAMES) {
+			DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+				Collections.singletonMap(LocaleUtil.getDefault(), name),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				ServiceContextTestUtil.getServiceContext());
+
+			_depotEntries.add(depotEntry);
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), _group.getGroupId());
+		}
+	}
+
+	private void _assertDepotEntries(int total, GroupSearch groupSearch) {
+		Assert.assertEquals(total, groupSearch.getTotal());
+
+		List<Group> groups = groupSearch.getResults();
+
+		for (int i = 0; i < total; i++) {
+			Group group = groups.get(i);
+
+			Assert.assertEquals(
+				_DEPOT_ENTRY_NAMES[i], group.getName(LocaleUtil.getDefault()));
+		}
+	}
+
+	private Object _getDepotAdminGroupSearchProvider() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest(_getMockHttpServletRequest());
+
+		_mvcRenderCommand.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+
+		return mockLiferayPortletRenderRequest.getAttribute(
+			"com.liferay.depot.web.internal.util." +
+				"DepotAdminGroupSearchProvider");
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(_company);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	private static final String[] _DEPOT_ENTRY_NAMES = {
+		"depot 1", "depot 2", "depot 3", "toped"
+	};
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private Object _depotAdminGroupSearchProvider;
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.depot.web.internal.portlet.action.ViewMVCRenderCommand"
+	)
+	private MVCRenderCommand _mvcRenderCommand;
+
+}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotAdminGroupSearchProvider.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/util/DepotAdminGroupSearchProvider.java
@@ -45,7 +45,9 @@ public class DepotAdminGroupSearchProvider {
 			PortletRequest portletRequest, PortletURL portletURL)
 		throws PortalException {
 
-		if (!groupItemSelectorCriterion.isIncludeAllVisibleGroups()) {
+		if (Validator.isNull(ParamUtil.getString(portletRequest, "keywords")) &&
+			!groupItemSelectorCriterion.isIncludeAllVisibleGroups()) {
+
 			return _getGroupConnectedDepotGroupsGroupSearch(
 				portletRequest, portletURL);
 		}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35856

Search is not working in asset library selector

# How am I fixing it?

Using the keywords attribute as flag to use the proper search method

# How can you verify that it works?

Running included test