### PR TITLE
LPD-37394 Fix test related with permissions in autosave test

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -427,9 +427,7 @@ autoSaveTest(
 		});
 
 		await expect(
-			page.getByText(
-				'Please enter a valid title for the default language'
-			)
+			page.getByText('The Title field is required.')
 		).toBeVisible({timeout: 1000});
 
 		const title = getRandomString();


### PR DESCRIPTION
[Link to issue ](https://liferay.atlassian.net/browse/LPD-37394)

# Motivation
This test 'Create a web content selecting permissions in the modal' is failing in testray

# How to test it
run `npm run playwright -- test -g 'LPD-32949' --reporter list`

![Screenshot 2024-09-30 at 13 23 17](https://github.com/user-attachments/assets/7bd4035b-bcee-442c-8df4-2f902982ecb7)

