### PR TITLE
LPD-36211 Message board thread attachment is deleted after clicking `Cancel` in the confirmation

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEditMessageDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBEditMessageDisplayContext.java
@@ -12,13 +12,18 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.trash.TrashHelper;
 
 import java.util.Map;
 
 import javax.portlet.ResourceURL;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Ambrín Chaudhary
@@ -26,12 +31,18 @@ import javax.portlet.ResourceURL;
 public class MBEditMessageDisplayContext {
 
 	public MBEditMessageDisplayContext(
+		HttpServletRequest httpServletRequest,
 		LiferayPortletRequest liferayPortletRequest,
-		LiferayPortletResponse liferayPortletResponse, MBMessage message) {
+		LiferayPortletResponse liferayPortletResponse, MBMessage message,
+		TrashHelper trashHelper) {
 
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_message = message;
+		_trashHelper = trashHelper;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	public Map<String, Object> getMBPortletComponentContext() throws Exception {
@@ -55,6 +66,9 @@ public class MBEditMessageDisplayContext {
 		).put(
 			"rootNodeId",
 			_liferayPortletResponse.getNamespace() + "mbEditPageContainer"
+		).put(
+			"trashEnabled",
+			() -> _trashHelper.isTrashEnabled(_themeDisplay.getScopeGroupId())
 		).build();
 
 		if (_message != null) {
@@ -90,5 +104,7 @@ public class MBEditMessageDisplayContext {
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private MBMessage _message;
+	private final ThemeDisplay _themeDisplay;
+	private final TrashHelper _trashHelper;
 
 }

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
@@ -298,13 +298,17 @@ class MBPortlet {
 					);
 				}
 
-				const deletedAttachmentsElement = document.getElementById(
+				const viewRemovedAttachmentsLink = document.getElementById(
 					'view-removed-attachments-link'
 				);
 
+				if (!viewRemovedAttachmentsLink) {
+					return;
+				}
+
 				if (attachments.deleted.length) {
-					deletedAttachmentsElement.style.display = 'initial';
-					deletedAttachmentsElement.innerHTML =
+					viewRemovedAttachmentsLink.style.display = 'initial';
+					viewRemovedAttachmentsLink.innerText =
 						sub(
 							attachments.deleted.length > 1
 								? RECENTLY_REMOVED_ATTACHMENTS.multiple
@@ -313,7 +317,7 @@ class MBPortlet {
 						) + ' &raquo';
 				}
 				else {
-					deletedAttachmentsElement.style.display = 'none';
+					viewRemovedAttachmentsLink.style.display = 'none';
 				}
 			});
 	}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
@@ -31,6 +31,7 @@ class MBPortlet {
 			confirmDiscardImages: CONFIRM_DISCARD_IMAGES,
 		},
 		viewTrashAttachmentsURL,
+		trashEnabled,
 	}) {
 		this._namespace = namespace;
 		this._constants = constants;
@@ -39,6 +40,7 @@ class MBPortlet {
 		this._replyToMessageId = replyToMessageId;
 		this._strings = strings;
 		this._viewTrashAttachmentsURL = viewTrashAttachmentsURL;
+		this._trashEnabled = trashEnabled;
 
 		this.rootNode = document.getElementById(rootNodeId);
 
@@ -104,7 +106,7 @@ class MBPortlet {
 				.get('contentBox')
 				.delegate(
 					'click',
-					this._removeAttachment.bind(this),
+					this._confirmRemoveAttachment.bind(this),
 					'.delete-attachment'
 				);
 		});
@@ -154,39 +156,53 @@ class MBPortlet {
 	}
 
 	/**
+	 * Show a confimation modal if trash is enabled
+	 *
+	 * @param {Event} event The click event that triggered the remove action
+	 */
+	_confirmRemoveAttachment(event) {
+		event.preventDefault();
+
+		if (this._trashEnabled) {
+			this._removeAttachment(event);
+		}
+		else {
+			openConfirmModal({
+				message: Liferay.Language.get(
+					'are-you-sure-you-want-to-delete-this'
+				),
+				onConfirm: (isConfirmed) => {
+					if (!isConfirmed) {
+						return;
+					}
+
+					this._removeAttachment(event);
+				},
+			});
+		}
+	}
+
+	/**
 	 * Sends a request to remove the selected attachment.
 	 *
 	 * @param {Event} event The click event that triggered the remove action
 	 */
 	_removeAttachment(event) {
-		event.preventDefault();
+		const link = event.currentTarget;
+		const deleteURL = link.getAttribute('href');
 
-		openConfirmModal({
-			message: Liferay.Language.get(
-				'are-you-sure-you-want-to-delete-this'
-			),
-			onConfirm: (isConfirmed) => {
-				if (!isConfirmed) {
-					return;
-				}
-
-				const link = event.currentTarget;
-				const deleteURL = link.getAttribute('href');
-
-				fetch(deleteURL).then(() => {
-					Liferay.componentReady(this.searchContainerId).then(
-						(searchContainer) => {
-							searchContainer.deleteRow(
-								link.ancestor('tr'),
-								link.getAttribute('data-rowid')
-							);
-							searchContainer.updateDataStore();
-						}
+		fetch(deleteURL).then(() => {
+			Liferay.componentReady(this.searchContainerId).then(
+				(searchContainer) => {
+					searchContainer.deleteRow(
+						link.ancestor('tr'),
+						link.getAttribute('data-rowid')
 					);
+					searchContainer.updateDataStore();
+				}
+			);
 
-					this._updateRemovedAttachments();
-				});
-			},
+			this._updateRemovedAttachments();
 		});
 	}
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
@@ -159,22 +159,34 @@ class MBPortlet {
 	 * @param {Event} event The click event that triggered the remove action
 	 */
 	_removeAttachment(event) {
-		const link = event.currentTarget;
+		event.preventDefault();
 
-		const deleteURL = link.getAttribute('data-url');
-
-		fetch(deleteURL).then(() => {
-			Liferay.componentReady(this.searchContainerId).then(
-				(searchContainer) => {
-					searchContainer.deleteRow(
-						link.ancestor('tr'),
-						link.getAttribute('data-rowid')
-					);
-					searchContainer.updateDataStore();
+		openConfirmModal({
+			message: Liferay.Language.get(
+				'are-you-sure-you-want-to-delete-this'
+			),
+			onConfirm: (isConfirmed) => {
+				if (!isConfirmed) {
+					return;
 				}
-			);
 
-			this._updateRemovedAttachments();
+				const link = event.currentTarget;
+				const deleteURL = link.getAttribute('href');
+
+				fetch(deleteURL).then(() => {
+					Liferay.componentReady(this.searchContainerId).then(
+						(searchContainer) => {
+							searchContainer.deleteRow(
+								link.ancestor('tr'),
+								link.getAttribute('data-rowid')
+							);
+							searchContainer.updateDataStore();
+						}
+					);
+
+					this._updateRemovedAttachments();
+				});
+			},
 		});
 	}
 
@@ -270,9 +282,9 @@ class MBPortlet {
 											attachment.size,
 											`<a class="delete-attachment" data-rowId="${
 												attachment.id
-											}" data-url="${
+											}" href="${
 												attachment.deleteURL
-											}" href="javascript:void(0);">${Liferay.Language.get(
+											}">${Liferay.Language.get(
 												'delete'
 											)}</a>`,
 										],

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -457,7 +457,7 @@ if (portletTitleBasedNavigation) {
 </clay:container-fluid>
 
 <%
-MBEditMessageDisplayContext mbEditMessageDisplayContext = new MBEditMessageDisplayContext(liferayPortletRequest, liferayPortletResponse, message);
+MBEditMessageDisplayContext mbEditMessageDisplayContext = new MBEditMessageDisplayContext(request, liferayPortletRequest, liferayPortletResponse, message, trashHelper);
 %>
 
 <liferay-frontend:component

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -275,19 +275,9 @@ if (portletTitleBasedNavigation) {
 											<portlet:param name="fileName" value="<%= HtmlUtil.unescape(fileEntry.getTitle()) %>" />
 										</liferay-portlet:actionURL>
 
-										<liferay-ui:icon-menu
-											direction="left-side"
-											icon="<%= StringPool.BLANK %>"
-											markupView="lexicon"
-											message="actions"
-										>
-											<div class="delete-attachment" data-rowid="<%= fileEntry.getFileEntryId() %>" data-url="<%= deleteURL.toString() %>">
-												<liferay-ui:icon-delete
-													trash="<%= trashHelper.isTrashEnabled(scopeGroupId) %>"
-													url="javascript:void(0);"
-												/>
-											</div>
-										</liferay-ui:icon-menu>
+										<a class="delete-attachment" data-rowid="<%= fileEntry.getFileEntryId() %>" href="<%= deleteURL.toString() %>">
+											<liferay-ui:message key="delete" />
+										</a>
 									</liferay-ui:search-container-column-text>
 								</liferay-ui:search-container-row>
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
@@ -15,7 +15,7 @@
 
 <tr>
 	<td>ATTACHMENTS_REMOVE_LINK</td>
-	<td>//*[@data-qa-id='row'][contains(.,'${key_attachmentName}')]//span[contains(@class,'item-remove')]</td>
+	<td>//*[@data-qa-id='row'][contains(.,'${key_attachmentName}')]//a[contains(@class,'delete-attachment')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36211

The message board thread attachment was deleted after clicking `Cancel` in the confirmation.

# How am I fixing it?

I use `href` attribute instead of `data-url`, and show the confirm modal if JS is enabled.
With JS disabled the attachment is deleted without confirmation. 

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-36211

# Why doesn't this include any test?
I updated the old poshi d1970ebbf215b4c7b0926777a92a22f4507f7a9d

> [!CAUTION]
> Only the default value of property `trash.enabled=true` is covered by [RecycleBin#RecycleBinMBAttachment](https://github.com/boton/liferay-portal/blob/LPD-36211-BUG-MB-delete-attachment-cancel-confirm/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase#L159) (recycle bin activated)
> PR doesn't contain automated tests covering the bug because the tests need to change the portal's default behavior disabling the trash in the test env.