### PR TITLE
LPD-36210 Add AM data attribute to imgs in rich_text fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -40,6 +40,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.5.1
+Liferay-Require-SchemaVersion: 5.5.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
@@ -24,9 +24,11 @@ dependencies {
 	compileOnly group: "org.apache.poi", name: "poi", version: "5.2.2"
 	compileOnly group: "org.apache.poi", name: "poi-ooxml", version: "5.2.2"
 	compileOnly group: "org.apache.poi", name: "poi-ooxml-lite", version: "5.2.2"
+	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:adaptive-media:adaptive-media-image-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:data-engine:data-engine-api")
 	compileOnly project(":apps:depot:depot-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -67,12 +67,15 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.repository.friendly.url.resolver.FileEntryFriendlyURLResolver;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseSQLServerDatetimeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -583,6 +586,14 @@ public class DDMServiceUpgradeStepRegistrator
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.
 				DDMFieldUpgradeProcess(),
 			new DDMFieldAttributeUpgradeProcess());
+
+		registry.register(
+			"5.5.1", "5.5.2",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2.
+				DDMFieldAttributeUpgradeProcess(
+					_classNameLocalService, _dlFileEntryLocalService,
+					_fileEntryFriendlyURLResolver, _groupLocalService,
+					_userLocalService));
 	}
 
 	@Activate
@@ -639,6 +650,12 @@ public class DDMServiceUpgradeStepRegistrator
 	@Reference
 	private ExpandoValueLocalService _expandoValueLocalService;
 
+	@Reference
+	private FileEntryFriendlyURLResolver _fileEntryFriendlyURLResolver;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
 	@Reference(target = "(ddm.form.deserializer.type=json)")
 	private DDMFormDeserializer _jsonDDMFormDeserializer;
 
@@ -680,6 +697,9 @@ public class DDMServiceUpgradeStepRegistrator
 
 	@Reference(target = "(default=true)")
 	private Store _store;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 	@Reference
 	private ViewCountEntryLocalService _viewCountEntryLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_2/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_2/DDMFieldAttributeUpgradeProcess.java
@@ -1,0 +1,280 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2;
+
+import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.repository.friendly.url.resolver.FileEntryFriendlyURLResolver;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
+
+	public DDMFieldAttributeUpgradeProcess(
+		ClassNameLocalService classNameLocalService,
+		DLFileEntryLocalService dlFileEntryLocalService,
+		FileEntryFriendlyURLResolver fileEntryFriendlyURLResolver,
+		GroupLocalService groupLocalService,
+		UserLocalService userLocalService) {
+
+		_classNameLocalService = classNameLocalService;
+		_dlFileEntryLocalService = dlFileEntryLocalService;
+		_fileEntryFriendlyURLResolver = fileEntryFriendlyURLResolver;
+		_groupLocalService = groupLocalService;
+		_userLocalService = userLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long classNameId = _classNameLocalService.getClassNameId(
+			"com.liferay.journal.model.JournalArticle");
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"select DDMFieldAttribute.companyId, ",
+					"DDMFieldAttribute.ctCollectionId, ",
+					"DDMFieldAttribute.fieldAttributeId, ",
+					"DDMFieldAttribute.smallAttributeValue, ",
+					"DDMFieldAttribute.largeAttributeValue from DDMStructure ",
+					"inner join DDMStructureVersion on ",
+					"DDMStructure.ctCollectionId = ",
+					"DDMStructureVersion.ctCollectionId and ",
+					"DDMStructure.structureId = ",
+					"DDMStructureVersion.structureId inner join DDMField on ",
+					"DDMStructureVersion.ctCollectionId = ",
+					"DDMField.ctCollectionId and ",
+					"DDMStructureVersion.structureVersionId = ",
+					"DDMField.structureVersionId inner join DDMFieldAttribute ",
+					"on DDMField.ctCollectionId = ",
+					"DDMFieldAttribute.ctCollectionId and DDMField.fieldId = ",
+					"DDMFieldAttribute.fieldId where DDMStructure.classNameId ",
+					"= ? and DDMField.fieldType = 'rich_text'"));
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update DDMFieldAttribute set smallAttributeValue = ?, " +
+						"largeAttributeValue = ? where ctCollectionId = ? " +
+							"and fieldAttributeId = ?")) {
+
+			preparedStatement1.setLong(1, classNameId);
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong(1);
+
+				preparedStatement2.setString(
+					1, _transform(companyId, resultSet.getString(4)));
+				preparedStatement2.setString(
+					2, _transform(companyId, resultSet.getString(5)));
+
+				preparedStatement2.setLong(3, resultSet.getLong(2));
+				preparedStatement2.setLong(4, resultSet.getLong(3));
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private DLFileEntry _getDLFileEntry(long companyId, Matcher matcher)
+		throws PortalException {
+
+		if (Objects.equals(
+				FriendlyURLResolverConstants.URL_SEPARATOR_Y_FILE_ENTRY,
+				matcher.group(7))) {
+
+			String groupName = matcher.group(8);
+
+			Group group = _getGroup(companyId, groupName);
+
+			String friendlyURL = matcher.group(9);
+
+			FileEntry fileEntry =
+				_fileEntryFriendlyURLResolver.resolveFriendlyURL(
+					group.getGroupId(), friendlyURL);
+
+			return (DLFileEntry)fileEntry.getModel();
+		}
+
+		if (matcher.group(5) != null) {
+			long groupId = GetterUtil.getLong(matcher.group(2));
+
+			String uuid = matcher.group(5);
+
+			return _dlFileEntryLocalService.getFileEntryByUuidAndGroupId(
+				uuid, groupId);
+		}
+
+		long groupId = GetterUtil.getLong(matcher.group(2));
+		long folderId = GetterUtil.getLong(matcher.group(3));
+		String title = matcher.group(4);
+
+		try {
+			return _dlFileEntryLocalService.getFileEntry(
+				groupId, folderId, title);
+		}
+		catch (NoSuchFileEntryException noSuchFileEntryException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchFileEntryException);
+			}
+
+			return _dlFileEntryLocalService.getFileEntryByFileName(
+				groupId, folderId, title);
+		}
+	}
+
+	private long _getDLFileEntryId(long companyId, String src)
+		throws PortalException {
+
+		// Check if the src starts with "data:image/" first because "data:image"
+		// indicates a Base64 URL which can potentially be millions of
+		// characters. So it is faster to run startsWith first to return early
+		// on these strings first so that we do not have to call "contains" over
+		// a very long string.
+
+		if (src.startsWith("data:image/")) {
+			return 0;
+		}
+
+		// If we got past the above check, we have a URL. Now we can do a quick
+		// check if the URL contains "/documents" as a crude way of bypassing
+		// most non-Liferay URLs before we have to get into the less performant
+		// regex logic.
+
+		if (!src.contains("/documents")) {
+			return 0;
+		}
+
+		Matcher matcher = _pattern.matcher(src);
+
+		if (matcher.find()) {
+			try {
+				DLFileEntry dlFileEntry = _getDLFileEntry(companyId, matcher);
+
+				return dlFileEntry.getFileEntryId();
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Missing file entry for URL " + src, portalException);
+				}
+
+				return 0;
+			}
+		}
+
+		return 0;
+	}
+
+	private Group _getGroup(long companyId, String name)
+		throws PortalException {
+
+		Group group = _groupLocalService.fetchFriendlyURLGroup(
+			companyId, StringPool.SLASH + name);
+
+		if (group != null) {
+			return group;
+		}
+
+		User user = _userLocalService.getUserByScreenName(companyId, name);
+
+		return user.getGroup();
+	}
+
+	private Document _parseDocument(String html) {
+		Document document = Jsoup.parseBodyFragment(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+		outputSettings.syntax(Document.OutputSettings.Syntax.xml);
+
+		document.outputSettings(outputSettings);
+
+		return document;
+	}
+
+	private String _transform(long companyId, String html)
+		throws PortalException {
+
+		if ((html == null) || !html.contains("/documents/") ||
+			!html.contains("<img")) {
+
+			return html;
+		}
+
+		Document document = _parseDocument(html);
+
+		for (Element imgElement : document.select("img:not(picture > img)")) {
+			if (!imgElement.hasAttr(
+					AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID)) {
+
+				long fileEntryId = _getDLFileEntryId(
+					companyId, imgElement.attr("src"));
+
+				if (fileEntryId != 0) {
+					imgElement.attr(
+						AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID,
+						String.valueOf(fileEntryId));
+				}
+			}
+		}
+
+		if (html.contains("<html>") || html.contains("<head>")) {
+			return document.html();
+		}
+
+		Element body = document.body();
+
+		return body.html();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFieldAttributeUpgradeProcess.class);
+
+	private static final Pattern _pattern = Pattern.compile(
+		"((?:/?[^\\s]*)/documents/(\\d+)/(\\d+)/([^/?]+)(?:/([-0-9a-fA-F]+))?" +
+			"(?:\\?.*$)?)|((?:/?[^\\s]*)/documents/(d)/(.*)/" +
+				"([_A-Za-z0-9-]+)?(?:\\?.*$)?)");
+
+	private final ClassNameLocalService _classNameLocalService;
+	private final DLFileEntryLocalService _dlFileEntryLocalService;
+	private final FileEntryFriendlyURLResolver _fileEntryFriendlyURLResolver;
+	private final GroupLocalService _groupLocalService;
+	private final UserLocalService _userLocalService;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_2/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_2/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.util.DLURLHelperUtil;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class DDMFieldAttributeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_addDLFileEntry();
+		_addJournalArticle();
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		_runUpgrade();
+
+		JournalArticle journalArticle =
+			_journalArticleLocalService.getJournalArticle(
+				_journalArticle.getId());
+
+		_assertContains(
+			journalArticle.getContent(),
+			"data-fileentryid=\"" + _dlFileEntry.getFileEntryId() + "\"");
+	}
+
+	private void _addDLFileEntry() throws Exception {
+		_dlFileEntry = _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			TestPropsValues.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, StringUtil.randomId(),
+			ContentTypes.IMAGE_PNG, StringUtil.randomString(),
+			StringUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new UnsyncByteArrayInputStream(new byte[0]), 0, null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
+	}
+
+	private void _addJournalArticle() throws Exception {
+		String previewURL = DLURLHelperUtil.getPreviewURL(
+			new LiferayFileEntry(_dlFileEntry),
+			new LiferayFileVersion(_dlFileEntry.getFileVersion()), null, null);
+
+		_journalArticle = JournalTestUtil.addArticleWithXMLContent(
+			DDMStructureTestUtil.getSampleStructuredContent(
+				"content",
+				Collections.singletonList(
+					HashMapBuilder.put(
+						LocaleUtil.US, "<img src=\"" + previewURL + "\"/>"
+					).build()),
+				LanguageUtil.getLanguageId(LocaleUtil.US)),
+			"BASIC-WEB-CONTENT", "BASIC-WEB-CONTENT");
+	}
+
+	private void _assertContains(String content, String fragment) {
+		Assert.assertTrue(content, content.contains(fragment));
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2." +
+			"DDMFieldAttributeUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.dynamic.data.mapping.internal.upgrade.registry.DDMServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private JournalArticle _journalArticle;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36210

Content created with the CKEditor Classic flavor wasn't injected with Adaptive Media's `data-fileentryid` metadata attribute.

# How am I fixing it?

The editor has already been fixed in [LPD-35630](https://liferay.atlassian.net/browse/LPD-35630), so that new content will already contain the metadata.  An upgrade process is added in this PR so that the metadata is added to old content as well.

# How can you verify that it works?

Run the included integration test.