### PR TITLE
LPD-36031 - blogs aggregator can fail due to organization reference returning as null

### DIFF
--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
@@ -171,4 +171,5 @@ public class BlogsAggregatorExportImportPortletPreferencesProcessorTest {
 
 	@Inject
 	private PortletLocalService _portletLocalService;
+
 }

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
@@ -84,6 +84,10 @@ public class BlogsAggregatorExportImportPortletPreferencesProcessorTest {
 
 	@Test
 	public void testOrganizationMissingRefValidation() throws Exception {
+		StagedModelDataHandler<?> stagedModelDataHandler =
+			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+				Organization.class.getName());
+
 		Portlet portlet = _portletLocalService.getPortletById(
 			_portletDataContextExport.getCompanyId(),
 			BlogsPortletKeys.BLOGS_AGGREGATOR);
@@ -92,16 +96,11 @@ public class BlogsAggregatorExportImportPortletPreferencesProcessorTest {
 			portlet, _portletDataContextExport.getExportDataRootElement(),
 			_organization, PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
 
-		StagedModelDataHandler<?> stagedModelDataHandler =
-			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
-				Organization.class.getName());
-
-		boolean result = stagedModelDataHandler.validateReference(
-			_portletDataContextImport,
-			_portletDataContextImport.getMissingReferenceElement(
-				_organization));
-
-		Assert.assertTrue(result);
+		Assert.assertTrue(
+			stagedModelDataHandler.validateReference(
+				_portletDataContextImport,
+				_portletDataContextImport.getMissingReferenceElement(
+					_organization)));
 	}
 
 	@Test

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/internal/exportimport/portlet/preferences/processor/test/BlogsAggregatorExportImportPortletPreferencesProcessorTest.java
@@ -8,14 +8,18 @@ package com.liferay.blogs.internal.exportimport.portlet.preferences.processor.te
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.constants.BlogsPortletKeys;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -76,6 +80,28 @@ public class BlogsAggregatorExportImportPortletPreferencesProcessorTest {
 
 		_portletDataContextImport.setPortletId(
 			BlogsPortletKeys.BLOGS_AGGREGATOR);
+	}
+
+	@Test
+	public void testOrganizationMissingRefValidation() throws Exception {
+		Portlet portlet = _portletLocalService.getPortletById(
+			_portletDataContextExport.getCompanyId(),
+			BlogsPortletKeys.BLOGS_AGGREGATOR);
+
+		_portletDataContextImport.addReferenceElement(
+			portlet, _portletDataContextExport.getExportDataRootElement(),
+			_organization, PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+
+		StagedModelDataHandler<?> stagedModelDataHandler =
+			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+				Organization.class.getName());
+
+		boolean result = stagedModelDataHandler.validateReference(
+			_portletDataContextImport,
+			_portletDataContextImport.getMissingReferenceElement(
+				_organization));
+
+		Assert.assertTrue(result);
 	}
 
 	@Test
@@ -143,4 +169,6 @@ public class BlogsAggregatorExportImportPortletPreferencesProcessorTest {
 	private PortletDataContext _portletDataContextExport;
 	private PortletDataContext _portletDataContextImport;
 
+	@Inject
+	private PortletLocalService _portletLocalService;
 }

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -106,15 +106,11 @@ public class OrganizationStagedModelDataHandler
 	public boolean validateReference(
 		PortletDataContext portletDataContext, Element referenceElement) {
 
-		long companyId = GetterUtil.getLong(
-			referenceElement.attributeValue("company-id"));
-
-		String uuid = GetterUtil.getString(
-			referenceElement.attributeValue("uuid"));
-
 		Organization organization =
 			_organizationLocalService.fetchOrganizationByUuidAndCompanyId(
-				uuid, companyId);
+				GetterUtil.getString(referenceElement.attributeValue("uuid")),
+				GetterUtil.getLong(
+					referenceElement.attributeValue("company-id")));
 
 		if (organization == null) {
 			return false;

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.service.PasswordPolicyRelLocalService;
 import com.liferay.portal.kernel.service.PhoneLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WebsiteLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
@@ -99,6 +100,27 @@ public class OrganizationStagedModelDataHandler
 	@Override
 	public String getDisplayName(Organization organization) {
 		return organization.getName();
+	}
+
+	@Override
+	public boolean validateReference(
+		PortletDataContext portletDataContext, Element referenceElement) {
+
+		long companyId = GetterUtil.getLong(
+			referenceElement.attributeValue("company-id"));
+
+		String uuid = GetterUtil.getString(
+			referenceElement.attributeValue("uuid"));
+
+		Organization organization =
+			_organizationLocalService.fetchOrganizationByUuidAndCompanyId(
+				uuid, companyId);
+
+		if (organization == null) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Hi @liferay-content-management ,

https://liferay.atlassian.net/browse/LPD-36031
https://liferay.atlassian.net/browse/LPP-55262

This is an issue overlapping USM and Blogs, so we wanted to send this to you since we'll be adding some test coverage for it but it ended up falling under the BlogsAggregator. Currently, a null reference can be returned for a BlogsAggregator due to the Organization missing reference. To circumvent this we've implemented a validateReference method to check for the existence of the Organization per Roberto's mention here: https://liferay.atlassian.net/browse/LPP-55262?focusedCommentId=2721512

I've placed the test in your file since I noticed you guys had a similar test already that wasn't quite fully catching this issue, but please let me know if there's any questions. Thanks!