### PR TITLE
LPD-33986 Exceptions in WC Structures page are not handled correctly

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -81,7 +81,7 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			_log.error(exception);
 
 			SessionErrors.add(
-				actionRequest, "importDataDefinitionErrorMessage");
+				actionRequest, "importDataDefinitionErrorMessage", exception);
 
 			hideDefaultErrorMessage(actionRequest);
 		}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -40,9 +40,6 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 
 	<liferay-ui:error embed="<%= false %>" key="importDataDefinitionErrorMessage">
 		<c:choose>
-			<c:when test="<%= errorException instanceof DataDefinitionValidationException %>">
-				<liferay-ui:message key="please-enter-a-valid-form-definition" />
-			</c:when>
 			<c:when test="<%= errorException instanceof DataDefinitionValidationException.MustNotDuplicateFieldName %>">
 
 				<%
@@ -73,8 +70,8 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 			<c:when test="<%= errorException instanceof DataDefinitionValidationException.MustSetValidName %>">
 				<liferay-ui:message key="please-enter-a-valid-name" />
 			</c:when>
-			<c:when test="<%= errorException instanceof DataLayoutValidationException %>">
-				<liferay-ui:message key="please-enter-a-valid-form-layout" />
+			<c:when test="<%= errorException instanceof DataDefinitionValidationException %>">
+				<liferay-ui:message key="please-enter-a-valid-form-definition" />
 			</c:when>
 			<c:when test="<%= errorException instanceof DataLayoutValidationException.MustNotDuplicateFieldName %>">
 
@@ -83,6 +80,9 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 				%>
 
 				<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(mndfn.getDuplicatedFieldNames(), StringPool.COMMA_AND_SPACE)) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
+			</c:when>
+			<c:when test="<%= errorException instanceof DataLayoutValidationException %>">
+				<liferay-ui:message key="please-enter-a-valid-form-layout" />
 			</c:when>
 			<c:when test="<%= errorException instanceof PrincipalException.MustHavePermission %>">
 				<liferay-ui:message key="you-do-not-have-the-required-permissions" />

--- a/modules/test/playwright/tests/journal-web/fixtures/journalPagesTest.ts
+++ b/modules/test/playwright/tests/journal-web/fixtures/journalPagesTest.ts
@@ -13,6 +13,7 @@ import {JournalEditStructureDefaultValuesPage} from '../pages/JournalEditStructu
 import {JournalEditStructurePage} from '../pages/JournalEditStructurePage';
 import {JournalEditTemplatePage} from '../pages/JournalEditTemplatePage';
 import {JournalPage} from '../pages/JournalPage';
+import {JournalStructuresPage} from '../pages/JournalStructuresPage';
 
 const journalPagesTest = test.extend<{
 	displayPageTemplatesPage: DisplayPageTemplatesPage;
@@ -23,6 +24,7 @@ const journalPagesTest = test.extend<{
 	journalEditStructurePage: JournalEditStructurePage;
 	journalEditTemplatePage: JournalEditTemplatePage;
 	journalPage: JournalPage;
+	journalStructuresPage: JournalStructuresPage;
 }>({
 	displayPageTemplatesPage: async ({page}, use) => {
 		await use(new DisplayPageTemplatesPage(page));
@@ -47,6 +49,9 @@ const journalPagesTest = test.extend<{
 	},
 	journalPage: async ({page}, use) => {
 		await use(new JournalPage(page));
+	},
+	journalStructuresPage: async ({page}, use) => {
+		await use(new JournalStructuresPage(page));
 	},
 });
 

--- a/modules/test/playwright/tests/journal-web/journalStructure.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalStructure.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import createTempFile from '../../utils/createTempFile';
+import getRandomString from '../../utils/getRandomString';
+import {journalPagesTest} from './fixtures/journalPagesTest';
+import getDataStructureDefinition from './utils/getDataStructureDefinition';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
+);
+
+test(
+	'Import and Override an empty file on an existing structure gives an error',
+	{
+		tag: '@LPD-33986',
+	},
+	async ({apiHelpers, journalStructuresPage, page, site}) => {
+		const structureName = 'Structure Test';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: 'Text', repeatable: false}],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalStructuresPage.goto(site.friendlyUrlPath);
+
+		await expect(
+			page.getByRole('link', {name: structureName})
+		).toBeVisible();
+
+		const filePath = createTempFile(getRandomString() + '.json');
+
+		await journalStructuresPage.importAndOverride(filePath, structureName);
+
+		await expect(page.locator('.alert-danger')).toContainText(
+			'argument "content" is null'
+		);
+	}
+);
+
+test(
+	'Import Structure using a JSON file without any field gives an error',
+	{
+		tag: '@LPD-33986',
+	},
+	async ({journalStructuresPage, page, site}) => {
+		await journalStructuresPage.goto(site.friendlyUrlPath);
+
+		const filePath = createTempFile(
+			getRandomString() + '.json',
+			'{"availableLanguageIds":["en_US"],"dataDefinitionFields":[],"name":{"en_US": "Structure Test"}}'
+		);
+
+		await journalStructuresPage.openOptionsMenu();
+		await journalStructuresPage.import(filePath, 'Structure Test');
+
+		await expect(page.locator('.alert-danger')).toContainText(
+			'At least one field must be added.'
+		);
+	}
+);

--- a/modules/test/playwright/tests/journal-web/pages/JournalStructuresPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalStructuresPage.ts
@@ -6,17 +6,31 @@
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 
 export class JournalStructuresPage {
 	readonly page: Page;
 
+	readonly importButton: Locator;
+	readonly importStructureOptionsMenuItem: Locator;
 	readonly newButton: Locator;
+	readonly optionsMenu: Locator;
+	readonly selectButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
+		this.importButton = page.getByRole('button', {name: 'Import'});
+		this.importStructureOptionsMenuItem = page.getByRole('menuitem', {
+			name: 'Import Structure',
+		});
 		this.newButton = page.getByText('New', {exact: true});
+		this.optionsMenu = page
+			.getByTestId('headerOptions')
+			.getByLabel('Options');
+
+		this.selectButton = page.getByRole('button', {name: 'Select'});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -41,5 +55,45 @@ export class JournalStructuresPage {
 				.getByRole('row', {name: `${title}`})
 				.getByLabel('Show Actions', {exact: true}),
 		});
+	}
+
+	async import(filePath: string, title: string) {
+		await this.importStructureOptionsMenuItem.click();
+
+		const textField = this.page.getByRole('textbox', {
+			name: 'Name',
+		});
+
+		await fillAndClickOutside(this.page, textField, title);
+
+		const fileChooserPromise = this.page.waitForEvent('filechooser');
+
+		await this.selectButton.click();
+
+		const fileChooser = await fileChooserPromise;
+
+		await fileChooser.setFiles(filePath);
+
+		await this.importButton.click();
+	}
+
+	async importAndOverride(filePath: string, title: string) {
+		await this.goToJournalStructureAction('Import and Override', title);
+
+		const fileChooserPromise = this.page.waitForEvent('filechooser');
+
+		await this.selectButton.click();
+
+		const fileChooser = await fileChooserPromise;
+
+		await fileChooser.setFiles(filePath);
+
+		await this.importButton.click();
+	}
+
+	async openOptionsMenu() {
+		await this.optionsMenu
+			.and(this.page.locator('[aria-haspopup]'))
+			.click();
 	}
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33986

1) Exceptions raised during the “Import and Override” action of a Structure produces an error page:

![image](https://github.com/user-attachments/assets/e1716f68-d43a-425c-b4f0-f4b60a08bca5)

2) Some exceptions have a specific message to show but a general one is shown instead (incorrect handling order)

# How am I fixing it?

1) I'm adding the exception object to the SessionError
2) Reording the handling of the exceptions in the JSP file

# How can you verify that it works?

Run: `npm run playwright -- test -g 'LPD-33986'`
