### PR TITLE
LPD-37193 fix POSHI test after removal of title on problem message

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/DocumentFolder.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/DocumentFolder.testcase
@@ -161,7 +161,7 @@ definition {
 		task ("Then there should be a 404 response telling me this folder is non-existent.") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No Folder exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -179,7 +179,7 @@ definition {
 		task ("Then there should be a 404 response telling me this folder is non-existent.") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No Folder exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
@@ -197,11 +197,11 @@ definition {
 				kBArticleErc = "KBAErc",
 				kBAttachmentErc = "KBAtErc");
 
-			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.title");
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.status");
 
 			TestUtils.assertPartialEquals(
 				actual = ${actualValue},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -239,11 +239,11 @@ definition {
 				kBArticleErc = "KBFAErc",
 				kBAttachmentErc = "KBFAtErc");
 
-			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.title");
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.status");
 
 			TestUtils.assertPartialEquals(
 				actual = ${actualValue},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
@@ -197,11 +197,9 @@ definition {
 				kBArticleErc = "KBAErc",
 				kBAttachmentErc = "KBAtErc");
 
-			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.status");
-
-			TestUtils.assertPartialEquals(
-				actual = ${actualValue},
-				expected = "NOT_FOUND");
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
+				responseToParse = ${response});
 		}
 	}
 
@@ -239,11 +237,9 @@ definition {
 				kBArticleErc = "KBFAErc",
 				kBAttachmentErc = "KBFAtErc");
 
-			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.status");
-
-			TestUtils.assertPartialEquals(
-				actual = ${actualValue},
-				expected = "NOT_FOUND");
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
+				responseToParse = ${response});
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -176,7 +176,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -231,7 +231,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No FileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -302,7 +302,7 @@ definition {
 		task ("Then it will show user that there is no message board message exists") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No MBMessage exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -320,7 +320,7 @@ definition {
 		task ("Then it will show user that there is no message board message exists") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No MBMessage exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -346,7 +346,7 @@ definition {
 		task ("Then it will show user that there is no file exists") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -370,7 +370,7 @@ definition {
 		task ("Then it will show user that there is no file exists") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
@@ -266,15 +266,16 @@ definition {
 			var response = CommentAPI.createCommentInBlogPosting(
 				blogPostingId = ${staticBlogPostingId},
 				commentText = "CommentOne");
+
+			var commentId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("When I make a GET request by external reference code using comment ID as external reference code") {
-			var repsonse = BlogPostingAPI.getBlogPostings();
+			var response = BlogPostingAPI.getBlogPostings();
 
 			var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
 				fieldName = "externalReferenceCode",
-				responseToParse = ${repsonse});
-			var commentId = JSONUtil.getWithJSONPath(${response}, "$.id");
+				responseToParse = ${response});
 		}
 
 		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
@@ -286,15 +286,6 @@ definition {
 			TestUtils.assertPartialEquals(
 				actual = ${commentText},
 				expected = "NOT_FOUND");
-
-			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingCommentErc = ${commentId},
-				blogPostingErc = ${blogPostingErc},
-				fieldName = "title");
-
-			TestUtils.assertPartialEquals(
-				actual = ${commentText},
-				expected = "No MBMessage exists with the key");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
@@ -226,12 +226,6 @@ definition {
 				actual = ${response},
 				expected = "NOT_FOUND");
 		}
-
-		task ("And Then I receive error message in server console") {
-			TestUtils.assertPartialEquals(
-				actual = ${response},
-				expected = "Unable to get a valid asset library with ID nonexistentId");
-		}
 	}
 
 	@description = "Unable to get document by nonexistent erc"
@@ -248,7 +242,7 @@ definition {
 		task ("Then I receive error message in response") {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No DLFileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
@@ -184,11 +184,11 @@ definition {
 		task ("And Then the document in the document folder is deleted") {
 			var response = DocumentAPI.getDocumentsByDifferentParameters(documentId = ${documentId});
 
-			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.title");
+			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.status");
 
 			TestUtils.assertPartialEquals(
 				actual = ${actualMessage},
-				expected = "No FileEntry exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 
@@ -319,11 +319,11 @@ definition {
 		}
 
 		task ("Then I receive no DLFolder exists error message in response") {
-			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.title");
+			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.status");
 
 			TestUtils.assertPartialEquals(
 				actual = ${actualMessage},
-				expected = "No DLFolder exists with the key");
+				expected = "NOT_FOUND");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
@@ -184,11 +184,9 @@ definition {
 		task ("And Then the document in the document folder is deleted") {
 			var response = DocumentAPI.getDocumentsByDifferentParameters(documentId = ${documentId});
 
-			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.status");
-
-			TestUtils.assertPartialEquals(
-				actual = ${actualMessage},
-				expected = "NOT_FOUND");
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
+				responseToParse = ${response});
 		}
 	}
 
@@ -319,11 +317,9 @@ definition {
 		}
 
 		task ("Then I receive no DLFolder exists error message in response") {
-			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.status");
-
-			TestUtils.assertPartialEquals(
-				actual = ${actualMessage},
-				expected = "NOT_FOUND");
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
+				responseToParse = ${response});
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/SiteDocumentEntry.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/SiteDocumentEntry.testcase
@@ -261,10 +261,6 @@ definition {
 				actual = ${response},
 				expected = "NOT_FOUND");
 
-			TestUtils.assertPartialEquals(
-				actual = ${response},
-				expected = "No FileEntry exists with the key {fileEntryId=40000}");
-
 			User.loginPG(
 				password = PropsUtil.get("default.admin.password"),
 				userEmailAddress = "test@liferay.com");


### PR DESCRIPTION
LPD-37193 fix POSHI test after removal of title on problem message

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37193

After https://liferay.atlassian.net/browse/LPD-35339 some changes were made, one of them is that now the exceptions do not have the title. On some cases we are checking that the title (exception message) were the correct.

# How am I fixing it?

Changing what we check on the assert, the status, no the title

# How can you verify that it works?

Run the included automated tests.


# Commits
- **LPD-37193 actually there is no title on the response message because NotFoundExceptionMapper return null on the title**
- **LPD-37193 reuse method**
