### PR TITLE
LPD-37099 Fix test QuestionsEntry#CanConfigureRootTopic

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Button.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Button.macro
@@ -125,7 +125,9 @@ definition {
 
 	@summary = "Default summary"
 	macro clickRemove() {
-		Button.click(button = "Remove");
+		Click.javaScriptClick(
+			key_text = "Remove",
+			locator1 = "Button#ANY");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37100

The POSHI test QuestionsEntry#CanConfigureRootTopic is failing

# How am I fixing it?

The click on the `Remove` button in the portlet configuration was not working. Now I'm using the JS version of the click.

# How can you verify that it works?

Just run the existing test: `ant -f build-test.xml run-selenium-test -Dtest.class=QuestionsEntry#CanConfigureRootTopic`