### PR TITLE
LPD-37712 Web Content style references to Document Library are not processed during Staging

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -376,7 +376,8 @@ public class DLReferencesExportImportContentProcessor
 		if (((beginPos == 0) && (endPos == content.length())) ||
 			_isCreoleReference(content, beginPos) ||
 			_isHTMLReference(content, beginPos) ||
-			_isJSONReference(content, beginPos)) {
+			_isJSONReference(content, beginPos) ||
+			_isStyleReference(content, beginPos)) {
 
 			return false;
 		}
@@ -455,7 +456,8 @@ public class DLReferencesExportImportContentProcessor
 				(((curBeginPos == 0) && (endPos == content.length())) ||
 				 _isCreoleReference(content, curBeginPos) ||
 				 _isHTMLReference(content, curBeginPos) ||
-				 _isJSONReference(content, curBeginPos))) {
+				 _isJSONReference(content, curBeginPos) ||
+				 _isStyleReference(content, beginPos - hostName.length()))) {
 
 				return false;
 			}
@@ -512,6 +514,22 @@ public class DLReferencesExportImportContentProcessor
 		}
 
 		return true;
+	}
+
+	private boolean _isStyleReference(String content, int beginPos) {
+		if (content.regionMatches(beginPos - 1, StringPool.APOSTROPHE, 0, 1) ||
+			content.regionMatches(beginPos - 1, StringPool.QUOTE, 0, 1)) {
+
+			beginPos = beginPos - 1;
+		}
+
+		String url = "url(";
+
+		if (content.regionMatches(true, beginPos - url.length(), url, 0, 2)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isValidateDLReferences() {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -1404,7 +1404,8 @@ public class DefaultExportImportContentProcessorTest {
 		LocaleUtil.US, LocaleUtil.GERMANY, LocaleUtil.SPAIN
 	};
 	private static String _oldLayoutFriendlyURLPrivateUserServletMapping;
-	private static final Pattern _pattern = Pattern.compile("href=|\\{|\\[");
+	private static final Pattern _pattern = Pattern.compile(
+		"href=|url\\(|\\{|\\[");
 
 	private Locale _defaultLocale;
 	private ExportImportContentProcessor<String> _exportImportContentProcessor;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/dl_references.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/dl_references.txt
@@ -133,3 +133,51 @@ Nonlegacy HTML reference with escaped single quotes:
 <a href=\'/documents/[$GROUP_ID$]/0/[$TITLE$]\'>Link</a>
 <a href=\'/documents/[$GROUP_ID$]/0/[$TITLE$]#page=2\'>Link</a>
 <a href=\'/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]\'>Link</a>
+
+Style reference with no quotes:
+
+background: url(/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]);
+background: url(/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]);
+background: url(/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]);
+background: url(/documents/[$GROUP_ID$]/0/[$TITLE$]);
+background: url(/documents/[$GROUP_ID$]/0/[$TITLE$]#page=2);
+background: url(/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]);
+background: url(/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]);
+background: url(/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]);
+background: url(/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]);
+background: url(/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]);
+background: url([$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]);
+background: url([$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]);
+background: url([$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]);
+
+Style reference with double quotes:
+
+background: url("/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]");
+background: url("/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]");
+background: url("/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]");
+background: url("/documents/[$GROUP_ID$]/0/[$TITLE$]");
+background: url("/documents/[$GROUP_ID$]/0/[$TITLE$]#page=2");
+background: url("/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]");
+background: url("/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]");
+background: url("/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]");
+background: url("/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]");
+background: url("/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]");
+background: url("[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]");
+background: url("[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]");
+background: url("[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]");
+
+Style reference with single quotes:
+
+background: url('/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]');
+background: url('/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]');
+background: url('/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]');
+background: url('/documents/[$GROUP_ID$]/0/[$TITLE$]');
+background: url('/documents/[$GROUP_ID$]/0/[$TITLE$]#page=2');
+background: url('/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]');
+background: url('/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]');
+background: url('/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]');
+background: url('/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]');
+background: url('/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]');
+background: url('[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]');
+background: url('[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]');
+background: url('[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/portlet_file_entry/[$GROUP_ID$]/[$TITLE$]/[$UUID$][$TIMESTAMP_ONLY$]');

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/dl_references_file_friendly_urls.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/dl_references_file_friendly_urls.txt
@@ -47,3 +47,18 @@ Nonlegacy HTML reference with escaped single quotes:
 
 <a href=\'/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]\'>Link</a>
 <a href=\'[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]\'>Link</a>
+
+Style references with no quotes:
+
+background: url(/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]);
+background: url([$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]);
+
+Style references with double quotes:
+
+background: url("/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]");
+background: url("[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]");
+
+Style references with single quotes:
+
+background: url('/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]');
+background: url('[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]');

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
@@ -47,3 +47,18 @@ Nonlegacy HTML reference with escaped single quotes:
 
 <a href=\'/documents/\'>Link</a>
 <a href=\'/documents/d/[$GROUP_NAME$]/\'>Link</a>
+
+Style references with no quotes:
+
+background: url(/documents/);
+background: url(/documents/d/[$GROUP_NAME$]/);
+
+Style references with double quotes:
+
+background: url("/documents/");
+background: url("/documents/d/[$GROUP_NAME$]/");
+
+Style references with single quotes:
+
+background: url('/documents/');
+background: url('/documents/d/[$GROUP_NAME$]/');


### PR DESCRIPTION
LPD-37712 Web Content style references to Document Library are not processed during Staging

# What is this trying to solve?
[LPD-37712](https://liferay.atlassian.net/browse/LPD-37712)
Web Contents using Documents as background images can't replace this reference when published from Staging to Live

# How am I fixing it?
Add the `url(` pattern to be recognised by DLReferencesExportImportContentProcessor.java

# How can you verify that it works?
```
cd /modules/apps/export-import/export-import-test
gw testIntegration --tests DefaultExportImportContentProcessorTest
```

Cheers,
Balázs