### PR TITLE
LPD-31829 Add ExternalReferenceCode to Blogs Images (Part 2)

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPostingImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPostingImage.java
@@ -187,6 +187,47 @@ public class BlogPostingImage implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _encodingFormatSupplier;
 
+	@Schema(description = "The image's external reference code.")
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The image's external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
 	@Schema(description = "The image's file extension.")
 	public String getFileExtension() {
 		if (_fileExtensionSupplier != null) {
@@ -478,6 +519,22 @@ public class BlogPostingImage implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(encodingFormat));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPostingImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPostingImage.java
@@ -392,6 +392,7 @@ public class BlogPostingImage implements Serializable {
 
 	@JsonGetter("viewableBy")
 	@Schema(
+		deprecated = true,
 		description = "A write-only property that specifies the default permissions."
 	)
 	@Valid
@@ -439,6 +440,7 @@ public class BlogPostingImage implements Serializable {
 		};
 	}
 
+	@Deprecated
 	@GraphQLField(
 		description = "A write-only property that specifies the default permissions."
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
@@ -81,6 +81,14 @@ public interface BlogPostingImageResource {
 			Object object)
 		throws Exception;
 
+	public void deleteSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPostingImage getSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/BlogPostingImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/BlogPostingImage.java
@@ -88,6 +88,27 @@ public class BlogPostingImage implements Cloneable, Serializable {
 
 	protected String encodingFormat;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
 	public String getFileExtension() {
 		return fileExtension;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingImageResource.java
@@ -100,6 +100,24 @@ public interface BlogPostingImageResource {
 			Map<String, File> multipartFiles, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPostingImage getSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -987,6 +1005,220 @@ public interface BlogPostingImageResource {
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/batch");
 
 			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteSiteBlogPostingImageByExternalReferenceCode(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public BlogPostingImage getSiteBlogPostingImageByExternalReferenceCode(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return BlogPostingImageSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingImageSerDes.java
@@ -88,6 +88,20 @@ public class BlogPostingImageSerDes {
 			sb.append("\"");
 		}
 
+		if (blogPostingImage.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(blogPostingImage.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (blogPostingImage.getFileExtension() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -195,6 +209,15 @@ public class BlogPostingImageSerDes {
 				String.valueOf(blogPostingImage.getEncodingFormat()));
 		}
 
+		if (blogPostingImage.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(blogPostingImage.getExternalReferenceCode()));
+		}
+
 		if (blogPostingImage.getFileExtension() == null) {
 			map.put("fileExtension", null);
 		}
@@ -262,6 +285,11 @@ public class BlogPostingImageSerDes {
 			else if (Objects.equals(jsonParserFieldName, "encodingFormat")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "fileExtension")) {
 				return false;
 			}
@@ -301,6 +329,14 @@ public class BlogPostingImageSerDes {
 			else if (Objects.equals(jsonParserFieldName, "encodingFormat")) {
 				if (jsonParserFieldValue != null) {
 					blogPostingImage.setEncodingFormat(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					blogPostingImage.setExternalReferenceCode(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	compileOnly project(":apps:site-navigation:site-navigation-api")
 	compileOnly project(":apps:style-book:style-book-api")
 	compileOnly project(":apps:subscription:subscription-api")
+	compileOnly project(":apps:upload:upload-api")
 	compileOnly project(":apps:wiki:wiki-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -244,6 +244,10 @@ components:
                         The image's content type (e.g., `application/png`, etc.).
                     readOnly: true
                     type: string
+                externalReferenceCode:
+                    description:
+                        The image's external reference code.
+                    type: string
                 fileExtension:
                     description:
                         The image's file extension.
@@ -11981,6 +11985,70 @@ paths:
                                     format: binary
                                     type: string
                             type: object
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/BlogPostingImage"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/BlogPostingImage"
+            tags: ["BlogPostingImage"]
+    "/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            # @review
+            description:
+                Deletes the site's blog post image by external reference code.
+            operationId: deleteSiteBlogPostingImageByExternalReferenceCode
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["BlogPostingImage"]
+        get:
+            # @review
+            description:
+                Retrieves the site's blog post image by external reference code. The binary image is returned as a
+                relative URL to the image itself.
+            operationId: getSiteBlogPostingImageByExternalReferenceCode
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: fields
+                  schema:
+                      type: string
+                - in: query
+                  name: nestedFields
+                  schema:
+                      type: string
+                - in: query
+                  name: restrictFields
+                  schema:
+                      type: string
             responses:
                 200:
                     content:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -270,6 +270,7 @@ components:
                         The image's title text.
                     type: string
                 viewableBy:
+                    deprecated: true
                     description:
                         A write-only property that specifies the default permissions.
                     enum: [Anyone, Members, Owner]

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -653,6 +653,25 @@ public class Mutation {
 					Long.valueOf(siteKey), multipartBody, callbackURL, object));
 	}
 
+	@GraphQLField(
+		description = "Deletes the site's blog post image by external reference code."
+	)
+	public boolean deleteSiteBlogPostingImageByExternalReferenceCode(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_blogPostingImageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			blogPostingImageResource ->
+				blogPostingImageResource.
+					deleteSiteBlogPostingImageByExternalReferenceCode(
+						Long.valueOf(siteKey), externalReferenceCode));
+
+		return true;
+	}
+
 	@GraphQLField
 	public Response createBlogPostingCommentsPageExportBatch(
 			@GraphQLName("blogPostingId") Long blogPostingId,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -458,7 +458,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {blogPostingImage(blogPostingImageId: ___){contentUrl, contentValue, encodingFormat, fileExtension, id, sizeInBytes, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {blogPostingImage(blogPostingImageId: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the blog post's image. The binary image is returned as a relative URL to the image itself."
@@ -506,6 +506,28 @@ public class Query {
 					Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(
 						blogPostingImageResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {blogPostingImageByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title, viewableBy}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the site's blog post image by external reference code. The binary image is returned as a relative URL to the image itself."
+	)
+	public BlogPostingImage blogPostingImageByExternalReferenceCode(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_blogPostingImageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			blogPostingImageResource ->
+				blogPostingImageResource.
+					getSiteBlogPostingImageByExternalReferenceCode(
+						Long.valueOf(siteKey), externalReferenceCode));
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -332,6 +332,11 @@ public class ServletDataImpl implements ServletData {
 							BlogPostingImageResourceImpl.class,
 							"postSiteBlogPostingImageBatch"));
 					put(
+						"mutation#deleteSiteBlogPostingImageByExternalReferenceCode",
+						new ObjectValuePair<>(
+							BlogPostingImageResourceImpl.class,
+							"deleteSiteBlogPostingImageByExternalReferenceCode"));
+					put(
 						"mutation#createBlogPostingCommentsPageExportBatch",
 						new ObjectValuePair<>(
 							CommentResourceImpl.class,
@@ -1798,6 +1803,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							BlogPostingImageResourceImpl.class,
 							"getSiteBlogPostingImagesPage"));
+					put(
+						"query#blogPostingImageByExternalReferenceCode",
+						new ObjectValuePair<>(
+							BlogPostingImageResourceImpl.class,
+							"getSiteBlogPostingImageByExternalReferenceCode"));
 					put(
 						"query#blogPostingComments",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -457,6 +457,106 @@ public abstract class BaseBlogPostingImageResourceImpl
 		).build();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the site's blog post image by external reference code."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "BlogPostingImage")
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteSiteBlogPostingImageByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the site's blog post image by external reference code. The binary image is returned as a relative URL to the image itself."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "BlogPostingImage")
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public BlogPostingImage getSiteBlogPostingImageByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+
+		return new BlogPostingImage();
+	}
+
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -8,14 +8,13 @@ package com.liferay.headless.delivery.internal.resource.v1_0;
 import com.liferay.blogs.constants.BlogsConstants;
 import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.util.DLURLHelper;
-import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.dto.v1_0.util.ContentValueUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.BlogPostingImageEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Field;
@@ -31,6 +30,7 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.upload.UniqueFileNameProvider;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -54,11 +54,13 @@ public class BlogPostingImageResourceImpl
 	public void deleteBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		FileEntry fileEntry = _dlAppService.getFileEntry(blogPostingImageId);
+		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
+			blogPostingImageId);
 
 		_validate(fileEntry);
 
-		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
+		_portletFileRepository.deletePortletFileEntry(
+			fileEntry.getFileEntryId());
 	}
 
 	@Override
@@ -69,19 +71,22 @@ public class BlogPostingImageResourceImpl
 		super.deleteSiteBlogPostingImageByExternalReferenceCode(
 			siteId, externalReferenceCode);
 
-		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
-			externalReferenceCode, siteId);
+		FileEntry fileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				externalReferenceCode, siteId);
 
 		_validate(fileEntry);
 
-		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
+		_portletFileRepository.deletePortletFileEntry(
+			fileEntry.getFileEntryId());
 	}
 
 	@Override
 	public BlogPostingImage getBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		FileEntry fileEntry = _dlAppService.getFileEntry(blogPostingImageId);
+		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
+			blogPostingImageId);
 
 		_validate(fileEntry);
 
@@ -98,8 +103,9 @@ public class BlogPostingImageResourceImpl
 			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
-			externalReferenceCode, siteId);
+		FileEntry fileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				externalReferenceCode, siteId);
 
 		_validate(fileEntry);
 
@@ -133,7 +139,7 @@ public class BlogPostingImageResourceImpl
 			},
 			sorts,
 			document -> _toBlogPostingImage(
-				_dlAppService.getFileEntry(
+				_portletFileRepository.getPortletFileEntry(
 					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
 	}
 
@@ -152,7 +158,6 @@ public class BlogPostingImageResourceImpl
 
 		String externalReferenceCode = null;
 		String title = null;
-		String viewableBy = null;
 
 		BlogPostingImage blogPostingImage =
 			multipartBody.getValueAsNullableInstance(
@@ -161,27 +166,35 @@ public class BlogPostingImageResourceImpl
 		if (blogPostingImage != null) {
 			externalReferenceCode = blogPostingImage.getExternalReferenceCode();
 			title = blogPostingImage.getTitle();
-			viewableBy = blogPostingImage.getViewableByAsString();
 		}
 
 		if (title == null) {
 			title = binaryFile.getFileName();
 		}
 
-		if (viewableBy == null) {
-			viewableBy = BlogPostingImage.ViewableBy.ANYONE.getValue();
+		return _toBlogPostingImage(
+			_portletFileRepository.addPortletFileEntry(
+				externalReferenceCode, siteId, contextUser.getUserId(), null, 0,
+				BlogsConstants.SERVICE_NAME, folder.getFolderId(),
+				binaryFile.getInputStream(),
+				_uniqueFileNameProvider.provide(
+					title,
+					fileName -> _hasFileEntry(
+						siteId, folder.getFolderId(), fileName)),
+				binaryFile.getContentType(), true));
+	}
+
+	private boolean _hasFileEntry(
+		long groupId, long folderId, String fileName) {
+
+		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
+			groupId, folderId, fileName);
+
+		if (fileEntry == null) {
+			return false;
 		}
 
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			externalReferenceCode, siteId, folder.getFolderId(),
-			binaryFile.getFileName(), binaryFile.getContentType(), title, null,
-			null, null, binaryFile.getInputStream(), binaryFile.getSize(), null,
-			null, null,
-			ServiceContextBuilder.create(
-				siteId, contextHttpServletRequest, viewableBy
-			).build());
-
-		return _toBlogPostingImage(fileEntry);
+		return true;
 	}
 
 	private BlogPostingImage _toBlogPostingImage(FileEntry fileEntry)
@@ -224,9 +237,12 @@ public class BlogPostingImageResourceImpl
 	private BlogsEntryService _blogsEntryService;
 
 	@Reference
-	private DLAppService _dlAppService;
+	private DLURLHelper _dlURLHelper;
 
 	@Reference
-	private DLURLHelper _dlURLHelper;
+	private PortletFileRepository _portletFileRepository;
+
+	@Reference
+	private UniqueFileNameProvider _uniqueFileNameProvider;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -62,6 +62,22 @@ public class BlogPostingImageResourceImpl
 	}
 
 	@Override
+	public void deleteSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception {
+
+		super.deleteSiteBlogPostingImageByExternalReferenceCode(
+			siteId, externalReferenceCode);
+
+		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
+			externalReferenceCode, siteId);
+
+		_validate(fileEntry);
+
+		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
+	}
+
+	@Override
 	public BlogPostingImage getBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
@@ -75,6 +91,19 @@ public class BlogPostingImageResourceImpl
 	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return _entityModel;
+	}
+
+	@Override
+	public BlogPostingImage getSiteBlogPostingImageByExternalReferenceCode(
+			Long siteId, String externalReferenceCode)
+		throws Exception {
+
+		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
+			externalReferenceCode, siteId);
+
+		_validate(fileEntry);
+
+		return _toBlogPostingImage(fileEntry);
 	}
 
 	@Override
@@ -121,6 +150,7 @@ public class BlogPostingImageResourceImpl
 			throw new BadRequestException("No file found in body");
 		}
 
+		String externalReferenceCode = null;
 		String title = null;
 		String viewableBy = null;
 
@@ -129,6 +159,7 @@ public class BlogPostingImageResourceImpl
 				"blogPostingImage", BlogPostingImage.class);
 
 		if (blogPostingImage != null) {
+			externalReferenceCode = blogPostingImage.getExternalReferenceCode();
 			title = blogPostingImage.getTitle();
 			viewableBy = blogPostingImage.getViewableByAsString();
 		}
@@ -142,9 +173,10 @@ public class BlogPostingImageResourceImpl
 		}
 
 		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, siteId, folder.getFolderId(), binaryFile.getFileName(),
-			binaryFile.getContentType(), title, null, null, null,
-			binaryFile.getInputStream(), binaryFile.getSize(), null, null, null,
+			externalReferenceCode, siteId, folder.getFolderId(),
+			binaryFile.getFileName(), binaryFile.getContentType(), title, null,
+			null, null, binaryFile.getInputStream(), binaryFile.getSize(), null,
+			null, null,
 			ServiceContextBuilder.create(
 				siteId, contextHttpServletRequest, viewableBy
 			).build());
@@ -165,6 +197,7 @@ public class BlogPostingImageResourceImpl
 						"contentValue", fileEntry::getContentStream,
 						contextUriInfo));
 				setEncodingFormat(fileEntry::getMimeType);
+				setExternalReferenceCode(fileEntry::getExternalReferenceCode);
 				setFileExtension(fileEntry::getExtension);
 				setId(fileEntry::getFileEntryId);
 				setSizeInBytes(fileEntry::getSize);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -226,7 +226,7 @@ public class BlogPostingImageResourceImpl
 		if (fileEntry.getFolderId() != folder.getFolderId()) {
 			throw new BadRequestException(
 				fileEntry.getFileEntryId() +
-					" does not correspond to a valid BlogPostingImage");
+					" does not correspond to a valid blog posting image");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -54,7 +54,9 @@ public class BlogPostingImageResourceImpl
 	public void deleteBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		FileEntry fileEntry = _getFileEntry(blogPostingImageId);
+		FileEntry fileEntry = _dlAppService.getFileEntry(blogPostingImageId);
+
+		_validate(fileEntry);
 
 		_dlAppService.deleteFileEntry(fileEntry.getFileEntryId());
 	}
@@ -63,7 +65,11 @@ public class BlogPostingImageResourceImpl
 	public BlogPostingImage getBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		return _toBlogPostingImage(_getFileEntry(blogPostingImageId));
+		FileEntry fileEntry = _dlAppService.getFileEntry(blogPostingImageId);
+
+		_validate(fileEntry);
+
+		return _toBlogPostingImage(fileEntry);
 	}
 
 	@Override
@@ -146,21 +152,6 @@ public class BlogPostingImageResourceImpl
 		return _toBlogPostingImage(fileEntry);
 	}
 
-	private FileEntry _getFileEntry(Long fileEntryId) throws Exception {
-		FileEntry fileEntry = _dlAppService.getFileEntry(fileEntryId);
-
-		Folder folder = _blogsEntryService.addAttachmentsFolder(
-			fileEntry.getGroupId());
-
-		if (fileEntry.getFolderId() != folder.getFolderId()) {
-			throw new BadRequestException(
-				fileEntryId +
-					" does not correspond to a valid BlogPostingImage");
-		}
-
-		return fileEntry;
-	}
-
 	private BlogPostingImage _toBlogPostingImage(FileEntry fileEntry)
 		throws Exception {
 
@@ -180,6 +171,17 @@ public class BlogPostingImageResourceImpl
 				setTitle(fileEntry::getTitle);
 			}
 		};
+	}
+
+	private void _validate(FileEntry fileEntry) throws Exception {
+		Folder folder = _blogsEntryService.addAttachmentsFolder(
+			fileEntry.getGroupId());
+
+		if (fileEntry.getFolderId() != folder.getFolderId()) {
+			throw new BadRequestException(
+				fileEntry.getFileEntryId() +
+					" does not correspond to a valid BlogPostingImage");
+		}
 	}
 
 	private static final EntityModel _entityModel =

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -173,6 +173,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		blogPostingImage.setContentUrl(regex);
 		blogPostingImage.setContentValue(regex);
 		blogPostingImage.setEncodingFormat(regex);
+		blogPostingImage.setExternalReferenceCode(regex);
 		blogPostingImage.setFileExtension(regex);
 		blogPostingImage.setTitle(regex);
 
@@ -185,6 +186,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		Assert.assertEquals(regex, blogPostingImage.getContentUrl());
 		Assert.assertEquals(regex, blogPostingImage.getContentValue());
 		Assert.assertEquals(regex, blogPostingImage.getEncodingFormat());
+		Assert.assertEquals(regex, blogPostingImage.getExternalReferenceCode());
 		Assert.assertEquals(regex, blogPostingImage.getFileExtension());
 		Assert.assertEquals(regex, blogPostingImage.getTitle());
 	}
@@ -983,6 +985,227 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			multipartFiles);
 	}
 
+	@Test
+	public void testDeleteSiteBlogPostingImageByExternalReferenceCode()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		BlogPostingImage blogPostingImage =
+			testDeleteSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage();
+
+		assertHttpResponseStatusCode(
+			204,
+			blogPostingImageResource.
+				deleteSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId(),
+					blogPostingImage.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingImageResource.
+				getSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId(),
+					blogPostingImage.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingImageResource.
+				getSiteBlogPostingImageByExternalReferenceCodeHttpResponse(
+					testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId(),
+					blogPostingImage.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected BlogPostingImage
+			testDeleteSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage()
+		throws Exception {
+
+		return blogPostingImageResource.postSiteBlogPostingImage(
+			testGroup.getGroupId(), randomBlogPostingImage(),
+			getMultipartFiles());
+	}
+
+	@Test
+	public void testGetSiteBlogPostingImageByExternalReferenceCode()
+		throws Exception {
+
+		BlogPostingImage postBlogPostingImage =
+			testGetSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage();
+
+		BlogPostingImage getBlogPostingImage =
+			blogPostingImageResource.
+				getSiteBlogPostingImageByExternalReferenceCode(
+					testGetSiteBlogPostingImageByExternalReferenceCode_getSiteId(),
+					postBlogPostingImage.getExternalReferenceCode());
+
+		assertEquals(postBlogPostingImage, getBlogPostingImage);
+		assertValid(getBlogPostingImage);
+	}
+
+	protected Long
+			testGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected BlogPostingImage
+			testGetSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage()
+		throws Exception {
+
+		return blogPostingImageResource.postSiteBlogPostingImage(
+			testGroup.getGroupId(), randomBlogPostingImage(),
+			getMultipartFiles());
+	}
+
+	@Test
+	public void testGraphQLGetSiteBlogPostingImageByExternalReferenceCode()
+		throws Exception {
+
+		BlogPostingImage blogPostingImage =
+			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				blogPostingImage,
+				BlogPostingImageSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"blogPostingImageByExternalReferenceCode",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"siteKey",
+											"\"" +
+												testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId() +
+													"\"");
+
+										put(
+											"externalReferenceCode",
+											"\"" +
+												blogPostingImage.
+													getExternalReferenceCode() +
+														"\"");
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/blogPostingImageByExternalReferenceCode"))));
+
+		// Using the namespace headlessDelivery_v1_0
+
+		Assert.assertTrue(
+			equals(
+				blogPostingImage,
+				BlogPostingImageSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessDelivery_v1_0",
+								new GraphQLField(
+									"blogPostingImageByExternalReferenceCode",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"siteKey",
+												"\"" +
+													testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId() +
+														"\"");
+
+											put(
+												"externalReferenceCode",
+												"\"" +
+													blogPostingImage.
+														getExternalReferenceCode() +
+															"\"");
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessDelivery_v1_0",
+						"Object/blogPostingImageByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetSiteBlogPostingImageByExternalReferenceCodeNotFound()
+		throws Exception {
+
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"blogPostingImageByExternalReferenceCode",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + irrelevantGroup.getGroupId() + "\"");
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessDelivery_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessDelivery_v1_0",
+						new GraphQLField(
+							"blogPostingImageByExternalReferenceCode",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"siteKey",
+										"\"" + irrelevantGroup.getGroupId() +
+											"\"");
+									put(
+										"externalReferenceCode",
+										irrelevantExternalReferenceCode);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected BlogPostingImage
+			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_addBlogPostingImage()
+		throws Exception {
+
+		return testGraphQLBlogPostingImage_addBlogPostingImage();
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -1069,6 +1292,8 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		sb.append("}");
 
 		List<GraphQLField> graphQLFields = getGraphQLFields();
+
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
 
 		graphQLFields.add(new GraphQLField("id"));
 
@@ -1195,6 +1420,16 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 			if (Objects.equals("encodingFormat", additionalAssertFieldName)) {
 				if (blogPostingImage.getEncodingFormat() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (blogPostingImage.getExternalReferenceCode() == null) {
 					valid = false;
 				}
 
@@ -1388,6 +1623,19 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 				if (!Objects.deepEquals(
 						blogPostingImage1.getEncodingFormat(),
 						blogPostingImage2.getEncodingFormat())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						blogPostingImage1.getExternalReferenceCode(),
+						blogPostingImage2.getExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1695,6 +1943,52 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = blogPostingImage.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("fileExtension")) {
 			Object object = blogPostingImage.getFileExtension();
 
@@ -1857,6 +2151,8 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 				contentValue = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				encodingFormat = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				fileExtension = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -33,8 +33,20 @@ import org.junit.runner.RunWith;
 public class BlogPostingImageResourceTest
 	extends BaseBlogPostingImageResourceTestCase {
 
+	@Override
 	@Test
-	public void testPostSiteBlogPostingImageRollback() throws Exception {
+	public void testPostSiteBlogPostingImage() throws Exception {
+		super.testPostSiteBlogPostingImage();
+
+		_testPostSiteBlogPostingImageRollback();
+		_testPostSiteBlogPostingImageWithDuplicatedExternalReferenceCode();
+		_testPostSiteBlogPostingImageWithDuplicatedTitle();
+	}
+
+	private void _testPostSiteBlogPostingImageRollback() throws Exception {
+		tearDown();
+		setUp();
+
 		Folder folder = BlogsEntryLocalServiceUtil.fetchAttachmentsFolder(
 			UserLocalServiceUtil.getGuestUserId(testGroup.getCompanyId()),
 			testGroup.getGroupId());
@@ -62,8 +74,7 @@ public class BlogPostingImageResourceTest
 		Assert.assertNull(folder);
 	}
 
-	@Test(expected = Problem.ProblemException.class)
-	public void testPostSiteBlogPostingImageWithDuplicatedExternalReferenceCode()
+	private void _testPostSiteBlogPostingImageWithDuplicatedExternalReferenceCode()
 		throws Exception {
 
 		Map<String, File> multipartFiles = getMultipartFiles();
@@ -78,12 +89,18 @@ public class BlogPostingImageResourceTest
 		randomBlogPostingImage2.setExternalReferenceCode(
 			randomBlogPostingImage1.getExternalReferenceCode());
 
-		testPostSiteBlogPostingImage_addBlogPostingImage(
-			randomBlogPostingImage2, multipartFiles);
+		try {
+			testPostSiteBlogPostingImage_addBlogPostingImage(
+				randomBlogPostingImage2, multipartFiles);
+
+			Assert.fail();
+		}
+		catch (Throwable throwable) {
+			Assert.assertTrue(throwable instanceof Problem.ProblemException);
+		}
 	}
 
-	@Test
-	public void testPostSiteBlogPostingImageWithDuplicatedTitle()
+	private void _testPostSiteBlogPostingImageWithDuplicatedTitle()
 		throws Exception {
 
 		Map<String, File> multipartFiles = getMultipartFiles();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -99,10 +99,34 @@ public class BlogPostingImageResourceTest
 	}
 
 	@Override
+	protected Long
+			testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected Long
+			testGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
 	protected BlogPostingImage testGraphQLBlogPostingImage_addBlogPostingImage()
 		throws Exception {
 
 		return testDeleteBlogPostingImage_addBlogPostingImage();
+	}
+
+	@Override
+	protected Long
+			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
 	}
 
 	private String _read(String url) throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -43,6 +43,78 @@ public class BlogPostingImageResourceTest
 		_testPostSiteBlogPostingImageWithDuplicatedTitle();
 	}
 
+	@Override
+	protected void assertValid(
+			BlogPostingImage blogPostingImage, Map<String, File> multipartFiles)
+		throws Exception {
+
+		Assert.assertEquals(
+			new String(FileUtil.getBytes(multipartFiles.get("file"))),
+			_read("http://localhost:8080" + blogPostingImage.getContentUrl()));
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"title"};
+	}
+
+	@Override
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[] {"fileExtension", "sizeInBytes"};
+	}
+
+	@Override
+	protected Map<String, File> getMultipartFiles() throws Exception {
+		return HashMapBuilder.<String, File>put(
+			"file",
+			() -> FileUtil.createTempFile(TestDataConstants.TEST_BYTE_ARRAY)
+		).build();
+	}
+
+	@Override
+	protected Long
+			testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected Long
+			testGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected BlogPostingImage testGraphQLBlogPostingImage_addBlogPostingImage()
+		throws Exception {
+
+		return testDeleteBlogPostingImage_addBlogPostingImage();
+	}
+
+	@Override
+	protected Long
+			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	private String _read(String url) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+		httpInvoker.path(url);
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
 	private void _testPostSiteBlogPostingImageRollback() throws Exception {
 		tearDown();
 		setUp();
@@ -125,78 +197,6 @@ public class BlogPostingImageResourceTest
 			StringUtil.appendParentheticalSuffix(
 				randomBlogPostingImage2.getTitle(), 1),
 			blogPostingImage.getTitle());
-	}
-
-	@Override
-	protected void assertValid(
-			BlogPostingImage blogPostingImage, Map<String, File> multipartFiles)
-		throws Exception {
-
-		Assert.assertEquals(
-			new String(FileUtil.getBytes(multipartFiles.get("file"))),
-			_read("http://localhost:8080" + blogPostingImage.getContentUrl()));
-	}
-
-	@Override
-	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"title"};
-	}
-
-	@Override
-	protected String[] getIgnoredEntityFieldNames() {
-		return new String[] {"fileExtension", "sizeInBytes"};
-	}
-
-	@Override
-	protected Map<String, File> getMultipartFiles() throws Exception {
-		return HashMapBuilder.<String, File>put(
-			"file",
-			() -> FileUtil.createTempFile(TestDataConstants.TEST_BYTE_ARRAY)
-		).build();
-	}
-
-	@Override
-	protected Long
-			testDeleteSiteBlogPostingImageByExternalReferenceCode_getSiteId()
-		throws Exception {
-
-		return testGroup.getGroupId();
-	}
-
-	@Override
-	protected Long
-			testGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
-		throws Exception {
-
-		return testGroup.getGroupId();
-	}
-
-	@Override
-	protected BlogPostingImage testGraphQLBlogPostingImage_addBlogPostingImage()
-		throws Exception {
-
-		return testDeleteBlogPostingImage_addBlogPostingImage();
-	}
-
-	@Override
-	protected Long
-			testGraphQLGetSiteBlogPostingImageByExternalReferenceCode_getSiteId()
-		throws Exception {
-
-		return testGroup.getGroupId();
-	}
-
-	private String _read(String url) throws Exception {
-		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
-		httpInvoker.path(url);
-		httpInvoker.userNameAndPassword(
-			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
-
-		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
-
-		return httpResponse.getContent();
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -42,20 +43,11 @@ public class BlogPostingImageResourceTest
 
 		BlogPostingImage blogPostingImage = randomBlogPostingImage();
 
+		blogPostingImage.setTitle("*,?" + blogPostingImage.getTitle());
+
 		try {
 			testPostSiteBlogPostingImage_addBlogPostingImage(
-				blogPostingImage,
-				HashMapBuilder.put(
-					"file",
-					() -> {
-						File tempFile = FileUtil.createTempFile("*,?", "txt");
-
-						FileUtil.write(
-							tempFile, TestDataConstants.TEST_BYTE_ARRAY);
-
-						return tempFile;
-					}
-				).build());
+				blogPostingImage, getMultipartFiles());
 
 			Assert.fail();
 		}
@@ -68,6 +60,54 @@ public class BlogPostingImageResourceTest
 			testGroup.getGroupId());
 
 		Assert.assertNull(folder);
+	}
+
+	@Test(expected = Problem.ProblemException.class)
+	public void testPostSiteBlogPostingImageWithDuplicatedExternalReferenceCode()
+		throws Exception {
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		BlogPostingImage randomBlogPostingImage1 = randomBlogPostingImage();
+
+		testPostSiteBlogPostingImage_addBlogPostingImage(
+			randomBlogPostingImage1, multipartFiles);
+
+		BlogPostingImage randomBlogPostingImage2 = randomBlogPostingImage();
+
+		randomBlogPostingImage2.setExternalReferenceCode(
+			randomBlogPostingImage1.getExternalReferenceCode());
+
+		testPostSiteBlogPostingImage_addBlogPostingImage(
+			randomBlogPostingImage2, multipartFiles);
+	}
+
+	@Test
+	public void testPostSiteBlogPostingImageWithDuplicatedTitle()
+		throws Exception {
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		BlogPostingImage randomBlogPostingImage1 = randomBlogPostingImage();
+
+		BlogPostingImage blogPostingImage =
+			testPostSiteBlogPostingImage_addBlogPostingImage(
+				randomBlogPostingImage1, multipartFiles);
+
+		Assert.assertEquals(
+			randomBlogPostingImage1.getTitle(), blogPostingImage.getTitle());
+
+		BlogPostingImage randomBlogPostingImage2 = randomBlogPostingImage();
+
+		randomBlogPostingImage2.setTitle(randomBlogPostingImage1.getTitle());
+
+		blogPostingImage = testPostSiteBlogPostingImage_addBlogPostingImage(
+			randomBlogPostingImage2, multipartFiles);
+
+		Assert.assertEquals(
+			StringUtil.appendParentheticalSuffix(
+				randomBlogPostingImage2.getTitle(), 1),
+			blogPostingImage.getTitle());
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-31829

Add API REST support for ERC in BlogPostingImage

NOTE: this work has been already sent in #5836 . Now I've added 3 commits to fix what requested by Brian

> 1.) every test in BlogPostingImageResourceTest.java must have an @OverRide
> 
> Type: `git grep super\.test **ResourceTest.java`
> 
> 2.) also change
> 
> " does not correspond to a valid BlogPostingImage");
> to
> " does not correspond to a valid blog posting image");

# How am I fixing it?

Created end point

* /sites/{siteId}/blog-posting-images/by-external-reference-code/{externalReferenceCode}
* Methods: DELETE, GET, PUT

# How can you verify that it works?

Run tests `gw tI --tests "BlogPostingImageResourceTest.*ExternalReferenceCode*"` in folder `modules/apps/headless/headless-delivery/headless-delivery-test`.
