### PR TITLE
LPD-36441 The available templates for the content do not appear if it is in an asset library

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -142,11 +142,6 @@ public class DDMTemplateItemSelectorViewDescriptor
 	}
 
 	@Override
-	public boolean isShowBreadcrumb() {
-		return false;
-	}
-
-	@Override
 	public boolean isShowSearch() {
 		return true;
 	}

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -191,6 +191,25 @@ baseTest(
 );
 
 baseTest(
+	'LPD-36441: Navigate in ddm template selector',
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await page.getByRole('link', {name: 'Default Template'}).click();
+
+		await page.getByRole('button', {exact: true, name: 'Select'}).waitFor();
+
+		await page.getByRole('button', {exact: true, name: 'Select'}).click();
+
+		const breadcrumb = page
+			.frameLocator('iframe[title="Templates"]')
+			.getByRole('link', {name: 'Sites and Libraries'});
+
+		await expect(breadcrumb).toBeVisible();
+	}
+);
+
+baseTest(
 	'LPD-32979: Ensure the presence of the Description column when needed',
 	async ({journalEditArticlePage, journalPage, page, site}) => {
 		page.on('dialog', (dialog) => dialog.accept());


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-36441
### How am I fixing it?
The issue is that the template is inside the asset library scope while the item selector starts in our current scope. Currently, it is not possible to navigate between asset libraries or sites in the ddm template item selector. I fixed it by enabling the breadcrumb menu to navigate.

### How can you verify that it works?

To test run:
`npm run playwright -- test -g 'LPD-36441'`

Or manually test based on the LPD steps