### PR TITLE
LPD-36634 Update the GroupERC on publication if the group is a Staging group

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -199,6 +199,32 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 	}
 
 	@Override
+	protected String getExportPortletPreferencesExternalReferenceCode(
+		PortletDataContext portletDataContext, Portlet portlet,
+		String className, String externalReferenceCode) {
+
+		if (className.equals(Group.class.getName())) {
+			Group group = groupLocalService.fetchGroupByExternalReferenceCode(
+				externalReferenceCode, portletDataContext.getCompanyId());
+
+			if (!group.isStagingGroup()) {
+				return externalReferenceCode;
+			}
+
+			Group liveGroup = groupLocalService.fetchGroup(
+				group.getLiveGroupId());
+
+			if (liveGroup == null) {
+				return externalReferenceCode;
+			}
+
+			return liveGroup.getExternalReferenceCode();
+		}
+
+		return externalReferenceCode;
+	}
+
+	@Override
 	protected String getExportPortletPreferencesValue(
 			PortletDataContext portletDataContext, Portlet portlet,
 			String className, long primaryKeyLong)
@@ -288,6 +314,26 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		}
 
 		return StringUtil.merge(new Object[] {uuid, groupId}, StringPool.POUND);
+	}
+
+	@Override
+	protected String getImportPortletPreferencesNewExternalReferenceCode(
+		PortletDataContext portletDataContext, Class<?> clazz,
+		long companyGroupId, Map<String, String[]> primaryKeys,
+		String externalReferenceCode) {
+
+		String className = clazz.getName();
+
+		if (className.equals(Group.class.getName())) {
+			Group group = groupLocalService.fetchGroupByExternalReferenceCode(
+				externalReferenceCode, portletDataContext.getCompanyId());
+
+			if (group != null) {
+				return externalReferenceCode;
+			}
+		}
+
+		return null;
 	}
 
 	@Override
@@ -1092,6 +1138,11 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 				portletPreferences.reset("assetListEntryId");
 			}
+			else if (name.equals("assetListEntryGroupExternalReferenceCode")) {
+				updateExportPortletPreferencesExternalReferenceCodes(
+					portletDataContext, portlet, portletPreferences, name,
+					Group.class.getName());
+			}
 			else if (name.equals("assetVocabularyId")) {
 				long assetVocabularyId = GetterUtil.getLong(value);
 
@@ -1299,6 +1350,11 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				updateImportPortletPreferencesClassPKs(
 					portletDataContext, portletPreferences, name,
 					DDMStructure.class, companyGroup.getGroupId());
+			}
+			else if (name.equals("assetListEntryGroupExternalReferenceCode")) {
+				updateImportPortletPreferencesExternalReferenceCodes(
+					portletDataContext, portletPreferences, name, Group.class,
+					companyGroup.getGroupId());
 			}
 			else if (name.equals("assetVocabularyId")) {
 				updateImportPortletPreferencesClassPKs(

--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 9.0.1
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.exportimport.configuration,\
 	com.liferay.exportimport.constants,\

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/base/BaseExportImportPortletPreferencesProcessor.java
@@ -28,10 +28,26 @@ import org.osgi.annotation.versioning.ProviderType;
 public abstract class BaseExportImportPortletPreferencesProcessor
 	implements ExportImportPortletPreferencesProcessor {
 
+	protected String getExportPortletPreferencesExternalReferenceCode(
+		PortletDataContext portletDataContext, Portlet portlet,
+		String className, String externalReferenceCode) {
+
+		return null;
+	}
+
 	protected abstract String getExportPortletPreferencesValue(
 			PortletDataContext portletDataContext, Portlet portlet,
 			String className, long primaryKeyLong)
 		throws Exception;
+
+	protected String getImportPortletPreferencesNewExternalReferenceCode(
+			PortletDataContext portletDataContext, Class<?> clazz,
+			long companyGroupId, Map<String, String[]> primaryKeys,
+			String portletPreferencesOldExternalReferenceCode)
+		throws Exception {
+
+		return null;
+	}
 
 	protected abstract Long getImportPortletPreferencesNewValue(
 			PortletDataContext portletDataContext, Class<?> clazz,
@@ -91,6 +107,54 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 		portletPreferences.setValues(key, newValues);
 	}
 
+	protected void updateExportPortletPreferencesExternalReferenceCodes(
+			PortletDataContext portletDataContext, Portlet portlet,
+			PortletPreferences portletPreferences, String key, String className)
+		throws Exception {
+
+		String[] oldValues = portletPreferences.getValues(key, null);
+
+		if (oldValues == null) {
+			return;
+		}
+
+		String[] newValues = new String[oldValues.length];
+
+		for (int i = 0; i < oldValues.length; i++) {
+			String oldValue = oldValues[i];
+
+			String newValue = oldValue;
+
+			String[] externalReferenceCodes = StringUtil.split(oldValue);
+
+			for (String externalReferenceCode : externalReferenceCodes) {
+				String newPreferencesValue =
+					getExportPortletPreferencesExternalReferenceCode(
+						portletDataContext, portlet, className,
+						externalReferenceCode);
+
+				if (Validator.isNull(newPreferencesValue)) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to export portlet preferences value ",
+								"for class ", className, " with external ",
+								"reference code", externalReferenceCode));
+					}
+
+					continue;
+				}
+
+				newValue = StringUtil.replace(
+					newValue, externalReferenceCode, newPreferencesValue);
+			}
+
+			newValues[i] = newValue;
+		}
+
+		portletPreferences.setValues(key, newValues);
+	}
+
 	protected void updateImportPortletPreferencesClassPKs(
 			PortletDataContext portletDataContext,
 			PortletPreferences portletPreferences, String key, Class<?> clazz,
@@ -133,6 +197,58 @@ public abstract class BaseExportImportPortletPreferencesProcessor
 					newValue = StringUtil.replace(
 						newValue, portletPreferencesOldValue,
 						newPrimaryKey.toString());
+				}
+			}
+
+			newValues[i] = newValue;
+		}
+
+		portletPreferences.setValues(key, newValues);
+	}
+
+	protected void updateImportPortletPreferencesExternalReferenceCodes(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences, String key, Class<?> clazz,
+			long companyGroupId)
+		throws Exception {
+
+		String[] oldValues = portletPreferences.getValues(key, null);
+
+		if (oldValues == null) {
+			return;
+		}
+
+		Map<String, String[]> parameterMap =
+			portletDataContext.getParameterMap();
+
+		String[] newValues = new String[oldValues.length];
+
+		for (int i = 0; i < oldValues.length; i++) {
+			String oldValue = oldValues[i];
+
+			String newValue = oldValue;
+
+			String[] portletPreferencesOldValues = StringUtil.split(oldValue);
+
+			for (String portletPreferencesOldValue :
+					portletPreferencesOldValues) {
+
+				String newExternalReferenceCode =
+					getImportPortletPreferencesNewExternalReferenceCode(
+						portletDataContext, clazz, companyGroupId, parameterMap,
+						portletPreferencesOldValue);
+
+				if (Validator.isNull(newExternalReferenceCode)) {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							"Unable to import portlet preferences value " +
+								portletPreferencesOldValue);
+					}
+				}
+				else {
+					newValue = StringUtil.replace(
+						newValue, portletPreferencesOldValue,
+						newExternalReferenceCode);
 				}
 			}
 

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/base/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/portlet/preferences/processor/base/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36634

There's an error when showing published assetListEntries and the asset publisher is not showing them

# How am I fixing it?

I'm updating the portal properties so they point to a published group instead of a staged one

# Why doesn't this include any test?

There are already tests that cover this (e.g. a regression bug or a library upgrade.):

- DepotCollections#CanBePublishedViaRemoteStaging
- DMRemoteStaging#CanViewImageInManualCollectionViaAPAfterPublish
- DepotRemoteStagingDM#CanViewImageInDynamicCollectionViaAPAfterFriendlyURLIsUpdated
