### PR TITLE
LPD-37754 Save as Draft in journal with Permissions but without autosave

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -323,9 +323,7 @@ export default function SaveButtons({
 							publishModalVisible: false,
 						})
 					}
-					onPublishButtonClick={() => {
-						handleButtonClick(ACTION_PUBLISH);
-					}}
+					onPublishButtonClick={handleButtonClick}
 					permissionsURL={permissionsURL}
 					portletNamespace={portletNamespace}
 					showPermissionsOptions={showPublishModal}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -107,7 +107,7 @@ export default function PublishModal({
 									setShowErrorAlert(true);
 								}
 								else {
-									onPublishButtonClick();
+									onPublishButtonClick(actionButton);
 								}
 							}}
 							type={

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -74,13 +74,6 @@ const prefixUrlTest = mergeTests(
 	})
 );
 
-const scheduleTest = mergeTests(
-	baseTest,
-	featureFlagsTest({
-		'LPD-15596': true,
-	})
-);
-
 const translationTest = mergeTests(
 	baseTest,
 	featureFlagsTest({
@@ -1284,62 +1277,6 @@ baseTest(
 	}
 );
 
-scheduleTest(
-	'Change permission of a web content in edition mode',
-	async ({journalEditArticlePage, journalPage, page, site}) => {
-		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
-
-		const title = getRandomString();
-
-		await journalEditArticlePage.fillTitle(title);
-
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {
-				name: 'Publish With Permissions',
-			}),
-			trigger: page.getByRole('button', {
-				name: 'Select and Confirm Publish Settings',
-			}),
-		});
-
-		await page.getByRole('button', {exact: true, name: 'Publish'}).click();
-
-		await waitForAlert(page, `Success:${title} was created successfully.`);
-
-		await page.getByLabel(`Actions for ${title}`).waitFor();
-
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {
-				exact: true,
-				name: 'Edit',
-			}),
-			trigger: page.getByLabel(`Actions for ${title}`, {
-				exact: true,
-			}),
-		});
-
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {
-				name: 'Permissions',
-			}),
-			trigger: page.getByRole('button', {
-				name: 'Options',
-			}),
-		});
-
-		await journalPage.setPermissions(['#power-user_ACTION_DELETE']);
-
-		await journalPage.goto(site.friendlyUrlPath);
-
-		await journalPage.assertJournalArticlePermissions(title, [
-			{enabled: true, locator: '#power-user_ACTION_DELETE'},
-		]);
-	}
-);
-
 baseTest(
 	'LPD-6800 Create AI Image option visible from Item Selector',
 	async ({journalEditArticlePage, page, site}) => {
@@ -1558,77 +1495,6 @@ baseTest(
 		await page.getByLabel('Go to page, 2').click();
 
 		await expect(page.getByText('page2')).toBeVisible();
-	}
-);
-
-scheduleTest(
-	'Create a web content scheduled',
-	async ({journalEditArticlePage, site}) => {
-		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
-
-		const articleTitle = getRandomString();
-		const expirationDate = '01/01/9999';
-		const publishDate = '9987-11-26 13:00';
-		const reviewDate = '01/01/9999';
-
-		await journalEditArticlePage.scheduleArticle(
-			articleTitle,
-			publishDate,
-			undefined,
-			expirationDate,
-			reviewDate
-		);
-
-		await journalEditArticlePage.assertScheduledArticleDates(
-			articleTitle,
-			publishDate,
-			undefined,
-			expirationDate,
-			reviewDate
-		);
-	}
-);
-
-scheduleTest(
-	'Create a web content scheduled with workflow activated',
-	async ({
-		journalEditArticlePage,
-		journalPage,
-		site,
-		workflowPage,
-		workflowTasksPage,
-	}) => {
-		await workflowPage.goto(site.friendlyUrlPath);
-
-		await workflowPage.changeWorkflow(
-			'Web Content Article',
-			'Single Approver'
-		);
-
-		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
-
-		const articleTitle = getRandomString();
-		const articleDate = '9987-11-26 13:00';
-
-		await journalEditArticlePage.scheduleArticle(
-			articleTitle,
-			articleDate,
-			{workflow: true}
-		);
-
-		await workflowTasksPage.goToAssignedToMyRoles(site.friendlyUrlPath);
-
-		await workflowTasksPage.assignToMe(articleTitle);
-
-		await workflowTasksPage.approve(articleTitle);
-
-		await journalPage.goto(site.friendlyUrlPath);
-
-		await journalEditArticlePage.assertScheduledArticleDates(
-			articleTitle,
-			articleDate,
-			{workflow: true}
-		);
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/journalArticlePermissionsAndSchedule.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticlePermissionsAndSchedule.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
@@ -148,5 +148,31 @@ scheduleTest(
 			articleDate,
 			{workflow: true}
 		);
+	}
+);
+
+scheduleTest(
+	'Web content can be saved as draft',
+	{
+		tag: '@LPD-37754',
+	},
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = 'Web Content Draft Title';
+
+		await journalEditArticlePage.saveAsDraftWithPermissions(articleTitle);
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await expect(
+			page.getByRole('link', {exact: true, name: articleTitle})
+		).toBeVisible();
+
+		await expect(
+			page.locator(
+				'[id="_com_liferay_journal_web_portlet_JournalPortlet_articles_1"] span.label-item'
+			)
+		).toHaveText('Draft');
 	}
 );

--- a/modules/test/playwright/tests/journal-web/journalArticlePermissionsAndSchedule.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticlePermissionsAndSchedule.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../utils/getRandomString';
+import {waitForAlert} from '../../utils/waitForAlert';
+import {journalPagesTest} from './fixtures/journalPagesTest';
+
+const scheduleTest = mergeTests(
+	featureFlagsTest({
+		'LPD-15596': true,
+	}),
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest(),
+	workflowPagesTest
+);
+
+scheduleTest(
+	'Change permission of a web content in edition mode',
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'Publish With Permissions',
+			}),
+			trigger: page.getByRole('button', {
+				name: 'Select and Confirm Publish Settings',
+			}),
+		});
+
+		await page.getByRole('button', {exact: true, name: 'Publish'}).click();
+
+		await waitForAlert(page, `Success:${title} was created successfully.`);
+
+		await page.getByLabel(`Actions for ${title}`).waitFor();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				exact: true,
+				name: 'Edit',
+			}),
+			trigger: page.getByLabel(`Actions for ${title}`, {
+				exact: true,
+			}),
+		});
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: 'Permissions',
+			}),
+			trigger: page.getByRole('button', {
+				name: 'Options',
+			}),
+		});
+
+		await journalPage.setPermissions(['#power-user_ACTION_DELETE']);
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await journalPage.assertJournalArticlePermissions(title, [
+			{enabled: true, locator: '#power-user_ACTION_DELETE'},
+		]);
+	}
+);
+
+scheduleTest(
+	'Create a web content scheduled',
+	async ({journalEditArticlePage, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = getRandomString();
+		const expirationDate = '01/01/9999';
+		const publishDate = '9987-11-26 13:00';
+		const reviewDate = '01/01/9999';
+
+		await journalEditArticlePage.scheduleArticle(
+			articleTitle,
+			publishDate,
+			undefined,
+			expirationDate,
+			reviewDate
+		);
+
+		await journalEditArticlePage.assertScheduledArticleDates(
+			articleTitle,
+			publishDate,
+			undefined,
+			expirationDate,
+			reviewDate
+		);
+	}
+);
+
+scheduleTest(
+	'Create a web content scheduled with workflow activated',
+	async ({
+		journalEditArticlePage,
+		journalPage,
+		site,
+		workflowPage,
+		workflowTasksPage,
+	}) => {
+		await workflowPage.goto(site.friendlyUrlPath);
+
+		await workflowPage.changeWorkflow(
+			'Web Content Article',
+			'Single Approver'
+		);
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = getRandomString();
+		const articleDate = '9987-11-26 13:00';
+
+		await journalEditArticlePage.scheduleArticle(
+			articleTitle,
+			articleDate,
+			{workflow: true}
+		);
+
+		await workflowTasksPage.goToAssignedToMyRoles(site.friendlyUrlPath);
+
+		await workflowTasksPage.assignToMe(articleTitle);
+
+		await workflowTasksPage.approve(articleTitle);
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await journalEditArticlePage.assertScheduledArticleDates(
+			articleTitle,
+			articleDate,
+			{workflow: true}
+		);
+	}
+);

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -258,6 +258,26 @@ export class JournalEditArticlePage {
 		});
 	}
 
+	async saveAsDraftWithPermissions(title: string) {
+		await this.fillTitle(title);
+
+		await this.page
+			.getByRole('button', {exact: true, name: 'Save as Draft'})
+			.click();
+
+		await expect(async () => {
+			const draftButton = await this.page
+				.getByLabel('Save as Draft With Permissions')
+				.getByRole('button', {name: 'Save as Draft'});
+
+			await draftButton.waitFor();
+
+			await draftButton.click();
+		}).toPass();
+
+		await expect(this.page.getByText('Version: 1.0 Draft')).toBeVisible();
+	}
+
 	async scheduleArticle(
 		title: string,
 		publishDate: string,

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -288,7 +288,7 @@ export class JournalEditArticlePage {
 		await this.fillTitle(title);
 
 		if (!(await this.page.getByText('Never Expire').isVisible())) {
-			await this.page.getByRole('link', {name: 'Schedule'}).click();
+			await this.page.getByRole('button', {name: 'Schedule'}).click();
 		}
 
 		if (expirationDate) {


### PR DESCRIPTION
[Link to issue ](https://liferay.atlassian.net/browse/LPD-37754)

# Motivation

Web Content cannot be saved as draft, is published instead 

# How did I solve it
It was caused by https://github.com/liferay-content-management/liferay-portal/pull/5770/files#diff-6475ec503527e9273c8409ce7484ff9657814260d69480848d5d0524234d506aR303. I fixed it by not overriding the action, but receive it from the Publish modal. 

To test it, you can follow the steps described in the ticket, or run 
`npm run playwright -- test -g 'LPD-37754' --reporter list`
![Screenshot 2024-10-01 at 13 05 28](https://github.com/user-attachments/assets/19ad4ed3-6a49-4f3c-a4c9-c2ae9c907f0b)


I also fixed to other tests related to scheduling a web content. 
![Screenshot 2024-10-01 at 13 25 03](https://github.com/user-attachments/assets/0718fd72-1d46-42c4-94ff-b5c139537738)
