### PR TITLE
Lpd 33602

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentMetadataSetResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentMetadataSetResource.java
@@ -59,6 +59,13 @@ public interface DocumentMetadataSetResource {
 			String fieldNames)
 		throws Exception;
 
+	public void deleteDocumentMetadataSet(Long documentMetadataSetId)
+		throws Exception;
+
+	public Response deleteDocumentMetadataSetBatch(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public DocumentMetadataSet getDocumentMetadataSet(
 			Long documentMetadataSetId)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentMetadataSetResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentMetadataSetResource.java
@@ -54,6 +54,21 @@ public interface DocumentMetadataSetResource {
 				String fieldNames)
 		throws Exception;
 
+	public void deleteDocumentMetadataSet(Long documentMetadataSetId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteDocumentMetadataSetHttpResponse(
+			Long documentMetadataSetId)
+		throws Exception;
+
+	public void deleteDocumentMetadataSetBatch(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteDocumentMetadataSetBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public DocumentMetadataSet getDocumentMetadataSet(
 			Long documentMetadataSetId)
 		throws Exception;
@@ -410,6 +425,208 @@ public interface DocumentMetadataSetResource {
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets/export-batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteDocumentMetadataSet(Long documentMetadataSetId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteDocumentMetadataSetHttpResponse(documentMetadataSetId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteDocumentMetadataSetHttpResponse(
+				Long documentMetadataSetId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/document-metadata-sets/{documentMetadataSetId}");
+
+			httpInvoker.path("documentMetadataSetId", documentMetadataSetId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteDocumentMetadataSetBatch(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteDocumentMetadataSetBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteDocumentMetadataSetBatchHttpResponse(
+					String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/document-metadata-sets/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -9016,6 +9016,23 @@ paths:
                                 $ref: "#/components/schemas/DocumentFolder"
             tags: ["DocumentFolder"]
     "/document-metadata-sets/{documentMetadataSetId}":
+        delete:
+            description:
+                Deletes the document metadata set and returns a 204 if the operation succeeds.
+            operationId: deleteDocumentMetadataSet
+            parameters:
+                - in: path
+                  name: documentMetadataSetId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["DocumentMetadataSet"]
         get:
             description:
                 Retrieves the document metadata set.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -2287,6 +2287,37 @@ public class Mutation {
 						fieldNames));
 	}
 
+	@GraphQLField(
+		description = "Deletes the document metadata set and returns a 204 if the operation succeeds."
+	)
+	public boolean deleteDocumentMetadataSet(
+			@GraphQLName("documentMetadataSetId") Long documentMetadataSetId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.deleteDocumentMetadataSet(
+					documentMetadataSetId));
+
+		return true;
+	}
+
+	@GraphQLField
+	public Response deleteDocumentMetadataSetBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.deleteDocumentMetadataSetBatch(
+					callbackURL, object));
+	}
+
 	@GraphQLField
 	public Response createSiteDocumentMetadataSetsPageExportBatch(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -760,6 +760,16 @@ public class ServletDataImpl implements ServletData {
 							DocumentMetadataSetResourceImpl.class,
 							"postAssetLibraryDocumentMetadataSetsPageExportBatch"));
 					put(
+						"mutation#deleteDocumentMetadataSet",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"deleteDocumentMetadataSet"));
+					put(
+						"mutation#deleteDocumentMetadataSetBatch",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"deleteDocumentMetadataSetBatch"));
+					put(
 						"mutation#createSiteDocumentMetadataSetsPageExportBatch",
 						new ObjectValuePair<>(
 							DocumentMetadataSetResourceImpl.class,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
@@ -200,6 +200,89 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/document-metadata-sets/{documentMetadataSetId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the document metadata set and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "documentMetadataSetId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path("/document-metadata-sets/{documentMetadataSetId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteDocumentMetadataSet(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentMetadataSetId")
+			Long documentMetadataSetId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/document-metadata-sets/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path("/document-metadata-sets/batch")
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response deleteDocumentMetadataSetBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.deleteImportTask(
+				DocumentMetadataSet.class.getName(), callbackURL, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/document-metadata-sets/{documentMetadataSetId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -387,8 +470,9 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		for (DocumentMetadataSet documentMetadataSet : documentMetadataSets) {
+			deleteDocumentMetadataSet(documentMetadataSet.getId());
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -26,7 +26,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
-import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -54,18 +53,10 @@ public class DocumentMetadataSetResourceImpl
 		_ddmStructureLinkLocalService.deleteStructureStructureLinks(
 			documentMetadataSetId);
 
+		_dlFileEntryMetadataLocalService.
+			deleteFileEntryMetadataByDDMStructureId(documentMetadataSetId);
+
 		_ddmStructureLocalService.deleteStructure(documentMetadataSetId);
-
-		List<DLFileEntryMetadata> dlFileEntryMetadataList =
-			_dlFileEntryMetadataLocalService.
-				getNoStructuresFileEntryMetadatas();
-
-		for (DLFileEntryMetadata dlFileEntryMetadata :
-				dlFileEntryMetadataList) {
-
-			_dlFileEntryMetadataLocalService.deleteDLFileEntryMetadata(
-				dlFileEntryMetadata);
-		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -8,7 +8,7 @@ package com.liferay.headless.delivery.internal.resource.v1_0;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
-import com.liferay.dynamic.data.mapping.service.DDMStructureService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet;
 import com.liferay.headless.delivery.resource.v1_0.DocumentMetadataSetResource;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -52,7 +52,7 @@ public class DocumentMetadataSetResourceImpl
 		_ddmStructureLinkLocalService.deleteStructureStructureLinks(
 			documentMetadataSetId);
 
-		_ddmStructureService.deleteStructure(documentMetadataSetId);
+		_ddmStructureLocalService.deleteStructure(documentMetadataSetId);
 	}
 
 	@Override
@@ -84,7 +84,7 @@ public class DocumentMetadataSetResourceImpl
 		}
 
 		return _toDocumentMetadataSet(
-			_ddmStructureService.getStructure(documentMetadataSetId));
+			_ddmStructureLocalService.getStructure(documentMetadataSetId));
 	}
 
 	@Override
@@ -118,13 +118,13 @@ public class DocumentMetadataSetResourceImpl
 		return Page.of(
 			actions,
 			transform(
-				_ddmStructureService.getStructures(
+				_ddmStructureLocalService.getStructures(
 					group.getCompanyId(), new long[] {groupId}, classNameId,
 					pagination.getStartPosition(), pagination.getEndPosition(),
 					null),
 				ddmStructure -> _toDocumentMetadataSet(ddmStructure)),
 			pagination,
-			_ddmStructureService.getStructuresCount(
+			_ddmStructureLocalService.getStructuresCount(
 				group.getCompanyId(), new long[] {groupId}, classNameId, null,
 				WorkflowConstants.STATUS_ANY));
 	}
@@ -158,7 +158,7 @@ public class DocumentMetadataSetResourceImpl
 	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
 
 	@Reference
-	private DDMStructureService _ddmStructureService;
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.delivery.internal.dto.v1_0.converter.DocumentMetadataSetDTOConverter)"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -5,10 +5,10 @@
 
 package com.liferay.headless.delivery.internal.resource.v1_0;
 
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet;
 import com.liferay.headless.delivery.resource.v1_0.DocumentMetadataSetResource;
@@ -50,13 +50,18 @@ public class DocumentMetadataSetResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		_ddmStructureLinkLocalService.deleteStructureStructureLinks(
-			documentMetadataSetId);
+		DataDefinitionResource.Builder dataDefinitionResourceBuilder =
+			_dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource =
+			dataDefinitionResourceBuilder.user(
+				contextUser
+			).build();
+
+		dataDefinitionResource.deleteDataDefinition(documentMetadataSetId);
 
 		_dlFileEntryMetadataLocalService.
 			deleteFileEntryMetadataByDDMStructureId(documentMetadataSetId);
-
-		_ddmStructureLocalService.deleteStructure(documentMetadataSetId);
 	}
 
 	@Override
@@ -159,7 +164,7 @@ public class DocumentMetadataSetResourceImpl
 	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
-	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
+	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.delivery.internal.resource.v1_0;
 
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -25,6 +26,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -53,6 +55,17 @@ public class DocumentMetadataSetResourceImpl
 			documentMetadataSetId);
 
 		_ddmStructureLocalService.deleteStructure(documentMetadataSetId);
+
+		List<DLFileEntryMetadata> dlFileEntryMetadataList =
+			_dlFileEntryMetadataLocalService.
+				getNoStructuresFileEntryMetadatas();
+
+		for (DLFileEntryMetadata dlFileEntryMetadata :
+				dlFileEntryMetadataList) {
+
+			_dlFileEntryMetadataLocalService.deleteDLFileEntryMetadata(
+				dlFileEntryMetadata);
+		}
 	}
 
 	@Override
@@ -159,6 +172,9 @@ public class DocumentMetadataSetResourceImpl
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Reference
+	private DLFileEntryMetadataLocalService _dlFileEntryMetadataLocalService;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.delivery.internal.dto.v1_0.converter.DocumentMetadataSetDTOConverter)"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.delivery.internal.resource.v1_0;
 
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet;
 import com.liferay.headless.delivery.resource.v1_0.DocumentMetadataSetResource;
@@ -39,6 +40,20 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class DocumentMetadataSetResourceImpl
 	extends BaseDocumentMetadataSetResourceImpl {
+
+	@Override
+	public void deleteDocumentMetadataSet(Long documentMetadataSetId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-32247")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_ddmStructureLinkLocalService.deleteStructureStructureLinks(
+			documentMetadataSetId);
+
+		_ddmStructureService.deleteStructure(documentMetadataSetId);
+	}
 
 	@Override
 	public Page<DocumentMetadataSet> getAssetLibraryDocumentMetadataSetsPage(
@@ -138,6 +153,9 @@ public class DocumentMetadataSetResourceImpl
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
 
 	@Reference
 	private DDMStructureService _ddmStructureService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -25,6 +25,7 @@ import com.liferay.headless.delivery.client.serdes.v1_0.DocumentMetadataSetSerDe
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -253,6 +254,12 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 			page,
 			testGetAssetLibraryDocumentMetadataSetsPage_getExpectedActions(
 				assetLibraryId));
+
+		documentMetadataSetResource.deleteDocumentMetadataSet(
+			documentMetadataSet1.getId());
+
+		documentMetadataSetResource.deleteDocumentMetadataSet(
+			documentMetadataSet2.getId());
 	}
 
 	protected Map<String, Map<String, String>>
@@ -399,6 +406,121 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		throws Exception {
 
 		return null;
+	}
+
+	@Test
+	public void testDeleteDocumentMetadataSet() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		DocumentMetadataSet documentMetadataSet =
+			testDeleteDocumentMetadataSet_addDocumentMetadataSet();
+
+		assertHttpResponseStatusCode(
+			204,
+			documentMetadataSetResource.deleteDocumentMetadataSetHttpResponse(
+				documentMetadataSet.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(
+				documentMetadataSet.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			documentMetadataSetResource.getDocumentMetadataSetHttpResponse(0L));
+	}
+
+	protected DocumentMetadataSet
+			testDeleteDocumentMetadataSet_addDocumentMetadataSet()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteDocumentMetadataSet() throws Exception {
+
+		// No namespace
+
+		DocumentMetadataSet documentMetadataSet1 =
+			testGraphQLDeleteDocumentMetadataSet_addDocumentMetadataSet();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"deleteDocumentMetadataSet",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"documentMetadataSetId",
+									documentMetadataSet1.getId());
+							}
+						})),
+				"JSONObject/data", "Object/deleteDocumentMetadataSet"));
+
+		JSONArray errorsJSONArray1 = JSONUtil.getValueAsJSONArray(
+			invokeGraphQLQuery(
+				new GraphQLField(
+					"documentMetadataSet",
+					new HashMap<String, Object>() {
+						{
+							put(
+								"documentMetadataSetId",
+								documentMetadataSet1.getId());
+						}
+					},
+					new GraphQLField("id"))),
+			"JSONArray/errors");
+
+		Assert.assertTrue(errorsJSONArray1.length() > 0);
+
+		// Using the namespace headlessDelivery_v1_0
+
+		DocumentMetadataSet documentMetadataSet2 =
+			testGraphQLDeleteDocumentMetadataSet_addDocumentMetadataSet();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"headlessDelivery_v1_0",
+						new GraphQLField(
+							"deleteDocumentMetadataSet",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"documentMetadataSetId",
+										documentMetadataSet2.getId());
+								}
+							}))),
+				"JSONObject/data", "JSONObject/headlessDelivery_v1_0",
+				"Object/deleteDocumentMetadataSet"));
+
+		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
+			invokeGraphQLQuery(
+				new GraphQLField(
+					"headlessDelivery_v1_0",
+					new GraphQLField(
+						"documentMetadataSet",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"documentMetadataSetId",
+									documentMetadataSet2.getId());
+							}
+						},
+						new GraphQLField("id")))),
+			"JSONArray/errors");
+
+		Assert.assertTrue(errorsJSONArray2.length() > 0);
+	}
+
+	protected DocumentMetadataSet
+			testGraphQLDeleteDocumentMetadataSet_addDocumentMetadataSet()
+		throws Exception {
+
+		return testGraphQLDocumentMetadataSet_addDocumentMetadataSet();
 	}
 
 	@Test
@@ -574,6 +696,12 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		assertValid(
 			page,
 			testGetSiteDocumentMetadataSetsPage_getExpectedActions(siteId));
+
+		documentMetadataSetResource.deleteDocumentMetadataSet(
+			documentMetadataSet1.getId());
+
+		documentMetadataSetResource.deleteDocumentMetadataSet(
+			documentMetadataSet2.getId());
 	}
 
 	protected Map<String, Map<String, String>>

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
@@ -67,6 +67,14 @@ public class DocumentMetadataSetResourceTest
 
 	@Override
 	protected DocumentMetadataSet
+			testDeleteDocumentMetadataSet_addDocumentMetadataSet()
+		throws Exception {
+
+		return _addDocumentMetadataSet(testGroup);
+	}
+
+	@Override
+	protected DocumentMetadataSet
 			testGetAssetLibraryDocumentMetadataSetsPage_addDocumentMetadataSet(
 				Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
 		throws Exception {

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
@@ -214,6 +214,13 @@ public class DLFileEntryMetadataPersistenceTest {
 	}
 
 	@Test
+	public void testCountByDDMStructureId() throws Exception {
+		_persistence.countByDDMStructureId(RandomTestUtil.nextLong());
+
+		_persistence.countByDDMStructureId(0L);
+	}
+
+	@Test
 	public void testCountByFileEntryId() throws Exception {
 		_persistence.countByFileEntryId(RandomTestUtil.nextLong());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -155,6 +155,9 @@
 
 		<!-- Finder methods -->
 
+		<finder name="DDMStructureId" return-type="Collection">
+			<finder-column name="DDMStructureId" />
+		</finder>
 		<finder name="FileEntryId" return-type="Collection">
 			<finder-column name="fileEntryId" />
 		</finder>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryMetadataLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryMetadataLocalServiceImpl.java
@@ -61,6 +61,18 @@ public class DLFileEntryMetadataLocalServiceImpl
 	}
 
 	@Override
+	public void deleteFileEntryMetadataByDDMStructureId(long ddmStructureId)
+		throws PortalException {
+
+		for (DLFileEntryMetadata dlFileEntryMetadata :
+				dlFileEntryMetadataPersistence.findByDDMStructureId(
+					ddmStructureId)) {
+
+			deleteFileEntryMetadata(dlFileEntryMetadata);
+		}
+	}
+
+	@Override
 	public void deleteFileEntryMetadataByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryMetadataPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryMetadataPersistenceImpl.java
@@ -1237,6 +1237,528 @@ public class DLFileEntryMetadataPersistenceImpl
 	private static final String _FINDER_COLUMN_UUID_C_COMPANYID_2 =
 		"dlFileEntryMetadata.companyId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByDDMStructureId;
+	private FinderPath _finderPathWithoutPaginationFindByDDMStructureId;
+	private FinderPath _finderPathCountByDDMStructureId;
+
+	/**
+	 * Returns all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the matching document library file entry metadatas
+	 */
+	@Override
+	public List<DLFileEntryMetadata> findByDDMStructureId(long DDMStructureId) {
+		return findByDDMStructureId(
+			DDMStructureId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @return the range of matching document library file entry metadatas
+	 */
+	@Override
+	public List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end) {
+
+		return findByDDMStructureId(DDMStructureId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	@Override
+	public List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		return findByDDMStructureId(
+			DDMStructureId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	@Override
+	public List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					DLFileEntryMetadata.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath =
+						_finderPathWithoutPaginationFindByDDMStructureId;
+					finderArgs = new Object[] {DDMStructureId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByDDMStructureId;
+				finderArgs = new Object[] {
+					DDMStructureId, start, end, orderByComparator
+				};
+			}
+
+			List<DLFileEntryMetadata> list = null;
+
+			if (useFinderCache) {
+				list = (List<DLFileEntryMetadata>)FinderCacheUtil.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (DLFileEntryMetadata dlFileEntryMetadata : list) {
+						if (DDMStructureId !=
+								dlFileEntryMetadata.getDDMStructureId()) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						3 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(3);
+				}
+
+				sb.append(_SQL_SELECT_DLFILEENTRYMETADATA_WHERE);
+
+				sb.append(_FINDER_COLUMN_DDMSTRUCTUREID_DDMSTRUCTUREID_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(DLFileEntryMetadataModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(DDMStructureId);
+
+					list = (List<DLFileEntryMetadata>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						FinderCacheUtil.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	@Override
+	public DLFileEntryMetadata findByDDMStructureId_First(
+			long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException {
+
+		DLFileEntryMetadata dlFileEntryMetadata = fetchByDDMStructureId_First(
+			DDMStructureId, orderByComparator);
+
+		if (dlFileEntryMetadata != null) {
+			return dlFileEntryMetadata;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("DDMStructureId=");
+		sb.append(DDMStructureId);
+
+		sb.append("}");
+
+		throw new NoSuchFileEntryMetadataException(sb.toString());
+	}
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	@Override
+	public DLFileEntryMetadata fetchByDDMStructureId_First(
+		long DDMStructureId,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		List<DLFileEntryMetadata> list = findByDDMStructureId(
+			DDMStructureId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	@Override
+	public DLFileEntryMetadata findByDDMStructureId_Last(
+			long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException {
+
+		DLFileEntryMetadata dlFileEntryMetadata = fetchByDDMStructureId_Last(
+			DDMStructureId, orderByComparator);
+
+		if (dlFileEntryMetadata != null) {
+			return dlFileEntryMetadata;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("DDMStructureId=");
+		sb.append(DDMStructureId);
+
+		sb.append("}");
+
+		throw new NoSuchFileEntryMetadataException(sb.toString());
+	}
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	@Override
+	public DLFileEntryMetadata fetchByDDMStructureId_Last(
+		long DDMStructureId,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		int count = countByDDMStructureId(DDMStructureId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<DLFileEntryMetadata> list = findByDDMStructureId(
+			DDMStructureId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the document library file entry metadatas before and after the current document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param fileEntryMetadataId the primary key of the current document library file entry metadata
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a document library file entry metadata with the primary key could not be found
+	 */
+	@Override
+	public DLFileEntryMetadata[] findByDDMStructureId_PrevAndNext(
+			long fileEntryMetadataId, long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException {
+
+		DLFileEntryMetadata dlFileEntryMetadata = findByPrimaryKey(
+			fileEntryMetadataId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DLFileEntryMetadata[] array = new DLFileEntryMetadataImpl[3];
+
+			array[0] = getByDDMStructureId_PrevAndNext(
+				session, dlFileEntryMetadata, DDMStructureId, orderByComparator,
+				true);
+
+			array[1] = dlFileEntryMetadata;
+
+			array[2] = getByDDMStructureId_PrevAndNext(
+				session, dlFileEntryMetadata, DDMStructureId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DLFileEntryMetadata getByDDMStructureId_PrevAndNext(
+		Session session, DLFileEntryMetadata dlFileEntryMetadata,
+		long DDMStructureId,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(3);
+		}
+
+		sb.append(_SQL_SELECT_DLFILEENTRYMETADATA_WHERE);
+
+		sb.append(_FINDER_COLUMN_DDMSTRUCTUREID_DDMSTRUCTUREID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(DLFileEntryMetadataModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(DDMStructureId);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						dlFileEntryMetadata)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<DLFileEntryMetadata> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the document library file entry metadatas where DDMStructureId = &#63; from the database.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 */
+	@Override
+	public void removeByDDMStructureId(long DDMStructureId) {
+		for (DLFileEntryMetadata dlFileEntryMetadata :
+				findByDDMStructureId(
+					DDMStructureId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(dlFileEntryMetadata);
+		}
+	}
+
+	/**
+	 * Returns the number of document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the number of matching document library file entry metadatas
+	 */
+	@Override
+	public int countByDDMStructureId(long DDMStructureId) {
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					DLFileEntryMetadata.class)) {
+
+			FinderPath finderPath = _finderPathCountByDDMStructureId;
+
+			Object[] finderArgs = new Object[] {DDMStructureId};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(2);
+
+				sb.append(_SQL_COUNT_DLFILEENTRYMETADATA_WHERE);
+
+				sb.append(_FINDER_COLUMN_DDMSTRUCTUREID_DDMSTRUCTUREID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(DDMStructureId);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_DDMSTRUCTUREID_DDMSTRUCTUREID_2 =
+		"dlFileEntryMetadata.DDMStructureId = ?";
+
 	private FinderPath _finderPathWithPaginationFindByFileEntryId;
 	private FinderPath _finderPathWithoutPaginationFindByFileEntryId;
 	private FinderPath _finderPathCountByFileEntryId;
@@ -3756,6 +4278,24 @@ public class DLFileEntryMetadataPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByUuid_C",
 			new String[] {String.class.getName(), Long.class.getName()},
 			new String[] {"uuid_", "companyId"}, false);
+
+		_finderPathWithPaginationFindByDDMStructureId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByDDMStructureId",
+			new String[] {
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"DDMStructureId"}, true);
+
+		_finderPathWithoutPaginationFindByDDMStructureId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByDDMStructureId",
+			new String[] {Long.class.getName()},
+			new String[] {"DDMStructureId"}, true);
+
+		_finderPathCountByDDMStructureId = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByDDMStructureId",
+			new String[] {Long.class.getName()},
+			new String[] {"DDMStructureId"}, false);
 
 		_finderPathWithPaginationFindByFileEntryId = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByFileEntryId",

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalService.java
@@ -135,6 +135,9 @@ public interface DLFileEntryMetadataLocalService
 	public void deleteFileEntryMetadata(long fileEntryId)
 		throws PortalException;
 
+	public void deleteFileEntryMetadataByDDMStructureId(long ddmStructureId)
+		throws PortalException;
+
 	public void deleteFileEntryMetadataByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalServiceUtil.java
@@ -122,6 +122,13 @@ public class DLFileEntryMetadataLocalServiceUtil {
 		getService().deleteFileEntryMetadata(fileEntryId);
 	}
 
+	public static void deleteFileEntryMetadataByDDMStructureId(
+			long ddmStructureId)
+		throws PortalException {
+
+		getService().deleteFileEntryMetadataByDDMStructureId(ddmStructureId);
+	}
+
 	public static void deleteFileEntryMetadataByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryMetadataLocalServiceWrapper.java
@@ -130,6 +130,14 @@ public class DLFileEntryMetadataLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteFileEntryMetadataByDDMStructureId(long ddmStructureId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_dlFileEntryMetadataLocalService.
+			deleteFileEntryMetadataByDDMStructureId(ddmStructureId);
+	}
+
+	@Override
 	public void deleteFileEntryMetadataByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryMetadataPersistence.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryMetadataPersistence.java
@@ -333,6 +333,150 @@ public interface DLFileEntryMetadataPersistence
 	public int countByUuid_C(String uuid, long companyId);
 
 	/**
+	 * Returns all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the matching document library file entry metadatas
+	 */
+	public java.util.List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId);
+
+	/**
+	 * Returns a range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @return the range of matching document library file entry metadatas
+	 */
+	public java.util.List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	public java.util.List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntryMetadata>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	public java.util.List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntryMetadata>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	public DLFileEntryMetadata findByDDMStructureId_First(
+			long DDMStructureId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException;
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	public DLFileEntryMetadata fetchByDDMStructureId_First(
+		long DDMStructureId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntryMetadata>
+			orderByComparator);
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	public DLFileEntryMetadata findByDDMStructureId_Last(
+			long DDMStructureId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException;
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	public DLFileEntryMetadata fetchByDDMStructureId_Last(
+		long DDMStructureId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntryMetadata>
+			orderByComparator);
+
+	/**
+	 * Returns the document library file entry metadatas before and after the current document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param fileEntryMetadataId the primary key of the current document library file entry metadata
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a document library file entry metadata with the primary key could not be found
+	 */
+	public DLFileEntryMetadata[] findByDDMStructureId_PrevAndNext(
+			long fileEntryMetadataId, long DDMStructureId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DLFileEntryMetadata> orderByComparator)
+		throws NoSuchFileEntryMetadataException;
+
+	/**
+	 * Removes all the document library file entry metadatas where DDMStructureId = &#63; from the database.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 */
+	public void removeByDDMStructureId(long DDMStructureId);
+
+	/**
+	 * Returns the number of document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the number of matching document library file entry metadatas
+	 */
+	public int countByDDMStructureId(long DDMStructureId);
+
+	/**
 	 * Returns all the document library file entry metadatas where fileEntryId = &#63;.
 	 *
 	 * @param fileEntryId the file entry ID

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryMetadataUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryMetadataUtil.java
@@ -472,6 +472,185 @@ public class DLFileEntryMetadataUtil {
 	}
 
 	/**
+	 * Returns all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the matching document library file entry metadatas
+	 */
+	public static List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId) {
+
+		return getPersistence().findByDDMStructureId(DDMStructureId);
+	}
+
+	/**
+	 * Returns a range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @return the range of matching document library file entry metadatas
+	 */
+	public static List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end) {
+
+		return getPersistence().findByDDMStructureId(
+			DDMStructureId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	public static List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		return getPersistence().findByDDMStructureId(
+			DDMStructureId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DLFileEntryMetadataModelImpl</code>.
+	 * </p>
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param start the lower bound of the range of document library file entry metadatas
+	 * @param end the upper bound of the range of document library file entry metadatas (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching document library file entry metadatas
+	 */
+	public static List<DLFileEntryMetadata> findByDDMStructureId(
+		long DDMStructureId, int start, int end,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByDDMStructureId(
+			DDMStructureId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	public static DLFileEntryMetadata findByDDMStructureId_First(
+			long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.
+			NoSuchFileEntryMetadataException {
+
+		return getPersistence().findByDDMStructureId_First(
+			DDMStructureId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	public static DLFileEntryMetadata fetchByDDMStructureId_First(
+		long DDMStructureId,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		return getPersistence().fetchByDDMStructureId_First(
+			DDMStructureId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a matching document library file entry metadata could not be found
+	 */
+	public static DLFileEntryMetadata findByDDMStructureId_Last(
+			long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.
+			NoSuchFileEntryMetadataException {
+
+		return getPersistence().findByDDMStructureId_Last(
+			DDMStructureId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry metadata, or <code>null</code> if a matching document library file entry metadata could not be found
+	 */
+	public static DLFileEntryMetadata fetchByDDMStructureId_Last(
+		long DDMStructureId,
+		OrderByComparator<DLFileEntryMetadata> orderByComparator) {
+
+		return getPersistence().fetchByDDMStructureId_Last(
+			DDMStructureId, orderByComparator);
+	}
+
+	/**
+	 * Returns the document library file entry metadatas before and after the current document library file entry metadata in the ordered set where DDMStructureId = &#63;.
+	 *
+	 * @param fileEntryMetadataId the primary key of the current document library file entry metadata
+	 * @param DDMStructureId the ddm structure ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library file entry metadata
+	 * @throws NoSuchFileEntryMetadataException if a document library file entry metadata with the primary key could not be found
+	 */
+	public static DLFileEntryMetadata[] findByDDMStructureId_PrevAndNext(
+			long fileEntryMetadataId, long DDMStructureId,
+			OrderByComparator<DLFileEntryMetadata> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.
+			NoSuchFileEntryMetadataException {
+
+		return getPersistence().findByDDMStructureId_PrevAndNext(
+			fileEntryMetadataId, DDMStructureId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the document library file entry metadatas where DDMStructureId = &#63; from the database.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 */
+	public static void removeByDDMStructureId(long DDMStructureId) {
+		getPersistence().removeByDDMStructureId(DDMStructureId);
+	}
+
+	/**
+	 * Returns the number of document library file entry metadatas where DDMStructureId = &#63;.
+	 *
+	 * @param DDMStructureId the ddm structure ID
+	 * @return the number of matching document library file entry metadatas
+	 */
+	public static int countByDDMStructureId(long DDMStructureId) {
+		return getPersistence().countByDDMStructureId(DDMStructureId);
+	}
+
+	/**
 	 * Returns all the document library file entry metadatas where fileEntryId = &#63;.
 	 *
 	 * @param fileEntryId the file entry ID

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 7.6.0
+version 7.7.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -99,9 +99,10 @@ create index IX_9EE96CAD on DLFileEntry (repositoryId);
 create index IX_25F5CAB9 on DLFileEntry (smallImageId, largeImageId, custom1ImageId, custom2ImageId);
 create index IX_64F0FE40 on DLFileEntry (uuid_[$COLUMN_LENGTH:75$]);
 
+create unique index IX_B9210CAD on DLFileEntryMetadata (DDMStructureId, fileVersionId, ctCollectionId);
 create unique index IX_36AA016C on DLFileEntryMetadata (ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$], companyId);
 create index IX_4F40FE5E on DLFileEntryMetadata (fileEntryId);
-create unique index IX_BE290777 on DLFileEntryMetadata (fileVersionId, ctCollectionId, DDMStructureId);
+create index IX_1FE9C04 on DLFileEntryMetadata (fileVersionId);
 create index IX_D49AB5D1 on DLFileEntryMetadata (uuid_[$COLUMN_LENGTH:75$]);
 
 create unique index IX_93ED0F06 on DLFileEntryType (groupId, ctCollectionId, dataDefinitionId);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33602

Create a new endpoint for Headless API to delete DocumentMetadataSets

# How am I fixing it?

Added a new endpoint for the delete method

# How can you verify that it works?

Run the tests in DocumentMetadataSetResourceTest

Resending this PR because Brian Chan requested we move the structure link removal to the DDMStructureLocalSerivceImpl method, however @jkappler noted we can use methods in DataDefinitionResource which call the proper DDM methods. I followed the pattern established in [DocumentDataDefinitionTypeResourceImpl](https://github.com/liferay-content-management/liferay-portal/blob/6df78b7469eeb2b04f177ecaf67aae5130dc3c3e/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentDataDefinitionTypeResourceImpl.java#L55-L80)

https://github.com/brianchandotcom/liferay-portal/pull/154301#issuecomment-2359729821