### PR TITLE
LPD-37097 [Playwright] Fix flaky test DM Show private icon when is needed

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -151,8 +151,11 @@ export class DocumentLibraryEditFilePage {
 		});
 	}
 
-	async publishNewFileWithoutGuestViewPermission(title: string) {
-		await this.goto();
+	async publishNewFileWithoutGuestViewPermission(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
 
 		await this.titleSelector.fill(title);
 		if (await this.permissionViewSelector.isVisible()) {

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -14,7 +14,6 @@ import {DocumentLibraryPage} from './DocumentLibraryPage';
 export class DocumentLibraryEditFilePage {
 	readonly page: Page;
 
-	readonly backButton: Locator;
 	readonly descriptionInput: Locator;
 	readonly documentLibraryPage: DocumentLibraryPage;
 	readonly permissionViewSelector: Locator;
@@ -28,7 +27,6 @@ export class DocumentLibraryEditFilePage {
 	constructor(page: Page) {
 		this.page = page;
 
-		this.backButton = page.getByRole('link', {name: 'Back'});
 		this.descriptionInput = page.locator(
 			'#_com_liferay_document_library_web_portlet_DLAdminPortlet_description'
 		);
@@ -68,10 +66,6 @@ export class DocumentLibraryEditFilePage {
 				'Select View, Currently Selected: '
 			),
 		});
-	}
-
-	async goBack() {
-		await this.backButton.click();
 	}
 
 	async goToNewFileDifferentType(type: string) {

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -166,11 +166,12 @@ baseTest(
 
 baseTest(
 	'LPD-16313 Show icon in the content admin and content editor',
-	async ({documentLibraryEditFilePage, documentLibraryPage, page}) => {
+	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
 		const title = getRandomString();
 
 		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(
-			title
+			title,
+			site.friendlyUrlPath
 		);
 
 		await documentLibraryPage.changeView('cards');
@@ -184,8 +185,6 @@ baseTest(
 		await page.getByRole('link', {name: title}).click();
 
 		await documentLibraryPage.assertPrivateFileIcon();
-
-		await documentLibraryPage.deleteFileEntry(title);
 	}
 );
 

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -180,7 +180,7 @@ baseTest(
 
 		await documentLibraryPage.assertPrivateFileIcon();
 
-		await documentLibraryEditFilePage.goBack();
+		await documentLibraryPage.goto(site.friendlyUrlPath);
 
 		await page.getByRole('link', {name: title}).click();
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37342

Fix flaky test 'LPD-16313 Show icon in the content admin and content editor'

# How am I fixing it?

Use IsolatedTest strategy to the test, and avoid the goBack isn't working as expected (sometimes return to the homepage).

# How can you verify that it works?

1. Go to /modules/test/playwright
1. Run npm install (setup)
1. Run npm run `npm run playwright test -- -g "LPD-16313 Show icon in the content admin and content editor"` to run the test

# Before the PR

![image](https://github.com/user-attachments/assets/3e56939f-c6e0-45a6-87ea-54274063e00a)


# After the PR (launched 10 times to avoid flaky results)

```sh
npm run playwright test -- -g "LPD-16313 Show icon in the content admin and content editor" --repeat-each 10 --reporter list
```

![image](https://github.com/user-attachments/assets/6619be70-6780-47c9-94cd-b3c68a9114c6)
