### PR TITLE
LPD-35636 Force the use of h264 codec in mp4 videos

### DIFF
--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
@@ -34,6 +34,7 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -59,20 +60,39 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 		Properties videoProperties = PropsUtil.getProperties(
 			PropsKeys.DL_FILE_ENTRY_PREVIEW_VIDEO, false);
 
-		_runFFMPEGCommand(
-			Arrays.asList(
-				"ffmpeg", "-y", "-i", file.getAbsolutePath(), "-b:v",
-				String.valueOf(
-					_getVideoBitRate(videoProperties, containerType)),
-				"-vf",
-				String.format(
-					"scale=min(%d\\,iw):-2",
-					GetterUtil.getInteger(
-						PropsValues.DL_FILE_ENTRY_PREVIEW_VIDEO_WIDTH)),
-				"-r",
-				String.valueOf(
-					_getVideoFrameRate(videoProperties, containerType)),
-				destinationFile.getAbsolutePath()));
+		if (Objects.equals(containerType, "mp4")) {
+			_runFFMPEGCommand(
+				Arrays.asList(
+					"ffmpeg", "-y", "-i", file.getAbsolutePath(), "-c:v",
+					"libx264", "-b:v",
+					String.valueOf(
+						_getVideoBitRate(videoProperties, containerType)),
+					"-vf",
+					String.format(
+						"scale=min(%d\\,iw):-2",
+						GetterUtil.getInteger(
+							PropsValues.DL_FILE_ENTRY_PREVIEW_VIDEO_WIDTH)),
+					"-r",
+					String.valueOf(
+						_getVideoFrameRate(videoProperties, containerType)),
+					destinationFile.getAbsolutePath()));
+		}
+		else {
+			_runFFMPEGCommand(
+				Arrays.asList(
+					"ffmpeg", "-y", "-i", file.getAbsolutePath(), "-b:v",
+					String.valueOf(
+						_getVideoBitRate(videoProperties, containerType)),
+					"-vf",
+					String.format(
+						"scale=min(%d\\,iw):-2",
+						GetterUtil.getInteger(
+							PropsValues.DL_FILE_ENTRY_PREVIEW_VIDEO_WIDTH)),
+					"-r",
+					String.valueOf(
+						_getVideoFrameRate(videoProperties, containerType)),
+					destinationFile.getAbsolutePath()));
+		}
 
 		return new AutoDeleteFileInputStream(destinationFile);
 	}

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
@@ -156,14 +156,19 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 				DLVideoFFMPEGVideoConverterConfiguration.class, properties);
 	}
 
-	private void _consumeProcessInputStream(InputStream inputStream)
+	private void _consumeProcessInputStream(
+			InputStream inputStream, String name)
 		throws IOException {
 
 		BufferedReader bufferedReader = new BufferedReader(
 			new InputStreamReader(inputStream));
 
 		while (bufferedReader.ready()) {
-			bufferedReader.readLine();
+			String line = bufferedReader.readLine();
+
+			if (_log.isErrorEnabled()) {
+				_log.error(name + StringPool.COLON + line);
+			}
 		}
 	}
 
@@ -214,14 +219,19 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 		Process process = processBuilder.start();
 
 		InputStream inputStream = process.getInputStream();
+		InputStream errorInputStream = process.getErrorStream();
 
 		while (true) {
 			try {
-				_consumeProcessInputStream(inputStream);
+				_consumeProcessInputStream(inputStream, "stdout");
+				_consumeProcessInputStream(errorInputStream, "stderr");
 
 				if (!process.waitFor(5, TimeUnit.SECONDS)) {
 					continue;
 				}
+
+				_consumeProcessInputStream(inputStream, "stdout");
+				_consumeProcessInputStream(errorInputStream, "stderr");
 
 				if (process.exitValue() != 0) {
 					throw new Exception(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35636 FFmpeg not using h264 codec in SUSE and RedHat systems..

# How am I fixing it?

Forcing the use of h264 codec in mp4 videos.

# How can you verify that it works?

1. Create an environment running SUSE Enterprise Linux 15
2. Setup a vanilla bundle of Liferay 7.4 U92
3. Configure and enable FFmpeg (compile version 7.0.2 from source as there is no install file option)
4. Go to Documents and Media
5. Upload any video file
6. Observe that the video does not have sound and does not play (except for a static image)

# Why does this pull not include tests?

This cannot be observed reliably from a test. The behavior is observed only with certain ffmpeg builds on some systems.