### PR TITLE
LPD-37097 [Playwright] Fix flaky test DM Maximum File Upload Size

### DIFF
--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -320,15 +320,7 @@ test(
 
 		// change back to english language
 
-		await page
-			.locator('.alert-info', {
-				hasText: 'Información: This page is displayed in Spanish',
-			})
-			.waitFor();
-
-		await page
-			.getByRole('link', {name: 'Display the page in English'})
-			.click();
+		await page.goto('/en');
 	}
 );
 

--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -11,29 +11,35 @@ import {PORTLET_URLS} from '../../utils/portletUrls';
 
 export const test = mergeTests(loginTest(), documentLibraryPagesTest);
 
-test('LPD-27271 Can create DM folder in French language', async ({page}) => {
-	const folderTitle = 'DM Folder FR';
+test(
+	'Can create DM folder in French language',
+	{
+		tag: '@LPD-27271',
+	},
+	async ({page}) => {
+		const folderTitle = 'DM Folder FR';
 
-	await page.goto(`/fr/group/guest${PORTLET_URLS.documentLibrary}`);
-	await page.getByRole('button', {name: 'Nouveau'}).click();
+		await page.goto(`/fr/group/guest${PORTLET_URLS.documentLibrary}`);
+		await page.getByRole('button', {name: 'Nouveau'}).click();
 
-	await page
-		.getByRole('menuitem', {
-			name: 'Répertoire',
-		})
-		.click();
+		await page
+			.getByRole('menuitem', {
+				name: 'Répertoire',
+			})
+			.click();
 
-	await page.getByRole('textbox').first().fill(folderTitle);
-	await page.getByRole('button', {name: 'Enregistrer'}).click();
+		await page.getByRole('textbox').first().fill(folderTitle);
+		await page.getByRole('button', {name: 'Enregistrer'}).click();
 
-	await expect(page.getByRole('link', {name: folderTitle})).toBeVisible();
+		await expect(page.getByRole('link', {name: folderTitle})).toBeVisible();
 
-	await page
-		.getByRole('checkbox', {name: `${folderTitle} More actions`})
-		.check();
-	await page.getByRole('button', {name: 'Effacer'}).nth(1).click();
+		await page
+			.getByRole('checkbox', {name: `${folderTitle} More actions`})
+			.check();
+		await page.getByRole('button', {name: 'Effacer'}).nth(1).click();
 
-	// change back to english language
+		// change back to english language
 
-	await page.goto('/en');
-});
+		await page.goto('/en');
+	}
+);

--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -32,4 +32,8 @@ test('LPD-27271 Can create DM folder in French language', async ({page}) => {
 		.getByRole('checkbox', {name: `${folderTitle} More actions`})
 		.check();
 	await page.getByRole('button', {name: 'Effacer'}).nth(1).click();
+
+	// change back to english language
+
+	await page.goto('/en');
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37097

Fix flaky test 'Updating Maximum File Upload Size at Instance level, not overrides site configuration'

# How am I fixing it?

The real problem isn't in the test, it exists in the previous one changing the site into French Language.
The problematic test: [document-library-web/dmFolder.spec.ts](https://github.com/liferay/liferay-portal/blob/e3aa3750f7bc3abd1aaf1a60d1f10a9098d64c45/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts#L17)
I added a navigation to `/en` at the end of the test to avoid the issue.

# How can you verify that it works?
1. Go to /modules/test/playwright
1. Run npm install (setup)
1. Run npm run `npm run playwright test -- -g "LPD-27271|LPD-17827"` to run the test

# Before the PR

![image](https://github.com/user-attachments/assets/30481611-e5af-44c0-8b47-f79501fc41ef) 

![image](https://github.com/user-attachments/assets/7a85c87c-1a94-47c5-9f1a-bfbba65f909f)


# After the PR (launched 10 times to avoid flaky results)

```sh
npm run playwright test -- -g "LPD-27271|LPD-17827" --repeat-each 10
```

![image](https://github.com/user-attachments/assets/c2151fe5-a6c3-44b9-b5c6-579a09ff8d9d)


