### PR TITLE
LPD-36848 When translating a web content with a repeatable group of fields and saving as draft, the translations of the repeating fields are overwritten

### DIFF
--- a/modules/apps/translation/translation-test/build.gradle
+++ b/modules/apps/translation/translation-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/portlet/action/test/TranslateMVCRenderCommandTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/portlet/action/test/TranslateMVCRenderCommandTest.java
@@ -1,0 +1,272 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.translation.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.translation.constants.TranslationPortletKeys;
+import com.liferay.translation.service.TranslationEntryLocalService;
+import com.liferay.translation.test.util.TranslationTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class TranslateMVCRenderCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetInfoFieldSetEntriesData() throws Exception {
+		JournalArticle journalArticle = _addJournalArticle();
+
+		_translationEntryLocalService.addOrUpdateTranslationEntry(
+			_group.getGroupId(), JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey(),
+			StringUtil.replace(
+				TranslationTestUtil.readFileToString(
+					"test-journal-article-with-repeatable-text-field.xlf"),
+				"[$JOURNAL_ARTICLE_ID$]",
+				String.valueOf(journalArticle.getResourcePrimKey())),
+			"application/xliff+xml", LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequests(journalArticle);
+
+		_mvcRenderCommand.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+
+		Map<String, Object> infoFieldSetEntriesData = ReflectionTestUtil.invoke(
+			mockLiferayPortletRenderRequest.getAttribute(
+				"com.liferay.translation.web.internal.display.context." +
+					"TranslateDisplayContext"),
+			"getInfoFieldSetEntriesData", new Class<?>[0]);
+
+		Assert.assertNotNull(infoFieldSetEntriesData);
+
+		List<Object> infoFieldSetEntries =
+			(List<Object>)infoFieldSetEntriesData.get("infoFieldSetEntries");
+
+		Assert.assertNotNull(infoFieldSetEntries);
+		Assert.assertEquals(
+			infoFieldSetEntries.toString(), 2, infoFieldSetEntries.size());
+
+		Map<String, Object> structureFields =
+			(Map<String, Object>)infoFieldSetEntries.get(1);
+
+		Assert.assertNotNull(structureFields);
+		Assert.assertEquals(
+			"Content (Test Structure)", structureFields.get("legend"));
+
+		List<Object> fields = (List<Object>)structureFields.get("fields");
+
+		Assert.assertNotNull(fields);
+		Assert.assertEquals(fields.toString(), 1, fields.size());
+
+		Map<String, Object> fieldAttributes = (Map<String, Object>)fields.get(
+			0);
+
+		Assert.assertNotNull(fieldAttributes);
+		Assert.assertEquals(
+			"infoField--DDMStructure_text--", fieldAttributes.get("id"));
+		Assert.assertEquals(
+			Arrays.asList("content 1 EN", "content 2 EN"),
+			fieldAttributes.get("sourceContent"));
+		Assert.assertEquals(
+			Arrays.asList("content 1 ES", "content 2 ES"),
+			fieldAttributes.get("targetContent"));
+		Assert.assertEquals(
+			LocaleUtil.SPAIN.toString(),
+			fieldAttributes.get("targetLanguageId"));
+	}
+
+	private JournalArticle _addJournalArticle() throws Exception {
+		String content = new String(
+			FileUtil.getBytes(
+				getClass(),
+				"dependencies/test-journal-content-with-repeatable-text-" +
+					"field.xml"));
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName(), 0,
+			DDMStructureTestUtil.getSampleDDMForm(
+				"text", "string", "text", true, DDMFormFieldTypeConstants.TEXT,
+				new Locale[] {LocaleUtil.getSiteDefault()},
+				LocaleUtil.getSiteDefault()),
+			LocaleUtil.getSiteDefault(), serviceContext);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), _portal.getClassNameId(DDMStructure.class),
+			ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class));
+
+		return _journalArticleLocalService.addArticle(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			Collections.singletonMap(LocaleUtil.US, "title example"), null,
+			content, ddmStructure.getStructureId(),
+			ddmTemplate.getTemplateKey(), serviceContext);
+	}
+
+	private MockLiferayPortletRenderRequest
+			_getMockLiferayPortletRenderRequests(JournalArticle journalArticle)
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(mockHttpServletRequest));
+
+		mockHttpServletRequest.setParameter(
+			"classNameId",
+			String.valueOf(_portal.getClassNameId(JournalArticle.class)));
+		mockHttpServletRequest.setParameter(
+			"classPK", String.valueOf(journalArticle.getResourcePrimKey()));
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(journalArticle.getGroupId()));
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"sourceLanguageId", LocaleUtil.US.toString());
+		mockLiferayPortletRenderRequest.setParameter(
+			"targetLanguageId", LocaleUtil.SPAIN.toString());
+
+		return mockLiferayPortletRenderRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(
+			MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setClayCSSURL("http://test.com");
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		themeDisplay.setLayout(layout);
+
+		themeDisplay.setLayoutSet(layoutSet);
+
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setLookAndFeel(
+			layoutSet.getTheme(), layoutSet.getColorScheme());
+		themeDisplay.setMainCSSURL("http://test.com");
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setPpid(TranslationPortletKeys.TRANSLATION);
+
+		themeDisplay.setRequest(mockHttpServletRequest);
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
+
+	@Inject(
+		filter = "mvc.command.name=/translation/translate",
+		type = MVCRenderCommand.class
+	)
+	private MVCRenderCommand _mvcRenderCommand;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private TranslationEntryLocalService _translationEntryLocalService;
+
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-with-repeatable-text-field.xlf
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/dependencies/test-journal-article-with-repeatable-text-field.xlf
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US" trgLang="es-ES" version="2.0">
+    <file id="com.liferay.journal.model.JournalArticle:[$JOURNAL_ARTICLE_ID$]">
+		<unit id="JournalArticle_title">
+			<segment>
+				<source><![CDATA[title example]]></source>
+				<target><![CDATA[title example ES]]></target>
+			</segment>
+		</unit>
+		<unit id="JournalArticle_description">
+			<segment>
+				<source><![CDATA[]]></source>
+				<target><![CDATA[]]></target>
+			</segment>
+		</unit>
+		<unit id="DDMStructure_text">
+			<segment>
+				<source><![CDATA[content 1 EN]]></source>
+				<target><![CDATA[content 1 ES]]></target>
+			</segment>
+			<segment>
+				<source><![CDATA[content 2 EN]]></source>
+				<target><![CDATA[content 2 ES]]></target>
+			</segment>
+		</unit>
+	</file>
+</xliff>

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/test-journal-content-with-repeatable-text-field.xml
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/test-journal-content-with-repeatable-text-field.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="no"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<request />
+	<dynamic-element index-type="keyword" name="text" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[content 1 EN]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element index-type="keyword" name="text" repeatable="true" type="text">
+		<dynamic-content language-id="en_US"><![CDATA[content 2 EN]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -150,11 +150,6 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 				renderRequest, "targetLanguageId",
 				_getDefaultTargetLanguageId(availableTargetLanguageIds));
 
-			InfoItemFieldValues targetInfoItemFieldValues =
-				_getTargetInfoItemFieldValues(
-					className, classPK, sourceInfoItemFieldValues,
-					targetLanguageId);
-
 			renderRequest.setAttribute(
 				TranslateDisplayContext.class.getName(),
 				new TranslateDisplayContext(
@@ -165,7 +160,10 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 					_portal.getLiferayPortletRequest(renderRequest),
 					_portal.getLiferayPortletResponse(renderResponse), object,
 					segmentsExperienceId, sourceInfoItemFieldValues,
-					sourceLanguageId, targetInfoItemFieldValues,
+					sourceLanguageId,
+					_getTargetInfoItemFieldValues(
+						className, classPK, sourceInfoItemFieldValues,
+						targetLanguageId),
 					targetLanguageId, _translationInfoFieldChecker));
 
 			return "/translate.jsp";

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/portlet/action/TranslateMVCRenderCommand.java
@@ -6,8 +6,6 @@
 package com.liferay.translation.web.internal.portlet.action;
 
 import com.liferay.info.exception.NoSuchInfoItemException;
-import com.liferay.info.field.InfoField;
-import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemFieldValues;
@@ -27,7 +25,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -297,40 +294,9 @@ public class TranslateMVCRenderCommand implements MVCRenderCommand {
 			return infoItemFieldValues;
 		}
 
-		InfoItemFieldValues translationEntryInfoItemFieldValues =
-			_translationEntryLocalService.getInfoItemFieldValues(
-				translationEntry.getGroupId(), translationEntry.getClassName(),
-				translationEntry.getClassPK(), translationEntry.getContent());
-
-		return InfoItemFieldValues.builder(
-		).infoItemReference(
-			infoItemFieldValues.getInfoItemReference()
-		).infoFieldValues(
-			TransformUtil.transform(
-				infoItemFieldValues.getInfoFieldValues(),
-				infoFieldValue -> new InfoFieldValue<>(
-					infoFieldValue.getInfoField(),
-					GetterUtil.getObject(
-						_getValue(
-							translationEntryInfoItemFieldValues,
-							infoFieldValue.getInfoField()),
-						infoFieldValue.getValue())))
-		).build();
-	}
-
-	private Object _getValue(
-		InfoItemFieldValues translationEntryInfoItemFieldValues,
-		InfoField infoField) {
-
-		InfoFieldValue<Object> infoFieldValue =
-			translationEntryInfoItemFieldValues.getInfoFieldValue(
-				infoField.getUniqueId());
-
-		if (infoFieldValue != null) {
-			return infoFieldValue.getValue();
-		}
-
-		return null;
+		return _translationEntryLocalService.getInfoItemFieldValues(
+			translationEntry.getGroupId(), translationEntry.getClassName(),
+			translationEntry.getClassPK(), translationEntry.getContent());
 	}
 
 	private boolean _hasTranslatePermission(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36848

This PR fix  an issue with repeatable fields using save as draft button, setting first repeatable value to all fields.

# How am I fixing it?

Directly using values from translations entries instead of iterate info fields  values of the content and getting draft translation entry finding the value iterating  translation entries.

# How can you verify that it works?

Run integration test.


