### PR TITLE
LPS-35426 check if the portlet for KB Article is present on layout and show url according to this

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/asset/model/test/KBArticleAssetRendererTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/asset/model/test/KBArticleAssetRendererTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.asset.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.knowledge.base.constants.KBFolderConstants;
+import com.liferay.knowledge.base.constants.KBPortletKeys;
+import com.liferay.knowledge.base.model.KBArticle;
+import com.liferay.knowledge.base.service.KBArticleLocalService;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class KBArticleAssetRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_kbArticle = _addKBArticle();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetURLViewInContextWithKBPortlet() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		ContentLayoutTestUtil.addPortletToLayout(
+			layout, KBPortletKeys.KNOWLEDGE_BASE_ARTICLE);
+
+		Assert.assertNotNull(
+			_getURLViewInContext(
+				_kbArticle.getResourcePrimKey(),
+				ContentLayoutTestUtil.getThemeDisplay(
+					_companyLocalService.getCompany(_group.getCompanyId()),
+					_group, layout)));
+	}
+
+	@Test
+	public void testGetURLViewInContextWithoutKBPortlet() throws Exception {
+		Assert.assertNull(
+			_getURLViewInContext(
+				_kbArticle.getResourcePrimKey(),
+				ContentLayoutTestUtil.getThemeDisplay(
+					_companyLocalService.getCompany(_group.getCompanyId()),
+					_group, LayoutTestUtil.addTypeContentLayout(_group))));
+	}
+
+	private KBArticle _addKBArticle() throws Exception {
+		return _kbArticleLocalService.addKBArticle(
+			null, TestPropsValues.getUserId(),
+			ClassNameLocalServiceUtil.getClassNameId(
+				KBFolderConstants.getClassName()),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID, "title KB Article",
+			StringUtil.randomString(), "<strong>Context text</strong>",
+			"Description", null, StringPool.BLANK, RandomTestUtil.nextDate(),
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private LiferayPortletRequest _getLiferayPortletRequest(
+		ThemeDisplay themeDisplay) {
+
+		MockRenderRequest renderRequest = new MockLiferayPortletRenderRequest();
+
+		renderRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return _portal.getLiferayPortletRequest(renderRequest);
+	}
+
+	private String _getURLViewInContext(
+			long resourcePrimKey, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		AssetRendererFactory<KBArticle> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+				KBArticle.class);
+
+		AssetRenderer<KBArticle> assetRenderer =
+			assetRendererFactory.getAssetRenderer(resourcePrimKey);
+
+		return assetRenderer.getURLViewInContext(
+			_getLiferayPortletRequest(themeDisplay), null, null);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private KBArticle _kbArticle;
+
+	@Inject
+	private KBArticleLocalService _kbArticleLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
@@ -168,15 +168,19 @@ public class KBArticleAssetRenderer
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
 		throws PortalException {
 
-		String friendlyURL =
-			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
-				new InfoItemReference(
-					getClassName(),
-					new ClassPKInfoItemIdentifier(_kbArticle.getKbArticleId())),
-				themeDisplay);
+		if (_assetDisplayPageFriendlyURLProvider != null) {
+			String friendlyURL =
+				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+					new InfoItemReference(
+						getClassName(),
+						new ClassPKInfoItemIdentifier(
+							_kbArticle.getKbArticleId())),
+					themeDisplay);
 
-		if (Validator.isNotNull(friendlyURL)) {
-			return friendlyURL;
+			if (Validator.isNotNull(friendlyURL)) {
+				return friendlyURL;
+			}
+		}
 		}
 
 		return KnowledgeBaseUtil.getKBArticleURL(

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
@@ -18,9 +18,13 @@ import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
 import com.liferay.knowledge.base.web.internal.constants.KBWebKeys;
 import com.liferay.knowledge.base.web.internal.security.permission.resource.KBArticlePermission;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletLayoutFinder;
+import com.liferay.portal.kernel.portlet.PortletLayoutFinderRegistryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -181,6 +185,11 @@ public class KBArticleAssetRenderer
 				return friendlyURL;
 			}
 		}
+
+		if (!_hasViewInContextGroupLayout(
+				themeDisplay, _kbArticle.getGroupId())) {
+
+			return null;
 		}
 
 		return KnowledgeBaseUtil.getKBArticleURL(
@@ -259,6 +268,39 @@ public class KBArticleAssetRenderer
 
 		return themeDisplay.getScopeGroup();
 	}
+
+	private boolean _hasViewInContextGroupLayout(
+		ThemeDisplay themeDisplay, long groupId) {
+
+		try {
+			PortletLayoutFinder portletLayoutFinder =
+				PortletLayoutFinderRegistryUtil.getPortletLayoutFinder(
+					getClassName());
+
+			if (portletLayoutFinder == null) {
+				return false;
+			}
+
+			PortletLayoutFinder.Result result = portletLayoutFinder.find(
+				themeDisplay, groupId);
+
+			if ((result == null) || Validator.isNull(result.getPortletId())) {
+				return false;
+			}
+
+			return true;
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		KBArticleAssetRenderer.class);
 
 	private final AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;


### PR DESCRIPTION
LPS-35426 check if the portlet for KB Article is present on layout and show url according to this

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-35426

On the cases where there is no KB article widget, the search link that is returned is wrong and we should let the Search panel work with the normal url. So we added a new comprobation to check it there is the widget or not

# How am I fixing it?

Check if the portlet for KB Article is present on layout and show url according to this, null or not. Or the url 

# How can you verify that it works?

Run the included automated tests.



1. Log in to a fresh Liferay bundle
2. Go to Site Admin → Content & Data → Knowledge Base
3. Create and publish a new Knowledge Base article:
	title: september
	content: september
4. Go to home page
5. Using the search bar, search for “september” and hit enter
6. In search results click on the Knowledge Base article “september”


# Commits




- **LPD-35426 check NPE**
- **LPD-35426 if there is  not a Widget for the KB Articles, let the search return the data, if yes, return the article url**
- **LPD-35426 add test to check the return of the GetURLViewInContext with and without the portlet for KB Article**
