### PR TITLE
LPD-37606 Web Content doesn't publish when FF LPD-11228 is enabled and LPD-15596 is disabled

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -273,7 +273,10 @@ export default function _JournalPortlet({
 	const handlePublishButtonClick = (event) => {
 		lockHolder.lock?.lock();
 
-		if (Liferay.FeatureFlags['LPD-11228']) {
+		if (
+			Liferay.FeatureFlags['LPD-11228'] &&
+			Liferay.FeatureFlags['LPD-15596']
+		) {
 			return;
 		}
 

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -47,7 +47,20 @@ const autosaveWithoutPermissionsTest = mergeTests(
 	}),
 	isolatedSiteTest,
 	journalPagesTest,
-	loginTest(),
+	loginTest()
+);
+
+const autoSaveUndoRedoTest = mergeTests(
+	apiHelpersTest,
+	applicationsMenuPageTest,
+	featureFlagsTest({
+		'LPD-11228': true,
+		'LPD-15596': true,
+		'LPD-36053': true,
+	}),
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
 );
 
 autoSaveTest(
@@ -80,19 +93,6 @@ autoSaveTest(
 		expect(journalEditArticlePage.undoButton).not.toBeVisible();
 		expect(journalEditArticlePage.redoButton).not.toBeVisible();
 	}
-);
-
-const autoSaveUndoRedoTest = mergeTests(
-	apiHelpersTest,
-	applicationsMenuPageTest,
-	featureFlagsTest({
-		'LPD-11228': true,
-		'LPD-15596': true,
-		'LPD-36053': true,
-	}),
-	isolatedSiteTest,
-	journalPagesTest,
-	loginTest()
 );
 
 autoSaveTest(
@@ -187,6 +187,7 @@ autoSaveTest(
 		);
 	}
 );
+
 autoSaveUndoRedoTest(
 	'Translation is removed when using Undo and restored when using Redo',
 	{
@@ -240,6 +241,7 @@ autoSaveUndoRedoTest(
 		});
 	}
 );
+
 autoSaveUndoRedoTest(
 	'Undo/Redo buttons work with metadata fields',
 	{

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -40,6 +40,16 @@ const autoSaveTest = mergeTests(
 	pagesAdminPagesTest
 );
 
+const autosaveWithoutPermissionsTest = mergeTests(
+	featureFlagsTest({
+		'LPD-11228': true,
+		'LPD-15596': false,
+	}),
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest(),
+);
+
 autoSaveTest(
 	'UndoRedo Should not appear when editing default values',
 	{
@@ -607,5 +617,21 @@ autoSaveTest(
 		await journalEditArticlePage.undoButton.click();
 
 		await expect(page.getByLabel(fieldName)).toHaveText('Choose an Option');
+	}
+);
+
+autosaveWithoutPermissionsTest(
+	'Web Content is published when Feature Flag LPD-11228 is enabled but LPD-15596 is disabled',
+	{
+		tag: '@LPD-37606',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = 'Web Content Title';
+
+		journalEditArticlePage.createWCWithBasicPublishButton(articleTitle);
+
+		await expect(page.getByTitle(articleTitle)).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -172,6 +172,17 @@ export class JournalEditArticlePage {
 		await expect(page.getByTitle(title, {exact: true})).toBeVisible();
 	}
 
+	async createWCWithBasicPublishButton(articleTitle: string) {
+		await this.titleInput.fill(articleTitle);
+		await this.publishButton.waitFor();
+		await this.publishButton.click();
+
+		await waitForSuccessAlert(
+			this.page,
+			`Success:${articleTitle} was created successfully.`
+		);
+	}
+
 	async fillTitle(title: string) {
 		await this.propertiesTab.waitFor();
 


### PR DESCRIPTION
[Issue to link](https://liferay.atlassian.net/browse/LPD-37606)

# Motivation
Web Content doesn't publish when FF LPD-11228 is enabled and LPD-15596 is disabled

# How did I solve it
taking in mind another FF for a condition. 

# How to test it
Follow the steps described in the issue https://liferay.atlassian.net/browse/LPD-37606, or run 
`npm run playwright -- test -g 'LPD-37606' --reporter list`