### PR TITLE
[playwright] [flaky] LPD-35969 Fix 'LPD-6677 Can add images to DM when API Key is provided'

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -63,9 +63,11 @@ export class DocumentLibraryPage {
 
 	async deleteAllFileEntries() {
 		await this.goto();
-		await this.page
+		for (const checkbox of await this.page
 			.locator('input[data-modelclassname="FileEntry"]')
-			.check();
+			.all()) {
+			await checkbox.check();
+		}
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 	}
 

--- a/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
@@ -40,8 +40,6 @@ export class AICreatorInstanceSettingsPage {
 		await this.saveButton.click();
 
 		await waitForSuccessAlert(this.page);
-
-		await this.page.waitForLoadState();
 	}
 
 	async disableDalleCreateImages() {
@@ -51,8 +49,6 @@ export class AICreatorInstanceSettingsPage {
 		await this.saveButton.click();
 
 		await waitForSuccessAlert(this.page);
-
-		await this.page.waitForLoadState();
 	}
 
 	async addApiKey() {
@@ -68,6 +64,6 @@ export class AICreatorInstanceSettingsPage {
 
 		await this.apiKeyInput.fill(apikey);
 		await this.saveButton.click();
-		await this.page.waitForLoadState();
+		await waitForSuccessAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/product-navigation-applications-menu/GogoShellPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/GogoShellPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {ApplicationsMenuPage} from './ApplicationsMenuPage';
 
 export class GogoShellPage {
@@ -28,8 +29,9 @@ export class GogoShellPage {
 	async addCommand(command: string) {
 		await this.goto();
 
+		await this.commandInput.waitFor();
 		await this.commandInput.fill(command);
 		await this.executeButton.click();
-		await this.page.waitForLoadState();
+		await waitForSuccessAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -7,6 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
 import {loginTest} from '../../fixtures/loginTest';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
 const MOCKED_IMAGE_PATH =
 	'USER_IMAGES_URL_https://images.freeimages.com/images/large-previews/83f/paris-1213603.jpg';
@@ -18,9 +19,7 @@ test('LPD-6717 Create AI Image option in Management Toolbar without API Key open
 	page,
 }) => {
 	await documentLibraryPage.goto();
-
 	await documentLibraryPage.openCreateAIImage();
-
 	await expect(page.getByText('Configure OpenAI')).toBeVisible();
 });
 
@@ -30,11 +29,8 @@ test('LPD-6717 and LPD-6691 Create AI Image option is hidden when disabled from 
 	page,
 }) => {
 	await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
-
 	await documentLibraryPage.goto();
-
 	await documentLibraryPage.openNewButton();
-
 	await expect(
 		page.getByRole('menuitem', {name: 'Create AI Image'})
 	).not.toBeVisible();
@@ -51,43 +47,29 @@ test('LPD-6677 Can add images to DM when API Key is provided', async ({
 	await gogoShellPage.addCommand(
 		'scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
 	);
-
 	await aiCreatorInstanceSettingsPage.addApiKey();
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
 	await documentLibraryPage.goto();
-
 	await documentLibraryPage.openCreateAIImage();
-
 	await expect(page.getByText('Create AI Image')).toBeVisible();
 
 	const createAIImageModalPage = page.frameLocator(
 		'iframe[title="Create AI Image"]'
 	);
-
 	await createAIImageModalPage
 		.getByPlaceholder('Write something...')
 		.fill(MOCKED_IMAGE_PATH);
-
 	await createAIImageModalPage.getByRole('button', {name: 'Create'}).click();
-
-	await createAIImageModalPage.getByRole('checkbox').click();
-
+	await createAIImageModalPage.getByRole('checkbox').first().check();
 	await createAIImageModalPage
 		.getByRole('button', {name: 'Add Selected'})
 		.click();
-
+	await waitForSuccessAlert(page, 'Success:1 files were successfully added.');
 	await expect(
 		page.getByRole('link').filter({hasText: 'AI-image-'})
 	).toHaveCount(1);
 
 	await documentLibraryPage.deleteAllFileEntries();
-
 	await aiCreatorInstanceSettingsPage.removeApiKey();
-
 	await gogoShellPage.addCommand(
 		'scr:disable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
 	);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35969

I'm trying to fix the flaky 'LPD-6677 Can add images to DM when API Key is provided' playwright test.

# How am I fixing it?

Using waitForSuccessAlert when is possible, adding waitFor in key points...
 
# How can you verify that it works?

You can check this PR https://github.com/boton/liferay-portal/pull/249 where I force CI to execute 20 times in a row, the flaky test.

## Before the fixes
https://testray.liferay.com/#/project/35392/routines/45357/build/7048324/case-result/7048380
![image](https://github.com/user-attachments/assets/6e757428-472a-487c-bb29-7800442695ee)

## After the fixes
https://testray.liferay.com/#/project/35392/routines/45357/build/8430983/case-result/8463380
![image](https://github.com/user-attachments/assets/f200d0c5-7e7b-440a-88b8-fd00001da205)

https://testray.liferay.com/#/project/35392/routines/45357/build/8974987/case-result/9000483
![image](https://github.com/user-attachments/assets/5c8a7018-9b07-45a4-bd4f-809eef888171)
