### PR TITLE
LPD-35631 Create test for Select From List field

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -545,3 +545,54 @@ autoSaveTest(
 		).toBeVisible();
 	}
 );
+
+autoSaveTest(
+	'Empty option restores in Select from List when using undo/redo',
+	{
+		tag: '@LPD-35631',
+	},
+	async ({apiHelpers, journalEditArticlePage, page, site}) => {
+		const fieldName = 'SelectFromList';
+		const structureName = 'Structure 1';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [
+				{
+					fieldType: 'select',
+					name: fieldName,
+					options: {
+						en_US: [
+							{
+								label: 'option1',
+								reference: 'option1',
+								value: 'option1',
+							},
+							{
+								label: 'option2',
+								reference: 'option2',
+								value: 'option2',
+							},
+						],
+					},
+				},
+			],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		await page.getByLabel(fieldName).click();
+
+		await page.getByRole('option', {name: 'option1'}).click();
+
+		await journalEditArticlePage.undoButton.click();
+
+		await expect(page.getByLabel(fieldName)).toHaveText('Choose an Option');
+	}
+);

--- a/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
+++ b/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
@@ -10,8 +10,10 @@ interface Props {
 }
 
 interface Field {
+	fieldType?: 'text' | 'select';
 	localizable?: boolean;
 	name: string;
+	options?: Options;
 	repeatable?: boolean;
 	required?: boolean;
 }
@@ -25,8 +27,10 @@ export default function getDataStructureDefinition({
 		availableLanguageIds: [defaultLanguageId],
 		dataDefinitionFields: fields.map(
 			({
+				fieldType = 'text',
 				localizable = true,
 				name: fieldName,
+				options,
 				repeatable = false,
 				required = false,
 			}) => {
@@ -35,9 +39,10 @@ export default function getDataStructureDefinition({
 						dataType: 'string',
 						displayStyle: 'singleline',
 						fieldReference: fieldName,
+						options,
 					},
 					defaultValue: {},
-					fieldType: 'text',
+					fieldType,
 					indexType: 'keyword',
 					label: {
 						[defaultLanguageId]: fieldName,

--- a/modules/test/playwright/types/data-definition.d.ts
+++ b/modules/test/playwright/types/data-definition.d.ts
@@ -30,7 +30,7 @@ type DefinitionField = {
 	showLabel: boolean;
 };
 
-type DataLayouRow = {
+type DataLayoutRow = {
 	dataLayoutColumns: [
 		{
 			columnSize: number;
@@ -42,7 +42,7 @@ type DataLayouRow = {
 type DataLayout = {
 	dataLayoutPages: [
 		{
-			dataLayoutRows: DataLayouRow[];
+			dataLayoutRows: DataLayoutRow[];
 			description: {[keys: string]: string};
 			title: {[keys: string]: string};
 		},

--- a/modules/test/playwright/types/data-definition.d.ts
+++ b/modules/test/playwright/types/data-definition.d.ts
@@ -28,6 +28,7 @@ type DefinitionField = {
 	localizable: boolean;
 	name: string;
 	repeatable: boolean;
+	required?: boolean;
 	showLabel: boolean;
 };
 

--- a/modules/test/playwright/types/data-definition.d.ts
+++ b/modules/test/playwright/types/data-definition.d.ts
@@ -19,6 +19,7 @@ type DefinitionField = {
 		dataType: 'string';
 		displayStyle: 'singleline' | 'multiline';
 		fieldReference: string;
+		options?: Options;
 	};
 	defaultValue: {[keys: string]: string};
 	fieldType: 'text' | 'select';
@@ -49,4 +50,14 @@ type DataLayout = {
 	];
 	name: {[keys: string]: string};
 	paginationMode: 'single-page';
+};
+
+type Option = {
+	label: string;
+	reference: string;
+	value: string;
+};
+
+type Options = {
+	[key: string]: Option[];
 };


### PR DESCRIPTION
LPD-35631 Create test for Select From List field

# What is this trying to solve?

- Create the test for the [improvement made for Select From List field](https://liferay.atlassian.net/browse/LPD-34654). This improvement allows us to restore the default "Choose an Option" option for this field when we use the undo/redo feature. The fix is already available in master.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-35631)

# How am I fixing it?

- Create playwright test

# How can I test it?

- Execute the test