### PR TITLE
LPP-55513 - prevent StringIndexOutOfBoundsException if a JournalArticle references different DLEntries by UUID and friendlyURL

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -823,9 +823,11 @@ public class DLReferencesExportImportContentProcessor
 					"[$dl-reference=" + path + "$,$include-uuid=true$]";
 
 				if (content.startsWith("[#dl-reference=", endPos)) {
-					if (content.contains("include-friendly-url=true")) {
-						int friendlyURLPosition = content.indexOf(
-							"#,#include-friendly-url=true", beginPos);
+					int friendlyURLPosition = content.indexOf(
+						"#,#include-friendly-url=true", beginPos);
+
+					if (content.contains("include-friendly-url=true") &&
+						(friendlyURLPosition != -1)) {
 
 						endPos = friendlyURLPosition + 2;
 					}


### PR DESCRIPTION
This is a solution proposal for LPP-55513.