### PR TITLE
LPD-36593 Fix versions tab display

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -22,13 +22,7 @@ import ManageCollaborators from './ManageCollaborators';
 import Subscribe from './Subscribe';
 import VersionsContent from './VersionsContent';
 
-const TABS_1 = {
-	categorization: 1,
-	details: 0,
-	version: 2,
-};
-
-const TABS_2 = {
+const TABS = {
 	categorization: 1,
 	details: 0,
 	performance: 2,
@@ -58,8 +52,6 @@ const SidebarPanelInfoView = ({
 	viewURLs = [],
 	vocabularies = {},
 }) => {
-	const TABS = Liferay.FeatureFlags['LPD-28830'] ? TABS_2 : TABS_1;
-
 	const [activeTabKeyValue, setActiveTabKeyValue] = useState(TABS.details);
 
 	const [error, setError] = useState(false);

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -1521,7 +1521,7 @@ exports[`SidebarPanelInfoView renders 1`] = `
               </div>
             </div>
             <div
-              aria-labelledby="tab-2"
+              aria-labelledby="tab-3"
               class="tab-pane fade flex-shrink-0"
               role="tabpanel"
               tabindex="0"


### PR DESCRIPTION
Hi Content Management, team!

In this fix, I removed the logic that sets the position of the tabs according to the feature flag. This was causing the ClayTabs component not to find the versions tab, and therefore the content was not loading.