### PR TITLE
LPD-37777 [playwright] fix blogs-web broken test 

### DIFF
--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
-import {expandSection} from '../../../utils/expandSection';
+import {openFieldset} from '../../../utils/openFieldset';
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import {BlogsPage} from './BlogsPage';
 
@@ -47,15 +47,7 @@ export class BlogsEditBlogEntryPage {
 		categories,
 		vocabularyName,
 	}: editBlogEntryAddfriendlyUrlType) {
-		const fieldset = await this.page.locator(
-			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_categorization'
-		);
-
-		if (await fieldset.locator('.panel-body').isHidden()) {
-			await fieldset
-				.getByRole('button', {name: 'Categorization'})
-				.click();
-		}
+		const fieldset = await openFieldset(this.page, 'Categorization');
 
 		await fieldset.getByLabel(`Select ${vocabularyName}`).click();
 
@@ -82,13 +74,7 @@ export class BlogsEditBlogEntryPage {
 			vocabularyName,
 		});
 
-		const fieldset = await this.page.locator(
-			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_friendly-url'
-		);
-
-		if (await fieldset.locator('.panel-body').isHidden()) {
-			await fieldset.getByRole('button', {name: 'Friendly URL'}).click();
-		}
+		const fieldset = await openFieldset(this.page, 'Friendly URL');
 
 		await fieldset.getByText('Use a Customized URL').click();
 
@@ -139,11 +125,11 @@ export class BlogsEditBlogEntryPage {
 	}
 
 	async selectSpecificDisplayPage(displayPageName: string) {
-		const displayPageFieldSet = this.page.locator('fieldset', {
-			hasText: 'Display Page',
-		});
+		const displayPageFieldSet = await openFieldset(
+			this.page,
+			'Display Page'
+		);
 
-		await expandSection(displayPageFieldSet);
 		await displayPageFieldSet
 			.getByLabel('Display Page Template')
 			.selectOption('Specific');

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -7,6 +7,7 @@ import {Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
+import {openFieldset} from '../../../utils/openFieldset';
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 import getPageDefinition from '../../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getWidgetDefinition';
@@ -75,12 +76,8 @@ export async function createAssetPublisherAndConfigure({
 		);
 	}
 
-	const configurationSourceAssetTypeSelect =
-		await configurationModal.getByLabel('Asset Type');
-	if (await configurationSourceAssetTypeSelect.isHidden()) {
-		await configurationModal.getByRole('link', {name: 'Source'}).click();
-	}
-	await configurationSourceAssetTypeSelect.selectOption({
+	await openFieldset(configurationModal, 'Source');
+	await configurationModal.getByLabel('Asset Type').selectOption({
 		label: 'Blogs Entry',
 	});
 

--- a/modules/test/playwright/utils/expandSection.ts
+++ b/modules/test/playwright/utils/expandSection.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator} from '@playwright/test';
+import {Locator, expect} from '@playwright/test';
 
 export async function expandSection(trigger: Locator) {
 	const isExpanded = await trigger.evaluate(
@@ -13,4 +13,6 @@ export async function expandSection(trigger: Locator) {
 	if (!isExpanded) {
 		await trigger.click();
 	}
+
+	await expect(trigger).toHaveAttribute('aria-expanded', 'true');
 }

--- a/modules/test/playwright/utils/openFieldset.ts
+++ b/modules/test/playwright/utils/openFieldset.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Page, expect} from '@playwright/test';
+
+export async function openFieldset(page: Page | FrameLocator, name: string) {
+	const fieldset = page.getByRole('group', {
+		name,
+	});
+
+	if (await fieldset.locator('.panel-body').isHidden()) {
+		await fieldset.getByRole('button', {name}).click();
+	}
+
+	await expect(fieldset.locator('.panel-body')).toBeVisible();
+}

--- a/modules/test/playwright/utils/openFieldset.ts
+++ b/modules/test/playwright/utils/openFieldset.ts
@@ -3,16 +3,19 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Page, expect} from '@playwright/test';
+import {FrameLocator, Locator, Page} from '@playwright/test';
 
-export async function openFieldset(page: Page | FrameLocator, name: string) {
+import {expandSection} from './expandSection';
+
+export async function openFieldset(
+	page: Page | FrameLocator,
+	name: string
+): Promise<Locator> {
 	const fieldset = page.getByRole('group', {
 		name,
 	});
 
-	if (await fieldset.locator('.panel-body').isHidden()) {
-		await fieldset.getByRole('button', {name}).click();
-	}
+	await expandSection(fieldset.getByRole('button', {name}));
 
-	await expect(fieldset.locator('.panel-body')).toBeVisible();
+	return fieldset;
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37777

Fix broken 6 broken test in blogs-web

![image](https://github.com/user-attachments/assets/4999c8ec-1a4a-4c95-bbb7-481be86f6fdb)

# How am I fixing it?

Some markup has been updated, the expandable fielset markup has changed from `role="link"` to `role="button"` and the test no longer expands.

I create a new util to centralize the open/get of fieldset.


# How can you verify that it works?
1. Go to /modules/test/playwright
1. Run npm install (setup)
1. Run npm run `npm run playwright -- test --project blogs-web  --reporter list` to run the test

# After the PR

```sh
npm run playwright -- test --project blogs-web  --reporter list
```

![image](https://github.com/user-attachments/assets/ac5c0563-4b82-4390-b3c5-835c1cad6762)
