### PR TITLE
LPP-55697 Default locale creating a web content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -36,7 +36,6 @@ import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
-import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalFolderPermission;
@@ -581,14 +580,8 @@ public class JournalEditArticleDisplayContext {
 			defaultArticleLanguageId = LocaleUtil.toLanguageId(
 				ddmFormValues.getDefaultLocale());
 		}
-		else if (Validator.isNull(defaultArticleLanguageId) &&
-				 (getClassNameId() ==
-					 JournalArticleConstants.CLASS_NAME_ID_DEFAULT)) {
 
-			defaultArticleLanguageId = _getDDMStructureDefaultLanguageId();
-		}
-
-		if ((defaultArticleLanguageId == null) ||
+		if (Validator.isNull(defaultArticleLanguageId) ||
 			!LanguageUtil.isAvailableLocale(
 				getGroupId(), defaultArticleLanguageId)) {
 
@@ -1469,28 +1462,6 @@ public class JournalEditArticleDisplayContext {
 		}
 
 		return _article.getAvailableLanguageIds();
-	}
-
-	private String _getDDMStructureDefaultLanguageId() {
-		DDMStructure ddmStructure = getDDMStructure();
-
-		if (ddmStructure != null) {
-			try {
-				JournalArticle ddmStructureJournalArticle =
-					JournalArticleServiceUtil.getArticle(
-						ddmStructure.getGroupId(), DDMStructure.class.getName(),
-						ddmStructure.getStructureId());
-
-				return ddmStructureJournalArticle.getDefaultLanguageId();
-			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
-				}
-			}
-		}
-
-		return null;
 	}
 
 	private LayoutPageTemplateEntry _getDefaultLayoutPageTemplateEntry() {

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
@@ -9,6 +9,7 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanProperties;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -102,6 +103,7 @@ public class JournalEditArticleDisplayContextTest {
 
 	@Test
 	public void testGetDefaultArticleLanguageId() throws PortalException {
+		_testGetDefaultArticleLanguageIdWithEmptyLocale();
 		_testGetDefaultArticleLanguageIdWithParameter();
 		_testGetDefaultArticleLanguageIdWithUnavailableLocale();
 	}
@@ -345,6 +347,38 @@ public class JournalEditArticleDisplayContextTest {
 		).getParameter(
 			"showSelectFolder"
 		);
+	}
+
+	private void _testGetDefaultArticleLanguageIdWithEmptyLocale()
+		throws PortalException {
+
+		String defaultLanguageId = StringPool.BLANK;
+
+		Mockito.when(
+			_httpServletRequest.getParameter("defaultLanguageId")
+		).thenReturn(
+			defaultLanguageId
+		);
+
+		Mockito.when(
+			_language.isAvailableLocale(0, defaultLanguageId)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_portal.getSiteDefaultLocale(0)
+		).thenReturn(
+			LocaleUtil.UK
+		);
+
+		_journalEditArticleDisplayContext =
+			new JournalEditArticleDisplayContext(
+				_httpServletRequest, _liferayPortletResponse, null);
+
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(LocaleUtil.UK),
+			_journalEditArticleDisplayContext.getDefaultArticleLanguageId());
 	}
 
 	private void _testGetDefaultArticleLanguageIdWithParameter() {

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.journal.web.internal.display.context;
 
-import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalService;
@@ -103,7 +102,6 @@ public class JournalEditArticleDisplayContextTest {
 
 	@Test
 	public void testGetDefaultArticleLanguageId() throws PortalException {
-		_testGetDefaultArticleLanguageIdFromArticle();
 		_testGetDefaultArticleLanguageIdWithParameter();
 		_testGetDefaultArticleLanguageIdWithUnavailableLocale();
 	}
@@ -347,61 +345,6 @@ public class JournalEditArticleDisplayContextTest {
 		).getParameter(
 			"showSelectFolder"
 		);
-	}
-
-	private void _testGetDefaultArticleLanguageIdFromArticle()
-		throws PortalException {
-
-		String defaultLanguageId = RandomTestUtil.randomString();
-
-		Mockito.when(
-			_httpServletRequest.getParameter("defaultLanguageId")
-		).thenReturn(
-			defaultLanguageId
-		);
-
-		Mockito.when(
-			_language.isAvailableLocale(
-				0, LocaleUtil.toLanguageId(LocaleUtil.SPAIN))
-		).thenReturn(
-			true
-		);
-
-		Mockito.when(
-			_portal.getSiteDefaultLocale(0)
-		).thenReturn(
-			LocaleUtil.UK
-		);
-
-		DDMFormValues ddmFormValues = Mockito.mock(DDMFormValues.class);
-
-		Mockito.when(
-			ddmFormValues.getDefaultLocale()
-		).thenReturn(
-			LocaleUtil.SPAIN
-		);
-
-		JournalArticle journalArticle = Mockito.mock(JournalArticle.class);
-
-		Mockito.when(
-			journalArticle.getArticleId()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		Mockito.when(
-			journalArticle.getDDMFormValues()
-		).thenReturn(
-			ddmFormValues
-		);
-
-		_journalEditArticleDisplayContext =
-			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, journalArticle);
-
-		Assert.assertEquals(
-			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
-			_journalEditArticleDisplayContext.getDefaultArticleLanguageId());
 	}
 
 	private void _testGetDefaultArticleLanguageIdWithParameter() {


### PR DESCRIPTION
LPP-55697 Default locale creating a web content

# What is this trying to solve?

Fix the issue reported in the LPP.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-37464)

# How am I fixing it?

- Remove the part that inherits the default locale from the structue and always inherit from the site, as the structure also inherits it from the site

# How can I test it?

Steps: 

- Follow the steps in the ticket