### PR TITLE
LPD-36856 Get the metadata of attached documents in a Web Content Template

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -464,7 +464,9 @@ public class JournalTransformer {
 
 		Map<String, String> attributes = new HashMap<>();
 
-		if (type.equals(DDMFormFieldTypeConstants.IMAGE)) {
+		if (type.equals(DDMFormFieldTypeConstants.DOCUMENT_LIBRARY) ||
+			type.equals(DDMFormFieldTypeConstants.IMAGE)) {
+
 			JSONObject dataJSONObject = JSONFactoryUtil.createJSONObject(data);
 
 			Iterator<String> iterator = dataJSONObject.keys();

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -32,6 +32,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -58,6 +59,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -170,9 +172,10 @@ public class JournalTransformerTest {
 	}
 
 	@Test
-	public void testCreateTemplateNode() {
+	public void testCreateTemplateNode() throws Exception {
 		_testCreateTemplateNodeSelectTypeDDMFormFieldWithOptions();
 		_testCreateTemplateNodeSelectTypeDDMFormFieldWithoutOptions();
+		_testCreateTemplateNodeDocumentLibraryDDMFormField();
 	}
 
 	@Test
@@ -693,6 +696,48 @@ public class JournalTransformerTest {
 	private String _read(String fileName) throws Exception {
 		return new String(
 			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
+	}
+
+	private void _testCreateTemplateNodeDocumentLibraryDDMFormField()
+		throws Exception {
+
+		JSONObject jsonObject = JSONUtil.put(
+			"fileEntryId", RandomTestUtil.randomLong()
+		).put(
+			"groupId", RandomTestUtil.randomLong()
+		);
+
+		DDMFormField ddmFormField = new DDMFormField(
+			"name", DDMFormFieldTypeConstants.DOCUMENT_LIBRARY);
+
+		ddmFormField.setDataType("document_library");
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		Element dynamicContentElement = rootElement.addElement(
+			"dynamic-content");
+
+		dynamicContentElement.setText(jsonObject.toString());
+
+		TemplateNode templateNode = ReflectionTestUtil.invoke(
+			_journalTransformer, "_createTemplateNode",
+			new Class<?>[] {
+				DDMFormField.class, Element.class, Locale.class,
+				ThemeDisplay.class
+			},
+			ddmFormField, rootElement, LocaleUtil.getDefault(),
+			new ThemeDisplay());
+
+		Assert.assertFalse(MapUtil.isEmpty(templateNode.getAttributes()));
+
+		Assert.assertEquals(
+			jsonObject.getString("fileEntryId"),
+			templateNode.getAttribute("fileEntryId"));
+		Assert.assertEquals(
+			jsonObject.getString("groupId"),
+			templateNode.getAttribute("groupId"));
 	}
 
 	private void _testCreateTemplateNodeSelectTypeDDMFormFieldWithOptions() {


### PR DESCRIPTION
Get the metadata of attached documents in a Web Content Template

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-36856)

DDM Document Library Fields don't have the attributes defined as in images, only the URL, so it makes it hard for the people that want to interact with them to use them in freemarker

# How am I fixing it?

Like with images, add the attributes to the image to the context

# How can you verify that it works?

1. Create a new Structure for Web Content with an upload field
2. Create a new Template for the Structure and specify something like ${Image08794291.getAttribute("title")} changing the reference for your reference
3. Create a web content for the structure with the template
4. Add an image to the upload field
5. Publish the web content
6. Add a page and a web content display widget to it, configure it so that the web content previously created is shown

The title of the file should be shown

Or run the integration test
