### PR TITLE
LPD-32872 Content Dashboard -  HTTP 414 errors when filtering or trying to see asset info

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
@@ -279,24 +279,12 @@ public class ContentDashboardAdminDisplayContext {
 			return _contentDashboardItemSubtypePayloads;
 		}
 
-		String[] contentDashboardItemSubtypePayloads =
-			ParamUtil.getParameterValues(
-				_liferayPortletRequest, "contentDashboardItemSubtypePayload",
-				new String[0], false);
-
-		if (ArrayUtil.isEmpty(contentDashboardItemSubtypePayloads)) {
-			_contentDashboardItemSubtypePayloads = Collections.emptyList();
-		}
-		else {
-			_contentDashboardItemSubtypePayloads =
-				TransformUtil.transformToList(
-					contentDashboardItemSubtypePayloads,
-					contentDashboardItemSubtypePayload ->
-						ContentDashboardItemSubtypeUtil.
-							toContentDashboardItemSubtype(
-								_contentDashboardItemSubtypeFactoryRegistry,
-								contentDashboardItemSubtypePayload));
-		}
+		_contentDashboardItemSubtypePayloads =
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_contentDashboardItemSubtypeFactoryRegistry,
+				ParamUtil.getString(
+					_liferayPortletRequest,
+					"contentDashboardItemSubtypePayload"));
 
 		return _contentDashboardItemSubtypePayloads;
 	}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.tags.item.selector.AssetTagsItemSelectorReturnType;
 import com.liferay.asset.tags.item.selector.criterion.AssetTagsItemSelectorCriterion;
+import com.liferay.content.dashboard.info.item.ClassNameClassPKInfoItemIdentifier;
 import com.liferay.content.dashboard.item.action.exception.ContentDashboardItemActionException;
 import com.liferay.content.dashboard.item.filter.ContentDashboardItemFilter;
 import com.liferay.content.dashboard.item.filter.provider.ContentDashboardItemFilterProvider;
@@ -35,6 +36,7 @@ import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
@@ -279,7 +281,7 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 				labelItem -> {
 					labelItem.putData(
 						"removeLabelURL",
-						_getRemoveContentDashboardItemSubtypePayloadsURL(
+						_getRemoveLabelURL(
 							contentDashboardItemSubtypes,
 							contentDashboardItemSubtype));
 					labelItem.setCloseable(true);
@@ -919,13 +921,34 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 		};
 	}
 
+	private JSONObject _getJSONObject(
+		JSONArray jsonArray, String className, String entryClassName) {
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			if (jsonObject == null) {
+				continue;
+			}
+
+			if (Objects.equals(jsonObject.getString("className"), className) &&
+				Objects.equals(
+					jsonObject.getString("entryClassName"), entryClassName)) {
+
+				return jsonObject;
+			}
+		}
+
+		return null;
+	}
+
 	private String _getLabel(String key, String value) {
 		return StringBundler.concat(
 			_language.get(httpServletRequest, key), StringPool.COLON,
 			StringPool.SPACE, value);
 	}
 
-	private String _getRemoveContentDashboardItemSubtypePayloadsURL(
+	private String _getRemoveLabelURL(
 			List<? extends ContentDashboardItemSubtype>
 				contentDashboardItemSubtypes,
 			ContentDashboardItemSubtype<?> contentDashboardItemSubtype)
@@ -938,21 +961,81 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 			PortletURLUtil.clone(currentURLObj, liferayPortletResponse)
 		).setParameter(
 			"contentDashboardItemSubtypePayload",
-			() -> TransformUtil.transformToArray(
-				contentDashboardItemSubtypes,
-				curContentDashboardItemSubtype -> {
+			() -> {
+				JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+				for (ContentDashboardItemSubtype
+						curContentDashboardItemSubtype :
+							contentDashboardItemSubtypes) {
+
 					InfoItemReference curInfoItemReference =
 						curContentDashboardItemSubtype.getInfoItemReference();
 
 					if (Objects.equals(
 							infoItemReference, curInfoItemReference)) {
 
-						return null;
+						continue;
 					}
 
-					return curContentDashboardItemSubtype.toJSONString(_locale);
-				},
-				String.class)
+					if (curInfoItemReference.getInfoItemIdentifier() instanceof
+							ClassNameClassPKInfoItemIdentifier) {
+
+						ClassNameClassPKInfoItemIdentifier
+							classNameClassPKInfoItemIdentifier =
+								(ClassNameClassPKInfoItemIdentifier)
+									curInfoItemReference.
+										getInfoItemIdentifier();
+
+						JSONObject jsonObject = _getJSONObject(
+							jsonArray,
+							classNameClassPKInfoItemIdentifier.getClassName(),
+							curInfoItemReference.getClassName());
+
+						if (jsonObject != null) {
+							JSONArray classPKsJSONArray =
+								jsonObject.getJSONArray("classPKs");
+
+							if (classPKsJSONArray != null) {
+								classPKsJSONArray.put(
+									classNameClassPKInfoItemIdentifier.
+										getClassPK());
+							}
+							else {
+								jsonObject.put(
+									"classPKs",
+									JSONUtil.put(
+										classNameClassPKInfoItemIdentifier.
+											getClassPK()));
+							}
+						}
+						else {
+							jsonArray.put(
+								JSONUtil.put(
+									"className",
+									classNameClassPKInfoItemIdentifier.
+										getClassName()
+								).put(
+									"classPKs",
+									JSONUtil.put(
+										String.valueOf(
+											classNameClassPKInfoItemIdentifier.
+												getClassPK()))
+								).put(
+									"entryClassName",
+									curInfoItemReference.getClassName()
+								));
+						}
+					}
+					else {
+						jsonArray.put(
+							JSONUtil.put(
+								"entryClassName",
+								curInfoItemReference.getClassName()));
+					}
+				}
+
+				return jsonArray.toString();
+			}
 		).buildString();
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,53 +71,6 @@ public class ContentDashboardItemSubtypeUtil {
 	public static ContentDashboardItemSubtype toContentDashboardItemSubtype(
 		ContentDashboardItemSubtypeFactoryRegistry
 			contentDashboardItemSubtypeFactoryRegistry,
-		JSONObject contentDashboardItemSubtypePayloadJSONObject) {
-
-		String className =
-			contentDashboardItemSubtypePayloadJSONObject.getString("className");
-
-		if (Validator.isNull(className)) {
-			return toContentDashboardItemSubtype(
-				contentDashboardItemSubtypeFactoryRegistry,
-				new InfoItemReference(
-					contentDashboardItemSubtypePayloadJSONObject.getString(
-						"entryClassName"),
-					0));
-		}
-
-		return toContentDashboardItemSubtype(
-			contentDashboardItemSubtypeFactoryRegistry,
-			new InfoItemReference(
-				contentDashboardItemSubtypePayloadJSONObject.getString(
-					"entryClassName"),
-				new ClassNameClassPKInfoItemIdentifier(
-					GetterUtil.getString(className),
-					GetterUtil.getLong(
-						contentDashboardItemSubtypePayloadJSONObject.getLong(
-							"classPK")))));
-	}
-
-	public static ContentDashboardItemSubtype toContentDashboardItemSubtype(
-		ContentDashboardItemSubtypeFactoryRegistry
-			contentDashboardItemSubtypeFactoryRegistry,
-		String contentDashboardItemSubtypePayload) {
-
-		try {
-			return toContentDashboardItemSubtype(
-				contentDashboardItemSubtypeFactoryRegistry,
-				JSONFactoryUtil.createJSONObject(
-					contentDashboardItemSubtypePayload));
-		}
-		catch (JSONException jsonException) {
-			_log.error(jsonException);
-
-			return null;
-		}
-	}
-
-	public static ContentDashboardItemSubtype toContentDashboardItemSubtype(
-		ContentDashboardItemSubtypeFactoryRegistry
-			contentDashboardItemSubtypeFactoryRegistry,
 		String className, String classPK, String entryClassName) {
 
 		if (Validator.isNull(className)) {
@@ -137,6 +91,54 @@ public class ContentDashboardItemSubtypeUtil {
 		toContentDashboardItemSubtypes(
 			ContentDashboardItemSubtypeFactoryRegistry
 				contentDashboardItemSubtypeFactoryRegistry,
+			JSONObject contentDashboardItemSubtypePayloadJSONObject) {
+
+		if (contentDashboardItemSubtypePayloadJSONObject == null) {
+			return Collections.emptyList();
+		}
+
+		String className =
+			contentDashboardItemSubtypePayloadJSONObject.getString("className");
+
+		if (Validator.isNull(className)) {
+			return Arrays.asList(
+				toContentDashboardItemSubtype(
+					contentDashboardItemSubtypeFactoryRegistry,
+					new InfoItemReference(
+						contentDashboardItemSubtypePayloadJSONObject.getString(
+							"entryClassName"),
+						0)));
+		}
+
+		JSONArray classPKsJSONArray =
+			contentDashboardItemSubtypePayloadJSONObject.getJSONArray(
+				"classPKs");
+
+		if (classPKsJSONArray == null) {
+			return Collections.emptyList();
+		}
+
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			new ArrayList<>();
+
+		for (int j = 0; j < classPKsJSONArray.length(); j++) {
+			contentDashboardItemSubtypes.add(
+				toContentDashboardItemSubtype(
+					contentDashboardItemSubtypeFactoryRegistry,
+					contentDashboardItemSubtypePayloadJSONObject.getString(
+						"className"),
+					classPKsJSONArray.getString(j),
+					contentDashboardItemSubtypePayloadJSONObject.getString(
+						Field.ENTRY_CLASS_NAME)));
+		}
+
+		return contentDashboardItemSubtypes;
+	}
+
+	public static List<ContentDashboardItemSubtype>
+		toContentDashboardItemSubtypes(
+			ContentDashboardItemSubtypeFactoryRegistry
+				contentDashboardItemSubtypeFactoryRegistry,
 			String contentDashboardItemSubtypePayload) {
 
 		if (Validator.isNull(contentDashboardItemSubtypePayload)) {
@@ -151,35 +153,10 @@ public class ContentDashboardItemSubtypeUtil {
 				contentDashboardItemSubtypePayload);
 
 			for (int i = 0; i < jsonArray.length(); i++) {
-				JSONObject jsonObject = jsonArray.getJSONObject(i);
-
-				if (jsonObject == null) {
-					continue;
-				}
-
-				if (jsonObject.has("className")) {
-					JSONArray classPKsJSONArray = jsonObject.getJSONArray(
-						"classPKs");
-
-					if (classPKsJSONArray == null) {
-						continue;
-					}
-
-					for (int j = 0; j < classPKsJSONArray.length(); j++) {
-						contentDashboardItemSubtypes.add(
-							toContentDashboardItemSubtype(
-								contentDashboardItemSubtypeFactoryRegistry,
-								jsonObject.getString("className"),
-								classPKsJSONArray.getString(j),
-								jsonObject.getString(Field.ENTRY_CLASS_NAME)));
-					}
-				}
-				else {
-					contentDashboardItemSubtypes.add(
-						toContentDashboardItemSubtype(
-							contentDashboardItemSubtypeFactoryRegistry, null,
-							null, jsonObject.getString("entryClassName")));
-				}
+				contentDashboardItemSubtypes.addAll(
+					toContentDashboardItemSubtypes(
+						contentDashboardItemSubtypeFactoryRegistry,
+						jsonArray.getJSONObject(i)));
 			}
 		}
 		catch (JSONException jsonException) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
@@ -101,13 +101,19 @@ public class ContentDashboardItemSubtypeUtil {
 			contentDashboardItemSubtypePayloadJSONObject.getString("className");
 
 		if (Validator.isNull(className)) {
-			return Arrays.asList(
+			ContentDashboardItemSubtype contentDashboardItemSubtype =
 				toContentDashboardItemSubtype(
 					contentDashboardItemSubtypeFactoryRegistry,
 					new InfoItemReference(
 						contentDashboardItemSubtypePayloadJSONObject.getString(
 							"entryClassName"),
-						0)));
+						0));
+
+			if (contentDashboardItemSubtype != null) {
+				return Arrays.asList(contentDashboardItemSubtype);
+			}
+
+			return Collections.emptyList();
 		}
 
 		JSONArray classPKsJSONArray =
@@ -122,14 +128,18 @@ public class ContentDashboardItemSubtypeUtil {
 			new ArrayList<>();
 
 		for (int j = 0; j < classPKsJSONArray.length(); j++) {
-			contentDashboardItemSubtypes.add(
+			ContentDashboardItemSubtype contentDashboardItemSubtype =
 				toContentDashboardItemSubtype(
 					contentDashboardItemSubtypeFactoryRegistry,
 					contentDashboardItemSubtypePayloadJSONObject.getString(
 						"className"),
 					classPKsJSONArray.getString(j),
 					contentDashboardItemSubtypePayloadJSONObject.getString(
-						Field.ENTRY_CLASS_NAME)));
+						Field.ENTRY_CLASS_NAME));
+
+			if (contentDashboardItemSubtype != null) {
+				contentDashboardItemSubtypes.add(contentDashboardItemSubtype);
+			}
 		}
 
 		return contentDashboardItemSubtypes;

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtil.java
@@ -12,13 +12,19 @@ import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactor
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Cristina González
@@ -106,6 +112,81 @@ public class ContentDashboardItemSubtypeUtil {
 
 			return null;
 		}
+	}
+
+	public static ContentDashboardItemSubtype toContentDashboardItemSubtype(
+		ContentDashboardItemSubtypeFactoryRegistry
+			contentDashboardItemSubtypeFactoryRegistry,
+		String className, String classPK, String entryClassName) {
+
+		if (Validator.isNull(className)) {
+			return toContentDashboardItemSubtype(
+				contentDashboardItemSubtypeFactoryRegistry,
+				new InfoItemReference(entryClassName, 0));
+		}
+
+		return toContentDashboardItemSubtype(
+			contentDashboardItemSubtypeFactoryRegistry,
+			new InfoItemReference(
+				entryClassName,
+				new ClassNameClassPKInfoItemIdentifier(
+					className, GetterUtil.getLong(classPK))));
+	}
+
+	public static List<ContentDashboardItemSubtype>
+		toContentDashboardItemSubtypes(
+			ContentDashboardItemSubtypeFactoryRegistry
+				contentDashboardItemSubtypeFactoryRegistry,
+			String contentDashboardItemSubtypePayload) {
+
+		if (Validator.isNull(contentDashboardItemSubtypePayload)) {
+			return Collections.emptyList();
+		}
+
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			new ArrayList<>();
+
+		try {
+			JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+				contentDashboardItemSubtypePayload);
+
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				if (jsonObject == null) {
+					continue;
+				}
+
+				if (jsonObject.has("className")) {
+					JSONArray classPKsJSONArray = jsonObject.getJSONArray(
+						"classPKs");
+
+					if (classPKsJSONArray == null) {
+						continue;
+					}
+
+					for (int j = 0; j < classPKsJSONArray.length(); j++) {
+						contentDashboardItemSubtypes.add(
+							toContentDashboardItemSubtype(
+								contentDashboardItemSubtypeFactoryRegistry,
+								jsonObject.getString("className"),
+								classPKsJSONArray.getString(j),
+								jsonObject.getString(Field.ENTRY_CLASS_NAME)));
+					}
+				}
+				else {
+					contentDashboardItemSubtypes.add(
+						toContentDashboardItemSubtype(
+							contentDashboardItemSubtypeFactoryRegistry, null,
+							null, jsonObject.getString("entryClassName")));
+				}
+			}
+		}
+		catch (JSONException jsonException) {
+			_log.error(jsonException);
+		}
+
+		return contentDashboardItemSubtypes;
 	}
 
 	private static ContentDashboardItemSubtype _toContentDashboardItemSubtype(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/search/request/ContentDashboardSearchContextBuilder.java
@@ -17,8 +17,8 @@ import com.liferay.content.dashboard.web.internal.constants.ContentDashboardCons
 import com.liferay.content.dashboard.web.internal.item.filter.ContentDashboardItemFilterProviderRegistry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -91,65 +92,52 @@ public class ContentDashboardSearchContextBuilder {
 		searchContext.setAttribute("status", status);
 		searchContext.setBooleanClauses(_getBooleanClauses());
 
-		String[] contentDashboardItemSubtypePayloads =
-			ParamUtil.getParameterValues(
-				_httpServletRequest, "contentDashboardItemSubtypePayload",
-				new String[0], false);
+		String contentDashboardItemSubtypePayload = ParamUtil.getString(
+			_httpServletRequest, "contentDashboardItemSubtypePayload");
 
-		if (!ArrayUtil.isEmpty(contentDashboardItemSubtypePayloads)) {
-			searchContext.setClassTypeIds(
-				TransformUtil.transformToLongArray(
-					Arrays.asList(contentDashboardItemSubtypePayloads),
-					contentDashboardItemSubtypePayload -> {
-						try {
-							JSONObject jsonObject =
-								JSONFactoryUtil.createJSONObject(
-									contentDashboardItemSubtypePayload);
+		if (Validator.isNotNull(contentDashboardItemSubtypePayload)) {
+			try {
+				JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+					contentDashboardItemSubtypePayload);
 
-							if (jsonObject.isNull("classPK")) {
-								return null;
-							}
+				List<Long> classTypeIds = new ArrayList<>();
+				String[] entryClassNames = new String[jsonArray.length()];
 
-							return jsonObject.getLong("classPK");
+				for (int i = 0; i < jsonArray.length(); i++) {
+					JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+					if (jsonObject == null) {
+						continue;
+					}
+
+					if (jsonObject.has("className")) {
+						JSONArray classPKsJSONArray = jsonObject.getJSONArray(
+							"classPKs");
+
+						if (classPKsJSONArray == null) {
+							continue;
 						}
-						catch (JSONException jsonException) {
-							_log.error(jsonException);
 
-							return null;
+						for (int j = 0; j < classPKsJSONArray.length(); j++) {
+							classTypeIds.add(classPKsJSONArray.getLong(j));
 						}
-					}));
+					}
+
+					entryClassNames[i] = jsonObject.getString(
+						Field.ENTRY_CLASS_NAME);
+				}
+
+				searchContext.setClassTypeIds(
+					ListUtil.toLongArray(classTypeIds, Long::longValue));
+				searchContext.setEntryClassNames(entryClassNames);
+			}
+			catch (JSONException jsonException) {
+				_log.error(jsonException);
+			}
 		}
 
 		if (_end != null) {
 			searchContext.setEnd(_end);
-		}
-
-		if (!ArrayUtil.isEmpty(contentDashboardItemSubtypePayloads)) {
-			searchContext.setEntryClassNames(
-				TransformUtil.transform(
-					contentDashboardItemSubtypePayloads,
-					contentDashboardItemSubtypePayload -> {
-						try {
-							JSONObject jsonObject =
-								JSONFactoryUtil.createJSONObject(
-									contentDashboardItemSubtypePayload);
-
-							String entryClassName = jsonObject.getString(
-								Field.ENTRY_CLASS_NAME);
-
-							if (Validator.isNull(entryClassName)) {
-								return null;
-							}
-
-							return entryClassName;
-						}
-						catch (JSONException jsonException) {
-							_log.error(jsonException);
-
-							return null;
-						}
-					},
-					String.class));
 		}
 
 		long groupId = ParamUtil.getLong(_httpServletRequest, "scopeId");

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -142,14 +142,39 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			onSelect: (selectedItems) => {
 				let redirectURL = itemData?.redirectURL;
 
+				const selectedItemsJSONArray = [];
+
 				selectedItems.forEach((item) => {
-					redirectURL = addParams(
-						`${portletNamespace}contentDashboardItemSubtypePayload=${JSON.stringify(
-							item
-						)}`,
-						redirectURL
+					const entryClassNameItem = selectedItemsJSONArray.find(
+						(object) =>
+							object.entryClassName === item.entryClassName
 					);
+
+					if (entryClassNameItem) {
+						entryClassNameItem.classPKs.push(item.classPK);
+					}
+					else {
+						if (item.className) {
+							selectedItemsJSONArray.push({
+								className: item.className,
+								classPKs: [item.classPK],
+								entryClassName: item.entryClassName,
+							});
+						}
+						else {
+							selectedItemsJSONArray.push({
+								entryClassName: item.entryClassName,
+							});
+						}
+					}
 				});
+
+				redirectURL = addParams(
+					`${portletNamespace}contentDashboardItemSubtypePayload=${JSON.stringify(
+						selectedItemsJSONArray
+					)}`,
+					redirectURL
+				);
 
 				const url = new URL(redirectURL);
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
@@ -5,21 +5,25 @@
 
 package com.liferay.content.dashboard.web.internal.item.type;
 
+import com.liferay.content.dashboard.info.item.ClassNameClassPKInfoItemIdentifier;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactoryRegistry;
-import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -70,7 +74,37 @@ public class ContentDashboardItemSubtypeUtilTest {
 	}
 
 	@Test
-	public void testToContentDashboardItemSubtypeByJSONObject()
+	public void testToContentDashboardItemSubtypeByJSONObjectWithoutContentDashboardItemSubtypeFactory()
+		throws JSONException {
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype =
+			_getContentDashboardItemSubtype();
+
+		Assert.assertTrue(
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_getContentDashboardItemSubtypeFactoryRegistry(
+					contentDashboardItemSubtype, null),
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(contentDashboardItemSubtype))
+			).isEmpty());
+	}
+
+	@Test
+	public void testToContentDashboardItemSubtypeByStringWithoutContentDashboardItemSubtypeFactory() {
+		ContentDashboardItemSubtype contentDashboardItemSubtype =
+			_getContentDashboardItemSubtype();
+
+		Assert.assertTrue(
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_getContentDashboardItemSubtypeFactoryRegistry(
+					contentDashboardItemSubtype, null),
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(contentDashboardItemSubtype))
+			).isEmpty());
+	}
+
+	@Test
+	public void testToContentDashboardItemSubtypesByJSONObject()
 		throws PortalException {
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
@@ -79,41 +113,19 @@ public class ContentDashboardItemSubtypeUtilTest {
 		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory =
 			_getContentDashboardItemSubtypeFactory(contentDashboardItemSubtype);
 
-		Assert.assertEquals(
-			contentDashboardItemSubtype,
-			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtype(
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
 				_getContentDashboardItemSubtypeFactoryRegistry(
 					contentDashboardItemSubtype,
 					contentDashboardItemSubtypeFactory),
-				JSONFactoryUtil.createJSONObject(
-					contentDashboardItemSubtype.toJSONString(LocaleUtil.US))));
-	}
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(contentDashboardItemSubtype)));
 
-	@Test
-	public void testToContentDashboardItemSubtypeByJSONObjectWithoutContentDashboardItemSubtypeFactory()
-		throws JSONException {
-
-		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
-
-		Assert.assertNull(
-			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtype(
-				_getContentDashboardItemSubtypeFactoryRegistry(
-					contentDashboardItemSubtype, null),
-				JSONFactoryUtil.createJSONObject(
-					contentDashboardItemSubtype.toJSONString(LocaleUtil.US))));
-	}
-
-	@Test
-	public void testToContentDashboardItemSubtypeByStringWithoutContentDashboardItemSubtypeFactory() {
-		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
-
-		Assert.assertNull(
-			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtype(
-				_getContentDashboardItemSubtypeFactoryRegistry(
-					contentDashboardItemSubtype, null),
-				contentDashboardItemSubtype.toJSONString(LocaleUtil.US)));
+		Assert.assertEquals(
+			contentDashboardItemSubtypes.toString(), 1,
+			contentDashboardItemSubtypes.size());
+		Assert.assertEquals(
+			contentDashboardItemSubtype, contentDashboardItemSubtypes.get(0));
 	}
 
 	private ContentDashboardItemSubtype _getContentDashboardItemSubtype() {
@@ -129,7 +141,9 @@ public class ContentDashboardItemSubtypeUtilTest {
 
 			@Override
 			public InfoItemReference getInfoItemReference() {
-				return new InfoItemReference(className, classPK);
+				return new InfoItemReference(
+					className,
+					new ClassNameClassPKInfoItemIdentifier(className, classPK));
 			}
 
 			@Override
@@ -164,15 +178,15 @@ public class ContentDashboardItemSubtypeUtilTest {
 			infoItemReference.getInfoItemIdentifier();
 
 		Assert.assertTrue(
-			infoItemIdentifier instanceof ClassPKInfoItemIdentifier);
+			infoItemIdentifier instanceof ClassNameClassPKInfoItemIdentifier);
 
-		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-			(ClassPKInfoItemIdentifier)
+		ClassNameClassPKInfoItemIdentifier classNameClassPKInfoItemIdentifier =
+			(ClassNameClassPKInfoItemIdentifier)
 				infoItemReference.getInfoItemIdentifier();
 
 		Mockito.when(
 			contentDashboardItemSubtypeFactory.create(
-				classPKInfoItemIdentifier.getClassPK())
+				classNameClassPKInfoItemIdentifier.getClassPK())
 		).thenReturn(
 			contentDashboardItemSubtype
 		);
@@ -202,6 +216,94 @@ public class ContentDashboardItemSubtypeUtilTest {
 		);
 
 		return contentDashboardItemSubtypeFactoryRegistry;
+	}
+
+	private String _getContentDashboardItemSubtypesJSONString(
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes) {
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		for (ContentDashboardItemSubtype curContentDashboardItemSubtype :
+				contentDashboardItemSubtypes) {
+
+			InfoItemReference curInfoItemReference =
+				curContentDashboardItemSubtype.getInfoItemReference();
+
+			if (curInfoItemReference.getInfoItemIdentifier() instanceof
+					ClassNameClassPKInfoItemIdentifier) {
+
+				ClassNameClassPKInfoItemIdentifier
+					classNameClassPKInfoItemIdentifier =
+						(ClassNameClassPKInfoItemIdentifier)
+							curInfoItemReference.getInfoItemIdentifier();
+
+				JSONObject jsonObject = _getJSONObject(
+					jsonArray,
+					classNameClassPKInfoItemIdentifier.getClassName(),
+					curInfoItemReference.getClassName());
+
+				if (jsonObject != null) {
+					JSONArray classPKsJSONArray = jsonObject.getJSONArray(
+						"classPKs");
+
+					if (classPKsJSONArray != null) {
+						classPKsJSONArray.put(
+							classNameClassPKInfoItemIdentifier.getClassPK());
+					}
+					else {
+						jsonObject.put(
+							"classPKs",
+							JSONUtil.put(
+								classNameClassPKInfoItemIdentifier.
+									getClassPK()));
+					}
+				}
+				else {
+					jsonArray.put(
+						JSONUtil.put(
+							"className",
+							classNameClassPKInfoItemIdentifier.getClassName()
+						).put(
+							"classPKs",
+							JSONUtil.put(
+								String.valueOf(
+									classNameClassPKInfoItemIdentifier.
+										getClassPK()))
+						).put(
+							"entryClassName",
+							curInfoItemReference.getClassName()
+						));
+				}
+			}
+			else {
+				jsonArray.put(
+					JSONUtil.put(
+						"entryClassName", curInfoItemReference.getClassName()));
+			}
+		}
+
+		return jsonArray.toString();
+	}
+
+	private JSONObject _getJSONObject(
+		JSONArray jsonArray, String className, String entryClassName) {
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			if (jsonObject == null) {
+				continue;
+			}
+
+			if (Objects.equals(jsonObject.getString("className"), className) &&
+				Objects.equals(
+					jsonObject.getString("entryClassName"), entryClassName)) {
+
+				return jsonObject;
+			}
+		}
+
+		return null;
 	}
 
 }

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
@@ -158,8 +158,44 @@ public class ContentDashboardItemSubtypeUtilTest {
 			contentDashboardItemSubtype2, contentDashboardItemSubtypes.get(1));
 	}
 
-	private ContentDashboardItemSubtype _getContentDashboardItemSubtype() {
+	@Test
+	public void testToToContentDashboardItemSubtypesByJSONObjectWithTwoItemsWithSameClassName()
+		throws PortalException {
+
 		String className = RandomTestUtil.randomString();
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype1 =
+			_getContentDashboardItemSubtype(className);
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype2 =
+			_getContentDashboardItemSubtype(className);
+
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_getContentDashboardItemSubtypeFactoryRegistry(
+					className, contentDashboardItemSubtype1,
+					contentDashboardItemSubtype2),
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(
+						contentDashboardItemSubtype1,
+						contentDashboardItemSubtype2)));
+
+		Assert.assertEquals(
+			contentDashboardItemSubtypes.toString(), 2,
+			contentDashboardItemSubtypes.size());
+		Assert.assertEquals(
+			contentDashboardItemSubtype1, contentDashboardItemSubtypes.get(0));
+		Assert.assertEquals(
+			contentDashboardItemSubtype2, contentDashboardItemSubtypes.get(1));
+	}
+
+	private ContentDashboardItemSubtype _getContentDashboardItemSubtype() {
+		return _getContentDashboardItemSubtype(RandomTestUtil.randomString());
+	}
+
+	private ContentDashboardItemSubtype _getContentDashboardItemSubtype(
+		String className) {
+
 		Long classPK = RandomTestUtil.randomLong();
 
 		return new ContentDashboardItemSubtype() {
@@ -276,6 +312,36 @@ public class ContentDashboardItemSubtypeUtilTest {
 				contentDashboardItemSubtypeFactory
 			);
 		}
+
+		return contentDashboardItemSubtypeFactoryRegistry;
+	}
+
+	private ContentDashboardItemSubtypeFactoryRegistry
+			_getContentDashboardItemSubtypeFactoryRegistry(
+				String className,
+				ContentDashboardItemSubtype contentDashboardItemSubtype1,
+				ContentDashboardItemSubtype contentDashboardItemSubtype2)
+		throws PortalException {
+
+		ContentDashboardItemSubtypeFactoryRegistry
+			contentDashboardItemSubtypeFactoryRegistry = Mockito.mock(
+				ContentDashboardItemSubtypeFactoryRegistry.class);
+
+		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory1 =
+			_getContentDashboardItemSubtypeFactory(
+				contentDashboardItemSubtype1);
+
+		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory2 =
+			_getContentDashboardItemSubtypeFactory(
+				contentDashboardItemSubtype2);
+
+		Mockito.when(
+			contentDashboardItemSubtypeFactoryRegistry.
+				getContentDashboardItemSubtypeFactory(className)
+		).thenReturn(
+			contentDashboardItemSubtypeFactory1,
+			contentDashboardItemSubtypeFactory2
+		);
 
 		return contentDashboardItemSubtypeFactoryRegistry;
 	}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
@@ -128,6 +128,36 @@ public class ContentDashboardItemSubtypeUtilTest {
 			contentDashboardItemSubtype, contentDashboardItemSubtypes.get(0));
 	}
 
+	@Test
+	public void testToToContentDashboardItemSubtypesByJSONObjectWithTwoItems()
+		throws PortalException {
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype1 =
+			_getContentDashboardItemSubtype();
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype2 =
+			_getContentDashboardItemSubtype();
+
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_getContentDashboardItemSubtypeFactoryRegistry(
+					Arrays.asList(
+						contentDashboardItemSubtype1,
+						contentDashboardItemSubtype2)),
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(
+						contentDashboardItemSubtype1,
+						contentDashboardItemSubtype2)));
+
+		Assert.assertEquals(
+			contentDashboardItemSubtypes.toString(), 2,
+			contentDashboardItemSubtypes.size());
+		Assert.assertEquals(
+			contentDashboardItemSubtype1, contentDashboardItemSubtypes.get(0));
+		Assert.assertEquals(
+			contentDashboardItemSubtype2, contentDashboardItemSubtypes.get(1));
+	}
+
 	private ContentDashboardItemSubtype _getContentDashboardItemSubtype() {
 		String className = RandomTestUtil.randomString();
 		Long classPK = RandomTestUtil.randomLong();
@@ -214,6 +244,38 @@ public class ContentDashboardItemSubtypeUtilTest {
 		).thenReturn(
 			contentDashboardItemSubtypeFactory
 		);
+
+		return contentDashboardItemSubtypeFactoryRegistry;
+	}
+
+	private ContentDashboardItemSubtypeFactoryRegistry
+			_getContentDashboardItemSubtypeFactoryRegistry(
+				List<ContentDashboardItemSubtype> contentDashboardItemSubtypes)
+		throws PortalException {
+
+		ContentDashboardItemSubtypeFactoryRegistry
+			contentDashboardItemSubtypeFactoryRegistry = Mockito.mock(
+				ContentDashboardItemSubtypeFactoryRegistry.class);
+
+		for (ContentDashboardItemSubtype contentDashboardItemSubtype :
+				contentDashboardItemSubtypes) {
+
+			ContentDashboardItemSubtypeFactory
+				contentDashboardItemSubtypeFactory =
+					_getContentDashboardItemSubtypeFactory(
+						contentDashboardItemSubtype);
+
+			InfoItemReference infoItemReference =
+				contentDashboardItemSubtype.getInfoItemReference();
+
+			Mockito.when(
+				contentDashboardItemSubtypeFactoryRegistry.
+					getContentDashboardItemSubtypeFactory(
+						infoItemReference.getClassName())
+			).thenReturn(
+				contentDashboardItemSubtypeFactory
+			);
+		}
 
 		return contentDashboardItemSubtypeFactoryRegistry;
 	}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/type/ContentDashboardItemSubtypeUtilTest.java
@@ -9,6 +9,7 @@ import com.liferay.content.dashboard.info.item.ClassNameClassPKInfoItemIdentifie
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtype;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactory;
 import com.liferay.content.dashboard.item.type.ContentDashboardItemSubtypeFactoryRegistry;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -47,7 +48,7 @@ public class ContentDashboardItemSubtypeUtilTest {
 		throws PortalException {
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory =
 			_getContentDashboardItemSubtypeFactory(contentDashboardItemSubtype);
@@ -64,7 +65,7 @@ public class ContentDashboardItemSubtypeUtilTest {
 	@Test
 	public void testToContentDashboardItemSubtypeByClassNameAndClassPKWithoutContentDashboardItemSubtypeFactory() {
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		Assert.assertNull(
 			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtype(
@@ -78,7 +79,7 @@ public class ContentDashboardItemSubtypeUtilTest {
 		throws JSONException {
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		Assert.assertTrue(
 			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
@@ -92,7 +93,7 @@ public class ContentDashboardItemSubtypeUtilTest {
 	@Test
 	public void testToContentDashboardItemSubtypeByStringWithoutContentDashboardItemSubtypeFactory() {
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		Assert.assertTrue(
 			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
@@ -108,7 +109,32 @@ public class ContentDashboardItemSubtypeUtilTest {
 		throws PortalException {
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
+
+		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory =
+			_getContentDashboardItemSubtypeFactory(contentDashboardItemSubtype);
+
+		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
+			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
+				_getContentDashboardItemSubtypeFactoryRegistry(
+					contentDashboardItemSubtype,
+					contentDashboardItemSubtypeFactory),
+				_getContentDashboardItemSubtypesJSONString(
+					Arrays.asList(contentDashboardItemSubtype)));
+
+		Assert.assertEquals(
+			contentDashboardItemSubtypes.toString(), 1,
+			contentDashboardItemSubtypes.size());
+		Assert.assertEquals(
+			contentDashboardItemSubtype, contentDashboardItemSubtypes.get(0));
+	}
+
+	@Test
+	public void testToContentDashboardItemSubtypesByJSONObjectWithClassPKInfoItemIdentifier()
+		throws PortalException {
+
+		ContentDashboardItemSubtype contentDashboardItemSubtype =
+			_getContentDashboardItemSubtypeWithClassPKInfoItemIdentifier();
 
 		ContentDashboardItemSubtypeFactory contentDashboardItemSubtypeFactory =
 			_getContentDashboardItemSubtypeFactory(contentDashboardItemSubtype);
@@ -133,10 +159,10 @@ public class ContentDashboardItemSubtypeUtilTest {
 		throws PortalException {
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype1 =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype2 =
-			_getContentDashboardItemSubtype();
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier();
 
 		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
 			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
@@ -165,10 +191,12 @@ public class ContentDashboardItemSubtypeUtilTest {
 		String className = RandomTestUtil.randomString();
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype1 =
-			_getContentDashboardItemSubtype(className);
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier(
+				className);
 
 		ContentDashboardItemSubtype contentDashboardItemSubtype2 =
-			_getContentDashboardItemSubtype(className);
+			_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier(
+				className);
 
 		List<ContentDashboardItemSubtype> contentDashboardItemSubtypes =
 			ContentDashboardItemSubtypeUtil.toContentDashboardItemSubtypes(
@@ -189,46 +217,6 @@ public class ContentDashboardItemSubtypeUtilTest {
 			contentDashboardItemSubtype2, contentDashboardItemSubtypes.get(1));
 	}
 
-	private ContentDashboardItemSubtype _getContentDashboardItemSubtype() {
-		return _getContentDashboardItemSubtype(RandomTestUtil.randomString());
-	}
-
-	private ContentDashboardItemSubtype _getContentDashboardItemSubtype(
-		String className) {
-
-		Long classPK = RandomTestUtil.randomLong();
-
-		return new ContentDashboardItemSubtype() {
-
-			@Override
-			public String getFullLabel(Locale locale) {
-				return null;
-			}
-
-			@Override
-			public InfoItemReference getInfoItemReference() {
-				return new InfoItemReference(
-					className,
-					new ClassNameClassPKInfoItemIdentifier(className, classPK));
-			}
-
-			@Override
-			public String getLabel(Locale locale) {
-				return null;
-			}
-
-			@Override
-			public String toJSONString(Locale locale) {
-				return JSONUtil.put(
-					"className", className
-				).put(
-					"classPK", classPK
-				).toString();
-			}
-
-		};
-	}
-
 	private ContentDashboardItemSubtypeFactory
 			_getContentDashboardItemSubtypeFactory(
 				ContentDashboardItemSubtype contentDashboardItemSubtype)
@@ -243,16 +231,26 @@ public class ContentDashboardItemSubtypeUtilTest {
 		InfoItemIdentifier infoItemIdentifier =
 			infoItemReference.getInfoItemIdentifier();
 
-		Assert.assertTrue(
-			infoItemIdentifier instanceof ClassNameClassPKInfoItemIdentifier);
+		long classPK;
 
-		ClassNameClassPKInfoItemIdentifier classNameClassPKInfoItemIdentifier =
-			(ClassNameClassPKInfoItemIdentifier)
-				infoItemReference.getInfoItemIdentifier();
+		if (infoItemIdentifier instanceof ClassNameClassPKInfoItemIdentifier) {
+			ClassNameClassPKInfoItemIdentifier
+				classNameClassPKInfoItemIdentifier =
+					(ClassNameClassPKInfoItemIdentifier)
+						infoItemReference.getInfoItemIdentifier();
+
+			classPK = classNameClassPKInfoItemIdentifier.getClassPK();
+		}
+		else {
+			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+				(ClassPKInfoItemIdentifier)
+					infoItemReference.getInfoItemIdentifier();
+
+			classPK = classPKInfoItemIdentifier.getClassPK();
+		}
 
 		Mockito.when(
-			contentDashboardItemSubtypeFactory.create(
-				classNameClassPKInfoItemIdentifier.getClassPK())
+			contentDashboardItemSubtypeFactory.create(classPK)
 		).thenReturn(
 			contentDashboardItemSubtype
 		);
@@ -411,6 +409,83 @@ public class ContentDashboardItemSubtypeUtilTest {
 		}
 
 		return jsonArray.toString();
+	}
+
+	private ContentDashboardItemSubtype
+		_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier() {
+
+		return _getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier(
+			RandomTestUtil.randomString());
+	}
+
+	private ContentDashboardItemSubtype
+		_getContentDashboardItemSubtypeWithClassNameClassPKInfoItemIdentifier(
+			String className) {
+
+		Long classPK = RandomTestUtil.randomLong();
+
+		return new ContentDashboardItemSubtype() {
+
+			@Override
+			public String getFullLabel(Locale locale) {
+				return null;
+			}
+
+			@Override
+			public InfoItemReference getInfoItemReference() {
+				return new InfoItemReference(
+					className,
+					new ClassNameClassPKInfoItemIdentifier(className, classPK));
+			}
+
+			@Override
+			public String getLabel(Locale locale) {
+				return null;
+			}
+
+			@Override
+			public String toJSONString(Locale locale) {
+				return JSONUtil.put(
+					"className", className
+				).put(
+					"classPK", classPK
+				).toString();
+			}
+
+		};
+	}
+
+	private ContentDashboardItemSubtype
+		_getContentDashboardItemSubtypeWithClassPKInfoItemIdentifier() {
+
+		String className = RandomTestUtil.randomString();
+
+		return new ContentDashboardItemSubtype() {
+
+			@Override
+			public String getFullLabel(Locale locale) {
+				return null;
+			}
+
+			@Override
+			public InfoItemReference getInfoItemReference() {
+				return new InfoItemReference(
+					className, new ClassPKInfoItemIdentifier(0));
+			}
+
+			@Override
+			public String getLabel(Locale locale) {
+				return null;
+			}
+
+			@Override
+			public String toJSONString(Locale locale) {
+				return JSONUtil.put(
+					"className", className
+				).toString();
+			}
+
+		};
 	}
 
 	private JSONObject _getJSONObject(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-32872

There is an error when we are trying to filter items in content  management when we are selecting a lot of types because of we are sending a high json structure as a payload for each filter type item and in a paramter and we are getting a 414 http error code, this means that the url is too long.

# How am I fixing it?

I am fixing the issue aplying two improvements:

1. Send all selected filters in one parameter.
2. Improve json structure payload to use less characters, changing it from :

```
[
   {
      "entryClassName": "com.liferay.portal.kernel.repository.model.FileEntry",
      "className": "com.liferay.document.library.kernel.model.DLFileEntryType",
      "classPk": "32205"
   },
   {
      "entryClassName": "com.liferay.portal.kernel.repository.model.FileEntry",
      "className": "com.liferay.document.library.kernel.model.DLFileEntryType",
      "classPk": "32206"
   },
   {
      "entryClassName": "com.liferay.portal.kernel.repository.model.FileEntry",
      "className": "com.liferay.document.library.kernel.model.DLFileEntryType",
      "classPk": "32207"
   }
]
```
to

```
[
   {
      "entryClassName": "com.liferay.portal.kernel.repository.model.FileEntry",
      "className": "com.liferay.document.library.kernel.model.DLFileEntryType",
      "classPks": [
         "32205",
         "32206",
         "32207"
      ]
   }
]
```

# How can you verify that it works?

Run included tests.
