### PR TITLE
 LPD-37236 Create playwright test to translate the Rich Text field and check if the translation persists after coming back to the page

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -125,6 +125,8 @@ const RichText = ({
 			newEditingLocale = {localeId};
 		}
 
+		const newValue = convertStringToObject(contents, localeId);
+
 		setCurrentEditingLocale({
 			...newEditingLocale,
 			icon: normalizeLocaleId(newEditingLocale.localeId),
@@ -134,9 +136,11 @@ const RichText = ({
 				defaultLocale,
 				editingLocale: newEditingLocale,
 				fieldName,
-				value: convertStringToObject(contents, localeId),
+				value: newValue,
 			})
 		);
+
+		setCurrentValue(newValue);
 	};
 
 	const handleContentChange = (content) => {

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1012,6 +1012,67 @@ translationTest(
 );
 
 translationTest(
+	'Translate the Rich Text field and check if the translation persists after coming back to the page',
+	{
+		tag: '@LPD-37236',
+	},
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		await journalPage.goto();
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		const englishContent = 'English Language Text';
+
+		const catalanContent = 'Catalan Language Text';
+
+		await journalEditArticlePage.fillContent(englishContent);
+
+		const translationButton = page.getByRole('combobox', {
+			name: 'Select a language',
+		});
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('option', {
+				name: 'Catalan Language: Not Translated',
+			}),
+			trigger: translationButton,
+		});
+
+		await journalEditArticlePage.fillContent(catalanContent);
+
+		await journalEditArticlePage.publishButton.click();
+
+		await waitForSuccessAlert(
+			page,
+			`Success:${title} was created successfully.`
+		);
+
+		await page.getByRole('link', {name: title}).click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('option', {
+				name: 'Catalan Language: Translating 1/2',
+			}),
+			trigger: translationButton,
+		});
+
+		await expect(
+			page
+				.getByLabel('Content', {exact: true})
+				.locator('iframe[title="editor"]')
+				.contentFrame()
+				.getByText(catalanContent)
+		).toBeVisible();
+	}
+);
+
+translationTest(
 	'LPD-19627: Translate all fields of a Web Content based on a custom structure with repeatable fields',
 	async ({apiHelpers, journalEditArticlePage, page, site}) => {
 		const localizableFieldName = 'Text5678';


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-37236

hi everyone! :cherry_blossom:

this PR has a fix on how the content of the rich text is being rendered related to translations; the changes are on our side (DDM) but the test is on web content, that's why i'm sending this to you as well.
could you please review this commit related to the test? 8b7cf0b4dddb2d09cc1e87ddaa30701d22f1c3f4

thanks a lot and if you have any questions please let me know!