### PR TITLE
LPD-37404

### DIFF
--- a/modules/apps/asset/asset-publisher-api/bnd.bnd
+++ b/modules/apps/asset/asset-publisher-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Publisher API
 Bundle-SymbolicName: com.liferay.asset.publisher.api
-Bundle-Version: 6.2.3
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.asset.publisher.action,\
 	com.liferay.asset.publisher.constants,\

--- a/modules/apps/asset/asset-publisher-api/src/main/java/com/liferay/asset/publisher/util/AssetPublisherHelper.java
+++ b/modules/apps/asset/asset-publisher-api/src/main/java/com/liferay/asset/publisher/util/AssetPublisherHelper.java
@@ -155,6 +155,8 @@ public interface AssetPublisherHelper {
 			int start, int end)
 		throws Exception;
 
+	public Group getItemSelectorScopeGroup(Group scopeGroup) throws Exception;
+
 	public String[] getKeywords(PortletPreferences portletPreferences);
 
 	public String getScopeId(Group group, long scopeGroupId);

--- a/modules/apps/asset/asset-publisher-api/src/main/resources/com/liferay/asset/publisher/util/packageinfo
+++ b/modules/apps/asset/asset-publisher-api/src/main/resources/com/liferay/asset/publisher/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/util/test/AssetPublisherHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/util/test/AssetPublisherHelperTest.java
@@ -20,6 +20,9 @@ import com.liferay.info.pagination.InfoPage;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -29,9 +32,11 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -44,6 +49,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.view.count.ViewCountManager;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -527,6 +533,30 @@ public class AssetPublisherHelperTest {
 	}
 
 	@Test
+	public void testGetItemSelectorScopeGroupWithLayoutPrototype()
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryService.addLayoutPageTemplateEntry(
+				null, _group1.getGroupId(), 0, RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE, 0,
+				WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					_group1.getGroupId(), TestPropsValues.getUserId()));
+
+		LayoutPrototype layoutPrototype =
+			_layoutPrototypeLocalService.getLayoutPrototype(
+				layoutPageTemplateEntry.getLayoutPrototypeId());
+
+		Assert.assertEquals(
+			_group1, _assetPublisherHelper.getItemSelectorScopeGroup(_group1));
+		Assert.assertEquals(
+			_group1,
+			_assetPublisherHelper.getItemSelectorScopeGroup(
+				layoutPrototype.getGroup()));
+	}
+
+	@Test
 	public void testHighestRatedAsset() throws Exception {
 		JournalArticle journalArticle1 = JournalTestUtil.addArticle(
 			_group1.getGroupId(),
@@ -798,6 +828,12 @@ public class AssetPublisherHelperTest {
 
 	@DeleteAfterTestRun
 	private Group _group2;
+
+	@Inject
+	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;
+
+	@Inject
+	private LayoutPrototypeLocalService _layoutPrototypeLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1263,6 +1263,9 @@ public class AssetPublisherDisplayContext {
 
 		dropdownItemList.add(
 			dropdownItem -> {
+				Group group = _assetPublisherHelper.getItemSelectorScopeGroup(
+					layout.getGroup());
+
 				dropdownItem.putData("action", "openScopeSelector");
 				dropdownItem.putData("eventName", itemSelectorEventName);
 				dropdownItem.putData(
@@ -1273,7 +1276,8 @@ public class AssetPublisherDisplayContext {
 						itemSelector.getItemSelectorURL(
 							RequestBackedPortletURLFactoryUtil.create(
 								_portletRequest),
-							itemSelectorEventName, groupItemSelectorCriterion)
+							group, group.getGroupId(), itemSelectorEventName,
+							groupItemSelectorCriterion)
 					).setPortletResource(
 						getPortletResource()
 					).setParameter(

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -27,6 +27,8 @@ import com.liferay.asset.publisher.web.internal.constants.AssetPublisherSelectio
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.info.pagination.InfoPage;
 import com.liferay.info.pagination.Pagination;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -39,6 +41,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -50,6 +53,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -857,6 +861,30 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			Pagination.of(end, start), assetEntries.size());
 	}
 
+	public Group getItemSelectorScopeGroup(Group scopeGroup)
+		throws PortalException {
+
+		if (scopeGroup.isLayoutPrototype()) {
+			LayoutPrototype layoutPrototype =
+				_layoutPrototypeLocalService.fetchLayoutPrototype(
+					scopeGroup.getClassPK());
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_layoutPageTemplateEntryLocalService.
+					fetchFirstLayoutPageTemplateEntry(
+						layoutPrototype.getLayoutPrototypeId());
+
+			if ((layoutPageTemplateEntry != null) &&
+				(layoutPageTemplateEntry.getGroupId() > 0)) {
+
+				return _groupLocalService.getGroup(
+					layoutPageTemplateEntry.getGroupId());
+			}
+		}
+
+		return scopeGroup;
+	}
+
 	@Override
 	public String[] getKeywords(PortletPreferences portletPreferences) {
 		String[] allKeywords = new String[0];
@@ -1455,6 +1483,13 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private LayoutPrototypeLocalService _layoutPrototypeLocalService;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-37404

### How am I fixing it?
The issue is that we are not associated with the asset library in the current scope(the scop of the widget page template group). I used a similar solution to [TemplateSelectorTag.java#L321](https://github.com/liferay/liferay-portal/blob/master/modules/apps/template/template-taglib/src/main/java/com/liferay/template/taglib/servlet/taglib/TemplateSelectorTag.java#L321) This way I can retrieve the actual scope for LayoutPageTemplateEntry.

### How can you verify that it works?

To test run:
`gw testIntegration --tests AssetPublisherHelperTest.testGetItemSelectorScopeGroupWithLayoutPrototype`

Or manually test based on the LPD steps

----

Previous pull request: https://github.com/brianchandotcom/liferay-portal/pull/154766

resent with updated nameing.