### PR TITLE
LPD-37931 portal proxi is not extended on calls to css on item-selector

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -47,7 +47,7 @@ if (uploadURL != null) {
 <liferay-util:html-top
 	outputKey="com.liferay.item.selector.taglib#/repository_entry_browser/page.jsp"
 >
-	<aui:link href='<%= ServletContextUtil.getContextPath() + "/repository_entry_browser/css/main.css" %>' rel="stylesheet" type="text/css" />
+	<aui:link href='<%= PortalUtil.getPathProxy() + ServletContextUtil.getContextPath() + "/repository_entry_browser/css/main.css" %>' rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <%


### PR DESCRIPTION
LPD-37931 portal.proxy.path is not extended to calls from item-selector-taglib

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37931

On environmets that has the proxy path changed, the css is not loading giving a server error on console and a visual missmatch. This do not perform any functional issue, only that the styles are not loaded

# How am I fixing it?

On the css loading line we should take into account that can have a proxi path on the portal.

# How can you verify that it works?

To test this we need a webserver to check if the css is loaded so we need to follow several steps that includes on the dev thing to load a modified webserver.
To do this we can reproduce the steps of the https://liferay.atlassian.net/browse/LPD-37931 ticket with the PR changes on docker to simplify the process.

An example of working after the changes:

https://github.com/user-attachments/assets/15224237-6008-43e4-92b2-7a8560caa4a0

![Captura de pantalla 2024-10-03 a las 10 28 49](https://github.com/user-attachments/assets/270b43b1-5e5b-4e22-844b-179d59091c1d)


# Why doesn't this include any test?


The PR doesn't include a commit with automated tests, because to test it we need to change the webserver on the typescript test and right now is not possible, if sometime is.
And is an UI issue.


# Commits


- **LPD-37931 add PathProxy to the href of the css**
