### PR TITLE
LPD-37385 [playwright] DM refactor

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
@@ -20,8 +20,8 @@ export class DocumentLibraryEditDocumentTypesPage {
 		this.titleSelector = page.getByPlaceholder('Untitled');
 	}
 
-	async goto() {
-		await this.documentLibraryPage.goto();
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.documentLibraryPage.goto(siteUrl);
 		await this.documentLibraryPage.changeTab('Document Types');
 		await this.documentLibraryPage.openNewDLTypeButton();
 	}
@@ -31,15 +31,21 @@ export class DocumentLibraryEditDocumentTypesPage {
 		await this.page.getByTitle(type).dblclick();
 	}
 
-	async createNewDLTypeWithNumericField(title: string) {
-		await this.goto();
+	async createNewDLTypeWithNumericField(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
 		await this.addField('Numeric');
 		await this.titleSelector.fill(title);
 		await this.saveButton.click();
 	}
 
-	async createNewDLTypeWithUploadField(title: string) {
-		await this.goto();
+	async createNewDLTypeWithUploadField(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
 		await this.addField('Upload');
 		await this.titleSelector.fill(title);
 		await this.saveButton.click();

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -68,8 +68,11 @@ export class DocumentLibraryEditFilePage {
 		});
 	}
 
-	async goToNewFileDifferentType(type: string) {
-		await this.documentLibraryPage.goto();
+	async goToNewFileDifferentType(
+		type: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.documentLibraryPage.goto(siteUrl);
 
 		await this.documentLibraryPage.goToCreateNewFileWithDifferentType(type);
 	}
@@ -163,8 +166,12 @@ export class DocumentLibraryEditFilePage {
 		await this.publishButton.click();
 	}
 
-	async publishNewFileWithScheduleDate(scheduleDate: string, title: string) {
-		await this.goto();
+	async publishNewFileWithScheduleDate(
+		scheduleDate: string,
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
 
 		await this.titleSelector.fill(title);
 

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -64,6 +64,10 @@ export class DocumentLibraryPage {
 			target: this.page.getByRole('menuitem', {name: viewName}),
 			trigger: this.page.getByLabel('Select View, Currently Selected: '),
 		});
+
+		await expect(
+			this.page.getByLabel(`Select View, Currently Selected: ${viewName}`)
+		).toBeVisible();
 	}
 
 	async deleteAllFileEntries() {

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -111,15 +111,7 @@ export class DocumentLibraryPage {
 			.click();
 	}
 
-	async goToEditFolder(entryTitle: string) {
-		await this.page
-			.locator(`.card-body:has-text('${entryTitle}')`)
-			.getByLabel('More actions')
-			.click();
-		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
-	}
-
-	async editFileEntry(entryTitle: string) {
+	async goToEditFileEntry(entryTitle: string) {
 		await this.page
 			.getByRole('link', {exact: true, name: entryTitle})
 			.click();
@@ -132,6 +124,14 @@ export class DocumentLibraryPage {
 			}),
 			trigger: this.page.getByRole('button', {name: 'Show Actions'}),
 		});
+	}
+
+	async goToEditFolder(entryTitle: string) {
+		await this.page
+			.locator(`.card-body:has-text('${entryTitle}')`)
+			.getByLabel('More actions')
+			.click();
+		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
 	}
 
 	async goToCreateNewFile() {

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
@@ -54,7 +54,7 @@ test.beforeEach(
 
 		title2 = getRandomString();
 
-		await documentLibraryPage.editFileEntry(title1);
+		await documentLibraryPage.goToEditFileEntry(title1);
 
 		await documentLibraryEditFilePage.titleSelector.fill(title2);
 
@@ -82,7 +82,7 @@ test('LPD-25853 Edit in x publication is added in the timeline dropdown actions'
 
 	await documentLibraryPage.goto(site.friendlyUrlPath);
 
-	await documentLibraryPage.editFileEntry(title1);
+	await documentLibraryPage.goToEditFileEntry(title1);
 
 	await page.getByLabel('timeline-button').click();
 
@@ -115,7 +115,7 @@ test('LPD-25853 Review Change is added in the timeline dropdown actions', async 
 }) => {
 	await documentLibraryPage.goto(site.friendlyUrlPath);
 
-	await documentLibraryPage.editFileEntry(title2);
+	await documentLibraryPage.goToEditFileEntry(title2);
 
 	await page.getByLabel('timeline-button').click();
 
@@ -145,7 +145,7 @@ test('LPD-25853 Discard Change is added in the timeline dropdown actions', async
 }) => {
 	await documentLibraryPage.goto(site.friendlyUrlPath);
 
-	await documentLibraryPage.editFileEntry(title2);
+	await documentLibraryPage.goToEditFileEntry(title2);
 
 	await page.getByLabel('timeline-button').click();
 
@@ -171,7 +171,7 @@ test('LPD-25853 Move Change is added in the timeline dropdown actions', async ({
 }) => {
 	await documentLibraryPage.goto(site.friendlyUrlPath);
 
-	await documentLibraryPage.editFileEntry(title2);
+	await documentLibraryPage.goToEditFileEntry(title2);
 
 	await page.getByLabel('timeline-button').click();
 
@@ -288,7 +288,7 @@ test('LPD-26155 Conflict warning is visible when content is edited in more than 
 
 	const title3 = getRandomString();
 
-	await documentLibraryPage.editFileEntry(title1);
+	await documentLibraryPage.goToEditFileEntry(title1);
 
 	await documentLibraryEditFilePage.titleSelector.fill(title3);
 
@@ -349,7 +349,7 @@ test('LPD-26155 Production conflict info is visible when new changes have been m
 
 	const title3 = getRandomString();
 
-	await documentLibraryPage.editFileEntry(title1);
+	await documentLibraryPage.goToEditFileEntry(title1);
 
 	await documentLibraryEditFilePage.titleSelector.fill(title3);
 

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -22,10 +22,17 @@ const test = mergeTests(
 test(
 	'Create AI Image option in Management Toolbar without API Key opens an alert',
 	{tag: '@LPD-6717'},
-	async ({documentLibraryPage, page, site}) => {
+	async ({
+		aiCreatorInstanceSettingsPage,
+		documentLibraryPage,
+		page,
+		site,
+	}) => {
+		await aiCreatorInstanceSettingsPage.enableDalleCreateImages();
+		await aiCreatorInstanceSettingsPage.removeApiKey();
+
 		await documentLibraryPage.goto(site.friendlyUrlPath);
 		await documentLibraryPage.openCreateAIImage();
-
 		await expect(page.getByText('Configure OpenAI')).toBeVisible();
 	}
 );
@@ -40,6 +47,7 @@ test(
 		site,
 	}) => {
 		await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
+
 		await documentLibraryPage.goto(site.friendlyUrlPath);
 		await documentLibraryPage.openNewButton();
 		await expect(
@@ -64,6 +72,7 @@ test(
 			'scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
 		);
 		await aiCreatorInstanceSettingsPage.addApiKey();
+
 		await documentLibraryPage.goto(site.friendlyUrlPath);
 		await documentLibraryPage.openCreateAIImage();
 		await expect(page.getByText('Create AI Image')).toBeVisible();

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -19,66 +19,79 @@ const test = mergeTests(
 	loginTest()
 );
 
-test('LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert', async ({
-	documentLibraryPage,
-	page,
-	site,
-}) => {
-	await documentLibraryPage.goto(site.friendlyUrlPath);
-	await documentLibraryPage.openCreateAIImage();
+test(
+	'Create AI Image option in Management Toolbar without API Key opens an alert',
+	{tag: '@LPD-6717'},
+	async ({documentLibraryPage, page, site}) => {
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.openCreateAIImage();
 
-	await expect(page.getByText('Configure OpenAI')).toBeVisible();
-});
+		await expect(page.getByText('Configure OpenAI')).toBeVisible();
+	}
+);
 
-test('LPD-6717 and LPD-6691 Create AI Image option is hidden when disabled from Instance Settings', async ({
-	aiCreatorInstanceSettingsPage,
-	documentLibraryPage,
-	page,
-	site,
-}) => {
-	await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
-	await documentLibraryPage.goto(site.friendlyUrlPath);
-	await documentLibraryPage.openNewButton();
-	await expect(
-		page.getByRole('menuitem', {name: 'Create AI Image'})
-	).not.toBeVisible();
+test(
+	'Create AI Image option is hidden when disabled from Instance Settings',
+	{tag: ['@LPD-6717', '@LPD-6691']},
+	async ({
+		aiCreatorInstanceSettingsPage,
+		documentLibraryPage,
+		page,
+		site,
+	}) => {
+		await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.openNewButton();
+		await expect(
+			page.getByRole('menuitem', {name: 'Create AI Image'})
+		).not.toBeVisible();
 
-	await aiCreatorInstanceSettingsPage.enableDalleCreateImages();
-});
+		await aiCreatorInstanceSettingsPage.enableDalleCreateImages();
+	}
+);
 
-test('LPD-6677 Can add images to DM when API Key is provided', async ({
-	aiCreatorInstanceSettingsPage,
-	documentLibraryPage,
-	gogoShellPage,
-	page,
-	site,
-}) => {
-	await gogoShellPage.addCommand(
-		'scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
-	);
-	await aiCreatorInstanceSettingsPage.addApiKey();
-	await documentLibraryPage.goto(site.friendlyUrlPath);
-	await documentLibraryPage.openCreateAIImage();
-	await expect(page.getByText('Create AI Image')).toBeVisible();
+test(
+	'Can add images to DM when API Key is provided',
+	{tag: '@LPD-6677'},
+	async ({
+		aiCreatorInstanceSettingsPage,
+		documentLibraryPage,
+		gogoShellPage,
+		page,
+		site,
+	}) => {
+		await gogoShellPage.addCommand(
+			'scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
+		);
+		await aiCreatorInstanceSettingsPage.addApiKey();
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.openCreateAIImage();
+		await expect(page.getByText('Create AI Image')).toBeVisible();
 
-	const createAIImageModalPage = page.frameLocator(
-		'iframe[title="Create AI Image"]'
-	);
-	await createAIImageModalPage
-		.getByPlaceholder('Write something...')
-		.fill(MOCKED_IMAGE_PATH);
-	await createAIImageModalPage.getByRole('button', {name: 'Create'}).click();
-	await createAIImageModalPage.getByRole('checkbox').first().check();
-	await createAIImageModalPage
-		.getByRole('button', {name: 'Add Selected'})
-		.click();
-	await waitForSuccessAlert(page, 'Success:1 files were successfully added.');
-	await expect(
-		page.getByRole('link').filter({hasText: 'AI-image-'})
-	).toHaveCount(1);
+		const createAIImageModalPage = page.frameLocator(
+			'iframe[title="Create AI Image"]'
+		);
+		await createAIImageModalPage
+			.getByPlaceholder('Write something...')
+			.fill(MOCKED_IMAGE_PATH);
+		await createAIImageModalPage
+			.getByRole('button', {name: 'Create'})
+			.click();
+		await createAIImageModalPage.getByRole('checkbox').first().check();
+		await createAIImageModalPage
+			.getByRole('button', {name: 'Add Selected'})
+			.click();
+		await waitForSuccessAlert(
+			page,
+			'Success:1 files were successfully added.'
+		);
+		await expect(
+			page.getByRole('link').filter({hasText: 'AI-image-'})
+		).toHaveCount(1);
 
-	await aiCreatorInstanceSettingsPage.removeApiKey();
-	await gogoShellPage.addCommand(
-		'scr:disable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
-	);
-});
+		await aiCreatorInstanceSettingsPage.removeApiKey();
+		await gogoShellPage.addCommand(
+			'scr:disable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
+		);
+	}
+);

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -6,20 +6,27 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
 const MOCKED_IMAGE_PATH =
 	'USER_IMAGES_URL_https://images.freeimages.com/images/large-previews/83f/paris-1213603.jpg';
 
-export const test = mergeTests(loginTest(), documentLibraryPagesTest);
+export const test = mergeTests(
+	documentLibraryPagesTest,
+	isolatedSiteTest,
+	loginTest()
+);
 
 test('LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert', async ({
 	documentLibraryPage,
 	page,
+	site,
 }) => {
-	await documentLibraryPage.goto();
+	await documentLibraryPage.goto(site.friendlyUrlPath);
 	await documentLibraryPage.openCreateAIImage();
+
 	await expect(page.getByText('Configure OpenAI')).toBeVisible();
 });
 
@@ -27,9 +34,10 @@ test('LPD-6717 and LPD-6691 Create AI Image option is hidden when disabled from 
 	aiCreatorInstanceSettingsPage,
 	documentLibraryPage,
 	page,
+	site,
 }) => {
 	await aiCreatorInstanceSettingsPage.disableDalleCreateImages();
-	await documentLibraryPage.goto();
+	await documentLibraryPage.goto(site.friendlyUrlPath);
 	await documentLibraryPage.openNewButton();
 	await expect(
 		page.getByRole('menuitem', {name: 'Create AI Image'})
@@ -43,12 +51,13 @@ test('LPD-6677 Can add images to DM when API Key is provided', async ({
 	documentLibraryPage,
 	gogoShellPage,
 	page,
+	site,
 }) => {
 	await gogoShellPage.addCommand(
 		'scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'
 	);
 	await aiCreatorInstanceSettingsPage.addApiKey();
-	await documentLibraryPage.goto();
+	await documentLibraryPage.goto(site.friendlyUrlPath);
 	await documentLibraryPage.openCreateAIImage();
 	await expect(page.getByText('Create AI Image')).toBeVisible();
 
@@ -68,7 +77,6 @@ test('LPD-6677 Can add images to DM when API Key is provided', async ({
 		page.getByRole('link').filter({hasText: 'AI-image-'})
 	).toHaveCount(1);
 
-	await documentLibraryPage.deleteAllFileEntries();
 	await aiCreatorInstanceSettingsPage.removeApiKey();
 	await gogoShellPage.addCommand(
 		'scr:disable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient'

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -13,7 +13,7 @@ import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 const MOCKED_IMAGE_PATH =
 	'USER_IMAGES_URL_https://images.freeimages.com/images/large-previews/83f/paris-1213603.jpg';
 
-export const test = mergeTests(
+const test = mergeTests(
 	documentLibraryPagesTest,
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -13,9 +13,7 @@ const test = mergeTests(loginTest(), isolatedSiteTest);
 
 test(
 	'Can create DM folder in French language',
-	{
-		tag: '@LPD-27271',
-	},
+	{tag: '@LPD-27271'},
 	async ({page, site}) => {
 		const folderTitle = 'DM Folder FR';
 

--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -9,7 +9,7 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 
-export const test = mergeTests(loginTest(), isolatedSiteTest);
+const test = mergeTests(loginTest(), isolatedSiteTest);
 
 test(
 	'Can create DM folder in French language',

--- a/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmFolder.spec.ts
@@ -5,21 +5,23 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 
-export const test = mergeTests(loginTest(), documentLibraryPagesTest);
+export const test = mergeTests(loginTest(), isolatedSiteTest);
 
 test(
 	'Can create DM folder in French language',
 	{
 		tag: '@LPD-27271',
 	},
-	async ({page}) => {
+	async ({page, site}) => {
 		const folderTitle = 'DM Folder FR';
 
-		await page.goto(`/fr/group/guest${PORTLET_URLS.documentLibrary}`);
+		await page.goto(
+			`/fr/group${site.friendlyUrlPath}${PORTLET_URLS.documentLibrary}`
+		);
 		await page.getByRole('button', {name: 'Nouveau'}).click();
 
 		await page
@@ -32,11 +34,6 @@ test(
 		await page.getByRole('button', {name: 'Enregistrer'}).click();
 
 		await expect(page.getByRole('link', {name: folderTitle})).toBeVisible();
-
-		await page
-			.getByRole('checkbox', {name: `${folderTitle} More actions`})
-			.check();
-		await page.getByRole('button', {name: 'Effacer'}).nth(1).click();
 
 		// change back to english language
 

--- a/modules/test/playwright/tests/document-library-web/dmInstanceSettings.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmInstanceSettings.spec.ts
@@ -7,13 +7,9 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {documentLibraryPagesTest} from './fixtures/documentLibraryPagesTest';
+import {dmSettingsPagesTest} from './fixtures/dmSettingsPagesTest';
 
-const test = mergeTests(
-	documentLibraryPagesTest,
-	isolatedSiteTest,
-	loginTest()
-);
+const test = mergeTests(dmSettingsPagesTest, isolatedSiteTest, loginTest());
 
 test(
 	'Updating Maximum File Upload Size at Instance level, not overrides site configuration',

--- a/modules/test/playwright/tests/document-library-web/dmInstanceSettings.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmInstanceSettings.spec.ts
@@ -22,13 +22,14 @@ test(
 		fileSizeLimitsInstanceSettingsPage,
 		fileSizeLimitsSiteSettingsPage,
 		page,
+		site,
 	}) => {
 		await fileSizeLimitsInstanceSettingsPage.goto();
 		await fileSizeLimitsInstanceSettingsPage.modifyInputAndSave(
 			'Maximum File Upload Size',
 			'2000'
 		);
-		await fileSizeLimitsSiteSettingsPage.goto();
+		await fileSizeLimitsSiteSettingsPage.goto(site.friendlyUrlPath);
 		await fileSizeLimitsSiteSettingsPage.modifyInputAndSave(
 			'Maximum File Upload Size',
 			'1000'
@@ -38,7 +39,7 @@ test(
 			'Maximum File Upload Size',
 			'2000'
 		);
-		await fileSizeLimitsSiteSettingsPage.goto();
+		await fileSizeLimitsSiteSettingsPage.goto(site.friendlyUrlPath);
 
 		await expect(page.getByLabel('Maximum File Upload Size')).toHaveValue(
 			'1000'

--- a/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
@@ -15,28 +15,31 @@ const test = mergeTests(
 	loginTest()
 );
 
-test('LPD-26290 DM Preview page has not a fixed navbar', async ({
-	documentLibraryEditFilePage,
-	documentLibraryPage,
-	page,
-	site,
-}) => {
-	const title = 'DM File Entry title';
+test(
+	'DM Preview page has not a fixed navbar',
+	{tag: '@LPD-26290'},
+	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
+		const title = 'DM File Entry title';
 
-	await documentLibraryEditFilePage.publishNewBasicFileEntry(
-		title,
-		site.friendlyUrlPath
-	);
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			title,
+			site.friendlyUrlPath
+		);
 
-	await page.getByRole('link', {name: title}).click();
+		await page.getByRole('link', {name: title}).click();
 
-	const navItem = await page.locator('nav.component-tbar.subnav-tbar-light');
+		const navItem = await page.locator(
+			'nav.component-tbar.subnav-tbar-light'
+		);
 
-	const navItemPosition = await navItem.evaluate((element) => {
-		return window.getComputedStyle(element).getPropertyValue('position');
-	});
+		const navItemPosition = await navItem.evaluate((element) => {
+			return window
+				.getComputedStyle(element)
+				.getPropertyValue('position');
+		});
 
-	await expect(navItemPosition).not.toBe('fixed');
+		await expect(navItemPosition).not.toBe('fixed');
 
-	await documentLibraryPage.goto(site.friendlyUrlPath);
-});
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+	}
+);

--- a/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
@@ -6,18 +6,27 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 
-export const test = mergeTests(loginTest(), documentLibraryPagesTest);
+export const test = mergeTests(
+	documentLibraryPagesTest,
+	isolatedSiteTest,
+	loginTest()
+);
 
 test('LPD-26290 DM Preview page has not a fixed navbar', async ({
 	documentLibraryEditFilePage,
 	documentLibraryPage,
 	page,
+	site,
 }) => {
 	const title = 'DM File Entry title';
 
-	await documentLibraryEditFilePage.publishNewBasicFileEntry(title);
+	await documentLibraryEditFilePage.publishNewBasicFileEntry(
+		title,
+		site.friendlyUrlPath
+	);
 
 	await page.getByRole('link', {name: title}).click();
 
@@ -29,7 +38,5 @@ test('LPD-26290 DM Preview page has not a fixed navbar', async ({
 
 	await expect(navItemPosition).not.toBe('fixed');
 
-	await documentLibraryPage.goto();
-
-	await documentLibraryPage.deleteAllFileEntries();
+	await documentLibraryPage.goto(site.friendlyUrlPath);
 });

--- a/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmPreview.spec.ts
@@ -9,7 +9,7 @@ import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixt
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 
-export const test = mergeTests(
+const test = mergeTests(
 	documentLibraryPagesTest,
 	isolatedSiteTest,
 	loginTest()

--- a/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
@@ -19,12 +19,12 @@ const test = mergeTests(
 	loginTest()
 );
 
-test('LPD-6878 DM Search bar hint', async ({
-	documentLibraryPage,
-	page,
-	site,
-}) => {
-	await documentLibraryPage.goto(site.friendlyUrlPath);
+test(
+	'DM Search bar hint',
+	{tag: '@LPD-6878'},
+	async ({documentLibraryPage, page, site}) => {
+		await documentLibraryPage.goto(site.friendlyUrlPath);
 
-	await expect(page.getByPlaceholder('Search')).toBeVisible();
-});
+		await expect(page.getByPlaceholder('Search')).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
@@ -10,7 +10,7 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 
-export const test = mergeTests(
+const test = mergeTests(
 	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPD-11313': true,

--- a/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmSearch.spec.ts
@@ -7,18 +7,24 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 
 export const test = mergeTests(
-	loginTest(),
+	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPD-11313': true,
 	}),
-	documentLibraryPagesTest
+	isolatedSiteTest,
+	loginTest()
 );
 
-test('LPD-6878 DM Search bar hint', async ({documentLibraryPage, page}) => {
-	await documentLibraryPage.goto();
+test('LPD-6878 DM Search bar hint', async ({
+	documentLibraryPage,
+	page,
+	site,
+}) => {
+	await documentLibraryPage.goto(site.friendlyUrlPath);
 
 	await expect(page.getByPlaceholder('Search')).toBeVisible();
 });

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -107,7 +107,8 @@ test(
 );
 
 test(
-	'LPD-16658 Show a success message after scheduling a new file',
+	'Show a success message after scheduling a new file',
+	{tag: '@LPD-16658'},
 	async ({documentLibraryEditFilePage, page, site}) => {
 		const scheduleDate = `01/01/${new Date().getFullYear() + 1}`;
 		const title = getRandomString();
@@ -135,7 +136,8 @@ test(
 );
 
 test(
-	'LPD-16313 Identify at a glance if a Document is visible for guests',
+	'Identify at a glance if a Document is visible for guests',
+	{tag: '@LPD-16313'},
 	async ({documentLibraryEditFilePage, documentLibraryPage, site}) => {
 		const title = getRandomString();
 
@@ -156,7 +158,8 @@ test(
 );
 
 test(
-	'LPD-16313 Show icon in the content admin and content editor',
+	'Show icon in the content admin and content editor',
+	{tag: '@LPD-16313'},
 	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
 		const title = getRandomString();
 
@@ -180,7 +183,8 @@ test(
 );
 
 test(
-	'LPD-16313 Show icon in the DL item selector',
+	'Show icon in the DL item selector',
+	{tag: '@LPD-16313'},
 	async ({
 		documentLibraryEditDocumentTypesPage,
 		documentLibraryEditFilePage,
@@ -262,7 +266,8 @@ test(
 );
 
 test(
-	'LPD-31694 Search in DL portlet does not show results in card view for LPS-202909',
+	'Search in DL portlet does not show results in card view',
+	{tag: ['@LPD-31694', '@LPD-202909']},
 	async ({
 		apiHelpers,
 		documentLibraryEditFilePage,

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -5,7 +5,6 @@
 
 import {expect, mergeTests} from '@playwright/test';
 import {createReadStream} from 'fs';
-import moment from 'moment';
 import path from 'path';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
@@ -126,11 +125,19 @@ test(
 		await expect(toastAlertContainer).toBeVisible();
 
 		await expect(toastAlertContainer).toHaveText(
-			'Success:' +
-				title +
-				' will be published on ' +
-				moment(new Date(scheduleDate)).format('M/D/YY h:mm A') +
-				'.'
+			`Success:${title} will be published on ${new Intl.DateTimeFormat(
+				'en-US',
+				{
+					day: 'numeric',
+					hour: 'numeric',
+					hour12: true,
+					minute: 'numeric',
+					month: 'numeric',
+					year: '2-digit',
+				}
+			)
+				.format(new Date(scheduleDate))
+				.replace(',', '')}.`
 		);
 	}
 );

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -83,7 +83,7 @@ test(
 			site.friendlyUrlPath
 		);
 
-		await documentLibraryPage.editFileEntry(title);
+		await documentLibraryPage.goToEditFileEntry(title);
 		await documentLibraryEditFilePage.descriptionInput.fill(
 			getRandomString()
 		);
@@ -177,7 +177,7 @@ test(
 
 		await documentLibraryPage.changeView('cards');
 
-		await documentLibraryPage.editFileEntry(title);
+		await documentLibraryPage.goToEditFileEntry(title);
 
 		await documentLibraryPage.assertPrivateFileIcon();
 
@@ -390,7 +390,7 @@ test(
 
 		for (const document of [document1, document2]) {
 			await documentLibraryPage.goto(site.friendlyUrlPath);
-			await documentLibraryPage.editFileEntry(document.title);
+			await documentLibraryPage.goToEditFileEntry(document.title);
 			await documentLibraryEditFilePage.openFieldset('Categorization');
 			await page.getByText(vocabularyName).waitFor();
 

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -113,13 +113,14 @@ baseTest(
 
 baseTest(
 	'LPD-16658 Show a success message after scheduling a new file',
-	async ({documentLibraryEditFilePage, documentLibraryPage, page}) => {
+	async ({documentLibraryEditFilePage, page, site}) => {
 		const scheduleDate = `01/01/${new Date().getFullYear() + 1}`;
 		const title = getRandomString();
 
 		await documentLibraryEditFilePage.publishNewFileWithScheduleDate(
 			scheduleDate,
-			title
+			title,
+			site.friendlyUrlPath
 		);
 
 		await expect(page.getByRole('link', {name: title})).toBeVisible();
@@ -135,32 +136,27 @@ baseTest(
 				moment(new Date(scheduleDate)).format('M/D/YY h:mm A') +
 				'.'
 		);
-		await documentLibraryPage.deleteFileEntry(title);
 	}
 );
 
 baseTest(
 	'LPD-16313 Identify at a glance if a Document is visible for guests',
-	async ({documentLibraryEditFilePage, documentLibraryPage}) => {
+	async ({documentLibraryEditFilePage, documentLibraryPage, site}) => {
 		const title = getRandomString();
 
 		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(
-			title
+			title,
+			site.friendlyUrlPath
 		);
 
 		await documentLibraryPage.changeView('cards');
-
 		await documentLibraryPage.assertPrivateFileIcon();
 
 		await documentLibraryPage.changeView('table');
-
 		await documentLibraryPage.assertPrivateFileIcon();
 
 		await documentLibraryPage.changeView('list');
-
 		await documentLibraryPage.assertPrivateFileIcon();
-
-		await documentLibraryPage.deleteFileEntry(title);
 	}
 );
 
@@ -194,12 +190,14 @@ baseTest(
 		documentLibraryEditDocumentTypesPage,
 		documentLibraryEditFilePage,
 		documentLibraryPage,
+		site,
 	}) => {
 		const dTypeTitle = getRandomString();
 		const title = getRandomString();
 
 		await documentLibraryEditDocumentTypesPage.createNewDLTypeWithUploadField(
-			dTypeTitle
+			dTypeTitle,
+			site.friendlyUrlPath
 		);
 
 		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -21,22 +21,17 @@ import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 
-const baseTest = mergeTests(
+const test = mergeTests(
 	apiHelpersTest,
 	documentLibraryPagesTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
 	isolatedSiteTest,
 	loginTest()
 );
 
-export const testSearchInDlPortlet = mergeTests(
-	apiHelpersTest,
-	baseTest,
-	featureFlagsTest({
-		'LPS-178052': true,
-	})
-);
-
-baseTest(
+test(
 	'Check order by Relevance in Search of DL',
 	{
 		tag: '@LPD-32481',
@@ -71,7 +66,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'Check if Ordering by Modified Date working, after editing a document',
 	{
 		tag: '@LPD-32483',
@@ -111,7 +106,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'LPD-16658 Show a success message after scheduling a new file',
 	async ({documentLibraryEditFilePage, page, site}) => {
 		const scheduleDate = `01/01/${new Date().getFullYear() + 1}`;
@@ -139,7 +134,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'LPD-16313 Identify at a glance if a Document is visible for guests',
 	async ({documentLibraryEditFilePage, documentLibraryPage, site}) => {
 		const title = getRandomString();
@@ -160,7 +155,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'LPD-16313 Show icon in the content admin and content editor',
 	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
 		const title = getRandomString();
@@ -184,7 +179,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'LPD-16313 Show icon in the DL item selector',
 	async ({
 		documentLibraryEditDocumentTypesPage,
@@ -236,7 +231,7 @@ baseTest(
 	}
 );
 
-baseTest(
+test(
 	'Error uploading multiples files with custom document type',
 	{
 		tag: '@LPD-29609',
@@ -266,7 +261,7 @@ baseTest(
 	}
 );
 
-testSearchInDlPortlet(
+test(
 	'LPD-31694 Search in DL portlet does not show results in card view for LPS-202909',
 	async ({
 		apiHelpers,
@@ -312,7 +307,7 @@ testSearchInDlPortlet(
 	}
 );
 
-baseTest(
+test(
 	'Replace option does not work on Categories Selector',
 	{
 		tag: '@LPD-27899',

--- a/modules/test/playwright/tests/document-library-web/fixtures/dmSettingsPagesTest.ts
+++ b/modules/test/playwright/tests/document-library-web/fixtures/dmSettingsPagesTest.ts
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {FileSizeLimitsInstanceSettingsPage} from '../pages/FileSizeLimitsInstanceSettingsPage';
 import {FileSizeLimitsSiteSettingsPage} from '../pages/FileSizeLimitsSiteSettingsPage';
 import {FileSizeLimitsSystemSettingsPage} from '../pages/FileSizeLimitsSystemSettingsPage';
 
-const documentLibraryPagesTest = test.extend<{
+const dmSettingsPagesTest = test.extend<{
 	fileSizeLimitsInstanceSettingsPage: FileSizeLimitsInstanceSettingsPage;
 	fileSizeLimitsSiteSettingsPage: FileSizeLimitsSiteSettingsPage;
 	fileSizeLimitsSystemSettingsPage: FileSizeLimitsSystemSettingsPage;
@@ -27,4 +25,4 @@ const documentLibraryPagesTest = test.extend<{
 	},
 });
 
-export {documentLibraryPagesTest};
+export {dmSettingsPagesTest};

--- a/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSiteSettingsPage.ts
+++ b/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSiteSettingsPage.ts
@@ -19,10 +19,11 @@ export class FileSizeLimitsSiteSettingsPage {
 		this.siteSettingsPage = new SiteSettingsPage(page);
 	}
 
-	async goto() {
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
 		await this.siteSettingsPage.goToSiteSetting(
 			'Documents and Media',
-			'File Size Limits'
+			'File Size Limits',
+			siteUrl
 		);
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37385

I'm trying to refactor some things like:

- Use IsolatedTest when is possible
    - Remove manual cleans
- Move LPD / LPS to tags
- Simplify the test creation - We don’t need different test functions if the Feature Flags don’t collision
- Remove dependencies (like moment)

>[!NOTE]
> I suspect some of the tests failed locally because they expect a clean portal for each run and my local postal became clean but later ran many tests.
> After refactor I will take a look at this cases and the flaky ones

# Before the PR

![image](https://github.com/user-attachments/assets/62d072a8-4c68-48fd-a64f-136950b07d20)

```
21 failed - master
    [document-library-web] › document-library-web/dmAICreator.spec.ts:17:1 › LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert
    [document-library-web] › document-library-web/dmAICreator.spec.ts:17:1 › LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert
    [document-library-web] › document-library-web/dmAICreator.spec.ts:17:1 › LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert
    [document-library-web] › document-library-web/dmAICreator.spec.ts:17:1 › LPD-6717 Create AI Image option in Management Toolbar without API Key opens an alert
    [document-library-web] › document-library-web/dmAICreator.spec.ts:41:1 › LPD-6677 Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:41:1 › LPD-6677 Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:41:1 › LPD-6677 Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:41:1 › LPD-6677 Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/fileEntry.spec.ts:167:1  › LPD-16313 Show icon in the content admin and content editor
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1  › LPD-16313 Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1  › LPD-16313 Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1  › LPD-16313 Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1  › LPD-16313 Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:318:1  › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:318:1  › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:318:1  › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:318:1  › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:39:1   › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:39:1   › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:39:1   › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:39:1   › Check order by Relevance in Search of DL
```

# After the PR

![image](https://github.com/user-attachments/assets/615cb3e0-79bc-48a1-b924-7be21d0478a1)



```
14 failed - LPD-37385-TEST-DM-playwright-refactor
    [document-library-web] › document-library-web/dmAICreator.spec.ts:61:1 › Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:61:1 › Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:61:1 › Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/dmAICreator.spec.ts:61:1 › Can add images to DM when API Key is provided
    [document-library-web] › document-library-web/fileEntry.spec.ts:33:1 › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1 › Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:322:1 › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:33:1 › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:322:1 › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:33:1 › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:322:1 › Replace option does not work on Categories Selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:33:1 › Check order by Relevance in Search of DL
    [document-library-web] › document-library-web/fileEntry.spec.ts:192:1 › Show icon in the DL item selector
    [document-library-web] › document-library-web/fileEntry.spec.ts:322:1 › Replace option does not work on Categories Selector
```