### PR TITLE
LPD-36442

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -144,7 +144,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 				<li class="tbar-item">
 					<div class="c-gap-3 form-group-sm journal-article-button-row mb-0 tbar-section text-right">
 						<c:choose>
-							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") %>'>
+							<c:when test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11228") && !JournalUtil.isEditDefaultValues(article) %>'>
 								<div class="align-items-center d-none small text-danger" id="<portlet:namespace />lockErrorIndicator">
 									<liferay-ui:message key="autosave-error" />
 

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -10,6 +10,7 @@ import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest'
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
@@ -35,7 +36,40 @@ const autoSaveTest = mergeTests(
 	}),
 	isolatedSiteTest,
 	journalPagesTest,
-	loginTest()
+	loginTest(),
+	pagesAdminPagesTest
+);
+
+autoSaveTest(
+	'UndoRedo Should not appear when editing default values',
+	{
+		tag: '@LPD-36442',
+	},
+	async ({
+		apiHelpers,
+		journalEditArticlePage,
+		journalEditStructureDefaultValuesPage,
+		site,
+	}) => {
+		const fieldName = 'Text1';
+		const structureName = 'Structure1';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: fieldName, repeatable: true}],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditStructureDefaultValuesPage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		expect(journalEditArticlePage.undoButton).not.toBeVisible();
+		expect(journalEditArticlePage.redoButton).not.toBeVisible();
+	}
 );
 
 autoSaveTest(


### PR DESCRIPTION
Hey,

Ticket: [LPD-36442](https://liferay.atlassian.net/browse/LPD-36442)

Root Cause:

Issue is caused by the fact we display the UndoRedo component, that was not designed to be displayed there. To fix it I hide it, when defaultValues are beeing edited.

How to test?
Follow ticket description [LPD-36442](https://liferay.atlassian.net/browse/LPD-36442)

Test included