### PR TITLE
LPD-32573 Use the url mapping to avoid missing parameters on language change

### DIFF
--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -152,6 +152,9 @@ public class UpdateLanguageActionTest {
 
 		_testGetRedirectWithFriendlyURL(false);
 		_testGetRedirectWithFriendlyURL(true);
+
+		_testGetRedirectWithPortletURLMapping(null);
+		_testGetRedirectWithPortletURLMapping(_sourceLocale);
 	}
 
 	@Test
@@ -469,6 +472,13 @@ public class UpdateLanguageActionTest {
 
 		_assertGetRedirectWithLayoutFriendlyURL(
 			path, sourceLocale, _targetLocale, false);
+	}
+
+	private void _testGetRedirectWithPortletURLMapping(Locale sourceLocale)
+		throws Exception {
+
+		_assertGetRedirectWithLayoutFriendlyURL(
+			"/tags/tagname", sourceLocale, _targetLocale, false);
 	}
 
 	private void _updateLayoutFriendlyURL(String suffix) throws Exception {

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -143,18 +143,23 @@ public class UpdateLanguageActionTest {
 	}
 
 	@Test
-	public void testGetRedirect() throws Exception {
-		_testGetRedirectWithPortletFriendlyURL(null);
-		_testGetRedirectWithPortletFriendlyURL(_sourceLocale);
-
+	public void testGetRedirectWithControlPanelURL() throws Exception {
 		_testGetRedirectWithControlPanelURL(false);
+	}
+
+	@Test
+	public void testGetRedirectWithControlPanelURLAndI18n() throws Exception {
 		_testGetRedirectWithControlPanelURL(true);
+	}
 
+	@Test
+	public void testGetRedirectWithFriendlyURL() throws Exception {
 		_testGetRedirectWithFriendlyURL(false);
-		_testGetRedirectWithFriendlyURL(true);
+	}
 
-		_testGetRedirectWithPortletURLMapping(null);
-		_testGetRedirectWithPortletURLMapping(_sourceLocale);
+	@Test
+	public void testGetRedirectWithFriendlyURLAndI18n() throws Exception {
+		_testGetRedirectWithFriendlyURL(true);
 	}
 
 	@Test
@@ -174,6 +179,20 @@ public class UpdateLanguageActionTest {
 			).build());
 
 		_assertGetRedirectWithLayoutFriendlyURL(true);
+	}
+
+	@Test
+	public void testGetRedirectWithFriendlyURLMapperMapping() throws Exception {
+		_assertGetRedirectWithLayoutFriendlyURL(
+			_FRIENDLY_URL_MAPPER_MAPPING, null, _targetLocale, false);
+	}
+
+	@Test
+	public void testGetRedirectWithFriendlyURLMapperMappingAndSourceLocale()
+		throws Exception {
+
+		_assertGetRedirectWithLayoutFriendlyURL(
+			_FRIENDLY_URL_MAPPER_MAPPING, _sourceLocale, _targetLocale, false);
 	}
 
 	@Test
@@ -246,6 +265,20 @@ public class UpdateLanguageActionTest {
 
 		updateLanguageAction.getRedirect(
 			mockHttpServletRequest, themeDisplay, _targetLocale);
+	}
+
+	@Test
+	public void testGetRedirectWithPortletFriendlyURL() throws Exception {
+		_assertGetRedirectWithLayoutFriendlyURL(
+			_getFriendlyURLPath(), null, _targetLocale, false);
+	}
+
+	@Test
+	public void testGetRedirectWithPortletFriendlyURLAndSourceLocale()
+		throws Exception {
+
+		_assertGetRedirectWithLayoutFriendlyURL(
+			_getFriendlyURLPath(), _sourceLocale, _targetLocale, false);
 	}
 
 	private void _assertGetRedirect(
@@ -344,6 +377,17 @@ public class UpdateLanguageActionTest {
 			expectedRedirect,
 			updateLanguageAction.getRedirect(
 				mockHttpServletRequest, themeDisplay, targetLocale));
+	}
+
+	private String _getFriendlyURLPath() throws Exception {
+		Map<Locale, String> friendlyURLMap =
+			_journalArticle.getFriendlyURLMap();
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			_group.getDefaultLanguageId());
+
+		return _PORTLET_FRIENDLY_URL_PART_ASSET_PUBLISHER +
+			friendlyURLMap.get(defaultLocale);
 	}
 
 	private String _getFriendlyURLSeparatorPart(Locale locale)
@@ -457,30 +501,6 @@ public class UpdateLanguageActionTest {
 			"/" + _sourceLocale.getLanguage() + sourceURL);
 	}
 
-	private void _testGetRedirectWithPortletFriendlyURL(Locale sourceLocale)
-		throws Exception {
-
-		Map<Locale, String> friendlyURLMap =
-			_journalArticle.getFriendlyURLMap();
-
-		Locale defaultLocale = LocaleUtil.fromLanguageId(
-			_group.getDefaultLanguageId());
-
-		String path =
-			_PORTLET_FRIENDLY_URL_PART_ASSET_PUBLISHER +
-				friendlyURLMap.get(defaultLocale);
-
-		_assertGetRedirectWithLayoutFriendlyURL(
-			path, sourceLocale, _targetLocale, false);
-	}
-
-	private void _testGetRedirectWithPortletURLMapping(Locale sourceLocale)
-		throws Exception {
-
-		_assertGetRedirectWithLayoutFriendlyURL(
-			"/tags/tagname", sourceLocale, _targetLocale, false);
-	}
-
 	private void _updateLayoutFriendlyURL(String suffix) throws Exception {
 		for (Locale locale : _availableLocales) {
 			_layout = _layoutLocalService.updateFriendlyURL(
@@ -489,6 +509,8 @@ public class UpdateLanguageActionTest {
 				LocaleUtil.toLanguageId(locale));
 		}
 	}
+
+	private static final String _FRIENDLY_URL_MAPPER_MAPPING = "/tags/tagname";
 
 	private static final String _PORTLET_FRIENDLY_URL_PART_ASSET_PUBLISHER =
 		"/-/asset_publisher/instanceID/content/";

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -15,8 +15,10 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
+import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.LayoutFriendlyURLSeparatorComposite;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -32,6 +34,7 @@ import com.liferay.portal.struts.Action;
 import com.liferay.portal.struts.model.ActionForward;
 import com.liferay.portal.struts.model.ActionMapping;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -185,6 +188,23 @@ public class UpdateLanguageAction implements Action {
 			layoutURL = layoutURL.substring(0, friendlyURLSeparatorIndex);
 		}
 
+		String mappingPart = StringPool.BLANK;
+
+		List<FriendlyURLMapper> friendlyURLMappers =
+			PortletLocalServiceUtil.getFriendlyURLMappers();
+
+		for (FriendlyURLMapper friendlyURLMapper : friendlyURLMappers) {
+			if (!friendlyURLMapper.isCheckMappingWithPrefix()) {
+				int mappingIndex = layoutURL.indexOf(
+					friendlyURLMapper.getMapping());
+
+				if (mappingIndex != -1) {
+					mappingPart =
+						StringPool.SLASH + layoutURL.substring(mappingIndex);
+				}
+			}
+		}
+
 		Locale currentLocale = themeDisplay.getLocale();
 
 		if (themeDisplay.isI18n()) {
@@ -249,6 +269,10 @@ public class UpdateLanguageAction implements Action {
 
 			if (Validator.isNotNull(friendlyURLSeparatorPart)) {
 				redirect += friendlyURLSeparatorPart;
+			}
+
+			if (Validator.isNotNull(mappingPart)) {
+				redirect += mappingPart;
 			}
 		}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32573

# How am I fixing it?

Using the existing implementations of FriendlyURLMapper to get the full url and avoid missing parameters

# How can you verify that it works?

Run the included automated tests.