### PR TITLE
LPD-37895 Include missing js unit test in content management CI routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4062,18 +4062,7 @@
         questions-web,\
         wiki-web
 
-    modules.excludes[js-unit-jdk8][content-management]=\
-        apps/asset/asset-display-page-*/**,\
-        apps/asset/asset-list-*/**,\
-        apps/asset/asset-publisher-*/**
-
-    modules.includes[js-unit-jdk8][content-management]=\
-        apps/asset/**,\
-        apps/content-dashboard/**,\
-        apps/journal/**,\
-        apps/questions/questions-web/test/js/**/*.js
-
-    modules.includes[modules-semantic-versioning-jdk8][content-management]=\
+    content.management.testing.modules=\
         apps/adaptive-media/**,\
         apps/ai-creator/**,\
         apps/announcements/**,\
@@ -4112,6 +4101,15 @@
         apps/trash/**,\
         apps/upload/**,\
         apps/wiki/**
+
+    modules.excludes[js-unit-jdk8][content-management]=\
+        apps/asset/asset-display-page-*/**,\
+        apps/asset/asset-list-*/**,\
+        apps/asset/asset-publisher-*/**
+
+    modules.includes[js-unit-jdk8][content-management]=${content.management.testing.modules}
+
+    modules.includes[modules-semantic-versioning-jdk8][content-management]=${content.management.testing.modules}
 
     modules.includes.private[modules-semantic-versioning-jdk8][content-management]=\
         dxp/apps/document-library-opener/**,\

--- a/test.properties
+++ b/test.properties
@@ -4111,6 +4111,8 @@
 
     modules.includes[modules-semantic-versioning-jdk8][content-management]=${content.management.testing.modules}
 
+    modules.includes.public[modules-semantic-versioning-jdk8][content-management]=${content.management.testing.modules}
+
     modules.includes.private[modules-semantic-versioning-jdk8][content-management]=\
         dxp/apps/document-library-opener/**,\
         dxp/apps/sharepoint-rest/**,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37895

Include the next missing js unit test.

<details>
  <summary>Click me</summary>
  
```
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/AICreatorImageModal.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/AICreatorModal.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/ErrorMessage.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/FormContent.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/FormFooter.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/FormImage.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/LoadingMessage.test.tsx:
modules/apps/ai-creator/ai-creator-openai-web/test/ai_creator_modal/TextContent.test.tsx:
modules/apps/asset/asset-list-web/test/js/components/VariationsNav.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/AuditBarChart.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/CategoriesPopover.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/DownloadSpreadsheetButton.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/EmptyAuditBarChart.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SelectFileExtension.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SelectTypeAndSubtype.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/Sidebar.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/VocabulariesSelectionBox.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/FileUrlCopyButton.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/ManageCollaborators.test.tsx:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/Share.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/VersionsContent.test.tsx:
modules/apps/content-dashboard/content-dashboard-web/test/js/components/TreeFilter/TreeFilter.test.js:
modules/apps/content-dashboard/content-dashboard-web/test/js/utils/openCustomDateModal.test.js:
modules/apps/depot/depot-web/test/Languages.es.js:
modules/apps/document-library/document-library-preview-document/test/DocumentPreviewer.es.js:
modules/apps/document-library/document-library-preview-image/test/ImagePreviewer.es.js:
modules/apps/document-library/document-library-video/test/DLVideoExternalShortcutDLFilePicker.js:
modules/apps/document-library/document-library-video/test/DLVideoExternalShortcutURLItemSelectorView.js:
modules/apps/document-library/document-library-web/test/document_library/js/checkin/Checkin.es.js:
modules/apps/flags/flags-taglib/test/js/components/Flags.es.js:
modules/apps/flags/flags-taglib/test/js/components/FlagsModal.es.js:
modules/apps/friendly-url/friendly-url-taglib/test/js/FriendlyURLHistory.js:
modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Carousel.es.js:
modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Footer.es.js:
modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Header.es.js:
modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/ItemSelectorPreview.es.js:
modules/apps/item-selector/item-selector-url-web/test/ItemSelectorUrl.es.js:
modules/apps/journal/journal-web/test/js/ChangeDefaultLanguage.es.js:
modules/apps/journal/journal-web/test/js/SaveButtons.test.js:
modules/apps/journal/journal-web/test/js/SearchOptions.test.js:
modules/apps/journal/journal-web/test/js/configuration_browse/HighlightedDDMStructuresConfiguration.test.tsx:
modules/apps/journal/journal-web/test/js/modals/ImportDataDefinitionModal.js:
modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx:
modules/apps/journal/journal-web/test/js/translation_manager/TranslationOptions.test.tsx:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/LockedKBArticleModal.js:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/ScheduleKBArticle.js:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/ScheduleModal.js:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/SuggestionsPanel.js:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/TemplatesPanel.js:
modules/apps/knowledge-base/knowledge-base-web/test/admin/js/components/VerticalBar.js:
modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/RequiredFields.spec.ts:
modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/RolesUtil.spec.ts:
modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/SecondaryRecipients.spec.ts:
modules/apps/questions/questions-web/test/js/components/Alert.es.js:
modules/apps/questions/questions-web/test/js/components/Answer.es.js:
modules/apps/questions/questions-web/test/js/components/NewTopicModal.es.js:
modules/apps/questions/questions-web/test/js/components/QuestionRow.es.js:
modules/apps/questions/questions-web/test/js/pages/questions/Questions.es.js:
modules/apps/questions/questions-web/test/js/pages/tags/Tags.es.js:
modules/apps/questions/questions-web/test/js/utils/utils.es.js:
modules/apps/ratings/ratings-taglib/test/components/RatingsLike.js:
modules/apps/ratings/ratings-taglib/test/components/RatingsSelectStars.js:
modules/apps/ratings/ratings-taglib/test/components/RatingsStackedStars.js:
modules/apps/ratings/ratings-taglib/test/components/RatingsThumbs.js:
modules/apps/sharing/sharing-taglib/test/js/components/UserIcon.es.js:
modules/apps/translation/translation-web/test/js/ExportTranslation.js:
modules/apps/translation/translation-web/test/js/ImportTranslationResultsPanelSuccess.js:
modules/apps/translation/translation-web/test/js/import-translation/ImportTranslation.js:
modules/apps/translation/translation-web/test/js/translate/Translate.js:
```
</details>


> [!NOTE] 
> **EXTRA BALL** I try to avoid executing global [modules-semantic-versioning-jdk8] and execute only our modules instead.

# How am I fixing it?

At first, I start to manually adding the missing test glob, but later I prefer to emulate **page-content** way and centralize a variable for all of our modules.

# How can you verify that it works?

I will run `ci:test:content-management:dryrun` and we should analyze the results.