### PR TITLE
LPD-37775 Missing Friendly-url throws silent error when trying to autosave the article as draft

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -67,6 +67,9 @@ export default function _JournalPortlet({
 
 	if (!Liferay.FeatureFlags['LPD-15596']) {
 		initializeLock('publishing', {
+			errorIndicator: document.getElementById(
+				`${namespace}lockErrorIndicator`
+			),
 			lockedIndicator: document.getElementById(
 				`${namespace}savingChangesIndicator`
 			),
@@ -448,10 +451,15 @@ export default function _JournalPortlet({
 
 					articleIdWrapper.classList.remove('hide');
 					displayedArticleId.innerHTML = articleId;
-				}
 
-				formDateInput.value = data.modifiedDate;
-				lockHolder.lock?.unlock();
+					formDateInput.value = data.modifiedDate;
+					lockHolder.lock?.unlock();
+				}
+				else {
+					formDateInput.value = data.modifiedDate;
+					lockHolder.lock?.unlock(true);
+					showAlert(data.errorMessage);
+				}
 			})
 			.catch((error) => {
 				console.error(error);

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -95,6 +95,48 @@ autoSaveTest(
 	}
 );
 
+autoSaveUndoRedoTest(
+	'After resetting the fields the user is warned about the missing friendly-url',
+	{
+		tag: '@LPD-34375',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		const savedIndicator = await page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
+		);
+
+		await expect(savedIndicator).toBeVisible();
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		await expect(savedIndicator).toBeVisible();
+
+		const historyButton = journalEditArticlePage.historyButton;
+
+		await historyButton.click();
+
+		await page.getByRole('menuitem', {name: 'Undo All'}).click();
+
+		const errorIndicator = await page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_lockErrorIndicator'
+		);
+
+		await expect(errorIndicator).toBeVisible();
+
+		await journalEditArticlePage.fillTitle(getRandomString());
+
+		await expect(
+			page.getByText(
+				'You must define a friendly URL for the default language.'
+			)
+		).toBeVisible();
+	}
+);
+
 autoSaveTest(
 	'LockIndicator should have an errorState',
 	{


### PR DESCRIPTION
[LPD-37775](https://liferay.atlassian.net/browse/LPD-37775)

Description:
Once we undo all the changes on a newly created article, that was already saved as draft, we remove the friendly-url field as well. Once the user fills in the required fields again and we are able to attempt a new autosave, the friendly-url is missing and it throws a silent error.

Solution:
We warn the user about the missing friendly-url field as it is a required field when updating an article

How to test:
run:
`npm run playwright -- test -g 'After resetting the fields the user is warned about the missing friendly-url'`

or

1. Create a new web content
2. fill in the title wait for autosave
3. Reset all the fields with the reset all button
4. fill in the title again

Autosave should fail and display an error msg about the missing friendly-url

