### PR TITLE
LPD-37380 Document types are not being deleted from the index

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
@@ -73,13 +73,15 @@ public class DataEngineDLFileEntryTypeLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteFileEntryType(DLFileEntryType dlFileEntryType)
+	public DLFileEntryType deleteFileEntryType(DLFileEntryType dlFileEntryType)
 		throws PortalException {
 
-		super.deleteFileEntryType(dlFileEntryType);
+		dlFileEntryType = super.deleteFileEntryType(dlFileEntryType);
 
 		updateDDMStructureLinks(
 			dlFileEntryType.getFileEntryTypeId(), Collections.emptySet());
+
+		return dlFileEntryType;
 	}
 
 	private void _updateDDMStructure(long structureId) {

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -29,11 +29,14 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -173,12 +176,22 @@ public class DLFileEntryTypeServiceTest {
 			_dlFileEntryTypeService.fetchFileEntryTypeByExternalReferenceCode(
 				"12345678", _group.getGroupId()));
 
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
+
+		searchContext.setEntryClassNames(
+			new String[] {DLFileEntryType.class.getName()});
+		searchContext.setGroupIds(new long[] {_group.getGroupId()});
+
+		Assert.assertEquals(1, _indexer.searchCount(searchContext));
+
 		_dlFileEntryTypeService.deleteFileEntryTypeByExternalReferenceCode(
 			"12345678", _group.getGroupId());
 
 		Assert.assertNull(
 			_dlFileEntryTypeService.fetchFileEntryTypeByExternalReferenceCode(
 				"12345678", _group.getGroupId()));
+
+		Assert.assertEquals(0, _indexer.searchCount(searchContext));
 	}
 
 	@Test
@@ -419,6 +432,11 @@ public class DLFileEntryTypeServiceTest {
 
 	private static final String _TEST_DDM_STRUCTURE =
 		"dependencies/ddmstructure.xml";
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntryType"
+	)
+	private static Indexer<DLFileEntryType> _indexer;
 
 	private DLFileEntryType _basicDocumentDLFileEntryType;
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -40,6 +40,8 @@ import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Indexable;
+import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -220,6 +222,7 @@ public class DLFileEntryTypeLocalServiceImpl
 		return dlFileEntryTypePersistence.update(dlFileEntryType);
 	}
 
+	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -228,7 +228,7 @@ public class DLFileEntryTypeLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteFileEntryType(DLFileEntryType dlFileEntryType)
+	public DLFileEntryType deleteFileEntryType(DLFileEntryType dlFileEntryType)
 		throws PortalException {
 
 		int count = _dlFileEntryPersistence.countByFileEntryTypeId(
@@ -273,7 +273,7 @@ public class DLFileEntryTypeLocalServiceImpl
 			ResourceConstants.SCOPE_INDIVIDUAL,
 			dlFileEntryType.getFileEntryTypeId());
 
-		dlFileEntryTypePersistence.remove(dlFileEntryType);
+		return dlFileEntryTypePersistence.remove(dlFileEntryType);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
@@ -186,6 +186,7 @@ public interface DLFileEntryTypeLocalService
 	public void deleteDLFolderDLFileEntryTypes(
 		long folderId, long[] fileEntryTypeIds);
 
+	@Indexable(type = IndexableType.DELETE)
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalService.java
@@ -191,7 +191,7 @@ public interface DLFileEntryTypeLocalService
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteFileEntryType(DLFileEntryType dlFileEntryType)
+	public DLFileEntryType deleteFileEntryType(DLFileEntryType dlFileEntryType)
 		throws PortalException;
 
 	public void deleteFileEntryType(long fileEntryTypeId)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceUtil.java
@@ -212,10 +212,11 @@ public class DLFileEntryTypeLocalServiceUtil {
 		getService().deleteDLFolderDLFileEntryTypes(folderId, fileEntryTypeIds);
 	}
 
-	public static void deleteFileEntryType(DLFileEntryType dlFileEntryType)
+	public static DLFileEntryType deleteFileEntryType(
+			DLFileEntryType dlFileEntryType)
 		throws PortalException {
 
-		getService().deleteFileEntryType(dlFileEntryType);
+		return getService().deleteFileEntryType(dlFileEntryType);
 	}
 
 	public static void deleteFileEntryType(long fileEntryTypeId)

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryTypeLocalServiceWrapper.java
@@ -234,10 +234,11 @@ public class DLFileEntryTypeLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteFileEntryType(DLFileEntryType dlFileEntryType)
+	public DLFileEntryType deleteFileEntryType(DLFileEntryType dlFileEntryType)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		_dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
+		return _dlFileEntryTypeLocalService.deleteFileEntryType(
+			dlFileEntryType);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 20.1.0
+version 21.0.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37380

Document tyoes are not being deleted from the index and this is causing some errors when we are using recently created headless apis : https://liferay.atlassian.net/browse/LPD-32248 

# How am I fixing it?

Adding  annotation : `@Indexable(type = IndexableType.DELETE) ` to delete DLFileEntryType from the index

# How can you verify that it works?

try to:

1. Go to documents & media and create a document type in the defaut site
2. Immediately afterwards, delete above document type.
3. Enable FF https://liferay.atlassian.net/browse/LPD-32247
4. Go to swagger http://localhost:8080/o/api? and try to get document type from the default site using getSiteDocumentDataDefinitionTypesPage

and:

Run updated test