### PR TITLE
LPD-37407 Narrow down set of tests in content-management suite

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4472,6 +4472,57 @@
         questions-web,\
         wiki-web
 
+    modules.includes[js-unit-jdk8][content-management]=\
+        apps/asset/**,\
+        apps/content-dashboard/**,\
+        apps/journal/**,\
+        apps/questions/questions-web/test/js/**/*.js
+
+    modules.includes[modules-semantic-versioning-jdk8][content-management]=\
+        apps/adaptive-media/**,\
+        apps/ai-creator/**,\
+        apps/announcements/**,\
+        apps/asset/**,\
+        apps/asset-tags-validator/**,\
+        apps/blogs/**,\
+        apps/bookmarks/**,\
+        apps/bulk/**,\
+        apps/comment/**,\
+        apps/connected-app/**,\
+        apps/content-dashboard/**,\
+        apps/depot/**,\
+        apps/document-library/**,\
+        apps/document-library-google-docs/**,\
+        apps/document-library-google-opener/**,\
+        apps/headless/headless-delivery/**,\
+        apps/headless/headless-admin-content/**,\
+        apps/headless/headless-admin-taxonomy/**,\
+        apps/image/**,\
+        apps/item-selector/**,\
+        apps/journal/**,\
+        apps/knowledge-base/**,\
+        apps/locked-items/**,\
+        apps/mentions/**,\
+        apps/microblogs/**,\
+        apps/my-subscriptions/**,\
+        apps/questions/**,\
+        apps/ratings/**,\
+        apps/reading-time/**,\
+        apps/repository/**,\
+        apps/saved-content/**,\
+        apps/sharing/**,\
+        apps/social/**,\
+        apps/subscription/**,\
+        apps/translation/**,\
+        apps/trash/**,\
+        apps/upload/**,\
+        apps/wiki/**
+
+    modules.includes.private[modules-semantic-versioning-jdk8][content-management]=\
+        dxp/apps/document-library-opener/**,\
+        dxp/apps/sharepoint-rest/**,\
+        dxp/apps/sharepoint-soap/**
+
     playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=${content-management-playwright-projects}
 
     test.batch.class.names.includes[content-management]=\

--- a/test.properties
+++ b/test.properties
@@ -4526,109 +4526,38 @@
     playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][content-management]=${content-management-playwright-projects}
 
     test.batch.class.names.includes[content-management]=\
-        **/adaptive-media-blogs-test/**/*Test.java,\
-        **/adaptive-media-blogs-web-test/**/*Test.java,\
-        **/adaptive-media-document-library-thumbnails-test/**/*Test.java,\
-        **/adaptive-media-document-library-web-test/**/*Test.java,\
-        **/adaptive-media-image-content-transformer-test/**/*Test.java,\
-        **/adaptive-media-image-impl-test/**/*Test.java,\
-        **/adaptive-media-image-item-selector-test/**/*Test.java,\
-        **/adaptive-media-image-test/**/*Test.java,\
-        **/adaptive-media-journal-test/**/*Test.java,\
-        **/announcements-test/**/*Test.java,\
-        **/announcements-uad-test/**/*Test.java,\
-        **/apps/content-dashboard/**/*Test.java,\
-        **/asset-auto-tagger-google-cloud-natural-language-test/**/*Test.java,\
-        **/asset-auto-tagger-opennlp-test/**/*Test.java,\
-        **/asset-auto-tagger-service/**/*Test.java,\
-        **/asset-auto-tagger-test/**/*Test.java,\
-        **/asset-category-property-test/**/*Test.java,\
-        **/asset-category-test/**/*Test.java,\
-        **/asset-entry-rel-test/**/*Test.java,\
-        **/asset-link-test/**/*Test.java,\
-        **/asset-taglib-test/**/*Test.java,\
-        **/asset-tags-test/**/*Test.java,\
+        **/adaptive-media/**/*Test.java,\
+        **/ai-creator/**/*Test.java,\
+        **/announcements/**/*Test.java,\
+        **/asset/**/*Test.java,\
         **/asset-tags-validator/**/*Test.java,\
-        **/asset-test/**/*Test.java,\
-        **/blogs-recent-bloggers-test/**/*Test.java,\
-        **/blogs-test/**/*Test.java,\
-        **/blogs-test-util/**/*Test.java,\
-        **/blogs-uad-test/**/*Test.java,\
-        **/blogs-web/**/*Test.java,\
-        **/blogs-web-test/**/*Test.java,\
-        **/bulk-rest-test/**/*Test.java,\
-        **/bulk-selection-test/**/*Test.java,\
-        **/comment-test/**/*Test.java,\
-        **/comment-web-test/**/*Test.java,\
-        **/depot-service/**/*Test.java,\
-        **/depot-test/**/*Test.java,\
-        **/depot-web/**/*Test.java,\
-        **/document-library-asset-auto-tagger-tensorflow-test/**/*Test.java,\
-        **/document-library-content-test/**/*Test.java,\
-        **/document-library-document-conversion/**/*Test.java,\
-        **/document-library-document-conversion-test/**/*Test.java,\
-        **/document-library-opener-google-drive-test/**/*Test.java,\
-        **/document-library-opener-test/**/*Test.java,\
-        **/document-library-opener-uad-test/**/*Test.java,\
-        **/document-library-preview-audio-test/**/*Test.java,\
-        **/document-library-repository-cmis-api/**/*Test.java,\
-        **/document-library-repository-cmis-impl/**/*Test.java,\
-        **/document-library-repository-portlet-file-repository-test/**/*Test.java,\
-        **/document-library-repository-portlet-repository-test/**/*Test.java,\
-        **/document-library-repository-search/**/*Test.java,\
-        **/document-library-service/**/*Test.java,\
-        **/document-library-taglib-test/**/*Test.java,\
-        **/document-library-test/**/*Test.java,\
-        **/document-library-test-util/**/*Test.java,\
-        **/document-library-uad-test/**/*Test.java,\
-        **/document-library-video-test/**/*Test.java,\
-        **/document-library-web-test/**/*Test.java,\
+        **/blogs/**/*Test.java,\
+        **/bookmarks/**/*Test.java,\
+        **/bulk/**/*Test.java,\
+        **/comment/**/*Test.java,\
+        **/connected-app/**/*Test.java,\
+        **/content-dashboard/**/*Test.java,\
+        **/depot/**/*Test.java,\
+        **/document-library/**/*Test.java,\
+        **/document-library-google-docs/**/*Test.java,\
+        **/document-library-google-opener/**/*Test.java,\
         **/headless/headless-admin-content/**/*Test.java,\
         **/headless/headless-admin-taxonomy/**/*Test.java,\
-        **/headless/headless-delivery/**/*BlogPosting*Test.java,\
-        **/headless/headless-delivery/**/*CommentResource*Test.java,\
-        **/headless/headless-delivery/**/*Document*Test.java,\
-        **/headless/headless-delivery/**/*KnowledgeBase*Test.java,\
-        **/headless/headless-delivery/**/*MessageBoard*Test.java,\
-        **/headless/headless-delivery/**/*StructuredContent*Test.java,\
-        **/headless/headless-delivery/**/*Wiki*Test.java,\
-        **/item-selector-taglib/**/*Test.java,\
-        **/item-selector-test/**/*Test.java,\
-        **/item-selector-web/**/*Test.java,\
+        **/headless/headless-delivery/**/*Test.java,\
+        **/image/**/*Test.java,\
+        **/item-selector/**/*Test.java,\
         **/journal/**/*Test.java,\
-        **/knowledge-base-markdown-converter-impl/**/*Test.java,\
-        **/knowledge-base-service/**/*Test.java,\
-        **/knowledge-base-test/**/*Test.java,\
-        **/knowledge-base-web-test/**/*Test.java,\
-        **/layout-content-page-editor-web/**/*test.js,\
-        **/mentions-service/**/*Test.java,\
-        **/mentions-web-test/**/*Test.java,\
-        **/message-boards-comment/**/*Test.java,\
-        **/message-boards-parser-bbcode/**/*Test.java,\
-        **/message-boards-service/**/*Test.java,\
-        **/message-boards-test/**/*Test.java,\
-        **/message-boards-test-util/**/*Test.java,\
-        **/message-boards-uad-test/**/*Test.java,\
-        **/message-boards-web/**/*Test.java,\
-        **/notifications-uad-test/**/*Test.java,\
-        **/notifications-web-test/**/*Test.java,\
-        **/questions-web/test/*test.js,\
+        **/knowledge-base/**/*Test.java,\
+        **/mentions/**/*Test.java,\
+        **/message-boards/**/*Test.java,\
         **/ratings-test/**/*Test.java,\
-        **/reading-time-test/**/*Test.java,\
-        **/repository-test/**/*Test.java,\
-        **/sharing-blogs-test/**/*Test.java,\
-        **/sharing-document-library-test/**/*Test.java,\
-        **/sharing-search-test/**/*Test.java,\
-        **/sharing-test/**/*Test.java,\
-        **/social-activity-test/**/*Test.java,\
-        **/translation-test/**/*Test.java,\
+        **/reading-time/**/*Test.java,\
+        **/repository/**/*Test.java,\
+        **/sharing/**/*Test.java,\
+        **/social/**/*Test.java,\
+        **/translation/**/*Test.java,\
         **/trash/**/*Test.java,\
-        **/wiki-editor-configuration/**/*Test.java,\
-        **/wiki-engine-creole/**/*Test.java,\
-        **/wiki-engine-html/**/*Test.java,\
-        **/wiki-test/**/*Test.java,\
-        **/wiki-uad-test/**/*Test.java,\
-        **/wiki-web-test/**/*Test.java
+        **/wiki/**/*Test.java
 
     test.batch.dist.app.servers[content-management]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -4494,9 +4494,9 @@
         apps/document-library/**,\
         apps/document-library-google-docs/**,\
         apps/document-library-google-opener/**,\
-        apps/headless/headless-delivery/**,\
         apps/headless/headless-admin-content/**,\
         apps/headless/headless-admin-taxonomy/**,\
+        apps/headless/headless-delivery/**,\
         apps/image/**,\
         apps/item-selector/**,\
         apps/journal/**,\

--- a/test.properties
+++ b/test.properties
@@ -4584,7 +4584,9 @@
     test.batch.names[content-management]=\
         functional-tomcat90-mysql57-jdk8,\
         js-unit-jdk8,\
+        modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
+        modules-unit-jdk8,\
         playwright-compile-jdk8,\
         playwright-js-tomcat90-mysql57-jdk8,\
         semantic-versioning-jdk8


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37407

Narrow down the set of modules/tests that are evaluated in our content-management suite.

# How am I fixing it?

By including only the set of modules owned by the team. In the case of Js unit tests, I'm only including those modules that have Js unit tests.

# How can you verify that it works?

We'll need to manually check the build results to ensure that it doesn't include additional modules.

# Why doesn't this include any test?

This only changes the CI configuration.