### PR TITLE
LPD-35926 Fix tests broken by FF LPS-188058 removal

### DIFF
--- a/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
@@ -49,12 +49,6 @@ export class KnowledgeBaseEditArticlePage {
 		await this.cancelButton.click();
 	}
 
-	async publishNewKnowledgeBaseArticle(content: string, title: string) {
-		await this.titlePlaceholder.fill(title);
-		await this.contentTextBox.fill(content);
-		await this.publishButton.click();
-	}
-
 	async publishNewKnowledgeBaseArticleWithSchedule(
 		content: string,
 		title: string

--- a/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
+++ b/modules/test/playwright/pages/knowledge-base-web/KnowledgeBaseEditArticlePage.ts
@@ -49,10 +49,7 @@ export class KnowledgeBaseEditArticlePage {
 		await this.cancelButton.click();
 	}
 
-	async publishNewKnowledgeBaseArticleWithSchedule(
-		content: string,
-		title: string
-	) {
+	async publishNewKnowledgeBaseArticle(content: string, title: string) {
 		await this.titlePlaceholder.fill(title);
 		await this.contentTextBox.fill(content);
 		await clickAndExpectToBeVisible({

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -18,222 +18,207 @@ import {performLogout} from '../../utils/performLogin';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import {KnowledgeBaseUrls} from './utils/knowledgeBaseUrls';
 
-const baseTest = mergeTests(
+const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	knowledgeBasePages,
+	featureFlagsTest({
+		'LPD-11003': true,
+	}),
 	loginTest()
 );
 
-const testFeatureFlagsDisabled = mergeTests(
-	baseTest,
-	featureFlagsTest({
-		'LPD-11003': false,
-	})
-);
-const testFeatureFlagsEnabled = mergeTests(
-	baseTest,
-	featureFlagsTest({
-		'LPD-11003': true,
-	})
-);
+test('LPD-27537: Article should be shown to guest users', async ({
+	apiHelpers,
+	page,
+	site,
+}) => {
+	const content = getRandomString();
+	const title = getRandomString();
 
-baseTest(
-	'LPD-27537: Article should be shown to guest users',
-	async ({apiHelpers, page, site}) => {
-		const content = getRandomString();
-		const title = getRandomString();
+	const knowledgeBaseArticle =
+		await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+			articleBody: content,
+			siteId: site.id,
+			title,
+		});
 
-		const knowledgeBaseArticle =
-			await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
-				articleBody: content,
-				siteId: site.id,
-				title,
-			});
+	await performLogout(page);
 
-		await performLogout(page);
+	await page.goto(
+		liferayConfig.environment.baseUrl +
+			'/c/knowledge_base/find_kb_article?resourcePrimKey=' +
+			knowledgeBaseArticle.id
+	);
 
-		await page.goto(
-			liferayConfig.environment.baseUrl +
-				'/c/knowledge_base/find_kb_article?resourcePrimKey=' +
-				knowledgeBaseArticle.id
+	await expect(
+		page.getByText('Error:Your request failed to complete.')
+	).toBeHidden();
+
+	await expect(page.getByText('Knowledge Base Article')).toBeVisible();
+});
+
+test('LPD-23801 error message is shown when an admin user tries to publish an article that an admin is currently editing', async ({
+	apiHelpers,
+	browser,
+	knowledgeBaseEditArticlePage,
+	page,
+	site,
+}) => {
+	const content = getRandomString();
+	const title = getRandomString();
+
+	const knowledgeBaseArticle =
+		await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
+			articleBody: content,
+			siteId: site.id,
+			title,
+		});
+	const knowledgeBaseUrls = new KnowledgeBaseUrls(site.friendlyUrlPath);
+
+	await page.goto(
+		knowledgeBaseUrls.getEditKBArticleUrl(knowledgeBaseArticle.id)
+	);
+
+	await expect(page.getByPlaceholder('Untitled Article')).toHaveValue(title);
+
+	const browserContext = await browser.newContext();
+
+	try {
+		const otherUserPage = await getLoggedInPage(
+			browserContext,
+			'demo.company.admin'
+		);
+
+		await otherUserPage.goto(
+			knowledgeBaseUrls.getEditKBArticleUrl(
+				knowledgeBaseArticle.id,
+				true,
+				knowledgeBaseUrls.home
+			)
 		);
 
 		await expect(
-			page.getByText('Error:Your request failed to complete.')
-		).toBeHidden();
+			otherUserPage.getByPlaceholder('Untitled Article')
+		).toHaveValue(title);
 
-		await expect(page.getByText('Knowledge Base Article')).toBeVisible();
-	}
-);
-
-testFeatureFlagsEnabled(
-	'LPD-23801 error message is shown when an admin user tries to publish an article that an admin is currently editing',
-	async ({apiHelpers, browser, knowledgeBaseEditArticlePage, page, site}) => {
-		const content = getRandomString();
-		const title = getRandomString();
-
-		const knowledgeBaseArticle =
-			await apiHelpers.headlessDelivery.postSiteKnowledgeBaseArticle({
-				articleBody: content,
-				siteId: site.id,
-				title,
-			});
-		const knowledgeBaseUrls = new KnowledgeBaseUrls(site.friendlyUrlPath);
-
-		await page.goto(
-			knowledgeBaseUrls.getEditKBArticleUrl(knowledgeBaseArticle.id)
+		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
+			`${content} test`,
+			`${title} test`
 		);
 
-		await expect(page.getByPlaceholder('Untitled Article')).toHaveValue(
-			title
-		);
+		await expect(
+			page.getByText('Your changes cannot be saved.')
+		).toBeVisible();
 
-		const browserContext = await browser.newContext();
+		const otherUserKnowledgeBaseEditArticlePage =
+			new KnowledgeBaseEditArticlePage(otherUserPage);
 
-		try {
-			const otherUserPage = await getLoggedInPage(
-				browserContext,
-				'demo.company.admin'
-			);
-
-			await otherUserPage.goto(
-				knowledgeBaseUrls.getEditKBArticleUrl(
-					knowledgeBaseArticle.id,
-					true,
-					knowledgeBaseUrls.home
-				)
-			);
-
-			await expect(
-				otherUserPage.getByPlaceholder('Untitled Article')
-			).toHaveValue(title);
-
-			await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
-				`${content} test`,
-				`${title} test`
-			);
-
-			await expect(
-				page.getByText('Your changes cannot be saved.')
-			).toBeVisible();
-
-			const otherUserKnowledgeBaseEditArticlePage =
-				new KnowledgeBaseEditArticlePage(otherUserPage);
-
-			await otherUserKnowledgeBaseEditArticlePage.cancel();
-		}
-		finally {
-			await browserContext.close();
-		}
+		await otherUserKnowledgeBaseEditArticlePage.cancel();
 	}
-);
+	finally {
+		await browserContext.close();
+	}
+});
 
-baseTest(
-	'can publish and delete an article with scheduling enabled',
-	async ({
-		knowledgeBaseEditArticlePage,
-		knowledgeBaseViewArticlePage,
+test('can publish and delete an article', async ({
+	knowledgeBaseEditArticlePage,
+	knowledgeBaseViewArticlePage,
+	page,
+	site,
+}) => {
+	const content = getRandomString();
+	const title = getRandomString();
+
+	const kbArticle = page.getByRole('link', {name: title});
+
+	await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
+	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
+		content,
+		title
+	);
+
+	await waitForSuccessAlert(
 		page,
-		site,
-	}) => {
-		const content = getRandomString();
-		const title = getRandomString();
+		`Success:${title} was successfully published.`
+	);
 
-		const kbArticle = page.getByRole('link', {name: title});
+	await expect(kbArticle).toBeVisible();
+	await expect(page.locator('.workflow-status-approved')).toBeVisible();
 
-		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
-			content,
-			title
-		);
+	await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
+	await knowledgeBaseViewArticlePage.deleteKnowledgeBaseArticle();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was successfully published.`
-		);
+	await expect(
+		page.locator(
+			'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
+		)
+	).toBeVisible();
+	await expect(kbArticle).toBeHidden();
+});
 
-		await expect(kbArticle).toBeVisible();
-		await expect(page.locator('.workflow-status-approved')).toBeVisible();
+test('can delete all articles (recycle bin enabled)', async ({
+	knowledgeBaseEditArticlePage,
+	knowledgeBasePage,
+	page,
+	site,
+}) => {
+	await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
 
-		await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
-		await knowledgeBaseViewArticlePage.deleteKnowledgeBaseArticle();
+	const title = getRandomString();
 
-		await expect(
-			page.locator(
-				'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
-			)
-		).toBeVisible();
-		await expect(kbArticle).toBeHidden();
-	}
-);
+	await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
+		getRandomString(),
+		title
+	);
 
-testFeatureFlagsEnabled(
-	'can delete all articles with a recycle bin enabled',
-	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {
-		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-
-		const title = getRandomString();
-
-		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticleWithSchedule(
-			getRandomString(),
-			title
-		);
-
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was successfully published.`
-		);
-
-		await knowledgeBasePage.goto(site.friendlyUrlPath);
-		await knowledgeBasePage.deleteAll(true);
-
-		await expect(
-			page.locator(
-				'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
-			)
-		).toBeVisible();
-		await expect(
-			page.getByRole('heading', {name: 'Knowledge base is empty.'})
-		).toBeVisible();
-	}
-);
-
-baseTest(
-	'can schedule and delete an article with scheduling enabled',
-	async ({
-		knowledgeBaseEditArticlePage,
-		knowledgeBaseViewArticlePage,
+	await waitForSuccessAlert(
 		page,
-		site,
-	}) => {
-		const title = getRandomString();
+		`Success:${title} was successfully published.`
+	);
 
-		const kbArticle = page.getByRole('link', {name: title});
+	await knowledgeBasePage.goto(site.friendlyUrlPath);
+	await knowledgeBasePage.deleteAll(true);
 
-		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-		await knowledgeBaseEditArticlePage.scheduleNewKnowledgeBaseArticle(
-			getRandomString(),
-			`${new Date().getFullYear() + 1}-01-01 00:00`,
-			title
-		);
+	await expect(
+		page.locator(
+			'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
+		)
+	).toBeVisible();
+	await expect(
+		page.getByRole('heading', {name: 'Knowledge base is empty.'})
+	).toBeVisible();
+});
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} will be published on`
-		);
+test('can schedule and delete an article', async ({
+	knowledgeBaseEditArticlePage,
+	knowledgeBaseViewArticlePage,
+	page,
+	site,
+}) => {
+	const title = getRandomString();
 
-		await expect(kbArticle).toBeVisible();
-		await expect(page.locator('.workflow-status-scheduled')).toBeVisible();
+	const kbArticle = page.getByRole('link', {name: title});
 
-		await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
-		await knowledgeBaseViewArticlePage.deleteKnowledgeBaseArticle();
+	await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
+	await knowledgeBaseEditArticlePage.scheduleNewKnowledgeBaseArticle(
+		getRandomString(),
+		`${new Date().getFullYear() + 1}-01-01 00:00`,
+		title
+	);
 
-		await expect(
-			page.locator(
-				'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
-			)
-		).toBeVisible();
-		await expect(kbArticle).toBeHidden();
-	}
-);
+	await waitForSuccessAlert(page, `Success:${title} will be published on`);
+
+	await expect(kbArticle).toBeVisible();
+	await expect(page.locator('.workflow-status-scheduled')).toBeVisible();
+
+	await knowledgeBaseViewArticlePage.goto(site.friendlyUrlPath, title);
+	await knowledgeBaseViewArticlePage.deleteKnowledgeBaseArticle();
+
+	await expect(
+		page.locator(
+			'[id="_com_liferay_knowledge_base_web_portlet_AdminPortlet_recycleBinAlert"]'
+		)
+	).toBeVisible();
+	await expect(kbArticle).toBeHidden();
+});

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -168,32 +168,6 @@ baseTest(
 	}
 );
 
-testFeatureFlagsDisabled(
-	'can delete all articles with a recycle bin disabled',
-	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {
-		await knowledgeBaseEditArticlePage.goto(site.friendlyUrlPath);
-
-		const title = getRandomString();
-
-		await knowledgeBaseEditArticlePage.publishNewKnowledgeBaseArticle(
-			getRandomString(),
-			title
-		);
-
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was successfully published.`
-		);
-
-		await knowledgeBasePage.goto(site.friendlyUrlPath);
-		await knowledgeBasePage.deleteAll(false);
-
-		await expect(
-			page.getByRole('heading', {name: 'Knowledge base is empty.'})
-		).toBeVisible();
-	}
-);
-
 testFeatureFlagsEnabled(
 	'can delete all articles with a recycle bin enabled',
 	async ({knowledgeBaseEditArticlePage, knowledgeBasePage, page, site}) => {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -75,7 +75,7 @@ definition {
 			Button.click(button = "Submit for Workflow");
 		}
 		else {
-			Button.click(button = "Publish");
+			KBArticle.clickPublish();
 		}
 
 		MenuItem.click(menuItem = "Schedule Publication");
@@ -157,7 +157,7 @@ definition {
 
 		CKEditor.addContent(content = ${kbChildArticleContent});
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 	}
 
 	@summary = "Default summary"
@@ -173,7 +173,9 @@ definition {
 			MenuItem.click(menuItem = "Basic Article");
 		}
 		else {
-			LexiconEntry.gotoAddMenuItem(menuItem = "Basic Article");
+			Button.click(button = "New");
+
+			MenuItem.click(menuItem = "Basic Article");
 		}
 
 		AssertElementPresent(locator1 = "TextInput#TITLE");
@@ -347,7 +349,7 @@ definition {
 		else {
 			ProductMenuHelper.closeProductMenu();
 
-			Button.click(button = "Publish");
+			KBArticle.clickPublish();
 		}
 
 		if (${kbArticleInvalidContent} == "true") {
@@ -406,7 +408,7 @@ definition {
 			locator1 = "MessageBoardsThread#MESSAGE_ATTACHMENT_INVALID_SIZE_ERROR",
 			value1 = "Please enter a file with a valid file size no larger than ${maxFileSize}KB.");
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 	}
 
 	@summary = "Default summary"
@@ -425,7 +427,7 @@ definition {
 
 		ProductMenuHelper.closeProductMenu();
 
-		Button.click(button = "Publish");
+		KBArticle.clickPublish();
 
 		AssertElementPresent(locator1 = "TextInput#REQUIRED_ALERT");
 	}
@@ -450,7 +452,7 @@ definition {
 			locator1 = "TextInput#CUSTOM_FIELD",
 			value1 = ${customFieldText});
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 	}
 
 	@summary = "Default summary"
@@ -465,7 +467,7 @@ definition {
 
 		CKEditor.addContent(content = ${kbArticleContent});
 
-		Button.click(button = "Publish");
+		KBArticle.clickPublish();
 	}
 
 	@summary = "Default summary"
@@ -481,6 +483,15 @@ definition {
 		CKEditor.addContent(content = ${kbArticleContent});
 
 		Button.clickCancel();
+	}
+
+	@summary = "Default summary"
+	macro clickPublish() {
+		Button.clickPublish();
+
+		Click(
+			key_text = "arrow-right-full",
+			locator1 = "Icon#ANY");
 	}
 
 	@summary = "Default summary"
@@ -579,14 +590,7 @@ definition {
 				kbArticleTitle = ${kbArticleTitle},
 				menuItem = "Delete");
 
-			if (isSet(moveToRecycleBin)) {
-				Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
-			}
-			else {
-				AssertConfirm(value1 = "Are you sure you want to delete this? It will be deleted immediately.");
-
-				Alert.viewSuccessMessage();
-			}
+			Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
 		}
 		else {
 			if (IsElementPresent(key_text = "trash", locator1 = "ManagementBar#ANY_ICON")) {
@@ -594,16 +598,11 @@ definition {
 					key_text = "trash",
 					locator1 = "ManagementBar#ANY_ICON");
 
-				if (${moveToRecycleBin} == "singleArticle") {
-					Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
-				}
-				else if (${moveToRecycleBin} == "multipleArticles") {
+				if (${moveToRecycleBin} == "multipleArticles") {
 					Alert.viewSuccessMessageText(successMessage = "Success: ${itemsNumber} items were moved to the Recycle Bin.");
 				}
 				else {
-					AssertConfirm(value1 = "Are you sure you want to delete the selected entries? They will be deleted immediately.");
-
-					Alert.viewSuccessMessage();
+					Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
 				}
 			}
 			else {
@@ -613,14 +612,7 @@ definition {
 
 				MenuItem.click(menuItem = "Delete");
 
-				if (isSet(moveToRecycleBin)) {
-					Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
-				}
-				else {
-					AssertConfirm(value1 = "Are you sure you want to delete this? It will be deleted immediately.");
-
-					Alert.viewSuccessMessage();
-				}
+				Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbArticleTitle} was moved to the Recycle Bin.");
 			}
 		}
 
@@ -637,12 +629,10 @@ definition {
 	macro deletePG() {
 		LexiconEntry.gotoVerticalEllipsisMenuItemNoError(menuItem = "Delete");
 
-		AssertConfirm(value1 = "Are you sure you want to delete this? It will be deleted immediately.");
-
 		if (isSet(deleteViaKbArticle)) {
 			AssertTextEquals.assertPartialText(
-				locator1 = "Message#INFO",
-				value1 = "Please configure this portlet to make it visible to all users.");
+				locator1 = "Message#ERROR",
+				value1 = "Error:The selected article no longer exists.");
 		}
 		else {
 			Alert.viewSuccessMessage();
@@ -784,7 +774,7 @@ definition {
 			PortletEntry.saveAsDraft();
 		}
 		else {
-			PortletEntry.publish();
+			KBArticle.clickPublish();
 		}
 	}
 
@@ -1305,6 +1295,19 @@ definition {
 		UploadCommonFile.uploadCommonFileHiddenNoMouseOver(
 			locator1 = "TextInput#FILE",
 			value1 = ${kbArticleAttachment});
+	}
+
+	@summary = "Default summary"
+	macro selectDisplayPageTemplate(groupName = null, siteURLKey = null, kbChildArticleTitle = null, entryTitle = null, pageName = null) {
+		KBArticle.openToEditKBArticleInSite(
+			groupName = ${groupName},
+			kbArticleTitle = ${entryTitle},
+			kbChildArticleTitle = ${kbChildArticleTitle},
+			siteURLKey = ${siteURLKey});
+
+		WebContent.editDisplayPage(pageName = ${pageName});
+
+		KBArticle.clickPublish();
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBDisplayWidget.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBDisplayWidget.macro
@@ -51,7 +51,7 @@ definition {
 			Button.clickSaveAsDraft();
 		}
 		else {
-			Button.click(button = "Publish");
+			KBArticle.clickPublish();
 		}
 	}
 
@@ -198,7 +198,7 @@ definition {
 			Button.clickSaveAsDraft();
 		}
 		else {
-			Button.click(button = "Publish");
+			KBArticle.clickPublish();
 		}
 	}
 
@@ -228,9 +228,11 @@ definition {
 			Click(locator1 = "Home#PORTAL_LOCALIZATION_IGNORE_BUTTON");
 		}
 
-		AssertClick(
-			locator1 = "Button#PUBLISH_LOCALIZED",
-			value1 = "Publicar");
+		Button.click(button = "Publicar");
+
+		Click(
+			key_text = "arrow-right-full",
+			locator1 = "Icon#ANY");
 
 		VerifyElementPresent(locator1 = "Message#SUCCESS");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBFolder.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBFolder.macro
@@ -53,14 +53,7 @@ definition {
 				rowEntry = ${kbFolderName});
 		}
 
-		if (isSet(moveToRecycleBin)) {
-			Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbFolderName} was moved to the Recycle Bin.");
-		}
-		else {
-			AssertConfirm(value1 = "Are you sure you want to delete this? It will be deleted immediately.");
-
-			Alert.viewSuccessMessage();
-		}
+		Alert.viewSuccessMessageText(successMessage = "Success: The element ${kbFolderName} was moved to the Recycle Bin.");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/displaypagetemplate/DisplayPageTemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/displaypagetemplate/DisplayPageTemplate.macro
@@ -43,13 +43,6 @@ definition {
 				groupName = ${groupName},
 				siteURLKey = ${siteURLKey});
 		}
-		else if (${assetType} == "Knowledge Base") {
-			KBArticle.openToEditKBArticleInSite(
-				groupName = ${groupName},
-				kbArticleTitle = ${entryTitle},
-				kbChildArticleTitle = ${kbChildArticleTitle},
-				siteURLKey = ${siteURLKey});
-		}
 		else if (${assetType} == "Web Content") {
 			WebContentNavigator.openToEditWCInSite(
 				groupName = ${groupName},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
@@ -56,7 +56,7 @@ definition {
 
 		KBArticle.selectArticleCP(kbArticleTitle = "Knowledge Base Article Title");
 
-		KBArticle.deleteCP();
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Article Title");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
@@ -323,7 +323,9 @@ definition {
 
 		LexiconEntry.changeDisplayStyle(displayStyle = "table");
 
-		LexiconTable.delete(tableEntry = "Knowledge Base Article Title");
+		LexiconTable.clickEllipsisItem(
+			item = "Delete",
+			tableEntry = "Knowledge Base Article Title");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -762,7 +764,7 @@ definition {
 
 		KBArticle.selectAttachmentCP(kbArticleAttachment = "Document_1.txt");
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -812,7 +814,7 @@ definition {
 			categoryName = "Category Name2",
 			vocabularyName = "Vocabulary Name");
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 
 		KBArticle.openToEditKBArticleInSite(
 			groupName = "Guest",
@@ -857,7 +859,7 @@ definition {
 			assetTitle = "Blogs Entry Title",
 			assetType = "Blogs Entry");
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -887,7 +889,7 @@ definition {
 
 		AssetCategorization.addTag(tagName = "Tag2");
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 
 		KBArticle.openToEditKBArticleInSite(
 			groupName = "Guest",
@@ -970,9 +972,7 @@ definition {
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
-		KBArticle.deleteCP(
-			kbArticleTitle = "Knowledge Base Article Title",
-			moveToRecycleBin = "true");
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Article Title");
 
 		KBArticle.viewDefaultCP();
 
@@ -1048,9 +1048,7 @@ definition {
 
 		KBArticle.gotoChildArticleDescriptiveDetails(kbArticleTitle = "Knowledge Base Article Title");
 
-		KBArticle.deleteCP(
-			kbArticleTitle = "Knowledge Base Child Article Title",
-			moveToRecycleBin = "true");
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Child Article Title");
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
@@ -1085,9 +1083,7 @@ definition {
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
-		KBArticle.deleteCP(
-			kbArticleTitle = "Knowledge Base Article Title",
-			moveToRecycleBin = "true");
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Article Title");
 
 		KBArticle.viewDefaultCP();
 
@@ -1281,7 +1277,7 @@ definition {
 
 		KBArticle.setReviewDate(increaseMinutes = 1);
 
-		PortletEntry.publish();
+		KBArticle.clickPublish();
 
 		Notifications.waitForNotificationFlexibly(flexibleRefreshingTime = 20000);
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayPage.testcase
@@ -48,8 +48,7 @@ definition {
 
 		PageEditor.publish();
 
-		DisplayPageTemplate.selectDisplayPageTemplateForAsset(
-			assetType = "Knowledge Base",
+		KBArticle.selectDisplayPageTemplate(
 			entryTitle = "Knowledge Base Article Title",
 			groupName = "Test Site Name",
 			pageName = "Display Page Name",
@@ -261,16 +260,14 @@ definition {
 
 		PageEditor.publish();
 
-		DisplayPageTemplate.selectDisplayPageTemplateForAsset(
-			assetType = "Knowledge Base",
+		KBArticle.selectDisplayPageTemplate(
 			entryTitle = "KB Parent Article",
 			groupName = "Guest",
 			pageName = "Display Page Template Name",
 			siteURLKey = "guest");
 
 		for (var kbChildArticleTitle : list "KB Child Article1,KB Child Article2") {
-			DisplayPageTemplate.selectDisplayPageTemplateForAsset(
-				assetType = "Knowledge Base",
+			KBArticle.selectDisplayPageTemplate(
 				entryTitle = "KB Parent Article",
 				groupName = "Guest",
 				kbChildArticleTitle = ${kbChildArticleTitle},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBExportImport.testcase
@@ -71,7 +71,6 @@ definition {
 	}
 
 	@priority = 5
-	@refactorneeded
 	test DeleteImportedArticles {
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -103,7 +102,9 @@ definition {
 
 		KBArticle.selectAllCP();
 
-		KBArticle.deleteCP();
+		KBArticle.deleteCP(
+			itemsNumber = 2,
+			moveToRecycleBin = "multipleArticles");
 	}
 
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBFolder.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBFolder.testcase
@@ -219,7 +219,9 @@ definition {
 
 		KBArticle.selectAllCP();
 
-		KBArticle.deleteCP();
+		KBArticle.deleteCP(
+			itemsNumber = 2,
+			moveToRecycleBin = "multipleArticles");
 
 		KBArticle.viewDefaultCP(newFolder = "true");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBSearchWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBSearchWidget.testcase
@@ -46,9 +46,7 @@ definition {
 
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
-		KBArticle.deleteCP(
-			kbArticleTitle = "Knowledge Base Article Title",
-			moveToRecycleBin = "true");
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Article Title");
 
 		Navigator.gotoPage(pageName = "Knowledge Base Display Page");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsKBArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsKBArticle.testcase
@@ -76,7 +76,7 @@ definition {
 
 		KBArticle.selectArticleCP(kbArticleTitle = "Knowledge Base Article Title");
 
-		KBArticle.deleteCP();
+		KBArticle.deleteCP(kbArticleTitle = "Knowledge Base Article Title");
 
 		PublicationsNavigator.gotoReviewChanges();
 


### PR DESCRIPTION
### Fixing tests after the FF 'LPS-188058' removal

1. Poshi tests are modified to apply the new user interface
2. Disable and refactor KB playwright: This PR only fixes one test and deletes another obsolete test. Now two tests are failing but they are unrelated to these changes.