### PR TITLE
LPD-36744 add external-reference-code to the Repository entity on service

### DIFF
--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AddRepositoryIdInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/AddRepositoryIdInitialRequestPortalInstanceLifecycleListener.java
@@ -110,7 +110,7 @@ public class AddRepositoryIdInitialRequestPortalInstanceLifecycleListener
 				serviceContext.setUserId(user.getCompanyId());
 
 				Repository repository = _repositoryLocalService.addRepository(
-					user.getUserId(), company.getGroupId(),
+					null, user.getUserId(), company.getGroupId(),
 					_portal.getClassNameId(PortletRepository.class.getName()),
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 					PropsKeys.IMAGE_DEFAULT_COMPANY_LOGO, null,

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -284,7 +284,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 			return _run(
 				() -> _repositoryLocalService.addRepository(
-					user.getUserId(), groupId, classNameId,
+					null, user.getUserId(), groupId, classNameId,
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, portletId,
 					StringPool.BLANK, portletId, typeSettingsUnicodeProperties,
 					true, serviceContext));

--- a/modules/apps/document-library/document-library-repository-portlet-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/repository/test/PortletRepositoryTest.java
+++ b/modules/apps/document-library/document-library-repository-portlet-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/repository/test/PortletRepositoryTest.java
@@ -50,7 +50,7 @@ public class PortletRepositoryTest {
 	@Test
 	public void testAddRepository() throws PortalException {
 		Repository repository = _repositoryLocalService.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			_portal.getClassNameId(PortletRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK,

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/RepositoryStagedModelDataHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/exportimport/data/handler/RepositoryStagedModelDataHandler.java
@@ -158,7 +158,8 @@ public class RepositoryStagedModelDataHandler
 					serviceContext.setUuid(repository.getUuid());
 
 					importedRepository = _repositoryLocalService.addRepository(
-						userId, portletDataContext.getScopeGroupId(),
+						repository.getExternalReferenceCode(), userId,
+						portletDataContext.getScopeGroupId(),
 						_getRepositoryClassNameId(
 							repositoryElement, repository.getClassNameId()),
 						DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -177,7 +178,8 @@ public class RepositoryStagedModelDataHandler
 			}
 			else if (existingRepository == null) {
 				importedRepository = _repositoryLocalService.addRepository(
-					userId, portletDataContext.getScopeGroupId(),
+					repository.getExternalReferenceCode(), userId,
+					portletDataContext.getScopeGroupId(),
 					_getRepositoryClassNameId(
 						repositoryElement, repository.getClassNameId()),
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/RepositoryEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/RepositoryEntryTableReferenceDefinitionTest.java
@@ -49,7 +49,7 @@ public class RepositoryEntryTableReferenceDefinitionTest
 		super.setUp();
 
 		_repository = _repositoryLocalService.addRepository(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			_portal.getClassNameId(PortletRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RepositoryTableReferenceDefinitionTest.class.getSimpleName(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/RepositoryTableReferenceDefinitionTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/change/tracking/test/RepositoryTableReferenceDefinitionTest.java
@@ -43,7 +43,7 @@ public class RepositoryTableReferenceDefinitionTest
 	@Override
 	protected CTModel<?> addCTModel() throws Exception {
 		return _repositoryLocalService.addRepository(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			_portal.getClassNameId(PortletRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RepositoryTableReferenceDefinitionTest.class.getSimpleName(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/FileEntryStagedModelDataHandlerTest.java
@@ -526,7 +526,7 @@ public class FileEntryStagedModelDataHandlerTest
 				stagingGroup.getGroupId(), TestPropsValues.getUserId());
 
 		Repository repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
 			PortalUtil.getClassNameId(PortletRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "com.liferay.blogs",
 			"test repository", DLPortletKeys.DOCUMENT_LIBRARY,

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/exportimport/data/handler/test/RepositoryStagedModelDataHandlerTest.java
@@ -70,7 +70,7 @@ public class RepositoryStagedModelDataHandlerTest
 			serviceContext);
 
 		_repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), group.getGroupId(), classNameId,
 			mountFolder.getFolderId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			new UnicodeProperties(), false, serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryFinderTest.java
@@ -85,7 +85,7 @@ public class DLFileEntryFinderTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
 		_repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Repository A",
 			StringPool.BLANK, "Test Portlet", new UnicodeProperties(), true,
 			serviceContext);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderFinderTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderFinderTest.java
@@ -69,7 +69,7 @@ public class DLFolderFinderTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(PortletRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Test Repository",
 			StringUtil.randomString(), StringUtil.randomString(),

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
@@ -464,7 +464,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	protected long addRepositoryEntries() throws Exception {
 		Repository repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			PortletKeys.BACKGROUND_TASK, StringPool.BLANK,

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditRepositoryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditRepositoryMVCActionCommand.java
@@ -122,8 +122,8 @@ public class EditRepositoryMVCActionCommand extends BaseMVCActionCommand {
 				DLFolder.class.getName(), actionRequest);
 
 			_repositoryService.addRepository(
-				themeDisplay.getScopeGroupId(), classNameId, folderId, name,
-				description, portletDisplay.getId(),
+				null, themeDisplay.getScopeGroupId(), classNameId, folderId,
+				name, description, portletDisplay.getId(),
 				typeSettingsUnicodeProperties, serviceContext);
 		}
 		else {

--- a/modules/apps/portal/portal-uad-test/src/testIntegration/java/com/liferay/portal/uad/test/RepositoryEntryUADTestHelper.java
+++ b/modules/apps/portal/portal-uad-test/src/testIntegration/java/com/liferay/portal/uad/test/RepositoryEntryUADTestHelper.java
@@ -31,7 +31,7 @@ public class RepositoryEntryUADTestHelper {
 
 	public RepositoryEntry addRepositoryEntry(long userId) throws Exception {
 		Repository repository = _repositoryLocalService.addRepository(
-			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			_portal.getClassNameId(LiferayRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),

--- a/modules/apps/portal/portal-uad-test/src/testIntegration/java/com/liferay/portal/uad/test/RepositoryUADTestHelper.java
+++ b/modules/apps/portal/portal-uad-test/src/testIntegration/java/com/liferay/portal/uad/test/RepositoryUADTestHelper.java
@@ -28,7 +28,7 @@ public class RepositoryUADTestHelper {
 
 	public Repository addRepository(long userId) throws Exception {
 		return _repositoryLocalService.addRepository(
-			userId, TestPropsValues.getGroupId(),
+			null, userId, TestPropsValues.getGroupId(),
 			_portal.getClassNameId(LiferayRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseExternalReferenceCodeUpgradeProcessTestCase;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class RepositoryExternalReferenceCodeUpgradeProcessTest
+	extends BaseExternalReferenceCodeUpgradeProcessTestCase {
+
+	@Override
+	protected ExternalReferenceCodeModel[] addExternalReferenceCodeModels(
+			String tableName)
+		throws PortalException {
+
+		Repository repository = _repositoryLocalService.addRepository(
+			TestPropsValues.getUserId(), group.getGroupId(),
+			_portal.getClassNameId(LiferayRepository.class.getName()),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new UnicodeProperties(), true,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		return new ExternalReferenceCodeModel[] {repository};
+	}
+
+	@Override
+	protected void assertExternalReferenceCode(
+			String[] externalReferenceCodes, String tableName)
+		throws Exception {
+
+		try (Connection connection = dataSource.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select 1 from ", tableName,
+					" where externalReferenceCode in ('",
+					StringUtil.merge(externalReferenceCodes, "', '"), "')"))) {
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				Assert.assertFalse(resultSet.next());
+			}
+		}
+	}
+
+	@Override
+	protected ExternalReferenceCodeModel fetchExternalReferenceCodeModel(
+		ExternalReferenceCodeModel externalReferenceCodeModel,
+		String tableName) {
+
+		Repository repository = (Repository)externalReferenceCodeModel;
+
+		return _repositoryLocalService.fetchRepository(
+			repository.getRepositoryId());
+	}
+
+	@Override
+	protected String[] getTableNames() {
+		return new String[] {"Repository"};
+	}
+
+	@Override
+	protected UpgradeProcess getUpgradeProcess() {
+		return new BaseExternalReferenceCodeUpgradeProcess() {
+
+			@Override
+			protected String[][] getTableAndPrimaryKeyColumnNames() {
+				return new String[][] {{"Repository", "repositoryId"}};
+			}
+
+		};
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return null;
+	}
+
+	@Override
+	protected Version getVersion() {
+		return null;
+	}
+
+	@Override
+	protected void updateExternalReferenceCode(
+			String[] externalReferenceCodes, String tableName)
+		throws Exception {
+
+		db.runSQL(
+			StringBundler.concat(
+				"update ", tableName,
+				" set externalReferenceCode = null where ",
+				"externalReferenceCode in ('",
+				StringUtil.merge(externalReferenceCodes, "', '"), "')"));
+
+		entityCache.clearCache();
+		multiVMPool.clear();
+	}
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
@@ -46,7 +46,7 @@ public class RepositoryExternalReferenceCodeUpgradeProcessTest
 		throws PortalException {
 
 		Repository repository = _repositoryLocalService.addRepository(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			_portal.getClassNameId(LiferayRepository.class.getName()),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/RepositoryExternalReferenceCodeUpgradeProcessTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.upgrade.v7_4_x.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Repository;
@@ -18,7 +17,6 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
@@ -26,11 +24,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.BaseExternalReferenceCodeUpgradeProcessTestCase;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-
-import org.junit.Assert;
 import org.junit.runner.RunWith;
 
 /**
@@ -54,24 +47,6 @@ public class RepositoryExternalReferenceCodeUpgradeProcessTest
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		return new ExternalReferenceCodeModel[] {repository};
-	}
-
-	@Override
-	protected void assertExternalReferenceCode(
-			String[] externalReferenceCodes, String tableName)
-		throws Exception {
-
-		try (Connection connection = dataSource.getConnection();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select 1 from ", tableName,
-					" where externalReferenceCode in ('",
-					StringUtil.merge(externalReferenceCodes, "', '"), "')"))) {
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				Assert.assertFalse(resultSet.next());
-			}
-		}
 	}
 
 	@Override
@@ -110,22 +85,6 @@ public class RepositoryExternalReferenceCodeUpgradeProcessTest
 	@Override
 	protected Version getVersion() {
 		return null;
-	}
-
-	@Override
-	protected void updateExternalReferenceCode(
-			String[] externalReferenceCodes, String tableName)
-		throws Exception {
-
-		db.runSQL(
-			StringBundler.concat(
-				"update ", tableName,
-				" set externalReferenceCode = null where ",
-				"externalReferenceCode in ('",
-				StringUtil.merge(externalReferenceCodes, "', '"), "')"));
-
-		entityCache.clearCache();
-		multiVMPool.clear();
 	}
 
 	@Inject

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
@@ -127,7 +127,7 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 
 		com.liferay.portal.kernel.model.Repository repository =
 			_repositoryLocalService.addRepository(
-				user.getUserId(), group.getGroupId(),
+				null, user.getUserId(), group.getGroupId(),
 				_portal.getClassNameId(LiferayRepository.class.getName()),
 				dlFolder.getFolderId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), "Test Portlet",

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryTest.java
@@ -68,7 +68,7 @@ public class RepositoryTest {
 	@Test
 	public void testAddFileEntryInRepository() throws Exception {
 		Repository repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -102,7 +102,7 @@ public class RepositoryTest {
 		long classNameId = PortalUtil.getClassNameId(LiferayRepository.class);
 
 		Repository repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new UnicodeProperties(), true,
@@ -117,7 +117,7 @@ public class RepositoryTest {
 			new ServiceContext());
 
 		repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
 			dlFolder.getFolderId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			new UnicodeProperties(), true, new ServiceContext());
@@ -175,7 +175,7 @@ public class RepositoryTest {
 		throws Exception {
 
 		Repository dlRepository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -214,7 +214,7 @@ public class RepositoryTest {
 		throws Exception {
 
 		RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -233,7 +233,7 @@ public class RepositoryTest {
 		throws Exception {
 
 		RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -259,7 +259,7 @@ public class RepositoryTest {
 		fileEntryIds[1] = primaryKeys[2];
 
 		Repository repository = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			PortalUtil.getClassNameId(LiferayRepository.class),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
@@ -302,7 +302,7 @@ public class RepositoryTest {
 		long classNameId = PortalUtil.getClassNameId(LiferayRepository.class);
 
 		Repository repository1 = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new UnicodeProperties(), true,
@@ -316,7 +316,7 @@ public class RepositoryTest {
 		fileEntryIds[1] = primaryKeys[2];
 
 		Repository repository2 = RepositoryLocalServiceUtil.addRepository(
-			TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), classNameId,
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new UnicodeProperties(), true,

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.exception.DuplicateRepositoryExternalReferenceCodeException;
 import com.liferay.portal.kernel.exception.NoSuchRepositoryException;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
@@ -120,6 +121,8 @@ public class RepositoryPersistenceTest {
 
 		newRepository.setUuid(RandomTestUtil.randomString());
 
+		newRepository.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newRepository.setGroupId(RandomTestUtil.nextLong());
 
 		newRepository.setCompanyId(RandomTestUtil.nextLong());
@@ -160,6 +163,9 @@ public class RepositoryPersistenceTest {
 		Assert.assertEquals(
 			existingRepository.getUuid(), newRepository.getUuid());
 		Assert.assertEquals(
+			existingRepository.getExternalReferenceCode(),
+			newRepository.getExternalReferenceCode());
+		Assert.assertEquals(
 			existingRepository.getRepositoryId(),
 			newRepository.getRepositoryId());
 		Assert.assertEquals(
@@ -194,6 +200,26 @@ public class RepositoryPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingRepository.getLastPublishDate()),
 			Time.getShortTimestamp(newRepository.getLastPublishDate()));
+	}
+
+	@Test(expected = DuplicateRepositoryExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		Repository repository = addRepository();
+
+		Repository newRepository = addRepository();
+
+		newRepository.setGroupId(repository.getGroupId());
+
+		newRepository = _persistence.update(newRepository);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newRepository);
+
+		newRepository.setExternalReferenceCode(
+			repository.getExternalReferenceCode());
+
+		_persistence.update(newRepository);
 	}
 
 	@Test
@@ -240,6 +266,15 @@ public class RepositoryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
+
+		_persistence.countByERC_G("null", 0L);
+
+		_persistence.countByERC_G((String)null, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		Repository newRepository = addRepository();
 
@@ -265,11 +300,11 @@ public class RepositoryPersistenceTest {
 	protected OrderByComparator<Repository> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"Repository", "mvccVersion", true, "ctCollectionId", true, "uuid",
-			true, "repositoryId", true, "groupId", true, "companyId", true,
-			"userId", true, "userName", true, "createDate", true,
-			"modifiedDate", true, "classNameId", true, "name", true,
-			"description", true, "portletId", true, "dlFolderId", true,
-			"lastPublishDate", true);
+			true, "externalReferenceCode", true, "repositoryId", true,
+			"groupId", true, "companyId", true, "userId", true, "userName",
+			true, "createDate", true, "modifiedDate", true, "classNameId", true,
+			"name", true, "description", true, "portletId", true, "dlFolderId",
+			true, "lastPublishDate", true);
 	}
 
 	@Test
@@ -558,6 +593,17 @@ public class RepositoryPersistenceTest {
 			ReflectionTestUtil.invoke(
 				repository, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "portletId"));
+
+		Assert.assertEquals(
+			repository.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				repository, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(repository.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				repository, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected Repository addRepository() throws Exception {
@@ -570,6 +616,8 @@ public class RepositoryPersistenceTest {
 		repository.setCtCollectionId(RandomTestUtil.nextLong());
 
 		repository.setUuid(RandomTestUtil.randomString());
+
+		repository.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		repository.setGroupId(RandomTestUtil.nextLong());
 

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -836,6 +836,7 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1339,6 +1339,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="repositoryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/portal-impl/src/com/liferay/portal/model/impl/RepositoryCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RepositoryCacheModel.java
@@ -68,7 +68,7 @@ public class RepositoryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(35);
+		StringBundler sb = new StringBundler(37);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -76,6 +76,8 @@ public class RepositoryCacheModel
 		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", repositoryId=");
 		sb.append(repositoryId);
 		sb.append(", groupId=");
@@ -121,6 +123,13 @@ public class RepositoryCacheModel
 		}
 		else {
 			repositoryImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			repositoryImpl.setExternalReferenceCode("");
+		}
+		else {
+			repositoryImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		repositoryImpl.setRepositoryId(repositoryId);
@@ -201,6 +210,7 @@ public class RepositoryCacheModel
 
 		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		repositoryId = objectInput.readLong();
 
@@ -234,6 +244,13 @@ public class RepositoryCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(repositoryId);
@@ -291,6 +308,7 @@ public class RepositoryCacheModel
 	public long mvccVersion;
 	public long ctCollectionId;
 	public String uuid;
+	public String externalReferenceCode;
 	public long repositoryId;
 	public long groupId;
 	public long companyId;

--- a/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
@@ -66,14 +66,14 @@ public class RepositoryModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
-		{"uuid_", Types.VARCHAR}, {"repositoryId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
-		{"classNameId", Types.BIGINT}, {"name", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"portletId", Types.VARCHAR},
-		{"typeSettings", Types.CLOB}, {"dlFolderId", Types.BIGINT},
-		{"lastPublishDate", Types.TIMESTAMP}
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"repositoryId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"classNameId", Types.BIGINT},
+		{"name", Types.VARCHAR}, {"description", Types.VARCHAR},
+		{"portletId", Types.VARCHAR}, {"typeSettings", Types.CLOB},
+		{"dlFolderId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -83,6 +83,7 @@ public class RepositoryModelImpl
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("repositoryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -100,7 +101,7 @@ public class RepositoryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Repository (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,repositoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,name VARCHAR(200) null,description STRING null,portletId VARCHAR(200) null,typeSettings TEXT null,dlFolderId LONG,lastPublishDate DATE null,primary key (repositoryId, ctCollectionId))";
+		"create table Repository (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,repositoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,name VARCHAR(200) null,description STRING null,portletId VARCHAR(200) null,typeSettings TEXT null,dlFolderId LONG,lastPublishDate DATE null,primary key (repositoryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table Repository";
 
@@ -144,32 +145,38 @@ public class RepositoryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 4L;
+	public static final long GROUPID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PORTLETID_COLUMN_BITMASK = 8L;
+	public static final long NAME_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 16L;
+	public static final long PORTLETID_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long REPOSITORYID_COLUMN_BITMASK = 32L;
+	public static final long REPOSITORYID_COLUMN_BITMASK = 64L;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.util.PropsUtil.get(
@@ -274,6 +281,8 @@ public class RepositoryModelImpl
 				"ctCollectionId", Repository::getCtCollectionId);
 			attributeGetterFunctions.put("uuid", Repository::getUuid);
 			attributeGetterFunctions.put(
+				"externalReferenceCode", Repository::getExternalReferenceCode);
+			attributeGetterFunctions.put(
 				"repositoryId", Repository::getRepositoryId);
 			attributeGetterFunctions.put("groupId", Repository::getGroupId);
 			attributeGetterFunctions.put("companyId", Repository::getCompanyId);
@@ -319,6 +328,10 @@ public class RepositoryModelImpl
 				(BiConsumer<Repository, Long>)Repository::setCtCollectionId);
 			attributeSetterBiConsumers.put(
 				"uuid", (BiConsumer<Repository, String>)Repository::setUuid);
+			attributeSetterBiConsumers.put(
+				"externalReferenceCode",
+				(BiConsumer<Repository, String>)
+					Repository::setExternalReferenceCode);
 			attributeSetterBiConsumers.put(
 				"repositoryId",
 				(BiConsumer<Repository, Long>)Repository::setRepositoryId);
@@ -423,6 +436,35 @@ public class RepositoryModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -805,6 +847,7 @@ public class RepositoryModelImpl
 		repositoryImpl.setMvccVersion(getMvccVersion());
 		repositoryImpl.setCtCollectionId(getCtCollectionId());
 		repositoryImpl.setUuid(getUuid());
+		repositoryImpl.setExternalReferenceCode(getExternalReferenceCode());
 		repositoryImpl.setRepositoryId(getRepositoryId());
 		repositoryImpl.setGroupId(getGroupId());
 		repositoryImpl.setCompanyId(getCompanyId());
@@ -834,6 +877,8 @@ public class RepositoryModelImpl
 		repositoryImpl.setCtCollectionId(
 			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		repositoryImpl.setUuid(this.<String>getColumnOriginalValue("uuid_"));
+		repositoryImpl.setExternalReferenceCode(
+			this.<String>getColumnOriginalValue("externalReferenceCode"));
 		repositoryImpl.setRepositoryId(
 			this.<Long>getColumnOriginalValue("repositoryId"));
 		repositoryImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
@@ -946,6 +991,17 @@ public class RepositoryModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			repositoryCacheModel.uuid = null;
+		}
+
+		repositoryCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode =
+			repositoryCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			repositoryCacheModel.externalReferenceCode = null;
 		}
 
 		repositoryCacheModel.repositoryId = getRepositoryId();
@@ -1091,6 +1147,7 @@ public class RepositoryModelImpl
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _repositoryId;
 	private long _groupId;
 	private long _companyId;
@@ -1140,6 +1197,8 @@ public class RepositoryModelImpl
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("repositoryId", _repositoryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1183,33 +1242,35 @@ public class RepositoryModelImpl
 
 		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("repositoryId", 8L);
+		columnBitmasks.put("externalReferenceCode", 8L);
 
-		columnBitmasks.put("groupId", 16L);
+		columnBitmasks.put("repositoryId", 16L);
 
-		columnBitmasks.put("companyId", 32L);
+		columnBitmasks.put("groupId", 32L);
 
-		columnBitmasks.put("userId", 64L);
+		columnBitmasks.put("companyId", 64L);
 
-		columnBitmasks.put("userName", 128L);
+		columnBitmasks.put("userId", 128L);
 
-		columnBitmasks.put("createDate", 256L);
+		columnBitmasks.put("userName", 256L);
 
-		columnBitmasks.put("modifiedDate", 512L);
+		columnBitmasks.put("createDate", 512L);
 
-		columnBitmasks.put("classNameId", 1024L);
+		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("name", 2048L);
+		columnBitmasks.put("classNameId", 2048L);
 
-		columnBitmasks.put("description", 4096L);
+		columnBitmasks.put("name", 4096L);
 
-		columnBitmasks.put("portletId", 8192L);
+		columnBitmasks.put("description", 8192L);
 
-		columnBitmasks.put("typeSettings", 16384L);
+		columnBitmasks.put("portletId", 16384L);
 
-		columnBitmasks.put("dlFolderId", 32768L);
+		columnBitmasks.put("typeSettings", 32768L);
 
-		columnBitmasks.put("lastPublishDate", 65536L);
+		columnBitmasks.put("dlFolderId", 65536L);
+
+		columnBitmasks.put("lastPublishDate", 131072L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2000,7 +2000,7 @@
 			<finder-column comparator="&lt;=" name="expirationDate" />
 		</finder>
 	</entity>
-	<entity change-tracking-enabled="true" local-service="true" name="Repository" remote-service="true" uad-dir-path="../modules/apps/portal/portal-uad/src/main/java" uad-package-path="com.liferay.portal" uuid="true">
+	<entity change-tracking-enabled="true" external-reference-code="group" local-service="true" name="Repository" remote-service="true" uad-dir-path="../modules/apps/portal/portal-uad/src/main/java" uad-package-path="com.liferay.portal" uuid="true">
 
 		<!-- PK fields -->
 

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
@@ -258,6 +258,23 @@ public abstract class RepositoryLocalServiceBaseImpl
 		return repositoryPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
+	@Override
+	public Repository fetchRepositoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return repositoryPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
+	public Repository getRepositoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return repositoryPersistence.findByERC_G(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the repository with the primary key.
 	 *

--- a/portal-impl/src/com/liferay/portal/service/http/RepositoryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/RepositoryServiceHttp.java
@@ -42,9 +42,9 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class RepositoryServiceHttp {
 
 	public static com.liferay.portal.kernel.model.Repository addRepository(
-			HttpPrincipal httpPrincipal, long groupId, long classNameId,
-			long parentFolderId, String name, String description,
-			String portletId,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId, long classNameId, long parentFolderId, String name,
+			String description, String portletId,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -56,9 +56,9 @@ public class RepositoryServiceHttp {
 				_addRepositoryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, classNameId, parentFolderId, name,
-				description, portletId, typeSettingsUnicodeProperties,
-				serviceContext);
+				methodKey, externalReferenceCode, groupId, classNameId,
+				parentFolderId, name, description, portletId,
+				typeSettingsUnicodeProperties, serviceContext);
 
 			Object returnObj = null;
 
@@ -323,8 +323,8 @@ public class RepositoryServiceHttp {
 
 	private static final Class<?>[] _addRepositoryParameterTypes0 =
 		new Class[] {
-			long.class, long.class, long.class, String.class, String.class,
-			String.class,
+			String.class, long.class, long.class, long.class, String.class,
+			String.class, String.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -45,11 +45,16 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 
 	@Override
 	public Repository addRepository(
-			long userId, long groupId, long classNameId, long parentFolderId,
-			String name, String description, String portletId,
+			String externalReferenceCode, long userId, long groupId,
+			long classNameId, long parentFolderId, String name,
+			String description, String portletId,
 			UnicodeProperties typeSettingsUnicodeProperties, boolean hidden,
 			ServiceContext serviceContext)
 		throws PortalException {
+
+		if (Validator.isBlank(externalReferenceCode)) {
+			externalReferenceCode = null;
+		}
 
 		User user = _userPersistence.findByPrimaryKey(userId);
 
@@ -58,6 +63,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		Repository repository = repositoryPersistence.create(repositoryId);
 
 		repository.setUuid(serviceContext.getUuid());
+		repository.setExternalReferenceCode(externalReferenceCode);
 		repository.setGroupId(groupId);
 		repository.setCompanyId(user.getCompanyId());
 		repository.setUserId(user.getUserId());

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryServiceImpl.java
@@ -39,9 +39,9 @@ public class RepositoryServiceImpl extends RepositoryServiceBaseImpl {
 
 	@Override
 	public Repository addRepository(
-			long groupId, long classNameId, long parentFolderId, String name,
-			String description, String portletId,
-			UnicodeProperties typeSettingsUnicodeProperties,
+			String externalReferenceCode, long groupId, long classNameId,
+			long parentFolderId, String name, String description,
+			String portletId, UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -52,9 +52,9 @@ public class RepositoryServiceImpl extends RepositoryServiceBaseImpl {
 			getPermissionChecker(), groupId, ActionKeys.ADD_REPOSITORY);
 
 		return repositoryLocalService.addRepository(
-			getUserId(), groupId, classNameId, parentFolderId, name,
-			description, portletId, typeSettingsUnicodeProperties, false,
-			serviceContext);
+			externalReferenceCode, getUserId(), groupId, classNameId,
+			parentFolderId, name, description, portletId,
+			typeSettingsUnicodeProperties, false, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RepositoryPersistenceImpl.java
@@ -18,18 +18,25 @@ import com.liferay.portal.kernel.dao.orm.Query;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.exception.DuplicateRepositoryExternalReferenceCodeException;
 import com.liferay.portal.kernel.exception.NoSuchRepositoryException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.RepositoryTable;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.RepositoryPersistence;
 import com.liferay.portal.kernel.service.persistence.RepositoryUtil;
 import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelperUtil;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -2286,6 +2293,267 @@ public class RepositoryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_N_P_PORTLETID_3 =
 		"(repository.portletId IS NULL OR repository.portletId = '')";
 
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchRepositoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository
+	 * @throws NoSuchRepositoryException if a matching repository could not be found
+	 */
+	@Override
+	public Repository findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchRepositoryException {
+
+		Repository repository = fetchByERC_G(externalReferenceCode, groupId);
+
+		if (repository == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchRepositoryException(sb.toString());
+		}
+
+		return repository;
+	}
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	@Override
+	public Repository fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
+	}
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	@Override
+	public Repository fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					Repository.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			Object[] finderArgs = null;
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {externalReferenceCode, groupId};
+			}
+
+			Object result = null;
+
+			if (useFinderCache) {
+				result = FinderCacheUtil.getResult(
+					_finderPathFetchByERC_G, finderArgs, this);
+			}
+
+			if (result instanceof Repository) {
+				Repository repository = (Repository)result;
+
+				if (!Objects.equals(
+						externalReferenceCode,
+						repository.getExternalReferenceCode()) ||
+					(groupId != repository.getGroupId())) {
+
+					result = null;
+				}
+			}
+
+			if (result == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_SELECT_REPOSITORY_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					List<Repository> list = query.list();
+
+					if (list.isEmpty()) {
+						if (useFinderCache) {
+							FinderCacheUtil.putResult(
+								_finderPathFetchByERC_G, finderArgs, list);
+						}
+					}
+					else {
+						Repository repository = list.get(0);
+
+						result = repository;
+
+						cacheResult(repository);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			if (result instanceof List<?>) {
+				return null;
+			}
+			else {
+				return (Repository)result;
+			}
+		}
+	}
+
+	/**
+	 * Removes the repository where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the repository that was removed
+	 */
+	@Override
+	public Repository removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchRepositoryException {
+
+		Repository repository = findByERC_G(externalReferenceCode, groupId);
+
+		return remove(repository);
+	}
+
+	/**
+	 * Returns the number of repositories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching repositories
+	 */
+	@Override
+	public int countByERC_G(String externalReferenceCode, long groupId) {
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					Repository.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			FinderPath finderPath = _finderPathCountByERC_G;
+
+			Object[] finderArgs = new Object[] {externalReferenceCode, groupId};
+
+			Long count = (Long)FinderCacheUtil.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_REPOSITORY_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					count = (Long)query.uniqueResult();
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"repository.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(repository.externalReferenceCode IS NULL OR repository.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"repository.groupId = ?";
+
 	public RepositoryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -2325,6 +2593,14 @@ public class RepositoryPersistenceImpl
 				new Object[] {
 					repository.getGroupId(), repository.getName(),
 					repository.getPortletId()
+				},
+				repository);
+
+			FinderCacheUtil.putResult(
+				_finderPathFetchByERC_G,
+				new Object[] {
+					repository.getExternalReferenceCode(),
+					repository.getGroupId()
 				},
 				repository);
 		}
@@ -2428,6 +2704,16 @@ public class RepositoryPersistenceImpl
 				_finderPathCountByG_N_P, args, Long.valueOf(1));
 			FinderCacheUtil.putResult(
 				_finderPathFetchByG_N_P, args, repositoryModelImpl);
+
+			args = new Object[] {
+				repositoryModelImpl.getExternalReferenceCode(),
+				repositoryModelImpl.getGroupId()
+			};
+
+			FinderCacheUtil.putResult(
+				_finderPathCountByERC_G, args, Long.valueOf(1));
+			FinderCacheUtil.putResult(
+				_finderPathFetchByERC_G, args, repositoryModelImpl);
 		}
 	}
 
@@ -2567,6 +2853,67 @@ public class RepositoryPersistenceImpl
 			String uuid = PortalUUIDUtil.generate();
 
 			repository.setUuid(uuid);
+		}
+
+		if (Validator.isNull(repository.getExternalReferenceCode())) {
+			repository.setExternalReferenceCode(repository.getUuid());
+		}
+		else {
+			if (!Objects.equals(
+					repositoryModelImpl.getColumnOriginalValue(
+						"externalReferenceCode"),
+					repository.getExternalReferenceCode())) {
+
+				long userId = GetterUtil.getLong(
+					PrincipalThreadLocal.getName());
+
+				if (userId > 0) {
+					long companyId = repository.getCompanyId();
+
+					long groupId = repository.getGroupId();
+
+					long classPK = 0;
+
+					if (!isNew) {
+						classPK = repository.getPrimaryKey();
+					}
+
+					try {
+						repository.setExternalReferenceCode(
+							SanitizerUtil.sanitize(
+								companyId, groupId, userId,
+								Repository.class.getName(), classPK,
+								ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+								repository.getExternalReferenceCode(), null));
+					}
+					catch (SanitizerException sanitizerException) {
+						throw new SystemException(sanitizerException);
+					}
+				}
+			}
+
+			Repository ercRepository = fetchByERC_G(
+				repository.getExternalReferenceCode(), repository.getGroupId());
+
+			if (isNew) {
+				if (ercRepository != null) {
+					throw new DuplicateRepositoryExternalReferenceCodeException(
+						"Duplicate repository with external reference code " +
+							repository.getExternalReferenceCode() +
+								" and group " + repository.getGroupId());
+				}
+			}
+			else {
+				if ((ercRepository != null) &&
+					(repository.getRepositoryId() !=
+						ercRepository.getRepositoryId())) {
+
+					throw new DuplicateRepositoryExternalReferenceCodeException(
+						"Duplicate repository with external reference code " +
+							repository.getExternalReferenceCode() +
+								" and group " + repository.getGroupId());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -3105,6 +3452,7 @@ public class RepositoryPersistenceImpl
 		ctControlColumnNames.add("mvccVersion");
 		ctControlColumnNames.add("ctCollectionId");
 		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctStrictColumnNames.add("userId");
@@ -3132,6 +3480,9 @@ public class RepositoryPersistenceImpl
 
 		_uniqueIndexColumnNames.add(
 			new String[] {"groupId", "name", "portletId"});
+
+		_uniqueIndexColumnNames.add(
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -3233,6 +3584,16 @@ public class RepositoryPersistenceImpl
 				String.class.getName()
 			},
 			new String[] {"groupId", "name", "portletId"}, false);
+
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
+
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		RepositoryUtil.setPersistence(this);
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -482,6 +482,17 @@ public class PortalUpgradeProcessRegistryImpl
 				}
 
 			});
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 10, 0),
+			new BaseExternalReferenceCodeUpgradeProcess() {
+
+				@Override
+				protected String[][] getTableAndPrimaryKeyColumnNames() {
+					return new String[][] {{"Repository", "repositoryId"}};
+				}
+
+			});
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateRepositoryExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/DuplicateRepositoryExternalReferenceCodeException.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.exception;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateRepositoryExternalReferenceCodeException
+	extends DuplicateExternalReferenceCodeException {
+
+	public DuplicateRepositoryExternalReferenceCodeException() {
+	}
+
+	public DuplicateRepositoryExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateRepositoryExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateRepositoryExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryModel.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryModel.java
@@ -25,7 +25,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface RepositoryModel
-	extends BaseModel<Repository>, CTModel<Repository>, MVCCModel, ShardedModel,
+	extends BaseModel<Repository>, CTModel<Repository>,
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
 			StagedGroupedModel, TypedModel {
 
 	/*
@@ -98,6 +99,23 @@ public interface RepositoryModel
 	 */
 	@Override
 	public void setUuid(String uuid);
+
+	/**
+	 * Returns the external reference code of this repository.
+	 *
+	 * @return the external reference code of this repository
+	 */
+	@AutoEscape
+	@Override
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this repository.
+	 *
+	 * @param externalReferenceCode the external reference code of this repository
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**
 	 * Returns the repository ID of this repository.

--- a/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryTable.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryTable.java
@@ -30,6 +30,10 @@ public class RepositoryTable extends BaseTable<RepositoryTable> {
 		"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<RepositoryTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<RepositoryTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<RepositoryTable, Long> repositoryId = createColumn(
 		"repositoryId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<RepositoryTable, Long> groupId = createColumn(

--- a/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/RepositoryWrapper.java
@@ -38,6 +38,7 @@ public class RepositoryWrapper
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("repositoryId", getRepositoryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -74,6 +75,13 @@ public class RepositoryWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long repositoryId = (Long)attributes.get("repositoryId");
@@ -234,6 +242,16 @@ public class RepositoryWrapper
 	@Override
 	public long getDlFolderId() {
 		return model.getDlFolderId();
+	}
+
+	/**
+	 * Returns the external reference code of this repository.
+	 *
+	 * @return the external reference code of this repository
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -441,6 +459,16 @@ public class RepositoryWrapper
 	@Override
 	public void setDlFolderId(long dlFolderId) {
 		model.setDlFolderId(dlFolderId);
+	}
+
+	/**
+	 * Sets the external reference code of this repository.
+	 *
+	 * @param externalReferenceCode the external reference code of this repository
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
@@ -65,12 +65,6 @@ public interface RepositoryLocalService
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.RepositoryLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the repository local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link RepositoryLocalServiceUtil} if injection and service tracking are not available.
 	 */
-	public Repository addRepository(
-			long userId, long groupId, long classNameId, long parentFolderId,
-			String name, String description, String portletId,
-			UnicodeProperties typeSettingsUnicodeProperties, boolean hidden,
-			ServiceContext serviceContext)
-		throws PortalException;
 
 	/**
 	 * Adds the repository to the database. Also notifies the appropriate model listeners.
@@ -84,6 +78,14 @@ public interface RepositoryLocalService
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	public Repository addRepository(Repository repository);
+
+	public Repository addRepository(
+			String externalReferenceCode, long userId, long groupId,
+			long classNameId, long parentFolderId, String name,
+			String description, String portletId,
+			UnicodeProperties typeSettingsUnicodeProperties, boolean hidden,
+			ServiceContext serviceContext)
+		throws PortalException;
 
 	public void checkRepository(long repositoryId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
@@ -227,6 +227,10 @@ public interface RepositoryLocalService
 	public Repository fetchRepository(
 		long groupId, String name, String portletId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Repository fetchRepositoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId);
+
 	/**
 	 * Returns the repository matching the UUID and group.
 	 *
@@ -330,6 +334,11 @@ public interface RepositoryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Repository getRepository(long groupId, String name, String portletId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Repository getRepositoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
@@ -233,6 +233,13 @@ public class RepositoryLocalServiceUtil {
 		return getService().fetchRepository(groupId, name, portletId);
 	}
 
+	public static Repository fetchRepositoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return getService().fetchRepositoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the repository matching the UUID and group.
 	 *
@@ -368,6 +375,14 @@ public class RepositoryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getRepository(groupId, name, portletId);
+	}
+
+	public static Repository getRepositoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getRepositoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
@@ -35,18 +35,6 @@ public class RepositoryLocalServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.service.impl.RepositoryLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
-	public static Repository addRepository(
-			long userId, long groupId, long classNameId, long parentFolderId,
-			String name, String description, String portletId,
-			com.liferay.portal.kernel.util.UnicodeProperties
-				typeSettingsUnicodeProperties,
-			boolean hidden, ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addRepository(
-			userId, groupId, classNameId, parentFolderId, name, description,
-			portletId, typeSettingsUnicodeProperties, hidden, serviceContext);
-	}
 
 	/**
 	 * Adds the repository to the database. Also notifies the appropriate model listeners.
@@ -60,6 +48,21 @@ public class RepositoryLocalServiceUtil {
 	 */
 	public static Repository addRepository(Repository repository) {
 		return getService().addRepository(repository);
+	}
+
+	public static Repository addRepository(
+			String externalReferenceCode, long userId, long groupId,
+			long classNameId, long parentFolderId, String name,
+			String description, String portletId,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			boolean hidden, ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addRepository(
+			externalReferenceCode, userId, groupId, classNameId, parentFolderId,
+			name, description, portletId, typeSettingsUnicodeProperties, hidden,
+			serviceContext);
 	}
 
 	public static void checkRepository(long repositoryId) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
@@ -260,6 +260,14 @@ public class RepositoryLocalServiceWrapper
 			groupId, name, portletId);
 	}
 
+	@Override
+	public Repository fetchRepositoryByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return _repositoryLocalService.fetchRepositoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the repository matching the UUID and group.
 	 *
@@ -412,6 +420,15 @@ public class RepositoryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _repositoryLocalService.getRepository(groupId, name, portletId);
+	}
+
+	@Override
+	public Repository getRepositoryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _repositoryLocalService.getRepositoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
@@ -30,20 +30,6 @@ public class RepositoryLocalServiceWrapper
 		_repositoryLocalService = repositoryLocalService;
 	}
 
-	@Override
-	public Repository addRepository(
-			long userId, long groupId, long classNameId, long parentFolderId,
-			String name, String description, String portletId,
-			com.liferay.portal.kernel.util.UnicodeProperties
-				typeSettingsUnicodeProperties,
-			boolean hidden, ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _repositoryLocalService.addRepository(
-			userId, groupId, classNameId, parentFolderId, name, description,
-			portletId, typeSettingsUnicodeProperties, hidden, serviceContext);
-	}
-
 	/**
 	 * Adds the repository to the database. Also notifies the appropriate model listeners.
 	 *
@@ -57,6 +43,22 @@ public class RepositoryLocalServiceWrapper
 	@Override
 	public Repository addRepository(Repository repository) {
 		return _repositoryLocalService.addRepository(repository);
+	}
+
+	@Override
+	public Repository addRepository(
+			String externalReferenceCode, long userId, long groupId,
+			long classNameId, long parentFolderId, String name,
+			String description, String portletId,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			boolean hidden, ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _repositoryLocalService.addRepository(
+			externalReferenceCode, userId, groupId, classNameId, parentFolderId,
+			name, description, portletId, typeSettingsUnicodeProperties, hidden,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryService.java
@@ -43,9 +43,9 @@ public interface RepositoryService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.RepositoryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the repository remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link RepositoryServiceUtil} if injection and service tracking are not available.
 	 */
 	public Repository addRepository(
-			long groupId, long classNameId, long parentFolderId, String name,
-			String description, String portletId,
-			UnicodeProperties typeSettingsUnicodeProperties,
+			String externalReferenceCode, long groupId, long classNameId,
+			long parentFolderId, String name, String description,
+			String portletId, UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryServiceUtil.java
@@ -28,16 +28,18 @@ public class RepositoryServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.service.impl.RepositoryServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static Repository addRepository(
-			long groupId, long classNameId, long parentFolderId, String name,
-			String description, String portletId,
+			String externalReferenceCode, long groupId, long classNameId,
+			long parentFolderId, String name, String description,
+			String portletId,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addRepository(
-			groupId, classNameId, parentFolderId, name, description, portletId,
-			typeSettingsUnicodeProperties, serviceContext);
+			externalReferenceCode, groupId, classNameId, parentFolderId, name,
+			description, portletId, typeSettingsUnicodeProperties,
+			serviceContext);
 	}
 
 	public static void checkRepository(long repositoryId)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryServiceWrapper.java
@@ -27,16 +27,18 @@ public class RepositoryServiceWrapper
 
 	@Override
 	public Repository addRepository(
-			long groupId, long classNameId, long parentFolderId, String name,
-			String description, String portletId,
+			String externalReferenceCode, long groupId, long classNameId,
+			long parentFolderId, String name, String description,
+			String portletId,
 			com.liferay.portal.kernel.util.UnicodeProperties
 				typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _repositoryService.addRepository(
-			groupId, classNameId, parentFolderId, name, description, portletId,
-			typeSettingsUnicodeProperties, serviceContext);
+			externalReferenceCode, groupId, classNameId, parentFolderId, name,
+			description, portletId, typeSettingsUnicodeProperties,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RepositoryPersistence.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RepositoryPersistence.java
@@ -578,6 +578,56 @@ public interface RepositoryPersistence
 	public int countByG_N_P(long groupId, String name, String portletId);
 
 	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchRepositoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository
+	 * @throws NoSuchRepositoryException if a matching repository could not be found
+	 */
+	public Repository findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchRepositoryException;
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	public Repository fetchByERC_G(String externalReferenceCode, long groupId);
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	public Repository fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
+
+	/**
+	 * Removes the repository where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the repository that was removed
+	 */
+	public Repository removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchRepositoryException;
+
+	/**
+	 * Returns the number of repositories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching repositories
+	 */
+	public int countByERC_G(String externalReferenceCode, long groupId);
+
+	/**
 	 * Caches the repository in the entity cache if it is enabled.
 	 *
 	 * @param repository the repository

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RepositoryUtil.java
@@ -761,6 +761,74 @@ public class RepositoryUtil {
 	}
 
 	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchRepositoryException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository
+	 * @throws NoSuchRepositoryException if a matching repository could not be found
+	 */
+	public static Repository findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.NoSuchRepositoryException {
+
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	public static Repository fetchByERC_G(
+		String externalReferenceCode, long groupId) {
+
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the repository where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 */
+	public static Repository fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
+	}
+
+	/**
+	 * Removes the repository where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the repository that was removed
+	 */
+	public static Repository removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.NoSuchRepositoryException {
+
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the number of repositories where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching repositories
+	 */
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
 	 * Caches the repository in the entity cache if it is enabled.
 	 *
 	 * @param repository the repository

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
@@ -209,7 +209,7 @@ public class TempFileEntryUtil {
 			DLAppHelperThreadLocal.setEnabled(false);
 
 			repository = RepositoryLocalServiceUtil.addRepository(
-				user.getUserId(), groupId, classNameId,
+				null, user.getUserId(), groupId, classNameId,
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				TempFileEntryUtil.class.getName(), StringPool.BLANK,
 				TempFileEntryUtil.class.getName(),

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -331,8 +331,10 @@ create unique index IX_8BD6BCA7 on Release_ (servletContextName[$COLUMN_LENGTH:7
 create index IX_D4C6FBCB on RememberMeToken (expirationDate);
 create index IX_291F58D4 on RememberMeToken (userId);
 
+create unique index IX_1F8735E5 on Repository (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create unique index IX_470608AE on Repository (groupId, ctCollectionId, name[$COLUMN_LENGTH:200$], portletId[$COLUMN_LENGTH:200$]);
-create unique index IX_4009E884 on Repository (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
+create unique index IX_E9E7CCD8 on Repository (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
+create index IX_74C17B04 on Repository (uuid_[$COLUMN_LENGTH:75$]);
 
 create unique index IX_B43A3F67 on RepositoryEntry (repositoryId, ctCollectionId, mappedId[$COLUMN_LENGTH:255$]);
 create unique index IX_239165C6 on RepositoryEntry (uuid_[$COLUMN_LENGTH:75$], ctCollectionId, groupId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -1168,6 +1168,7 @@ create table Repository (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	repositoryId LONG not null,
 	groupId LONG,
 	companyId LONG,


### PR DESCRIPTION
LPD-36744 add external-reference-code to the Repository entity

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36744

As a developer I want Repositories to use ERC so that the data referenced is migrated properly in import/export scenarios

# How am I fixing it?

The repository table should have a column for externalReferenceCode so I adding it to it.

# How can you verify that it works?

Run the included automated tests

# Commits


- **LPD-36744 add external-reference-code to the repository entity on service**
- **LPD-36744 buildService**
- **LPD-36744 baseline**
- **LPD-36744 on addRepository method assert that ERC is the same that UUID**
- **LPD-36744 upgrade process for Repository table**
- **LPD-36744 test for upgrade process**
