### PR TITLE
LPD-33263 Add ExternalReferenceCode to MBCategory (2nd try)

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
@@ -276,7 +276,7 @@ public class MessageBoardSectionResourceImpl
 
 		return _toMessageBoardSection(
 			_mbCategoryService.addCategory(
-				contextUser.getUserId(), parentMessageBoardSectionId,
+				null, contextUser.getUserId(), parentMessageBoardSectionId,
 				messageBoardSection.getTitle(),
 				messageBoardSection.getDescription(),
 				_createServiceContext(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardSectionResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardSectionResourceTest.java
@@ -42,7 +42,7 @@ public class MessageBoardSectionResourceTest
 		serviceContext.setScopeGroupId(testGroup.getGroupId());
 
 		MBCategory mbCategory = MBCategoryLocalServiceUtil.addCategory(
-			UserLocalServiceUtil.getGuestUserId(testGroup.getCompanyId()),
+			null, UserLocalServiceUtil.getGuestUserId(testGroup.getCompanyId()),
 			testGroup.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
@@ -49,7 +49,7 @@ public class MessageBoardThreadResourceTest
 		serviceContext.setScopeGroupId(testGroup.getGroupId());
 
 		_mbCategory = MBCategoryLocalServiceUtil.addCategory(
-			UserLocalServiceUtil.getGuestUserId(testGroup.getCompanyId()),
+			null, UserLocalServiceUtil.getGuestUserId(testGroup.getCompanyId()),
 			testGroup.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 25.1.0
+Bundle-Version: 26.0.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards API
 Bundle-SymbolicName: com.liferay.message.boards.api
-Bundle-Version: 25.0.1
+Bundle-Version: 25.1.0
 Export-Package:\
 	com.liferay.message.boards.configuration,\
 	com.liferay.message.boards.constants,\

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMBCategoryExternalReferenceCodeException.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/exception/DuplicateMBCategoryExternalReferenceCodeException.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.exception;
+
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateMBCategoryExternalReferenceCodeException
+	extends DuplicateExternalReferenceCodeException {
+
+	public DuplicateMBCategoryExternalReferenceCodeException() {
+	}
+
+	public DuplicateMBCategoryExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateMBCategoryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateMBCategoryExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryModel.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryModel.java
@@ -8,6 +8,7 @@ package com.liferay.message.boards.model;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ContainerModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -33,8 +34,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface MBCategoryModel
 	extends BaseModel<MBCategory>, ContainerModel, CTModel<MBCategory>,
-			MVCCModel, ShardedModel, StagedGroupedModel, TrashedModel,
-			WorkflowedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel, TrashedModel, WorkflowedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -106,6 +107,23 @@ public interface MBCategoryModel
 	 */
 	@Override
 	public void setUuid(String uuid);
+
+	/**
+	 * Returns the external reference code of this message boards category.
+	 *
+	 * @return the external reference code of this message boards category
+	 */
+	@AutoEscape
+	@Override
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this message boards category.
+	 *
+	 * @param externalReferenceCode the external reference code of this message boards category
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**
 	 * Returns the category ID of this message boards category.

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryTable.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryTable.java
@@ -29,6 +29,10 @@ public class MBCategoryTable extends BaseTable<MBCategoryTable> {
 		"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<MBCategoryTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<MBCategoryTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<MBCategoryTable, Long> categoryId = createColumn(
 		"categoryId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<MBCategoryTable, Long> groupId = createColumn(

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBCategoryWrapper.java
@@ -39,6 +39,7 @@ public class MBCategoryWrapper
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("categoryId", getCategoryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -78,6 +79,13 @@ public class MBCategoryWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long categoryId = (Long)attributes.get("categoryId");
@@ -280,6 +288,16 @@ public class MBCategoryWrapper
 	@Override
 	public String getDisplayStyle() {
 		return model.getDisplayStyle();
+	}
+
+	/**
+	 * Returns the external reference code of this message boards category.
+	 *
+	 * @return the external reference code of this message boards category
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -657,6 +675,16 @@ public class MBCategoryWrapper
 	@Override
 	public void setDisplayStyle(String displayStyle) {
 		model.setDisplayStyle(displayStyle);
+	}
+
+	/**
+	 * Sets the external reference code of this message boards category.
+	 *
+	 * @param externalReferenceCode the external reference code of this message boards category
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
@@ -252,6 +252,10 @@ public interface MBCategoryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBCategory fetchMBCategory(long groupId, String friendlyURL);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public MBCategory fetchMBCategoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId);
+
 	/**
 	 * Returns the message boards category matching the UUID and group.
 	 *
@@ -423,6 +427,11 @@ public interface MBCategoryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBCategory getMBCategory(long groupId, String friendlyURL)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public MBCategory getMBCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
@@ -65,19 +65,20 @@ public interface MBCategoryLocalService
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.message.boards.service.impl.MBCategoryLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the message boards category local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link MBCategoryLocalServiceUtil} if injection and service tracking are not available.
 	 */
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean allowAnonymous,
-			boolean mailingListActive, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, String displayStyle,
+			String emailAddress, String inProtocol, String inServerName,
+			int inServerPort, boolean inUseSSL, String inUserName,
+			String inPassword, int inReadInterval, String outEmailAddress,
+			boolean outCustom, String outServerName, int outServerPort,
+			boolean outUseSSL, String outUserName, String outPassword,
+			boolean allowAnonymous, boolean mailingListActive,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void addCategoryResources(
@@ -138,6 +139,9 @@ public interface MBCategoryLocalService
 	)
 	public void deleteCategory(
 			MBCategory category, boolean includeTrashedEntries)
+		throws PortalException;
+
+	public void deleteCategory(String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalService.java
@@ -141,7 +141,8 @@ public interface MBCategoryLocalService
 			MBCategory category, boolean includeTrashedEntries)
 		throws PortalException;
 
-	public void deleteCategory(String externalReferenceCode, long groupId)
+	public void deleteCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
@@ -37,32 +37,34 @@ public class MBCategoryLocalServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.message.boards.service.impl.MBCategoryLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
-			userId, parentCategoryId, name, description, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			serviceContext);
 	}
 
 	public static MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean allowAnonymous,
-			boolean mailingListActive,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, String displayStyle,
+			String emailAddress, String inProtocol, String inServerName,
+			int inServerPort, boolean inUseSSL, String inUserName,
+			String inPassword, int inReadInterval, String outEmailAddress,
+			boolean outCustom, String outServerName, int outServerPort,
+			boolean outUseSSL, String outUserName, String outPassword,
+			boolean allowAnonymous, boolean mailingListActive,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
-			userId, parentCategoryId, name, description, displayStyle,
-			emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
-			inUserName, inPassword, inReadInterval, outEmailAddress, outCustom,
-			outServerName, outServerPort, outUseSSL, outUserName, outPassword,
-			allowAnonymous, mailingListActive, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			displayStyle, emailAddress, inProtocol, inServerName, inServerPort,
+			inUseSSL, inUserName, inPassword, inReadInterval, outEmailAddress,
+			outCustom, outServerName, outServerPort, outUseSSL, outUserName,
+			outPassword, allowAnonymous, mailingListActive, serviceContext);
 	}
 
 	public static void addCategoryResources(
@@ -154,6 +156,13 @@ public class MBCategoryLocalServiceUtil {
 		throws PortalException {
 
 		getService().deleteCategory(category, includeTrashedEntries);
+	}
+
+	public static void deleteCategory(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		getService().deleteCategory(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
@@ -290,6 +290,13 @@ public class MBCategoryLocalServiceUtil {
 		return getService().fetchMBCategory(groupId, friendlyURL);
 	}
 
+	public static MBCategory fetchMBCategoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return getService().fetchMBCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the message boards category matching the UUID and group.
 	 *
@@ -547,6 +554,14 @@ public class MBCategoryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getMBCategory(groupId, friendlyURL);
+	}
+
+	public static MBCategory getMBCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getMBCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceUtil.java
@@ -158,11 +158,12 @@ public class MBCategoryLocalServiceUtil {
 		getService().deleteCategory(category, includeTrashedEntries);
 	}
 
-	public static void deleteCategory(
+	public static void deleteCategoryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		getService().deleteCategory(externalReferenceCode, groupId);
+		getService().deleteCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
@@ -326,6 +326,14 @@ public class MBCategoryLocalServiceWrapper
 		return _mbCategoryLocalService.fetchMBCategory(groupId, friendlyURL);
 	}
 
+	@Override
+	public MBCategory fetchMBCategoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return _mbCategoryLocalService.fetchMBCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the message boards category matching the UUID and group.
 	 *
@@ -621,6 +629,15 @@ public class MBCategoryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbCategoryLocalService.getMBCategory(groupId, friendlyURL);
+	}
+
+	@Override
+	public MBCategory getMBCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
@@ -33,33 +33,35 @@ public class MBCategoryLocalServiceWrapper
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbCategoryLocalService.addCategory(
-			userId, parentCategoryId, name, description, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			serviceContext);
 	}
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean allowAnonymous,
-			boolean mailingListActive,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, String displayStyle,
+			String emailAddress, String inProtocol, String inServerName,
+			int inServerPort, boolean inUseSSL, String inUserName,
+			String inPassword, int inReadInterval, String outEmailAddress,
+			boolean outCustom, String outServerName, int outServerPort,
+			boolean outUseSSL, String outUserName, String outPassword,
+			boolean allowAnonymous, boolean mailingListActive,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbCategoryLocalService.addCategory(
-			userId, parentCategoryId, name, description, displayStyle,
-			emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
-			inUserName, inPassword, inReadInterval, outEmailAddress, outCustom,
-			outServerName, outServerPort, outUseSSL, outUserName, outPassword,
-			allowAnonymous, mailingListActive, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			displayStyle, emailAddress, inProtocol, inServerName, inServerPort,
+			inUseSSL, inUserName, inPassword, inReadInterval, outEmailAddress,
+			outCustom, outServerName, outServerPort, outUseSSL, outUserName,
+			outPassword, allowAnonymous, mailingListActive, serviceContext);
 	}
 
 	@Override
@@ -168,6 +170,13 @@ public class MBCategoryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mbCategoryLocalService.deleteCategory(category, includeTrashedEntries);
+	}
+
+	@Override
+	public void deleteCategory(String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_mbCategoryLocalService.deleteCategory(externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryLocalServiceWrapper.java
@@ -173,10 +173,12 @@ public class MBCategoryLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteCategory(String externalReferenceCode, long groupId)
+	public void deleteCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_mbCategoryLocalService.deleteCategory(externalReferenceCode, groupId);
+		_mbCategoryLocalService.deleteCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryService.java
@@ -48,18 +48,18 @@ public interface MBCategoryService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.message.boards.service.impl.MBCategoryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the message boards category remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link MBCategoryServiceUtil} if injection and service tracking are not available.
 	 */
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public MBCategory addCategory(
-			long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean mailingListActive,
+			String externalReferenceCode, long parentCategoryId, String name,
+			String description, String displayStyle, String emailAddress,
+			String inProtocol, String inServerName, int inServerPort,
+			boolean inUseSSL, String inUserName, String inPassword,
+			int inReadInterval, String outEmailAddress, boolean outCustom,
+			String outServerName, int outServerPort, boolean outUseSSL,
+			String outUserName, String outPassword, boolean mailingListActive,
 			boolean allowAnonymousEmail, ServiceContext serviceContext)
 		throws PortalException;
 
@@ -67,6 +67,9 @@ public interface MBCategoryService extends BaseService {
 		throws PortalException;
 
 	public void deleteCategory(long groupId, long categoryId)
+		throws PortalException;
+
+	public void deleteCategory(String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryServiceUtil.java
@@ -32,32 +32,35 @@ public class MBCategoryServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.message.boards.service.impl.MBCategoryServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
-			userId, parentCategoryId, name, description, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			serviceContext);
 	}
 
 	public static MBCategory addCategory(
-			long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean mailingListActive,
+			String externalReferenceCode, long parentCategoryId, String name,
+			String description, String displayStyle, String emailAddress,
+			String inProtocol, String inServerName, int inServerPort,
+			boolean inUseSSL, String inUserName, String inPassword,
+			int inReadInterval, String outEmailAddress, boolean outCustom,
+			String outServerName, int outServerPort, boolean outUseSSL,
+			String outUserName, String outPassword, boolean mailingListActive,
 			boolean allowAnonymousEmail,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addCategory(
-			parentCategoryId, name, description, displayStyle, emailAddress,
-			inProtocol, inServerName, inServerPort, inUseSSL, inUserName,
-			inPassword, inReadInterval, outEmailAddress, outCustom,
-			outServerName, outServerPort, outUseSSL, outUserName, outPassword,
-			mailingListActive, allowAnonymousEmail, serviceContext);
+			externalReferenceCode, parentCategoryId, name, description,
+			displayStyle, emailAddress, inProtocol, inServerName, inServerPort,
+			inUseSSL, inUserName, inPassword, inReadInterval, outEmailAddress,
+			outCustom, outServerName, outServerPort, outUseSSL, outUserName,
+			outPassword, mailingListActive, allowAnonymousEmail,
+			serviceContext);
 	}
 
 	public static void deleteCategory(
@@ -71,6 +74,13 @@ public class MBCategoryServiceUtil {
 		throws PortalException {
 
 		getService().deleteCategory(groupId, categoryId);
+	}
+
+	public static void deleteCategory(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		getService().deleteCategory(externalReferenceCode, groupId);
 	}
 
 	public static MBCategory fetchMBCategory(long groupId, String friendlyURL)

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBCategoryServiceWrapper.java
@@ -28,33 +28,36 @@ public class MBCategoryServiceWrapper
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbCategoryService.addCategory(
-			userId, parentCategoryId, name, description, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			serviceContext);
 	}
 
 	@Override
 	public MBCategory addCategory(
-			long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean mailingListActive,
+			String externalReferenceCode, long parentCategoryId, String name,
+			String description, String displayStyle, String emailAddress,
+			String inProtocol, String inServerName, int inServerPort,
+			boolean inUseSSL, String inUserName, String inPassword,
+			int inReadInterval, String outEmailAddress, boolean outCustom,
+			String outServerName, int outServerPort, boolean outUseSSL,
+			String outUserName, String outPassword, boolean mailingListActive,
 			boolean allowAnonymousEmail,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _mbCategoryService.addCategory(
-			parentCategoryId, name, description, displayStyle, emailAddress,
-			inProtocol, inServerName, inServerPort, inUseSSL, inUserName,
-			inPassword, inReadInterval, outEmailAddress, outCustom,
-			outServerName, outServerPort, outUseSSL, outUserName, outPassword,
-			mailingListActive, allowAnonymousEmail, serviceContext);
+			externalReferenceCode, parentCategoryId, name, description,
+			displayStyle, emailAddress, inProtocol, inServerName, inServerPort,
+			inUseSSL, inUserName, inPassword, inReadInterval, outEmailAddress,
+			outCustom, outServerName, outServerPort, outUseSSL, outUserName,
+			outPassword, mailingListActive, allowAnonymousEmail,
+			serviceContext);
 	}
 
 	@Override
@@ -69,6 +72,13 @@ public class MBCategoryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mbCategoryService.deleteCategory(groupId, categoryId);
+	}
+
+	@Override
+	public void deleteCategory(String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_mbCategoryService.deleteCategory(externalReferenceCode, groupId);
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBCategoryPersistence.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBCategoryPersistence.java
@@ -3039,6 +3039,56 @@ public interface MBCategoryPersistence
 		long[] categoryIds, long groupId, long[] parentCategoryIds, int status);
 
 	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCategoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category
+	 * @throws NoSuchCategoryException if a matching message boards category could not be found
+	 */
+	public MBCategory findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchCategoryException;
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	public MBCategory fetchByERC_G(String externalReferenceCode, long groupId);
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	public MBCategory fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
+
+	/**
+	 * Removes the message boards category where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the message boards category that was removed
+	 */
+	public MBCategory removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchCategoryException;
+
+	/**
+	 * Returns the number of message boards categories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching message boards categories
+	 */
+	public int countByERC_G(String externalReferenceCode, long groupId);
+
+	/**
 	 * Caches the message boards category in the entity cache if it is enabled.
 	 *
 	 * @param mbCategory the message boards category

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBCategoryUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/persistence/MBCategoryUtil.java
@@ -3754,6 +3754,74 @@ public class MBCategoryUtil {
 	}
 
 	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCategoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category
+	 * @throws NoSuchCategoryException if a matching message boards category could not be found
+	 */
+	public static MBCategory findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.message.boards.exception.NoSuchCategoryException {
+
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	public static MBCategory fetchByERC_G(
+		String externalReferenceCode, long groupId) {
+
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	public static MBCategory fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
+	}
+
+	/**
+	 * Removes the message boards category where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the message boards category that was removed
+	 */
+	public static MBCategory removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.message.boards.exception.NoSuchCategoryException {
+
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the number of message boards categories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching message boards categories
+	 */
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
 	 * Caches the message boards category in the entity cache if it is enabled.
 	 *
 	 * @param mbCategory the message boards category

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
@@ -1,1 +1,1 @@
-version 10.3.0
+version 10.4.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 11.0.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0

--- a/modules/apps/message-boards/message-boards-demo-data-creator-impl/src/main/java/com/liferay/message/boards/demo/data/creator/internal/BaseMBCategoryDemoDataCreatorImpl.java
+++ b/modules/apps/message-boards/message-boards-demo-data-creator-impl/src/main/java/com/liferay/message/boards/demo/data/creator/internal/BaseMBCategoryDemoDataCreatorImpl.java
@@ -39,7 +39,7 @@ public abstract class BaseMBCategoryDemoDataCreatorImpl
 		serviceContext.setScopeGroupId(groupId);
 
 		MBCategory category = mbCategoryLocalService.addCategory(
-			userId, categoryId, name, description, serviceContext);
+			null, userId, categoryId, name, description, serviceContext);
 
 		categoryIds.add(category.getCategoryId());
 

--- a/modules/apps/message-boards/message-boards-service/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards Service
 Bundle-SymbolicName: com.liferay.message.boards.service
 Bundle-Version: 5.0.107
-Liferay-Require-SchemaVersion: 6.5.1
+Liferay-Require-SchemaVersion: 6.6.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/message-boards/message-boards-service/service.xml
+++ b/modules/apps/message-boards/message-boards-service/service.xml
@@ -42,7 +42,7 @@
 			<finder-column name="banUserId" />
 		</finder>
 	</entity>
-	<entity human-name="message boards category" local-service="true" name="MBCategory" remote-service="true" trash-enabled="true" uuid="true">
+	<entity external-reference-code="group" human-name="message boards category" local-service="true" name="MBCategory" remote-service="true" trash-enabled="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
@@ -14,8 +14,11 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.service.MBCategoryLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
@@ -149,8 +152,15 @@ public class MBCategoryStagedModelDataHandler
 		MBCategory importedCategory = null;
 
 		if (portletDataContext.isDataStrategyMirror()) {
-			MBCategory existingCategory = fetchStagedModelByUuidAndGroupId(
-				category.getUuid(), portletDataContext.getScopeGroupId());
+			MBCategory existingCategory =
+				_fetchMBCategoryByExternalReferenceCode(
+					category.getExternalReferenceCode(),
+					portletDataContext.getScopeGroupId());
+
+			if (existingCategory == null) {
+				existingCategory = fetchStagedModelByUuidAndGroupId(
+					category.getUuid(), portletDataContext.getScopeGroupId());
+			}
 
 			if (existingCategory == null) {
 				serviceContext.setUuid(category.getUuid());
@@ -210,6 +220,36 @@ public class MBCategoryStagedModelDataHandler
 				existingCategory.getCategoryId());
 		}
 	}
+
+	private MBCategory _fetchMBCategoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		MBCategory mbCategory =
+			_mbCategoryLocalService.fetchMBCategoryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		if (mbCategory == null) {
+			if (_log.isDebugEnabled()) {
+				StringBundler sb = new StringBundler(6);
+
+				sb.append("No MBCategory exists with the key {");
+				sb.append("externalReferenceCode=");
+				sb.append(externalReferenceCode);
+				sb.append(", groupId=");
+				sb.append(groupId);
+				sb.append("}");
+
+				_log.debug(sb.toString());
+			}
+
+			return null;
+		}
+
+		return mbCategory;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MBCategoryStagedModelDataHandler.class);
 
 	@Reference
 	private MBCategoryLocalService _mbCategoryLocalService;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
@@ -156,7 +156,7 @@ public class MBCategoryStagedModelDataHandler
 				serviceContext.setUuid(category.getUuid());
 
 				importedCategory = _mbCategoryLocalService.addCategory(
-					userId, parentCategoryId, category.getName(),
+					null, userId, parentCategoryId, category.getName(),
 					category.getDescription(), category.getDisplayStyle(),
 					emailAddress, inProtocol, inServerName, inServerPort,
 					inUseSSL, inUserName, inPassword, inReadInterval,
@@ -178,7 +178,7 @@ public class MBCategoryStagedModelDataHandler
 		}
 		else {
 			importedCategory = _mbCategoryLocalService.addCategory(
-				userId, parentCategoryId, category.getName(),
+				null, userId, parentCategoryId, category.getName(),
 				category.getDescription(), category.getDisplayStyle(),
 				emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
 				inUserName, inPassword, inReadInterval, outEmailAddress,

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/exportimport/data/handler/MBCategoryStagedModelDataHandler.java
@@ -14,7 +14,6 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.service.MBCategoryLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -152,15 +151,8 @@ public class MBCategoryStagedModelDataHandler
 		MBCategory importedCategory = null;
 
 		if (portletDataContext.isDataStrategyMirror()) {
-			MBCategory existingCategory =
-				_fetchMBCategoryByExternalReferenceCode(
-					category.getExternalReferenceCode(),
-					portletDataContext.getScopeGroupId());
-
-			if (existingCategory == null) {
-				existingCategory = fetchStagedModelByUuidAndGroupId(
-					category.getUuid(), portletDataContext.getScopeGroupId());
-			}
+			MBCategory existingCategory = _fetchStagedModel(
+				category, portletDataContext.getScopeGroupId());
 
 			if (existingCategory == null) {
 				serviceContext.setUuid(category.getUuid());
@@ -221,31 +213,18 @@ public class MBCategoryStagedModelDataHandler
 		}
 	}
 
-	private MBCategory _fetchMBCategoryByExternalReferenceCode(
-		String externalReferenceCode, long groupId) {
-
-		MBCategory mbCategory =
-			_mbCategoryLocalService.fetchMBCategoryByExternalReferenceCode(
-				externalReferenceCode, groupId);
-
-		if (mbCategory == null) {
+	private MBCategory _fetchStagedModel(MBCategory category, long groupId) {
+		try {
+			return _mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
+				category.getExternalReferenceCode(), groupId);
+		}
+		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
-				StringBundler sb = new StringBundler(6);
-
-				sb.append("No MBCategory exists with the key {");
-				sb.append("externalReferenceCode=");
-				sb.append(externalReferenceCode);
-				sb.append(", groupId=");
-				sb.append(groupId);
-				sb.append("}");
-
-				_log.debug(sb.toString());
+				_log.debug(portalException);
 			}
-
-			return null;
 		}
 
-		return mbCategory;
+		return fetchStagedModelByUuidAndGroupId(category.getUuid(), groupId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/registry/MBServiceUpgradeStepRegistrator.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/registry/MBServiceUpgradeStepRegistrator.java
@@ -20,6 +20,7 @@ import com.liferay.message.boards.internal.upgrade.v3_0_0.MBMessageTreePathUpgra
 import com.liferay.message.boards.internal.upgrade.v3_1_0.UrlSubjectUpgradeProcess;
 import com.liferay.message.boards.internal.upgrade.v6_3_0.util.MBSuspiciousActivityTable;
 import com.liferay.message.boards.internal.upgrade.v6_5_0.FriendlyURLUpgradeProcess;
+import com.liferay.message.boards.internal.upgrade.v6_6_0.MBCategoryExternalReferenceCodeUpgradeProcess;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
@@ -158,6 +159,10 @@ public class MBServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 			"6.5.0", "6.5.1",
 			UpgradeProcessFactory.alterColumnType(
 				"MBCategory", "name", "VARCHAR(255) null"));
+
+		registry.register(
+			"6.5.1", "6.6.0",
+			new MBCategoryExternalReferenceCodeUpgradeProcess());
 	}
 
 	@Reference(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_6_0/MBCategoryExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v6_6_0/MBCategoryExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.internal.upgrade.v6_6_0;
+
+import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class MBCategoryExternalReferenceCodeUpgradeProcess
+	extends BaseExternalReferenceCodeUpgradeProcess {
+
+	@Override
+	protected String[][] getTableAndPrimaryKeyColumnNames() {
+		return new String[][] {{"MBCategory", "categoryId"}};
+	}
+
+}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBCategoryCacheModel.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBCategoryCacheModel.java
@@ -68,7 +68,7 @@ public class MBCategoryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(41);
+		StringBundler sb = new StringBundler(43);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -76,6 +76,8 @@ public class MBCategoryCacheModel
 		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", categoryId=");
 		sb.append(categoryId);
 		sb.append(", groupId=");
@@ -127,6 +129,13 @@ public class MBCategoryCacheModel
 		}
 		else {
 			mbCategoryImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			mbCategoryImpl.setExternalReferenceCode("");
+		}
+		else {
+			mbCategoryImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		mbCategoryImpl.setCategoryId(categoryId);
@@ -220,6 +229,7 @@ public class MBCategoryCacheModel
 
 		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		categoryId = objectInput.readLong();
 
@@ -257,6 +267,13 @@ public class MBCategoryCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(categoryId);
@@ -326,6 +343,7 @@ public class MBCategoryCacheModel
 	public long mvccVersion;
 	public long ctCollectionId;
 	public String uuid;
+	public String externalReferenceCode;
 	public long categoryId;
 	public long groupId;
 	public long companyId;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBCategoryModelImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBCategoryModelImpl.java
@@ -66,15 +66,16 @@ public class MBCategoryModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
-		{"uuid_", Types.VARCHAR}, {"categoryId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
-		{"parentCategoryId", Types.BIGINT}, {"name", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"displayStyle", Types.VARCHAR},
-		{"friendlyURL", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP},
-		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
-		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"categoryId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"parentCategoryId", Types.BIGINT},
+		{"name", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"displayStyle", Types.VARCHAR}, {"friendlyURL", Types.VARCHAR},
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
+		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
+		{"statusDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -84,6 +85,7 @@ public class MBCategoryModelImpl
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("categoryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -104,7 +106,7 @@ public class MBCategoryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table MBCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,name VARCHAR(255) null,description STRING null,displayStyle VARCHAR(75) null,friendlyURL VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (categoryId, ctCollectionId))";
+		"create table MBCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,name VARCHAR(255) null,description STRING null,displayStyle VARCHAR(75) null,friendlyURL VARCHAR(255) null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (categoryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table MBCategory";
 
@@ -139,38 +141,44 @@ public class MBCategoryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long FRIENDLYURL_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 8L;
+	public static final long FRIENDLYURL_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PARENTCATEGORYID_COLUMN_BITMASK = 16L;
+	public static final long GROUPID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long STATUS_COLUMN_BITMASK = 32L;
+	public static final long PARENTCATEGORYID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long STATUS_COLUMN_BITMASK = 64L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 128L;
+	public static final long NAME_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -285,6 +293,8 @@ public class MBCategoryModelImpl
 				"ctCollectionId", MBCategory::getCtCollectionId);
 			attributeGetterFunctions.put("uuid", MBCategory::getUuid);
 			attributeGetterFunctions.put(
+				"externalReferenceCode", MBCategory::getExternalReferenceCode);
+			attributeGetterFunctions.put(
 				"categoryId", MBCategory::getCategoryId);
 			attributeGetterFunctions.put("groupId", MBCategory::getGroupId);
 			attributeGetterFunctions.put("companyId", MBCategory::getCompanyId);
@@ -336,6 +346,10 @@ public class MBCategoryModelImpl
 				(BiConsumer<MBCategory, Long>)MBCategory::setCtCollectionId);
 			attributeSetterBiConsumers.put(
 				"uuid", (BiConsumer<MBCategory, String>)MBCategory::setUuid);
+			attributeSetterBiConsumers.put(
+				"externalReferenceCode",
+				(BiConsumer<MBCategory, String>)
+					MBCategory::setExternalReferenceCode);
 			attributeSetterBiConsumers.put(
 				"categoryId",
 				(BiConsumer<MBCategory, Long>)MBCategory::setCategoryId);
@@ -450,6 +464,35 @@ public class MBCategoryModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1018,6 +1061,7 @@ public class MBCategoryModelImpl
 		mbCategoryImpl.setMvccVersion(getMvccVersion());
 		mbCategoryImpl.setCtCollectionId(getCtCollectionId());
 		mbCategoryImpl.setUuid(getUuid());
+		mbCategoryImpl.setExternalReferenceCode(getExternalReferenceCode());
 		mbCategoryImpl.setCategoryId(getCategoryId());
 		mbCategoryImpl.setGroupId(getGroupId());
 		mbCategoryImpl.setCompanyId(getCompanyId());
@@ -1050,6 +1094,8 @@ public class MBCategoryModelImpl
 		mbCategoryImpl.setCtCollectionId(
 			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		mbCategoryImpl.setUuid(this.<String>getColumnOriginalValue("uuid_"));
+		mbCategoryImpl.setExternalReferenceCode(
+			this.<String>getColumnOriginalValue("externalReferenceCode"));
 		mbCategoryImpl.setCategoryId(
 			this.<Long>getColumnOriginalValue("categoryId"));
 		mbCategoryImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
@@ -1180,6 +1226,17 @@ public class MBCategoryModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			mbCategoryCacheModel.uuid = null;
+		}
+
+		mbCategoryCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode =
+			mbCategoryCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			mbCategoryCacheModel.externalReferenceCode = null;
 		}
 
 		mbCategoryCacheModel.categoryId = getCategoryId();
@@ -1344,6 +1401,7 @@ public class MBCategoryModelImpl
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _categoryId;
 	private long _groupId;
 	private long _companyId;
@@ -1396,6 +1454,8 @@ public class MBCategoryModelImpl
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("categoryId", _categoryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1442,39 +1502,41 @@ public class MBCategoryModelImpl
 
 		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("categoryId", 8L);
+		columnBitmasks.put("externalReferenceCode", 8L);
 
-		columnBitmasks.put("groupId", 16L);
+		columnBitmasks.put("categoryId", 16L);
 
-		columnBitmasks.put("companyId", 32L);
+		columnBitmasks.put("groupId", 32L);
 
-		columnBitmasks.put("userId", 64L);
+		columnBitmasks.put("companyId", 64L);
 
-		columnBitmasks.put("userName", 128L);
+		columnBitmasks.put("userId", 128L);
 
-		columnBitmasks.put("createDate", 256L);
+		columnBitmasks.put("userName", 256L);
 
-		columnBitmasks.put("modifiedDate", 512L);
+		columnBitmasks.put("createDate", 512L);
 
-		columnBitmasks.put("parentCategoryId", 1024L);
+		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("name", 2048L);
+		columnBitmasks.put("parentCategoryId", 2048L);
 
-		columnBitmasks.put("description", 4096L);
+		columnBitmasks.put("name", 4096L);
 
-		columnBitmasks.put("displayStyle", 8192L);
+		columnBitmasks.put("description", 8192L);
 
-		columnBitmasks.put("friendlyURL", 16384L);
+		columnBitmasks.put("displayStyle", 16384L);
 
-		columnBitmasks.put("lastPublishDate", 32768L);
+		columnBitmasks.put("friendlyURL", 32768L);
 
-		columnBitmasks.put("status", 65536L);
+		columnBitmasks.put("lastPublishDate", 65536L);
 
-		columnBitmasks.put("statusByUserId", 131072L);
+		columnBitmasks.put("status", 131072L);
 
-		columnBitmasks.put("statusByUserName", 262144L);
+		columnBitmasks.put("statusByUserId", 262144L);
 
-		columnBitmasks.put("statusDate", 524288L);
+		columnBitmasks.put("statusByUserName", 524288L);
+
+		columnBitmasks.put("statusDate", 1048576L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBCategoryLocalServiceBaseImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/base/MBCategoryLocalServiceBaseImpl.java
@@ -265,6 +265,23 @@ public abstract class MBCategoryLocalServiceBaseImpl
 		return mbCategoryPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
+	@Override
+	public MBCategory fetchMBCategoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return mbCategoryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
+	public MBCategory getMBCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return mbCategoryPersistence.findByERC_G(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the message boards category with the primary key.
 	 *

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBCategoryServiceHttp.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBCategoryServiceHttp.java
@@ -42,8 +42,8 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class MBCategoryServiceHttp {
 
 	public static com.liferay.message.boards.model.MBCategory addCategory(
-			HttpPrincipal httpPrincipal, long userId, long parentCategoryId,
-			String name, String description,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long userId, long parentCategoryId, String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -53,8 +53,8 @@ public class MBCategoryServiceHttp {
 				_addCategoryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, userId, parentCategoryId, name, description,
-				serviceContext);
+				methodKey, externalReferenceCode, userId, parentCategoryId,
+				name, description, serviceContext);
 
 			Object returnObj = null;
 
@@ -85,13 +85,14 @@ public class MBCategoryServiceHttp {
 	}
 
 	public static com.liferay.message.boards.model.MBCategory addCategory(
-			HttpPrincipal httpPrincipal, long parentCategoryId, String name,
-			String description, String displayStyle, String emailAddress,
-			String inProtocol, String inServerName, int inServerPort,
-			boolean inUseSSL, String inUserName, String inPassword,
-			int inReadInterval, String outEmailAddress, boolean outCustom,
-			String outServerName, int outServerPort, boolean outUseSSL,
-			String outUserName, String outPassword, boolean mailingListActive,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long parentCategoryId, String name, String description,
+			String displayStyle, String emailAddress, String inProtocol,
+			String inServerName, int inServerPort, boolean inUseSSL,
+			String inUserName, String inPassword, int inReadInterval,
+			String outEmailAddress, boolean outCustom, String outServerName,
+			int outServerPort, boolean outUseSSL, String outUserName,
+			String outPassword, boolean mailingListActive,
 			boolean allowAnonymousEmail,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -102,12 +103,12 @@ public class MBCategoryServiceHttp {
 				_addCategoryParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, parentCategoryId, name, description, displayStyle,
-				emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
-				inUserName, inPassword, inReadInterval, outEmailAddress,
-				outCustom, outServerName, outServerPort, outUseSSL, outUserName,
-				outPassword, mailingListActive, allowAnonymousEmail,
-				serviceContext);
+				methodKey, externalReferenceCode, parentCategoryId, name,
+				description, displayStyle, emailAddress, inProtocol,
+				inServerName, inServerPort, inUseSSL, inUserName, inPassword,
+				inReadInterval, outEmailAddress, outCustom, outServerName,
+				outServerPort, outUseSSL, outUserName, outPassword,
+				mailingListActive, allowAnonymousEmail, serviceContext);
 
 			Object returnObj = null;
 
@@ -210,6 +211,43 @@ public class MBCategoryServiceHttp {
 		}
 	}
 
+	public static void deleteCategory(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				MBCategoryServiceUtil.class, "deleteCategory",
+				_deleteCategoryParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.message.boards.model.MBCategory fetchMBCategory(
 			HttpPrincipal httpPrincipal, long groupId, String friendlyURL)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -217,7 +255,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "fetchMBCategory",
-				_fetchMBCategoryParameterTypes4);
+				_fetchMBCategoryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, friendlyURL);
@@ -256,7 +294,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes5);
+				_getCategoriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -288,7 +326,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes6);
+				_getCategoriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -323,7 +361,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes7);
+				_getCategoriesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId, start, end);
@@ -358,7 +396,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes8);
+				_getCategoriesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId, status, start, end);
@@ -393,7 +431,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes9);
+				_getCategoriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, excludedCategoryId, parentCategoryId,
@@ -433,7 +471,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes10);
+				_getCategoriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId, queryDefinition);
@@ -475,7 +513,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes11);
+				_getCategoriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryIds, start, end);
@@ -510,7 +548,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes12);
+				_getCategoriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryIds, status, start, end);
@@ -546,7 +584,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategories",
-				_getCategoriesParameterTypes13);
+				_getCategoriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, excludedCategoryIds, parentCategoryIds,
@@ -580,7 +618,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreads",
-				_getCategoriesAndThreadsParameterTypes14);
+				_getCategoriesAndThreadsParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId);
@@ -613,7 +651,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreads",
-				_getCategoriesAndThreadsParameterTypes15);
+				_getCategoriesAndThreadsParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, status);
@@ -646,7 +684,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreads",
-				_getCategoriesAndThreadsParameterTypes16);
+				_getCategoriesAndThreadsParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, status, start, end);
@@ -680,7 +718,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreads",
-				_getCategoriesAndThreadsParameterTypes17);
+				_getCategoriesAndThreadsParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, status, start, end,
@@ -716,7 +754,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreads",
-				_getCategoriesAndThreadsParameterTypes18);
+				_getCategoriesAndThreadsParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, queryDefinition);
@@ -755,7 +793,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreadsCount",
-				_getCategoriesAndThreadsCountParameterTypes19);
+				_getCategoriesAndThreadsCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId);
@@ -788,7 +826,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreadsCount",
-				_getCategoriesAndThreadsCountParameterTypes20);
+				_getCategoriesAndThreadsCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, status);
@@ -823,7 +861,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesAndThreadsCount",
-				_getCategoriesAndThreadsCountParameterTypes21);
+				_getCategoriesAndThreadsCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, queryDefinition);
@@ -862,7 +900,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes22);
+				_getCategoriesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId);
@@ -895,7 +933,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes23);
+				_getCategoriesCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId, status);
@@ -928,7 +966,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes24);
+				_getCategoriesCountParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, excludedCategoryId, parentCategoryId,
@@ -964,7 +1002,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes25);
+				_getCategoriesCountParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryId, queryDefinition);
@@ -1003,7 +1041,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes26);
+				_getCategoriesCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryIds);
@@ -1036,7 +1074,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes27);
+				_getCategoriesCountParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentCategoryIds, status);
@@ -1069,7 +1107,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoriesCount",
-				_getCategoriesCountParameterTypes28);
+				_getCategoriesCountParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, excludedCategoryIds, parentCategoryIds,
@@ -1103,7 +1141,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategory",
-				_getCategoryParameterTypes29);
+				_getCategoryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId);
@@ -1142,7 +1180,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getCategoryIds",
-				_getCategoryIdsParameterTypes30);
+				_getCategoryIdsParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId);
@@ -1175,7 +1213,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getMBCategory",
-				_getMBCategoryParameterTypes31);
+				_getMBCategoryParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, friendlyURL);
@@ -1215,7 +1253,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getSubcategoryIds",
-				_getSubcategoryIdsParameterTypes32);
+				_getSubcategoryIdsParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryIds, groupId, categoryId);
@@ -1249,7 +1287,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getSubscribedCategories",
-				_getSubscribedCategoriesParameterTypes33);
+				_getSubscribedCategoriesParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, start, end);
@@ -1282,7 +1320,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "getSubscribedCategoriesCount",
-				_getSubscribedCategoriesCountParameterTypes34);
+				_getSubscribedCategoriesCountParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId);
@@ -1316,7 +1354,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "moveCategory",
-				_moveCategoryParameterTypes35);
+				_moveCategoryParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId, parentCategoryId,
@@ -1359,7 +1397,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "moveCategoryFromTrash",
-				_moveCategoryFromTrashParameterTypes36);
+				_moveCategoryFromTrashParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId, newCategoryId);
@@ -1399,7 +1437,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "moveCategoryToTrash",
-				_moveCategoryToTrashParameterTypes37);
+				_moveCategoryToTrashParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId);
@@ -1439,7 +1477,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "restoreCategoryFromTrash",
-				_restoreCategoryFromTrashParameterTypes38);
+				_restoreCategoryFromTrashParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId);
@@ -1475,7 +1513,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "subscribeCategory",
-				_subscribeCategoryParameterTypes39);
+				_subscribeCategoryParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId);
@@ -1511,7 +1549,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "unsubscribeCategory",
-				_unsubscribeCategoryParameterTypes40);
+				_unsubscribeCategoryParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId);
@@ -1556,7 +1594,7 @@ public class MBCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBCategoryServiceUtil.class, "updateCategory",
-				_updateCategoryParameterTypes41);
+				_updateCategoryParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, categoryId, parentCategoryId, name, description,
@@ -1598,122 +1636,125 @@ public class MBCategoryServiceHttp {
 		MBCategoryServiceHttp.class);
 
 	private static final Class<?>[] _addCategoryParameterTypes0 = new Class[] {
-		long.class, long.class, String.class, String.class,
+		String.class, long.class, long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _addCategoryParameterTypes1 = new Class[] {
-		long.class, String.class, String.class, String.class, String.class,
-		String.class, String.class, int.class, boolean.class, String.class,
-		String.class, int.class, String.class, boolean.class, String.class,
-		int.class, boolean.class, String.class, String.class, boolean.class,
-		boolean.class, com.liferay.portal.kernel.service.ServiceContext.class
+		String.class, long.class, String.class, String.class, String.class,
+		String.class, String.class, String.class, int.class, boolean.class,
+		String.class, String.class, int.class, String.class, boolean.class,
+		String.class, int.class, boolean.class, String.class, String.class,
+		boolean.class, boolean.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _deleteCategoryParameterTypes2 =
 		new Class[] {long.class, boolean.class};
 	private static final Class<?>[] _deleteCategoryParameterTypes3 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _fetchMBCategoryParameterTypes4 =
+	private static final Class<?>[] _deleteCategoryParameterTypes4 =
+		new Class[] {String.class, long.class};
+	private static final Class<?>[] _fetchMBCategoryParameterTypes5 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getCategoriesParameterTypes5 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getCategoriesParameterTypes6 =
-		new Class[] {long.class, int.class};
+		new Class[] {long.class};
 	private static final Class<?>[] _getCategoriesParameterTypes7 =
-		new Class[] {long.class, long.class, int.class, int.class};
+		new Class[] {long.class, int.class};
 	private static final Class<?>[] _getCategoriesParameterTypes8 =
-		new Class[] {long.class, long.class, int.class, int.class, int.class};
+		new Class[] {long.class, long.class, int.class, int.class};
 	private static final Class<?>[] _getCategoriesParameterTypes9 =
+		new Class[] {long.class, long.class, int.class, int.class, int.class};
+	private static final Class<?>[] _getCategoriesParameterTypes10 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCategoriesParameterTypes10 =
+	private static final Class<?>[] _getCategoriesParameterTypes11 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.dao.orm.QueryDefinition.class
 		};
-	private static final Class<?>[] _getCategoriesParameterTypes11 =
-		new Class[] {long.class, long[].class, int.class, int.class};
 	private static final Class<?>[] _getCategoriesParameterTypes12 =
-		new Class[] {long.class, long[].class, int.class, int.class, int.class};
+		new Class[] {long.class, long[].class, int.class, int.class};
 	private static final Class<?>[] _getCategoriesParameterTypes13 =
+		new Class[] {long.class, long[].class, int.class, int.class, int.class};
+	private static final Class<?>[] _getCategoriesParameterTypes14 =
 		new Class[] {
 			long.class, long[].class, long[].class, int.class, int.class,
 			int.class
 		};
-	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes14 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes15 =
-		new Class[] {long.class, long.class, int.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes16 =
-		new Class[] {long.class, long.class, int.class, int.class, int.class};
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes17 =
+		new Class[] {long.class, long.class, int.class, int.class, int.class};
+	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes18 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes18 =
+	private static final Class<?>[] _getCategoriesAndThreadsParameterTypes19 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.dao.orm.QueryDefinition.class
-		};
-	private static final Class<?>[]
-		_getCategoriesAndThreadsCountParameterTypes19 = new Class[] {
-			long.class, long.class
 		};
 	private static final Class<?>[]
 		_getCategoriesAndThreadsCountParameterTypes20 = new Class[] {
-			long.class, long.class, int.class
+			long.class, long.class
 		};
 	private static final Class<?>[]
 		_getCategoriesAndThreadsCountParameterTypes21 = new Class[] {
+			long.class, long.class, int.class
+		};
+	private static final Class<?>[]
+		_getCategoriesAndThreadsCountParameterTypes22 = new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.dao.orm.QueryDefinition.class
 		};
-	private static final Class<?>[] _getCategoriesCountParameterTypes22 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getCategoriesCountParameterTypes23 =
-		new Class[] {long.class, long.class, int.class};
+		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getCategoriesCountParameterTypes24 =
-		new Class[] {long.class, long.class, long.class, int.class};
+		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getCategoriesCountParameterTypes25 =
+		new Class[] {long.class, long.class, long.class, int.class};
+	private static final Class<?>[] _getCategoriesCountParameterTypes26 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.dao.orm.QueryDefinition.class
 		};
-	private static final Class<?>[] _getCategoriesCountParameterTypes26 =
-		new Class[] {long.class, long[].class};
 	private static final Class<?>[] _getCategoriesCountParameterTypes27 =
-		new Class[] {long.class, long[].class, int.class};
+		new Class[] {long.class, long[].class};
 	private static final Class<?>[] _getCategoriesCountParameterTypes28 =
+		new Class[] {long.class, long[].class, int.class};
+	private static final Class<?>[] _getCategoriesCountParameterTypes29 =
 		new Class[] {long.class, long[].class, long[].class, int.class};
-	private static final Class<?>[] _getCategoryParameterTypes29 = new Class[] {
+	private static final Class<?>[] _getCategoryParameterTypes30 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getCategoryIdsParameterTypes30 =
+	private static final Class<?>[] _getCategoryIdsParameterTypes31 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getMBCategoryParameterTypes31 =
+	private static final Class<?>[] _getMBCategoryParameterTypes32 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getSubcategoryIdsParameterTypes32 =
+	private static final Class<?>[] _getSubcategoryIdsParameterTypes33 =
 		new Class[] {java.util.List.class, long.class, long.class};
-	private static final Class<?>[] _getSubscribedCategoriesParameterTypes33 =
+	private static final Class<?>[] _getSubscribedCategoriesParameterTypes34 =
 		new Class[] {long.class, long.class, int.class, int.class};
 	private static final Class<?>[]
-		_getSubscribedCategoriesCountParameterTypes34 = new Class[] {
+		_getSubscribedCategoriesCountParameterTypes35 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _moveCategoryParameterTypes35 =
+	private static final Class<?>[] _moveCategoryParameterTypes36 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _moveCategoryFromTrashParameterTypes36 =
+	private static final Class<?>[] _moveCategoryFromTrashParameterTypes37 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _moveCategoryToTrashParameterTypes37 =
+	private static final Class<?>[] _moveCategoryToTrashParameterTypes38 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreCategoryFromTrashParameterTypes38 =
+	private static final Class<?>[] _restoreCategoryFromTrashParameterTypes39 =
 		new Class[] {long.class};
-	private static final Class<?>[] _subscribeCategoryParameterTypes39 =
+	private static final Class<?>[] _subscribeCategoryParameterTypes40 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _unsubscribeCategoryParameterTypes40 =
+	private static final Class<?>[] _unsubscribeCategoryParameterTypes41 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _updateCategoryParameterTypes41 =
+	private static final Class<?>[] _updateCategoryParameterTypes42 =
 		new Class[] {
 			long.class, long.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, int.class, boolean.class,

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -67,12 +67,12 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException {
 
 		return mbCategoryLocalService.addCategory(
-			userId, parentCategoryId, name, description,
+			externalReferenceCode, userId, parentCategoryId, name, description,
 			MBCategoryConstants.DEFAULT_DISPLAY_STYLE, null, null, null, 0,
 			false, null, null, 0, null, false, null, 0, false, null, null,
 			false, false, serviceContext);
@@ -80,14 +80,15 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean allowAnonymous,
-			boolean mailingListActive, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, String displayStyle,
+			String emailAddress, String inProtocol, String inServerName,
+			int inServerPort, boolean inUseSSL, String inUserName,
+			String inPassword, int inReadInterval, String outEmailAddress,
+			boolean outCustom, String outServerName, int outServerPort,
+			boolean outUseSSL, String outUserName, String outPassword,
+			boolean allowAnonymous, boolean mailingListActive,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Category
@@ -105,6 +106,7 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 		MBCategory category = mbCategoryPersistence.create(categoryId);
 
 		category.setUuid(serviceContext.getUuid());
+		category.setExternalReferenceCode(externalReferenceCode);
 		category.setGroupId(groupId);
 		category.setCompanyId(user.getCompanyId());
 		category.setUserId(user.getUserId());

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -307,6 +307,14 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 	}
 
 	@Override
+	public void deleteCategory(String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		mbCategoryLocalService.deleteCategory(
+			mbCategoryPersistence.findByERC_G(externalReferenceCode, groupId));
+	}
+
+	@Override
 	public MBCategory fetchMBCategory(long groupId, String friendlyURL) {
 		return mbCategoryPersistence.fetchByG_F(
 			groupId,

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryLocalServiceImpl.java
@@ -307,7 +307,8 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void deleteCategory(String externalReferenceCode, long groupId)
+	public void deleteCategoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		mbCategoryLocalService.deleteCategory(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
@@ -105,6 +105,20 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 	}
 
 	@Override
+	public void deleteCategory(String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		MBCategory category =
+			mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		_categoryModelResourcePermission.check(
+			getPermissionChecker(), category, ActionKeys.DELETE);
+
+		mbCategoryLocalService.deleteCategory(category);
+	}
+
+	@Override
 	public MBCategory fetchMBCategory(long groupId, String friendlyURL)
 		throws PortalException {
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBCategoryServiceImpl.java
@@ -40,8 +40,8 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 
 	@Override
 	public MBCategory addCategory(
-			long userId, long parentCategoryId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long parentCategoryId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException {
 
 		ModelResourcePermissionUtil.check(
@@ -50,18 +50,19 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 			ActionKeys.ADD_CATEGORY);
 
 		return mbCategoryLocalService.addCategory(
-			userId, parentCategoryId, name, description, serviceContext);
+			externalReferenceCode, userId, parentCategoryId, name, description,
+			serviceContext);
 	}
 
 	@Override
 	public MBCategory addCategory(
-			long parentCategoryId, String name, String description,
-			String displayStyle, String emailAddress, String inProtocol,
-			String inServerName, int inServerPort, boolean inUseSSL,
-			String inUserName, String inPassword, int inReadInterval,
-			String outEmailAddress, boolean outCustom, String outServerName,
-			int outServerPort, boolean outUseSSL, String outUserName,
-			String outPassword, boolean mailingListActive,
+			String externalReferenceCode, long parentCategoryId, String name,
+			String description, String displayStyle, String emailAddress,
+			String inProtocol, String inServerName, int inServerPort,
+			boolean inUseSSL, String inUserName, String inPassword,
+			int inReadInterval, String outEmailAddress, boolean outCustom,
+			String outServerName, int outServerPort, boolean outUseSSL,
+			String outUserName, String outPassword, boolean mailingListActive,
 			boolean allowAnonymousEmail, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -71,11 +72,12 @@ public class MBCategoryServiceImpl extends MBCategoryServiceBaseImpl {
 			ActionKeys.ADD_CATEGORY);
 
 		return mbCategoryLocalService.addCategory(
-			getUserId(), parentCategoryId, name, description, displayStyle,
-			emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
-			inUserName, inPassword, inReadInterval, outEmailAddress, outCustom,
-			outServerName, outServerPort, outUseSSL, outUserName, outPassword,
-			mailingListActive, allowAnonymousEmail, serviceContext);
+			externalReferenceCode, getUserId(), parentCategoryId, name,
+			description, displayStyle, emailAddress, inProtocol, inServerName,
+			inServerPort, inUseSSL, inUserName, inPassword, inReadInterval,
+			outEmailAddress, outCustom, outServerName, outServerPort, outUseSSL,
+			outUserName, outPassword, mailingListActive, allowAnonymousEmail,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBCategoryPersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBCategoryPersistenceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.message.boards.service.persistence.impl;
 
+import com.liferay.message.boards.exception.DuplicateMBCategoryExternalReferenceCodeException;
 import com.liferay.message.boards.exception.NoSuchCategoryException;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBCategoryTable;
@@ -27,15 +28,21 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelper;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -11788,6 +11795,267 @@ public class MBCategoryPersistenceImpl
 	private static final String _FINDER_COLUMN_NOTC_G_P_S_STATUS_2 =
 		"mbCategory.status = ?";
 
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCategoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category
+	 * @throws NoSuchCategoryException if a matching message boards category could not be found
+	 */
+	@Override
+	public MBCategory findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchCategoryException {
+
+		MBCategory mbCategory = fetchByERC_G(externalReferenceCode, groupId);
+
+		if (mbCategory == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchCategoryException(sb.toString());
+		}
+
+		return mbCategory;
+	}
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	@Override
+	public MBCategory fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
+	}
+
+	/**
+	 * Returns the message boards category where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching message boards category, or <code>null</code> if a matching message boards category could not be found
+	 */
+	@Override
+	public MBCategory fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					MBCategory.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			Object[] finderArgs = null;
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {externalReferenceCode, groupId};
+			}
+
+			Object result = null;
+
+			if (useFinderCache) {
+				result = finderCache.getResult(
+					_finderPathFetchByERC_G, finderArgs, this);
+			}
+
+			if (result instanceof MBCategory) {
+				MBCategory mbCategory = (MBCategory)result;
+
+				if (!Objects.equals(
+						externalReferenceCode,
+						mbCategory.getExternalReferenceCode()) ||
+					(groupId != mbCategory.getGroupId())) {
+
+					result = null;
+				}
+			}
+
+			if (result == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_SELECT_MBCATEGORY_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					List<MBCategory> list = query.list();
+
+					if (list.isEmpty()) {
+						if (useFinderCache) {
+							finderCache.putResult(
+								_finderPathFetchByERC_G, finderArgs, list);
+						}
+					}
+					else {
+						MBCategory mbCategory = list.get(0);
+
+						result = mbCategory;
+
+						cacheResult(mbCategory);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			if (result instanceof List<?>) {
+				return null;
+			}
+			else {
+				return (MBCategory)result;
+			}
+		}
+	}
+
+	/**
+	 * Removes the message boards category where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the message boards category that was removed
+	 */
+	@Override
+	public MBCategory removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchCategoryException {
+
+		MBCategory mbCategory = findByERC_G(externalReferenceCode, groupId);
+
+		return remove(mbCategory);
+	}
+
+	/**
+	 * Returns the number of message boards categories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching message boards categories
+	 */
+	@Override
+	public int countByERC_G(String externalReferenceCode, long groupId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					MBCategory.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			FinderPath finderPath = _finderPathCountByERC_G;
+
+			Object[] finderArgs = new Object[] {externalReferenceCode, groupId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_MBCATEGORY_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"mbCategory.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(mbCategory.externalReferenceCode IS NULL OR mbCategory.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"mbCategory.groupId = ?";
+
 	public MBCategoryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -11826,6 +12094,14 @@ public class MBCategoryPersistenceImpl
 				_finderPathFetchByG_F,
 				new Object[] {
 					mbCategory.getGroupId(), mbCategory.getFriendlyURL()
+				},
+				mbCategory);
+
+			finderCache.putResult(
+				_finderPathFetchByERC_G,
+				new Object[] {
+					mbCategory.getExternalReferenceCode(),
+					mbCategory.getGroupId()
 				},
 				mbCategory);
 		}
@@ -11928,6 +12204,16 @@ public class MBCategoryPersistenceImpl
 			finderCache.putResult(_finderPathCountByG_F, args, Long.valueOf(1));
 			finderCache.putResult(
 				_finderPathFetchByG_F, args, mbCategoryModelImpl);
+
+			args = new Object[] {
+				mbCategoryModelImpl.getExternalReferenceCode(),
+				mbCategoryModelImpl.getGroupId()
+			};
+
+			finderCache.putResult(
+				_finderPathCountByERC_G, args, Long.valueOf(1));
+			finderCache.putResult(
+				_finderPathFetchByERC_G, args, mbCategoryModelImpl);
 		}
 	}
 
@@ -12065,6 +12351,67 @@ public class MBCategoryPersistenceImpl
 			String uuid = PortalUUIDUtil.generate();
 
 			mbCategory.setUuid(uuid);
+		}
+
+		if (Validator.isNull(mbCategory.getExternalReferenceCode())) {
+			mbCategory.setExternalReferenceCode(mbCategory.getUuid());
+		}
+		else {
+			if (!Objects.equals(
+					mbCategoryModelImpl.getColumnOriginalValue(
+						"externalReferenceCode"),
+					mbCategory.getExternalReferenceCode())) {
+
+				long userId = GetterUtil.getLong(
+					PrincipalThreadLocal.getName());
+
+				if (userId > 0) {
+					long companyId = mbCategory.getCompanyId();
+
+					long groupId = mbCategory.getGroupId();
+
+					long classPK = 0;
+
+					if (!isNew) {
+						classPK = mbCategory.getPrimaryKey();
+					}
+
+					try {
+						mbCategory.setExternalReferenceCode(
+							SanitizerUtil.sanitize(
+								companyId, groupId, userId,
+								MBCategory.class.getName(), classPK,
+								ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+								mbCategory.getExternalReferenceCode(), null));
+					}
+					catch (SanitizerException sanitizerException) {
+						throw new SystemException(sanitizerException);
+					}
+				}
+			}
+
+			MBCategory ercMBCategory = fetchByERC_G(
+				mbCategory.getExternalReferenceCode(), mbCategory.getGroupId());
+
+			if (isNew) {
+				if (ercMBCategory != null) {
+					throw new DuplicateMBCategoryExternalReferenceCodeException(
+						"Duplicate message boards category with external reference code " +
+							mbCategory.getExternalReferenceCode() +
+								" and group " + mbCategory.getGroupId());
+				}
+			}
+			else {
+				if ((ercMBCategory != null) &&
+					(mbCategory.getCategoryId() !=
+						ercMBCategory.getCategoryId())) {
+
+					throw new DuplicateMBCategoryExternalReferenceCodeException(
+						"Duplicate message boards category with external reference code " +
+							mbCategory.getExternalReferenceCode() +
+								" and group " + mbCategory.getGroupId());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -12603,6 +12950,7 @@ public class MBCategoryPersistenceImpl
 		ctControlColumnNames.add("mvccVersion");
 		ctControlColumnNames.add("ctCollectionId");
 		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctStrictColumnNames.add("userId");
@@ -12632,6 +12980,9 @@ public class MBCategoryPersistenceImpl
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
 
 		_uniqueIndexColumnNames.add(new String[] {"groupId", "friendlyURL"});
+
+		_uniqueIndexColumnNames.add(
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -12898,6 +13249,16 @@ public class MBCategoryPersistenceImpl
 				"categoryId", "groupId", "parentCategoryId", "status"
 			},
 			false);
+
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
+
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		MBCategoryUtil.setPersistence(this);
 	}

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/module-hbm.xml
@@ -33,6 +33,7 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -19,6 +19,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="categoryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
@@ -4,6 +4,7 @@ create index IX_48814BBA on MBBan (userId);
 create unique index IX_6F119354 on MBBan (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create index IX_BC735DCF on MBCategory (companyId);
+create unique index IX_ED533FEE on MBCategory (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create unique index IX_B73EC7E5 on MBCategory (groupId, ctCollectionId, friendlyURL[$COLUMN_LENGTH:255$]);
 create index IX_72DC3FF5 on MBCategory (groupId, parentCategoryId, categoryId);
 create index IX_F69FCDDB on MBCategory (groupId, parentCategoryId, status, categoryId);

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
@@ -18,6 +18,7 @@ create table MBCategory (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	categoryId LONG not null,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/attachments/test/MBAttachmentsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/attachments/test/MBAttachmentsTest.java
@@ -296,7 +296,7 @@ public class MBAttachmentsTest {
 		}
 
 		_category = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/change/tracking/test/MBCategoryTableReferenceDefinitionTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/change/tracking/test/MBCategoryTableReferenceDefinitionTest.java
@@ -38,7 +38,7 @@ public class MBCategoryTableReferenceDefinitionTest
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
 		return _mbCategoryLocalService.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			MBCategoryTableReferenceDefinitionTest.class.getSimpleName(),
 			MBCategoryTableReferenceDefinitionTest.class.getName(),

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/change/tracking/test/MBMailingListTableReferenceDefinitionTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/change/tracking/test/MBMailingListTableReferenceDefinitionTest.java
@@ -45,7 +45,7 @@ public class MBMailingListTableReferenceDefinitionTest
 		super.setUp();
 
 		_mbCategory = _mbCategoryLocalService.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			MBCategoryTableReferenceDefinitionTest.class.getSimpleName(),
 			MBCategoryTableReferenceDefinitionTest.class.getName(),

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBCategoryStagedModelDataHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBCategoryStagedModelDataHandlerTest.java
@@ -51,7 +51,7 @@ public class MBCategoryStagedModelDataHandlerTest
 			new HashMap<>();
 
 		MBCategory category = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
@@ -75,7 +75,7 @@ public class MBCategoryStagedModelDataHandlerTest
 		MBCategory category = (MBCategory)dependentStagedModels.get(0);
 
 		return MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(), category.getCategoryId(),
+			null, TestPropsValues.getUserId(), category.getCategoryId(),
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
 				group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBMessageStagedModelDataHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBMessageStagedModelDataHandlerTest.java
@@ -135,7 +135,7 @@ public class MBMessageStagedModelDataHandlerTest
 		exportImportStagedModel(mbMessage);
 
 		MBCategory mbCategory = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
@@ -170,7 +170,7 @@ public class MBMessageStagedModelDataHandlerTest
 			new HashMap<>();
 
 		MBCategory category = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBPortletDataHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/exportimport/data/handler/test/MBPortletDataHandlerTest.java
@@ -74,12 +74,12 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory parentCategory = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategory childCategory = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentCategory.getCategoryId(),
+			null, TestPropsValues.getUserId(), parentCategory.getCategoryId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategoryLocalServiceUtil.moveCategoryToTrash(
@@ -113,7 +113,7 @@ public class MBPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 				stagingGroup.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category = MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_5_0/test/FriendlyURLUpgradeProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_5_0/test/FriendlyURLUpgradeProcessTest.java
@@ -61,7 +61,7 @@ public class FriendlyURLUpgradeProcessTest {
 				CTCollectionThreadLocal.setProductionModeWithSafeCloseable()) {
 
 			productionMBCategory = _mbCategoryLocalService.addCategory(
-				TestPropsValues.getUserId(),
+				null, TestPropsValues.getUserId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				StringUtil.randomString(), StringUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_6_0/test/MBCategoryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_6_0/test/MBCategoryExternalReferenceCodeUpgradeProcessTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.service.MBCategoryLocalService;
-import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
@@ -34,7 +33,7 @@ public class MBCategoryExternalReferenceCodeUpgradeProcessTest
 		throws PortalException {
 
 		return new ExternalReferenceCodeModel[] {
-			MBCategoryLocalServiceUtil.addCategory(
+			_mbCategoryLocalService.addCategory(
 				null, serviceContext.getUserId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				RandomTestUtil.randomString(), StringPool.BLANK, serviceContext)

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_6_0/test/MBCategoryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/internal/upgrade/v6_6_0/test/MBCategoryExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.internal.upgrade.v6_6_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.message.boards.constants.MBCategoryConstants;
+import com.liferay.message.boards.model.MBCategory;
+import com.liferay.message.boards.service.MBCategoryLocalService;
+import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseExternalReferenceCodeUpgradeProcessTestCase;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class MBCategoryExternalReferenceCodeUpgradeProcessTest
+	extends BaseExternalReferenceCodeUpgradeProcessTestCase {
+
+	@Override
+	protected ExternalReferenceCodeModel[] addExternalReferenceCodeModels(
+			String tableName)
+		throws PortalException {
+
+		return new ExternalReferenceCodeModel[] {
+			MBCategoryLocalServiceUtil.addCategory(
+				null, serviceContext.getUserId(),
+				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				RandomTestUtil.randomString(), StringPool.BLANK, serviceContext)
+		};
+	}
+
+	@Override
+	protected ExternalReferenceCodeModel fetchExternalReferenceCodeModel(
+			ExternalReferenceCodeModel externalReferenceCodeModel,
+			String tableName)
+		throws PortalException {
+
+		MBCategory mbCategory = (MBCategory)externalReferenceCodeModel;
+
+		return _mbCategoryLocalService.fetchMBCategory(
+			mbCategory.getCategoryId());
+	}
+
+	@Override
+	protected String[] getTableNames() {
+		return new String[] {"MBCategory"};
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return _upgradeStepRegistrator;
+	}
+
+	@Override
+	protected Version getVersion() {
+		return new Version(6, 6, 0);
+	}
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.message.boards.internal.upgrade.registry.MBServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private MBCategoryLocalService _mbCategoryLocalService;
+
+}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/notifications/test/MBUserNotificationTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/notifications/test/MBUserNotificationTest.java
@@ -69,7 +69,7 @@ public class MBUserNotificationTest extends BaseUserNotificationTestCase {
 			serviceContext, Constants.ADD);
 
 		_category = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/permission/test/MBCategoryPermissionCheckerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/permission/test/MBCategoryPermissionCheckerTest.java
@@ -66,12 +66,12 @@ public class MBCategoryPermissionCheckerTest extends BasePermissionTestCase {
 				group.getGroupId(), TestPropsValues.getUserId());
 
 		_category = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		_subcategory = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(), _category.getCategoryId(),
+			null, TestPropsValues.getUserId(), _category.getCategoryId(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/permission/test/MBMessagePermissionCheckerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/permission/test/MBMessagePermissionCheckerTest.java
@@ -74,7 +74,7 @@ public class MBMessagePermissionCheckerTest extends BasePermissionTestCase {
 			serviceContext);
 
 		MBCategory category = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/ratings/test/MBCategoryRatingsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/ratings/test/MBCategoryRatingsTest.java
@@ -39,7 +39,7 @@ public class MBCategoryRatingsTest extends BaseRatingsTestCase {
 		throws Exception {
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/ratings/test/MBMessageRatingsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/ratings/test/MBMessageRatingsTest.java
@@ -80,7 +80,7 @@ public class MBMessageRatingsTest extends BaseRatingsTestCase {
 		throws Exception {
 
 		return MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerIndexedFieldsTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerIndexedFieldsTest.java
@@ -148,6 +148,8 @@ public class MBCategoryIndexerIndexedFieldsTest {
 		).put(
 			Field.USER_NAME, StringUtil.lowerCase(mbCategory.getUserName())
 		).put(
+			"externalReferenceCode", mbCategory.getExternalReferenceCode()
+		).put(
 			"groupExternalReferenceCode", _group.getExternalReferenceCode()
 		).put(
 			"scopeGroupExternalReferenceCode", _group.getExternalReferenceCode()

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBCategoryIndexerTest.java
@@ -87,8 +87,8 @@ public class MBCategoryIndexerTest {
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			MBCategory mbCategory = MBCategoryLocalServiceUtil.addCategory(
-				TestPropsValues.getUserId(), 0, RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(),
+				null, TestPropsValues.getUserId(), 0,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
 					_group.getGroupId(), TestPropsValues.getUserId()));
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBFixture.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBFixture.java
@@ -47,7 +47,7 @@ public class MBFixture {
 
 	public MBCategory createMBCategory() throws Exception {
 		MBCategory mbCategory = MBCategoryLocalServiceUtil.addCategory(
-			getUserId(), 0, RandomTestUtil.randomString(),
+			null, getUserId(), 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), getServiceContext());
 
 		_mbCategories.add(mbCategory);

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
@@ -152,7 +152,7 @@ public class MBMessageSearchTest extends BaseSearchTestCase {
 		throws Exception {
 
 		return MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/persistence/test/MBCategoryPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.message.boards.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.message.boards.exception.DuplicateMBCategoryExternalReferenceCodeException;
 import com.liferay.message.boards.exception.NoSuchCategoryException;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
@@ -125,6 +126,8 @@ public class MBCategoryPersistenceTest {
 
 		newMBCategory.setUuid(RandomTestUtil.randomString());
 
+		newMBCategory.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newMBCategory.setGroupId(RandomTestUtil.nextLong());
 
 		newMBCategory.setCompanyId(RandomTestUtil.nextLong());
@@ -171,6 +174,9 @@ public class MBCategoryPersistenceTest {
 		Assert.assertEquals(
 			existingMBCategory.getUuid(), newMBCategory.getUuid());
 		Assert.assertEquals(
+			existingMBCategory.getExternalReferenceCode(),
+			newMBCategory.getExternalReferenceCode());
+		Assert.assertEquals(
 			existingMBCategory.getCategoryId(), newMBCategory.getCategoryId());
 		Assert.assertEquals(
 			existingMBCategory.getGroupId(), newMBCategory.getGroupId());
@@ -214,6 +220,26 @@ public class MBCategoryPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingMBCategory.getStatusDate()),
 			Time.getShortTimestamp(newMBCategory.getStatusDate()));
+	}
+
+	@Test(expected = DuplicateMBCategoryExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		MBCategory mbCategory = addMBCategory();
+
+		MBCategory newMBCategory = addMBCategory();
+
+		newMBCategory.setGroupId(mbCategory.getGroupId());
+
+		newMBCategory = _persistence.update(newMBCategory);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newMBCategory);
+
+		newMBCategory.setExternalReferenceCode(
+			mbCategory.getExternalReferenceCode());
+
+		_persistence.update(newMBCategory);
 	}
 
 	@Test
@@ -367,6 +393,15 @@ public class MBCategoryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
+
+		_persistence.countByERC_G("null", 0L);
+
+		_persistence.countByERC_G((String)null, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		MBCategory newMBCategory = addMBCategory();
 
@@ -416,12 +451,13 @@ public class MBCategoryPersistenceTest {
 	protected OrderByComparator<MBCategory> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"MBCategory", "mvccVersion", true, "ctCollectionId", true, "uuid",
-			true, "categoryId", true, "groupId", true, "companyId", true,
-			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "parentCategoryId", true, "name", true,
-			"description", true, "displayStyle", true, "friendlyURL", true,
-			"lastPublishDate", true, "status", true, "statusByUserId", true,
-			"statusByUserName", true, "statusDate", true);
+			true, "externalReferenceCode", true, "categoryId", true, "groupId",
+			true, "companyId", true, "userId", true, "userName", true,
+			"createDate", true, "modifiedDate", true, "parentCategoryId", true,
+			"name", true, "description", true, "displayStyle", true,
+			"friendlyURL", true, "lastPublishDate", true, "status", true,
+			"statusByUserId", true, "statusByUserName", true, "statusDate",
+			true);
 	}
 
 	@Test
@@ -705,6 +741,17 @@ public class MBCategoryPersistenceTest {
 			ReflectionTestUtil.invoke(
 				mbCategory, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "friendlyURL"));
+
+		Assert.assertEquals(
+			mbCategory.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				mbCategory, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(mbCategory.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				mbCategory, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected MBCategory addMBCategory() throws Exception {
@@ -717,6 +764,8 @@ public class MBCategoryPersistenceTest {
 		mbCategory.setCtCollectionId(RandomTestUtil.nextLong());
 
 		mbCategory.setUuid(RandomTestUtil.randomString());
+
+		mbCategory.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		mbCategory.setGroupId(RandomTestUtil.nextLong());
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
@@ -11,9 +11,8 @@ import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.constants.MBThreadConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
-import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
-import com.liferay.message.boards.service.MBCategoryServiceUtil;
-import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
+import com.liferay.message.boards.service.MBCategoryLocalService;
+import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -27,6 +26,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -81,7 +81,7 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			4,
-			MBCategoryLocalServiceUtil.getCategoriesAndThreadsCount(
+			_mbCategoryLocalService.getCategoriesAndThreadsCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
@@ -99,7 +99,7 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			2,
-			MBCategoryLocalServiceUtil.getCategoriesAndThreadsCount(
+			_mbCategoryLocalService.getCategoriesAndThreadsCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
@@ -115,7 +115,7 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			2,
-			MBCategoryLocalServiceUtil.getCategoriesAndThreadsCount(
+			_mbCategoryLocalService.getCategoriesAndThreadsCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
@@ -133,7 +133,7 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			1,
-			MBCategoryLocalServiceUtil.getCategoriesAndThreadsCount(
+			_mbCategoryLocalService.getCategoriesAndThreadsCount(
 				_group.getGroupId(), category1.getCategoryId(),
 				WorkflowConstants.STATUS_APPROVED));
 	}
@@ -155,7 +155,7 @@ public class MBCategoryLocalServiceTest {
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
 
 		List<Object> categoriesAndThreads =
-			MBCategoryLocalServiceUtil.getCategoriesAndThreads(
+			_mbCategoryLocalService.getCategoriesAndThreads(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED);
@@ -179,7 +179,7 @@ public class MBCategoryLocalServiceTest {
 		MBCategory category2 = addCategory();
 
 		List<Object> categoriesAndThreads =
-			MBCategoryLocalServiceUtil.getCategoriesAndThreads(
+			_mbCategoryLocalService.getCategoriesAndThreads(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED);
@@ -201,7 +201,7 @@ public class MBCategoryLocalServiceTest {
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
 
 		List<Object> categoriesAndThreads =
-			MBCategoryLocalServiceUtil.getCategoriesAndThreads(
+			_mbCategoryLocalService.getCategoriesAndThreads(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED);
@@ -223,7 +223,7 @@ public class MBCategoryLocalServiceTest {
 		addCategory();
 
 		List<Object> categoriesAndThreads =
-			MBCategoryLocalServiceUtil.getCategoriesAndThreads(
+			_mbCategoryLocalService.getCategoriesAndThreads(
 				_group.getGroupId(), category1.getCategoryId(),
 				WorkflowConstants.STATUS_APPROVED);
 
@@ -250,7 +250,7 @@ public class MBCategoryLocalServiceTest {
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
 
 		List<Object> categoriesAndThreads =
-			MBCategoryLocalServiceUtil.getCategoriesAndThreads(
+			_mbCategoryLocalService.getCategoriesAndThreads(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED);
@@ -275,13 +275,13 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			3,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_ANY));
 		Assert.assertEquals(
 			1,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				new long[] {
 					excludedCategory1.getCategoryId(),
@@ -300,13 +300,13 @@ public class MBCategoryLocalServiceTest {
 
 		Assert.assertEquals(
 			3,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_ANY));
 		Assert.assertEquals(
 			2,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(), excludedCategory.getCategoryId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_ANY));
@@ -323,19 +323,19 @@ public class MBCategoryLocalServiceTest {
 
 		MBCategory draftCategory = addCategory();
 
-		MBCategoryLocalServiceUtil.updateStatus(
+		_mbCategoryLocalService.updateStatus(
 			draftCategory.getUserId(), draftCategory.getCategoryId(),
 			WorkflowConstants.STATUS_DRAFT);
 
 		Assert.assertEquals(
 			3,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
 		Assert.assertEquals(
 			1,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				new long[] {
 					excludedCategory1.getCategoryId(),
@@ -355,19 +355,19 @@ public class MBCategoryLocalServiceTest {
 
 		MBCategory draftCategory = addCategory();
 
-		MBCategoryLocalServiceUtil.updateStatus(
+		_mbCategoryLocalService.updateStatus(
 			draftCategory.getUserId(), draftCategory.getCategoryId(),
 			WorkflowConstants.STATUS_DRAFT);
 
 		Assert.assertEquals(
 			2,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
 		Assert.assertEquals(
 			1,
-			MBCategoryLocalServiceUtil.getCategoriesCount(
+			_mbCategoryLocalService.getCategoriesCount(
 				_group.getGroupId(), excludedCategory.getCategoryId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED));
@@ -389,14 +389,14 @@ public class MBCategoryLocalServiceTest {
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(_group.getGroupId()));
+			_mbCategoryLocalService.getCategories(_group.getGroupId()));
 
 		expectedCategories.remove(excludedCategory1);
 		expectedCategories.remove(excludedCategory2);
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(),
 				new long[] {
 					excludedCategory1.getCategoryId(),
@@ -420,13 +420,13 @@ public class MBCategoryLocalServiceTest {
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(_group.getGroupId()));
+			_mbCategoryLocalService.getCategories(_group.getGroupId()));
 
 		expectedCategories.remove(excludedCategory);
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(), excludedCategory.getCategoryId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
@@ -451,13 +451,13 @@ public class MBCategoryLocalServiceTest {
 
 		MBCategory draftCategory = addCategory();
 
-		MBCategoryLocalServiceUtil.updateStatus(
+		_mbCategoryLocalService.updateStatus(
 			draftCategory.getUserId(), draftCategory.getCategoryId(),
 			WorkflowConstants.STATUS_DRAFT);
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(), WorkflowConstants.STATUS_APPROVED));
 
 		expectedCategories.remove(excludedCategory1);
@@ -465,7 +465,7 @@ public class MBCategoryLocalServiceTest {
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(),
 				new long[] {
 					excludedCategory1.getCategoryId(),
@@ -490,20 +490,20 @@ public class MBCategoryLocalServiceTest {
 
 		MBCategory draftCategory = addCategory();
 
-		MBCategoryLocalServiceUtil.updateStatus(
+		_mbCategoryLocalService.updateStatus(
 			draftCategory.getUserId(), draftCategory.getCategoryId(),
 			WorkflowConstants.STATUS_DRAFT);
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(), WorkflowConstants.STATUS_APPROVED));
 
 		expectedCategories.remove(excludedCategory);
 
 		AssertUtils.assertEquals(
 			expectedCategories,
-			MBCategoryLocalServiceUtil.getCategories(
+			_mbCategoryLocalService.getCategories(
 				_group.getGroupId(), excludedCategory.getCategoryId(),
 				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
@@ -523,7 +523,7 @@ public class MBCategoryLocalServiceTest {
 
 	@Test
 	public void testGetParentDiscussionCategory() throws Exception {
-		MBCategory discussionCategory = MBCategoryLocalServiceUtil.getCategory(
+		MBCategory discussionCategory = _mbCategoryLocalService.getCategory(
 			MBCategoryConstants.DISCUSSION_CATEGORY_ID);
 
 		Assert.assertNotNull(discussionCategory);
@@ -535,7 +535,7 @@ public class MBCategoryLocalServiceTest {
 	}
 
 	protected MBCategory addCategory(long parentCategoryId) throws Exception {
-		return MBCategoryServiceUtil.addCategory(
+		return _mbCategoryLocalService.addCategory(
 			null, TestPropsValues.getUserId(), parentCategoryId,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
@@ -556,7 +556,7 @@ public class MBCategoryLocalServiceTest {
 		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
 			Collections.emptyList();
 
-		return MBMessageLocalServiceUtil.addMessage(
+		return _mbMessageLocalService.addMessage(
 			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
 			_group.getGroupId(), categoryId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), MBMessageConstants.DEFAULT_FORMAT,
@@ -565,5 +565,11 @@ public class MBCategoryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private MBCategoryLocalService _mbCategoryLocalService;
+
+	@Inject
+	private MBMessageLocalService _mbMessageLocalService;
 
 }

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.constants.MBThreadConstants;
+import com.liferay.message.boards.exception.DuplicateMBCategoryExternalReferenceCodeException;
+import com.liferay.message.boards.exception.NoSuchCategoryException;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.service.MBCategoryLocalService;
@@ -61,6 +63,52 @@ public class MBCategoryLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test(expected = DuplicateMBCategoryExternalReferenceCodeException.class)
+	public void testAddCategoryWithExistingExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		addCategory(externalReferenceCode);
+		addCategory(externalReferenceCode);
+	}
+
+	@Test
+	public void testAddCategoryWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		MBCategory category1 = addCategory(externalReferenceCode);
+
+		Assert.assertNotNull(category1);
+
+		Assert.assertEquals(
+			externalReferenceCode, category1.getExternalReferenceCode());
+
+		MBCategory category2 =
+			_mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
+				externalReferenceCode, _group.getGroupId());
+
+		Assert.assertEquals(category1, category2);
+	}
+
+	@Test(expected = NoSuchCategoryException.class)
+	public void testDeleteCategoryByExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		MBCategory category = addCategory(externalReferenceCode);
+
+		Assert.assertNotNull(category);
+
+		Assert.assertEquals(
+			externalReferenceCode, category.getExternalReferenceCode());
+
+		_mbCategoryLocalService.deleteCategoryByExternalReferenceCode(
+			externalReferenceCode, _group.getGroupId());
+
+		_mbCategoryLocalService.getMBCategoryByExternalReferenceCode(
+			externalReferenceCode, _group.getGroupId());
 	}
 
 	@Test
@@ -535,9 +583,24 @@ public class MBCategoryLocalServiceTest {
 	}
 
 	protected MBCategory addCategory(long parentCategoryId) throws Exception {
+		return addCategory(null, parentCategoryId);
+	}
+
+	protected MBCategory addCategory(String externalReferenceCode)
+		throws Exception {
+
+		return addCategory(
+			externalReferenceCode,
+			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID);
+	}
+
+	protected MBCategory addCategory(
+			String externalReferenceCode, long parentCategoryId)
+		throws Exception {
+
 		return _mbCategoryLocalService.addCategory(
-			null, TestPropsValues.getUserId(), parentCategoryId,
-			RandomTestUtil.randomString(), StringPool.BLANK,
+			externalReferenceCode, TestPropsValues.getUserId(),
+			parentCategoryId, RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryLocalServiceTest.java
@@ -536,7 +536,7 @@ public class MBCategoryLocalServiceTest {
 
 	protected MBCategory addCategory(long parentCategoryId) throws Exception {
 		return MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentCategoryId,
+			null, TestPropsValues.getUserId(), parentCategoryId,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBCategoryServiceTest.java
@@ -323,12 +323,12 @@ public class MBCategoryServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category1 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -353,12 +353,12 @@ public class MBCategoryServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category1 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -383,12 +383,12 @@ public class MBCategoryServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category1 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategory category2 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -414,12 +414,12 @@ public class MBCategoryServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category1 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategory category2 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -445,12 +445,12 @@ public class MBCategoryServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		MBCategory category1 = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -479,7 +479,7 @@ public class MBCategoryServiceTest {
 		serviceContext.setAddGuestPermissions(false);
 
 		MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 
@@ -509,7 +509,7 @@ public class MBCategoryServiceTest {
 
 	protected MBCategory addCategory(long parentCategoryId) throws Exception {
 		return MBCategoryServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentCategoryId,
+			null, TestPropsValues.getUserId(), parentCategoryId,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
@@ -113,11 +113,12 @@ public class MBMessageServiceTest {
 				MBCategory.class.getName()));
 
 		_category = MBCategoryServiceUtil.addCategory(
-			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, name, description,
-			displayStyle, emailAddress, inProtocol, inServerName, inServerPort,
-			inUseSSL, inUserName, inPassword, inReadInterval, outEmailAddress,
-			outCustom, outServerName, outServerPort, outUseSSL, outUserName,
-			outPassword, allowAnonymous, mailingListActive, serviceContext);
+			null, MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, name,
+			description, displayStyle, emailAddress, inProtocol, inServerName,
+			inServerPort, inUseSSL, inUserName, inPassword, inReadInterval,
+			outEmailAddress, outCustom, outServerName, outServerPort, outUseSSL,
+			outUserName, outPassword, allowAnonymous, mailingListActive,
+			serviceContext);
 	}
 
 	@Test

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBThreadServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBThreadServiceTest.java
@@ -69,7 +69,7 @@ public class MBThreadServiceTest {
 			serviceContext, Constants.ADD);
 
 		_category = MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionAuthorTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionAuthorTest.java
@@ -64,7 +64,7 @@ public class MBSubscriptionAuthorTest extends BaseSubscriptionAuthorTestCase {
 				group.getGroupId(), userId);
 
 		MBCategory category = MBCategoryLocalServiceUtil.addCategory(
-			userId, containerModelId, RandomTestUtil.randomString(),
+			null, userId, containerModelId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		return category.getCategoryId();

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionBaseModelTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionBaseModelTest.java
@@ -73,7 +73,7 @@ public class MBSubscriptionBaseModelTest
 			serviceContext, Constants.ADD);
 
 		_category = MBCategoryLocalServiceUtil.addCategory(
-			userId, containerModelId, RandomTestUtil.randomString(),
+			null, userId, containerModelId, RandomTestUtil.randomString(),
 			StringPool.BLANK, serviceContext);
 
 		return _category.getCategoryId();

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionContainerModelTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionContainerModelTest.java
@@ -69,7 +69,7 @@ public class MBSubscriptionContainerModelTest
 			serviceContext, Constants.ADD);
 
 		MBCategory category = MBCategoryLocalServiceUtil.addCategory(
-			userId, containerModelId, RandomTestUtil.randomString(),
+			null, userId, containerModelId, RandomTestUtil.randomString(),
 			StringPool.BLANK, serviceContext);
 
 		return category.getCategoryId();

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionRootContainerModelTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/subscription/test/MBSubscriptionRootContainerModelTest.java
@@ -71,7 +71,7 @@ public class MBSubscriptionRootContainerModelTest
 			serviceContext, Constants.ADD);
 
 		MBCategory category = MBCategoryLocalServiceUtil.addCategory(
-			userId, containerModelId, RandomTestUtil.randomString(),
+			null, userId, containerModelId, RandomTestUtil.randomString(),
 			StringPool.BLANK, serviceContext);
 
 		return category.getCategoryId();

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/trash/test/MBCategoryTrashHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/trash/test/MBCategoryTrashHandlerTest.java
@@ -124,8 +124,8 @@ public class MBCategoryTrashHandlerTest
 		MBCategory parentCategory = (MBCategory)parentBaseModel;
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentCategory.getCategoryId(), _TITLE,
-			StringPool.BLANK, serviceContext);
+			null, TestPropsValues.getUserId(), parentCategory.getCategoryId(),
+			_TITLE, StringPool.BLANK, serviceContext);
 	}
 
 	@Override
@@ -134,7 +134,7 @@ public class MBCategoryTrashHandlerTest
 		throws Exception {
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, _TITLE,
 			StringPool.BLANK, serviceContext);
 	}
@@ -176,7 +176,7 @@ public class MBCategoryTrashHandlerTest
 		throws Exception {
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentBaseModelId, _TITLE,
+			null, TestPropsValues.getUserId(), parentBaseModelId, _TITLE,
 			StringPool.BLANK, serviceContext);
 	}
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/trash/test/MBThreadTrashHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/trash/test/MBThreadTrashHandlerTest.java
@@ -314,7 +314,7 @@ public class MBThreadTrashHandlerTest
 		throws Exception {
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(), parentBaseModelId,
+			null, TestPropsValues.getUserId(), parentBaseModelId,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}
 
@@ -324,7 +324,7 @@ public class MBThreadTrashHandlerTest
 		throws Exception {
 
 		return MBCategoryLocalServiceUtil.addCategory(
-			TestPropsValues.getUserId(),
+			null, TestPropsValues.getUserId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}

--- a/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBCategoryUADTestUtil.java
+++ b/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBCategoryUADTestUtil.java
@@ -30,7 +30,7 @@ public class MBCategoryUADTestUtil {
 		throws Exception {
 
 		return mbCategoryLocalService.addCategory(
-			userId, parentMBCategoryId, RandomTestUtil.randomString(),
+			null, userId, parentMBCategoryId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId()));

--- a/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBMessageUADTestUtil.java
+++ b/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBMessageUADTestUtil.java
@@ -35,7 +35,7 @@ public class MBMessageUADTestUtil {
 		throws Exception {
 
 		MBCategory mbCategory = mbCategoryLocalService.addCategory(
-			userId, 0, RandomTestUtil.randomString(),
+			null, userId, 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId()));

--- a/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBThreadUADTestUtil.java
+++ b/modules/apps/message-boards/message-boards-uad-test/src/testIntegration/java/com/liferay/message/boards/uad/test/util/MBThreadUADTestUtil.java
@@ -31,7 +31,7 @@ public class MBThreadUADTestUtil {
 		throws Exception {
 
 		MBCategory mbCategory = mbCategoryLocalService.addCategory(
-			userId, 0, RandomTestUtil.randomString(),
+			null, userId, 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId()));

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditCategoryMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditCategoryMVCActionCommand.java
@@ -244,10 +244,10 @@ public class EditCategoryMVCActionCommand extends BaseMVCActionCommand {
 			// Add category
 
 			_mbCategoryService.addCategory(
-				parentCategoryId, name, description, displayStyle, emailAddress,
-				inProtocol, inServerName, inServerPort, inUseSSL, inUserName,
-				inPassword, inReadInterval, outEmailAddress, outCustom,
-				outServerName, outServerPort, outUseSSL, outUserName,
+				null, parentCategoryId, name, description, displayStyle,
+				emailAddress, inProtocol, inServerName, inServerPort, inUseSSL,
+				inUserName, inPassword, inReadInterval, outEmailAddress,
+				outCustom, outServerName, outServerPort, outUseSSL, outUserName,
 				outPassword, allowAnonymous, mailingListActive, serviceContext);
 		}
 		else {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/message-boards/JSONMBMessage.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/message-boards/JSONMBMessage.macro
@@ -34,6 +34,10 @@ definition {
 		var portalURL = JSONCompany.getPortalURL();
 		var userId = JSONUserAPI._getUserIdByEmailAddress(userEmailAddress = ${userEmailAddress});
 
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
 		if (!(isSet(parentCategoryId))) {
 			var parentCategoryId = 0;
 		}
@@ -64,6 +68,7 @@ definition {
 		var curl = '''
 			${portalURL}/api/jsonws/mb.mbcategory/add-category \
 				-u ${userLoginInfo} \
+				-d externalReferenceCode=${externalReferenceCode}
 				-d userId=${userId} \
 				-d parentCategoryId=${parentCategoryId} \
 				-d name=${categoryName} \


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33263

Add the ExternalReferenceCode to MBCategory entity

NOTE: added one [additional commit](https://github.com/liferay-content-management/liferay-portal/commit/0a5dd100920462f4317944e1f76e2ea4500aa759) to previous PR #5866 to simplify code according to what [requested by Brian](https://github.com/brianchandotcom/liferay-portal/pull/154326#issuecomment-2360958260)

# How am I fixing it?

Changing model, adding the ERC to ADD methods, create DELETE methods. Fixing all usages.
Also creating upgrade process.

# How can you verify that it works?

Run `gw tI --tests MBCategoryExternalReferenceCodeUpgradeProcessTest`

