### PR TITLE
[Playwright] LPD-35873 Fix 'displays second dropdown level for Size item with Small, Medium and Large options'

### DIFF
--- a/modules/test/playwright/tests/content-dashboard-web/filters.spec.ts
+++ b/modules/test/playwright/tests/content-dashboard-web/filters.spec.ts
@@ -28,7 +28,11 @@ test('displays second dropdown level for Size item with Small, Medium and Large 
 
 	await sizeMenuItem.hover();
 
-	for (const size of ['Small', 'Medium', 'Large']) {
+	for (const size of [
+		'Small (up to 150 kb)',
+		'Medium (from 150 kb to 1 mb)',
+		'Large (from 1 mb)',
+	]) {
 		await expect(page.getByText(size)).toBeVisible();
 	}
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35873

We are fixing a failing test.
![image](https://github.com/user-attachments/assets/41dbbaa6-01db-40c5-a2a8-7a6f5a92c264)

# How am I fixing it?

I'm making the locator selectors more explicit.

# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run playwright -- test -g 'displays second dropdown level for Size item with Small, Medium and Large options'` to run the test

# Avoid flakiness by repeating 20 times

```sh
npm run playwright -- test -g 'displays second dropdown level for Size item with Small, Medium and Large options' --repeat-each 20
```
![image](https://github.com/user-attachments/assets/671d5d88-3d94-4acd-bc6a-b5fcd644dc96)
