### PR TITLE
LPD-38011 Refactor BlogsPostingImageResourceImpl

### DIFF
--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 18.0.1
+Bundle-Version: 18.1.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
@@ -76,6 +76,11 @@ public interface BlogsEntryLocalService
 			InputStream inputStream)
 		throws PortalException;
 
+	public FileEntry addAttachmentFileEntry(
+			String externalReferenceCode, long userId, long groupId,
+			String fileName, String mimeType, InputStream inputStream)
+		throws PortalException;
+
 	public Folder addAttachmentsFolder(long userId, long groupId)
 		throws PortalException;
 
@@ -190,6 +195,9 @@ public interface BlogsEntryLocalService
 	 * @throws PortalException
 	 */
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
+		throws PortalException;
+
+	public void deleteAttachmentFileEntry(long fileEntryId)
 		throws PortalException;
 
 	/**
@@ -332,6 +340,15 @@ public interface BlogsEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry getAttachmentFileEntry(long fileEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry getAttachmentFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException;
 
 	/**
 	 * Returns a range of all the blogs entries.

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
@@ -48,6 +48,17 @@ public class BlogsEntryLocalServiceUtil {
 			entry, userId, fileName, mimeType, inputStream);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			addAttachmentFileEntry(
+				String externalReferenceCode, long userId, long groupId,
+				String fileName, String mimeType, InputStream inputStream)
+		throws PortalException {
+
+		return getService().addAttachmentFileEntry(
+			externalReferenceCode, userId, groupId, fileName, mimeType,
+			inputStream);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.Folder
 			addAttachmentsFolder(long userId, long groupId)
 		throws PortalException {
@@ -255,6 +266,12 @@ public class BlogsEntryLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
+	public static void deleteAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		getService().deleteAttachmentFileEntry(fileEntryId);
+	}
+
 	/**
 	 * Deletes the blogs entry from the database. Also notifies the appropriate model listeners.
 	 *
@@ -433,6 +450,22 @@ public class BlogsEntryLocalServiceUtil {
 		getActionableDynamicQuery() {
 
 		return getService().getActionableDynamicQuery();
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getService().getAttachmentFileEntry(fileEntryId);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getAttachmentFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
@@ -43,6 +43,19 @@ public class BlogsEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			addAttachmentFileEntry(
+				String externalReferenceCode, long userId, long groupId,
+				String fileName, String mimeType,
+				java.io.InputStream inputStream)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryLocalService.addAttachmentFileEntry(
+			externalReferenceCode, userId, groupId, fileName, mimeType,
+			inputStream);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.Folder
 			addAttachmentsFolder(long userId, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -270,6 +283,13 @@ public class BlogsEntryLocalServiceWrapper
 		return _blogsEntryLocalService.createPersistedModel(primaryKeyObj);
 	}
 
+	@Override
+	public void deleteAttachmentFileEntry(long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_blogsEntryLocalService.deleteAttachmentFileEntry(fileEntryId);
+	}
+
 	/**
 	 * Deletes the blogs entry from the database. Also notifies the appropriate model listeners.
 	 *
@@ -482,6 +502,25 @@ public class BlogsEntryLocalServiceWrapper
 		getActionableDynamicQuery() {
 
 		return _blogsEntryLocalService.getActionableDynamicQuery();
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntry(long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryLocalService.getAttachmentFileEntry(fileEntryId);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryLocalService.
+			getAttachmentFileEntryByExternalReferenceCode(
+				externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.service.BaseService;
@@ -20,6 +21,8 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
+
+import java.io.InputStream;
 
 import java.util.Date;
 import java.util.List;
@@ -50,6 +53,11 @@ public interface BlogsEntryService extends BaseService {
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.blogs.service.impl.BlogsEntryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the blogs entry remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link BlogsEntryServiceUtil} if injection and service tracking are not available.
 	 */
+	public FileEntry addAttachmentFileEntry(
+			String externalReferenceCode, long groupId, String fileName,
+			String mimeType, InputStream inputStream)
+		throws PortalException;
+
 	public Folder addAttachmentsFolder(long groupId) throws PortalException;
 
 	public BlogsEntry addEntry(
@@ -73,11 +81,23 @@ public interface BlogsEntryService extends BaseService {
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public void deleteAttachmentFileEntry(long fileEntryId)
+		throws PortalException;
+
 	public void deleteEntry(long entryId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BlogsEntry fetchBlogsEntryByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry getAttachmentFileEntry(long fileEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FileEntry getAttachmentFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -10,6 +10,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.io.InputStream;
+
 import java.util.List;
 
 /**
@@ -31,6 +33,16 @@ public class BlogsEntryServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.blogs.service.impl.BlogsEntryServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			addAttachmentFileEntry(
+				String externalReferenceCode, long groupId, String fileName,
+				String mimeType, InputStream inputStream)
+		throws PortalException {
+
+		return getService().addAttachmentFileEntry(
+			externalReferenceCode, groupId, fileName, mimeType, inputStream);
+	}
+
 	public static com.liferay.portal.kernel.repository.model.Folder
 			addAttachmentsFolder(long groupId)
 		throws PortalException {
@@ -80,6 +92,12 @@ public class BlogsEntryServiceUtil {
 			smallImageImageSelector, serviceContext);
 	}
 
+	public static void deleteAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		getService().deleteAttachmentFileEntry(fileEntryId);
+	}
+
 	public static void deleteEntry(long entryId) throws PortalException {
 		getService().deleteEntry(entryId);
 	}
@@ -90,6 +108,22 @@ public class BlogsEntryServiceUtil {
 
 		return getService().fetchBlogsEntryByExternalReferenceCode(
 			groupId, externalReferenceCode);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		return getService().getAttachmentFileEntry(fileEntryId);
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getAttachmentFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	public static BlogsEntry getBlogsEntryByExternalReferenceCode(

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -27,6 +27,17 @@ public class BlogsEntryServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			addAttachmentFileEntry(
+				String externalReferenceCode, long groupId, String fileName,
+				String mimeType, java.io.InputStream inputStream)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.addAttachmentFileEntry(
+			externalReferenceCode, groupId, fileName, mimeType, inputStream);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.repository.model.Folder
 			addAttachmentsFolder(long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -79,6 +90,13 @@ public class BlogsEntryServiceWrapper
 	}
 
 	@Override
+	public void deleteAttachmentFileEntry(long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_blogsEntryService.deleteAttachmentFileEntry(fileEntryId);
+	}
+
+	@Override
 	public void deleteEntry(long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -92,6 +110,24 @@ public class BlogsEntryServiceWrapper
 
 		return _blogsEntryService.fetchBlogsEntryByExternalReferenceCode(
 			groupId, externalReferenceCode);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntry(long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.getAttachmentFileEntry(fileEntryId);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.getAttachmentFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -41,6 +41,51 @@ import com.liferay.portal.kernel.util.MethodKey;
  */
 public class BlogsEntryServiceHttp {
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			addAttachmentFileEntry(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId, String fileName, String mimeType,
+				java.io.InputStream inputStream)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class, "addAttachmentFileEntry",
+				_addAttachmentFileEntryParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId, fileName, mimeType,
+				inputStream);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.portal.kernel.repository.model.Folder
 			addAttachmentsFolder(HttpPrincipal httpPrincipal, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -48,7 +93,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "addAttachmentsFolder",
-				_addAttachmentsFolderParameterTypes0);
+				_addAttachmentsFolderParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -97,7 +142,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "addEntry",
-				_addEntryParameterTypes1);
+				_addEntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, title, subtitle, description, content,
@@ -152,7 +197,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "addEntry",
-				_addEntryParameterTypes2);
+				_addEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, title, subtitle, urlTitle,
@@ -190,13 +235,49 @@ public class BlogsEntryServiceHttp {
 		}
 	}
 
+	public static void deleteAttachmentFileEntry(
+			HttpPrincipal httpPrincipal, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class, "deleteAttachmentFileEntry",
+				_deleteAttachmentFileEntryParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, fileEntryId);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void deleteEntry(HttpPrincipal httpPrincipal, long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "deleteEntry",
-				_deleteEntryParameterTypes3);
+				_deleteEntryParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -234,7 +315,7 @@ public class BlogsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class,
 				"fetchBlogsEntryByExternalReferenceCode",
-				_fetchBlogsEntryByExternalReferenceCodeParameterTypes4);
+				_fetchBlogsEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -267,6 +348,92 @@ public class BlogsEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntry(
+				HttpPrincipal httpPrincipal, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class, "getAttachmentFileEntry",
+				_getAttachmentFileEntryParameterTypes7);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, fileEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentFileEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class,
+				"getAttachmentFileEntryByExternalReferenceCode",
+				_getAttachmentFileEntryByExternalReferenceCodeParameterTypes8);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.repository.model.FileEntry)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.blogs.model.BlogsEntry
 			getBlogsEntryByExternalReferenceCode(
 				HttpPrincipal httpPrincipal, long groupId,
@@ -277,7 +444,7 @@ public class BlogsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class,
 				"getBlogsEntryByExternalReferenceCode",
-				_getBlogsEntryByExternalReferenceCodeParameterTypes5);
+				_getBlogsEntryByExternalReferenceCodeParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -319,7 +486,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntries",
-				_getCompanyEntriesParameterTypes6);
+				_getCompanyEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max);
@@ -364,7 +531,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntriesRSS",
-				_getCompanyEntriesRSSParameterTypes7);
+				_getCompanyEntriesRSSParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max, type, version,
@@ -405,7 +572,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntriesPrevAndNext",
-				_getEntriesPrevAndNextParameterTypes8);
+				_getEntriesPrevAndNextParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -444,7 +611,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes9);
+				_getEntryParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -483,7 +650,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes10);
+				_getEntryParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -524,7 +691,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes11);
+				_getGroupEntriesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max);
@@ -559,7 +726,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes12);
+				_getGroupEntriesParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, start, end);
@@ -593,7 +760,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes13);
+				_getGroupEntriesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, max);
@@ -628,7 +795,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes14);
+				_getGroupEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end);
@@ -665,7 +832,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes15);
+				_getGroupEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -699,7 +866,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes16);
+				_getGroupEntriesCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status);
@@ -731,7 +898,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes17);
+				_getGroupEntriesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -768,7 +935,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesRSS",
-				_getGroupEntriesRSSParameterTypes18);
+				_getGroupEntriesRSSParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max, type, version,
@@ -811,7 +978,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupsEntries",
-				_getGroupsEntriesParameterTypes19);
+				_getGroupsEntriesParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, displayDate, status, max);
@@ -855,7 +1022,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes20);
+				_getGroupUserEntriesParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status, start, end,
@@ -893,7 +1060,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes21);
+				_getGroupUserEntriesParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses, start, end,
@@ -927,7 +1094,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes22);
+				_getGroupUserEntriesCountParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status);
@@ -960,7 +1127,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes23);
+				_getGroupUserEntriesCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses);
@@ -995,7 +1162,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntries",
-				_getOrganizationEntriesParameterTypes24);
+				_getOrganizationEntriesParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max);
@@ -1040,7 +1207,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntriesRSS",
-				_getOrganizationEntriesRSSParameterTypes25);
+				_getOrganizationEntriesRSSParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max, type,
@@ -1081,7 +1248,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "moveEntryToTrash",
-				_moveEntryToTrashParameterTypes26);
+				_moveEntryToTrashParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1120,7 +1287,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "restoreEntryFromTrash",
-				_restoreEntryFromTrashParameterTypes27);
+				_restoreEntryFromTrashParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1154,7 +1321,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "subscribe",
-				_subscribeParameterTypes28);
+				_subscribeParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1188,7 +1355,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes29);
+				_unsubscribeParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1233,7 +1400,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes30);
+				_updateEntryParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, description, content,
@@ -1288,7 +1455,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes31);
+				_updateEntryParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, urlTitle, description,
@@ -1329,9 +1496,14 @@ public class BlogsEntryServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(
 		BlogsEntryServiceHttp.class);
 
-	private static final Class<?>[] _addAttachmentsFolderParameterTypes0 =
+	private static final Class<?>[] _addAttachmentFileEntryParameterTypes0 =
+		new Class[] {
+			String.class, long.class, String.class, String.class,
+			java.io.InputStream.class
+		};
+	private static final Class<?>[] _addAttachmentsFolderParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[] _addEntryParameterTypes1 = new Class[] {
+	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
 		String.class, String.class, String.class, String.class, int.class,
 		int.class, int.class, int.class, int.class, boolean.class,
 		boolean.class, String[].class, String.class,
@@ -1339,7 +1511,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
+	private static final Class<?>[] _addEntryParameterTypes3 = new Class[] {
 		String.class, String.class, String.class, String.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		boolean.class, boolean.class, String[].class, String.class,
@@ -1347,95 +1519,102 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _deleteEntryParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteAttachmentFileEntryParameterTypes4 =
+		new Class[] {long.class};
+	private static final Class<?>[] _deleteEntryParameterTypes5 = new Class[] {
 		long.class
 	};
 	private static final Class<?>[]
-		_fetchBlogsEntryByExternalReferenceCodeParameterTypes4 = new Class[] {
+		_fetchBlogsEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
 			long.class, String.class
 		};
+	private static final Class<?>[] _getAttachmentFileEntryParameterTypes7 =
+		new Class[] {long.class};
 	private static final Class<?>[]
-		_getBlogsEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+		_getAttachmentFileEntryByExternalReferenceCodeParameterTypes8 =
+			new Class[] {String.class, long.class};
+	private static final Class<?>[]
+		_getBlogsEntryByExternalReferenceCodeParameterTypes9 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes6 =
+	private static final Class<?>[] _getCompanyEntriesParameterTypes10 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes7 =
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes11 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes8 =
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes12 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes13 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getEntryParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes14 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getGroupEntriesParameterTypes11 =
+	private static final Class<?>[] _getGroupEntriesParameterTypes15 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getGroupEntriesParameterTypes12 =
+	private static final Class<?>[] _getGroupEntriesParameterTypes16 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes13 =
+	private static final Class<?>[] _getGroupEntriesParameterTypes17 =
 		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getGroupEntriesParameterTypes14 =
+	private static final Class<?>[] _getGroupEntriesParameterTypes18 =
 		new Class[] {long.class, int.class, int.class, int.class};
-	private static final Class<?>[] _getGroupEntriesParameterTypes15 =
+	private static final Class<?>[] _getGroupEntriesParameterTypes19 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 =
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes20 =
 		new Class[] {long.class, java.util.Date.class, int.class};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes17 =
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes21 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes18 =
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes22 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes19 =
+	private static final Class<?>[] _getGroupsEntriesParameterTypes23 =
 		new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes24 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes21 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes25 =
 		new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 =
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes26 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes23 =
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes27 =
 		new Class[] {long.class, long.class, int[].class};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes24 =
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes28 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes25 =
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes29 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes26 =
+	private static final Class<?>[] _moveEntryToTrashParameterTypes30 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes27 =
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes31 =
 		new Class[] {long.class};
-	private static final Class<?>[] _subscribeParameterTypes28 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes32 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _unsubscribeParameterTypes29 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes33 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes34 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		int.class, int.class, int.class, int.class, int.class, boolean.class,
 		boolean.class, String[].class, String.class,
@@ -1443,7 +1622,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes35 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		boolean.class, boolean.class, String[].class, String.class,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.blogs.settings.BlogsGroupServiceSettings;
 import com.liferay.blogs.social.BlogsActivityKeys;
 import com.liferay.blogs.util.comparator.EntryDisplayDateComparator;
 import com.liferay.blogs.util.comparator.EntryIdComparator;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
@@ -162,17 +163,23 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			InputStream inputStream)
 		throws PortalException {
 
-		Folder folder = addAttachmentsFolder(userId, entry.getGroupId());
+		return addAttachmentFileEntry(
+			null, userId, entry.getGroupId(), fileName, mimeType, inputStream);
+	}
 
-		String uniqueFileName = _uniqueFileNameProvider.provide(
-			fileName,
-			curFileName -> _hasFileEntry(
-				entry.getGroupId(), folder.getFolderId(), curFileName));
+	@Override
+	public FileEntry addAttachmentFileEntry(
+			String externalReferenceCode, long userId, long groupId,
+			String fileName, String mimeType, InputStream inputStream)
+		throws PortalException {
+
+		Folder folder = addAttachmentsFolder(userId, groupId);
 
 		return _portletFileRepository.addPortletFileEntry(
-			null, entry.getGroupId(), userId, null, 0,
+			externalReferenceCode, groupId, userId, null, 0,
 			BlogsConstants.SERVICE_NAME, folder.getFolderId(), inputStream,
-			uniqueFileName, mimeType, true);
+			_getUniqueFileName(groupId, fileName, folder.getFolderId()),
+			mimeType, true);
 	}
 
 	@Override
@@ -602,6 +609,19 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	}
 
 	@Override
+	public void deleteAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
+			fileEntryId);
+
+		_validateAttachmentFileEntry(fileEntry);
+
+		_portletFileRepository.deletePortletFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
+	@Override
 	public BlogsEntry deleteBlogsEntry(BlogsEntry blogsEntry) {
 		try {
 			return blogsEntryLocalService.deleteEntry(blogsEntry);
@@ -745,6 +765,32 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		}
 
 		return blogsEntryPersistence.fetchByG_UT(groupId, urlTitle);
+	}
+
+	@Override
+	public FileEntry getAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
+			fileEntryId);
+
+		_validateAttachmentFileEntry(fileEntry);
+
+		return fileEntry;
+	}
+
+	@Override
+	public FileEntry getAttachmentFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		FileEntry fileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		_validateAttachmentFileEntry(fileEntry);
+
+		return fileEntry;
 	}
 
 	@Override
@@ -2400,6 +2446,24 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		if (content.length() > contentMaxLength) {
 			throw new EntryContentException(
 				"Content has more than " + contentMaxLength + " characters");
+		}
+	}
+
+	private void _validateAttachmentFileEntry(FileEntry fileEntry)
+		throws PortalException {
+
+		Repository repository = _portletFileRepository.getPortletRepository(
+			fileEntry.getGroupId(), BlogsConstants.SERVICE_NAME);
+
+		Folder folder = _portletFileRepository.getPortletFolder(
+			repository.getRepositoryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			BlogsConstants.SERVICE_NAME);
+
+		if (fileEntry.getFolderId() != folder.getFolderId()) {
+			throw new NoSuchFileEntryException(
+				"Not a valid blog attachment file {fileEntryId=" +
+					fileEntry.getFileEntryId() + "}");
 		}
 	}
 

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -42,6 +43,8 @@ import com.liferay.rss.model.SyndFeed;
 import com.liferay.rss.model.SyndLink;
 import com.liferay.rss.model.SyndModelFactory;
 import com.liferay.rss.util.RSSUtil;
+
+import java.io.InputStream;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -68,6 +71,20 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 	service = AopService.class
 )
 public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
+
+	@Override
+	public FileEntry addAttachmentFileEntry(
+			String externalReferenceCode, long groupId, String fileName,
+			String mimeType, InputStream inputStream)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), groupId, ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addAttachmentFileEntry(
+			externalReferenceCode, getUserId(), groupId, fileName, mimeType,
+			inputStream);
+	}
 
 	@Override
 	public Folder addAttachmentsFolder(long groupId) throws PortalException {
@@ -126,6 +143,19 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	@Override
+	public void deleteAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		FileEntry fileEntry = blogsEntryLocalService.getAttachmentFileEntry(
+			fileEntryId);
+
+		_fileEntryModelResourcePermission.check(
+			getPermissionChecker(), fileEntry, ActionKeys.DELETE);
+
+		blogsEntryLocalService.deleteAttachmentFileEntry(fileEntryId);
+	}
+
+	@Override
 	public void deleteEntry(long entryId) throws PortalException {
 		_blogsEntryModelResourcePermission.check(
 			getPermissionChecker(), entryId, ActionKeys.DELETE);
@@ -147,6 +177,35 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 		}
 
 		return blogsEntry;
+	}
+
+	@Override
+	public FileEntry getAttachmentFileEntry(long fileEntryId)
+		throws PortalException {
+
+		FileEntry fileEntry = blogsEntryLocalService.getAttachmentFileEntry(
+			fileEntryId);
+
+		_fileEntryModelResourcePermission.check(
+			getPermissionChecker(), fileEntry, ActionKeys.VIEW);
+
+		return fileEntry;
+	}
+
+	@Override
+	public FileEntry getAttachmentFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		FileEntry fileEntry =
+			blogsEntryLocalService.
+				getAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, groupId);
+
+		_fileEntryModelResourcePermission.check(
+			getPermissionChecker(), fileEntry, ActionKeys.VIEW);
+
+		return fileEntry;
 	}
 
 	@Override
@@ -717,6 +776,12 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.repository.model.FileEntry)"
+	)
+	private ModelResourcePermission<FileEntry>
+		_fileEntryModelResourcePermission;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -201,7 +201,7 @@ public class BlogsEntryLocalServiceTest {
 			BlogsEntry.class.getName(), entry.getEntryId());
 
 		CommentManagerUtil.addComment(
-			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			BlogsEntry.class.getName(), entry.getEntryId(),
 			StringUtil.randomString(),
 			new IdentityServiceContextFunction(serviceContext));
@@ -631,7 +631,7 @@ public class BlogsEntryLocalServiceTest {
 		_blogsEntries.add(entry);
 
 		CommentManagerUtil.addComment(
-			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			BlogsEntry.class.getName(), entry.getEntryId(),
 			StringUtil.randomString(),
 			new IdentityServiceContextFunction(serviceContext));
@@ -684,7 +684,7 @@ public class BlogsEntryLocalServiceTest {
 	public void testFetchNullAttachmentsFolder() throws Exception {
 		Assert.assertNull(
 			_blogsEntryLocalService.fetchAttachmentsFolder(
-				TestPropsValues.getUserId(), TestPropsValues.getGroupId()));
+				TestPropsValues.getUserId(), _group.getGroupId()));
 	}
 
 	@Test

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -18,7 +18,7 @@ import com.liferay.blogs.exception.EntryTitleException;
 import com.liferay.blogs.exception.EntryUrlTitleException;
 import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
-import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
+import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.blogs.test.util.BlogsTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.friendly.url.exception.DuplicateFriendlyURLEntryException;
@@ -138,10 +138,10 @@ public class BlogsEntryLocalServiceTest {
 
 		String coverImageURL = StringUtil.randomString();
 
-		BlogsEntryLocalServiceUtil.addCoverImage(
+		_blogsEntryLocalService.addCoverImage(
 			entry.getEntryId(), new ImageSelector(coverImageURL));
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getCoverImageFileEntryId());
@@ -156,13 +156,13 @@ public class BlogsEntryLocalServiceTest {
 		byte[] bytes = FileUtil.getBytes(
 			new UnsyncByteArrayInputStream(TestDataConstants.TEST_BYTE_ARRAY));
 
-		BlogsEntryLocalServiceUtil.addCoverImage(
+		_blogsEntryLocalService.addCoverImage(
 			entry.getEntryId(),
 			new ImageSelector(
 				bytes, StringUtil.randomString() + ".bin",
 				ContentTypes.APPLICATION_OCTET_STREAM, StringPool.BLANK));
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertNotEquals(0, updatedEntry.getCoverImageFileEntryId());
@@ -176,10 +176,10 @@ public class BlogsEntryLocalServiceTest {
 
 		String imageURL = StringUtil.randomString();
 
-		BlogsEntryLocalServiceUtil.addCoverImage(
+		_blogsEntryLocalService.addCoverImage(
 			entry.getEntryId(), new ImageSelector(imageURL));
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getCoverImageFileEntryId());
@@ -191,7 +191,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), StringUtil.randomString(),
 			StringUtil.randomString(), new Date(), serviceContext);
 
@@ -214,7 +214,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddDraftEntryWithBlankTitle() throws Exception {
-		int initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int initialCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusAnyQueryDefinition);
 
 		ServiceContext serviceContext =
@@ -222,11 +222,11 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), StringPool.BLANK, RandomTestUtil.randomString(),
 			serviceContext);
 
-		int actualCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int actualCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusAnyQueryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
@@ -239,7 +239,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			urlTitle, RandomTestUtil.randomString(),
@@ -248,7 +248,7 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			urlTitle, RandomTestUtil.randomString(),
@@ -260,7 +260,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddDraftEntryWithNullTitle() throws Exception {
-		int initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int initialCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusAnyQueryDefinition);
 
 		ServiceContext serviceContext =
@@ -268,11 +268,11 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), null, RandomTestUtil.randomString(),
 			serviceContext);
 
-		int actualCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int actualCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusAnyQueryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
@@ -284,17 +284,15 @@ public class BlogsEntryLocalServiceTest {
 
 		String fileName = StringUtil.randomString();
 
-		FileEntry fileEntry1 =
-			BlogsEntryLocalServiceUtil.addAttachmentFileEntry(
-				entry, entry.getUserId(), fileName,
-				ContentTypes.APPLICATION_OCTET_STREAM,
-				new UnsyncByteArrayInputStream(new byte[0]));
+		FileEntry fileEntry1 = _blogsEntryLocalService.addAttachmentFileEntry(
+			entry, entry.getUserId(), fileName,
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			new UnsyncByteArrayInputStream(new byte[0]));
 
-		FileEntry fileEntry2 =
-			BlogsEntryLocalServiceUtil.addAttachmentFileEntry(
-				entry, entry.getUserId(), fileName,
-				ContentTypes.APPLICATION_OCTET_STREAM,
-				new UnsyncByteArrayInputStream(new byte[0]));
+		FileEntry fileEntry2 = _blogsEntryLocalService.addAttachmentFileEntry(
+			entry, entry.getUserId(), fileName,
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			new UnsyncByteArrayInputStream(new byte[0]));
 
 		Assert.assertNotEquals(
 			fileEntry1.getFileName(), fileEntry2.getFileName());
@@ -309,10 +307,10 @@ public class BlogsEntryLocalServiceTest {
 	public void testAddEmptyCoverImage() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.addCoverImage(
+		_blogsEntryLocalService.addCoverImage(
 			entry.getEntryId(), new ImageSelector());
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getCoverImageFileEntryId());
@@ -325,7 +323,7 @@ public class BlogsEntryLocalServiceTest {
 
 		Assert.assertEquals(
 			0,
-			BlogsEntryLocalServiceUtil.addOriginalImageFileEntry(
+			_blogsEntryLocalService.addOriginalImageFileEntry(
 				entry.getUserId(), entry.getGroupId(), entry.getEntryId(),
 				new ImageSelector()));
 	}
@@ -334,10 +332,10 @@ public class BlogsEntryLocalServiceTest {
 	public void testAddEmptySmallImage() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.addSmallImage(
+		_blogsEntryLocalService.addSmallImage(
 			entry.getEntryId(), new ImageSelector());
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getSmallImageFileEntryId());
@@ -347,12 +345,12 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddEntry() throws Exception {
-		int initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int initialCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusApprovedQueryDefinition);
 
 		addEntry(false);
 
-		int actualCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+		int actualCount = _blogsEntryLocalService.getGroupEntriesCount(
 			_group.getGroupId(), _statusApprovedQueryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
@@ -370,7 +368,7 @@ public class BlogsEntryLocalServiceTest {
 					ServiceContextTestUtil.getServiceContext(
 						_group.getGroupId(), _creatorUser.getUserId());
 
-				BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+				BlogsEntry entry = _blogsEntryLocalService.addEntry(
 					_creatorUser.getUserId(), RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), serviceContext);
 
@@ -390,13 +388,13 @@ public class BlogsEntryLocalServiceTest {
 
 		String title = "title";
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(), title,
 			StringUtil.randomString(), StringPool.BLANK,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
 			true, true, new String[0], null, null, null, serviceContext);
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(), title,
 			StringUtil.randomString(), StringPool.BLANK,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
@@ -429,13 +427,13 @@ public class BlogsEntryLocalServiceTest {
 
 		String urlTitle = "urlTitle";
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(), urlTitle,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
 			true, true, new String[0], null, null, null, serviceContext);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(), urlTitle,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
@@ -444,7 +442,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test(expected = EntryUrlTitleException.class)
 	public void testAddEntryWithInvalidURLTitle() throws Exception {
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(256), StringUtil.randomString(),
@@ -454,7 +452,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddEntryWithNoImages() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(),
 			StringUtil.randomString(), StringUtil.randomString(),
@@ -473,7 +471,7 @@ public class BlogsEntryLocalServiceTest {
 	public void testAddEntryWithURLTitle() throws Exception {
 		String urlTitle = StringUtil.toLowerCase(StringUtil.randomString());
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(), urlTitle,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
@@ -490,7 +488,7 @@ public class BlogsEntryLocalServiceTest {
 
 		String bakedUrlTitle = "///////" + expectedUrlTitle;
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			StringUtil.randomString(), StringUtil.randomString(), bakedUrlTitle,
 			StringUtil.randomString(), StringUtil.randomString(), new Date(),
@@ -507,7 +505,7 @@ public class BlogsEntryLocalServiceTest {
 
 		String content = _repeat("0", maxLength + 1);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(), content,
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -520,7 +518,7 @@ public class BlogsEntryLocalServiceTest {
 
 		String title = _repeat("0", maxLength + 1);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), title, RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -530,9 +528,9 @@ public class BlogsEntryLocalServiceTest {
 	public void testAddNullCoverImage() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.addCoverImage(entry.getEntryId(), null);
+		_blogsEntryLocalService.addCoverImage(entry.getEntryId(), null);
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getCoverImageFileEntryId());
@@ -544,9 +542,9 @@ public class BlogsEntryLocalServiceTest {
 	public void testAddNullSmallImage() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.addSmallImage(entry.getEntryId(), null);
+		_blogsEntryLocalService.addSmallImage(entry.getEntryId(), null);
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getSmallImageFileEntryId());
@@ -556,7 +554,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddOriginalImageInVisibleImageFolder() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
@@ -571,7 +569,7 @@ public class BlogsEntryLocalServiceTest {
 			StringPool.BLANK);
 
 		long originalImageFileEntryId =
-			BlogsEntryLocalServiceUtil.addOriginalImageFileEntry(
+			_blogsEntryLocalService.addOriginalImageFileEntry(
 				_user.getUserId(), _group.getGroupId(), entry.getEntryId(),
 				imageSelector);
 
@@ -600,7 +598,7 @@ public class BlogsEntryLocalServiceTest {
 			FileUtil.getBytes(fileEntry.getContentStream()),
 			fileEntry.getTitle(), fileEntry.getMimeType(), StringPool.BLANK);
 
-		BlogsEntryLocalServiceUtil.addSmallImage(
+		_blogsEntryLocalService.addSmallImage(
 			entry.getEntryId(), imageSelector);
 	}
 
@@ -610,10 +608,10 @@ public class BlogsEntryLocalServiceTest {
 
 		String imageURL = StringUtil.randomString();
 
-		BlogsEntryLocalServiceUtil.addSmallImage(
+		_blogsEntryLocalService.addSmallImage(
 			entry.getEntryId(), new ImageSelector(imageURL));
 
-		BlogsEntry updatedEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry updatedEntry = _blogsEntryLocalService.getEntry(
 			entry.getEntryId());
 
 		Assert.assertEquals(0, updatedEntry.getSmallImageFileEntryId());
@@ -626,7 +624,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), StringUtil.randomString(),
 			StringUtil.randomString(), new Date(), serviceContext);
 
@@ -654,9 +652,9 @@ public class BlogsEntryLocalServiceTest {
 	public void testDeleteEntry() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.deleteEntry(entry);
+		_blogsEntryLocalService.deleteEntry(entry);
 
-		BlogsEntryLocalServiceUtil.getEntry(entry.getEntryId());
+		_blogsEntryLocalService.getEntry(entry.getEntryId());
 	}
 
 	@Test
@@ -671,21 +669,21 @@ public class BlogsEntryLocalServiceTest {
 			bytes = FileUtil.getBytes(inputStream);
 		}
 
-		BlogsEntryLocalServiceUtil.addOriginalImageFileEntry(
+		_blogsEntryLocalService.addOriginalImageFileEntry(
 			entry.getUserId(), entry.getGroupId(), entry.getEntryId(),
 			new ImageSelector(
 				bytes, StringUtil.randomString() + ".bin",
 				ContentTypes.APPLICATION_OCTET_STREAM, StringPool.BLANK));
 
 		Assert.assertNotNull(
-			BlogsEntryLocalServiceUtil.fetchAttachmentsFolder(
+			_blogsEntryLocalService.fetchAttachmentsFolder(
 				entry.getUserId(), entry.getGroupId()));
 	}
 
 	@Test
 	public void testFetchNullAttachmentsFolder() throws Exception {
 		Assert.assertNull(
-			BlogsEntryLocalServiceUtil.fetchAttachmentsFolder(
+			_blogsEntryLocalService.fetchAttachmentsFolder(
 				TestPropsValues.getUserId(), TestPropsValues.getGroupId()));
 	}
 
@@ -726,7 +724,7 @@ public class BlogsEntryLocalServiceTest {
 
 		BlogsEntry secondEntry = addEntry(false, 2);
 
-		BlogsEntry[] entries = BlogsEntryLocalServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] entries = _blogsEntryLocalService.getEntriesPrevAndNext(
 			secondEntry.getEntryId());
 
 		Assert.assertNotNull(
@@ -775,7 +773,7 @@ public class BlogsEntryLocalServiceTest {
 
 		BlogsEntry nextEntry = addEntry(false);
 
-		BlogsEntry[] entries = BlogsEntryLocalServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] entries = _blogsEntryLocalService.getEntriesPrevAndNext(
 			currentEntry.getEntryId());
 
 		Assert.assertNotNull(
@@ -824,7 +822,7 @@ public class BlogsEntryLocalServiceTest {
 
 		BlogsEntry nextEntry = addEntry(false);
 
-		BlogsEntry[] entries = BlogsEntryLocalServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] entries = _blogsEntryLocalService.getEntriesPrevAndNext(
 			nextEntry.getEntryId());
 
 		Assert.assertNull(
@@ -863,7 +861,7 @@ public class BlogsEntryLocalServiceTest {
 
 		addEntry(false);
 
-		BlogsEntry[] entries = BlogsEntryLocalServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] entries = _blogsEntryLocalService.getEntriesPrevAndNext(
 			previousEntry.getEntryId());
 
 		Assert.assertNull(
@@ -902,7 +900,7 @@ public class BlogsEntryLocalServiceTest {
 
 		String urlTitle = "new-friendly-url";
 
-		BlogsEntryLocalServiceUtil.updateEntry(
+		_blogsEntryLocalService.updateEntry(
 			expectedEntry.getUserId(), expectedEntry.getEntryId(),
 			expectedEntry.getTitle(), expectedEntry.getSubtitle(), urlTitle,
 			expectedEntry.getDescription(), expectedEntry.getContent(),
@@ -912,12 +910,12 @@ public class BlogsEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
 
-		BlogsEntry actualEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry actualEntry = _blogsEntryLocalService.getEntry(
 			expectedEntry.getGroupId(), oldUrlTitle);
 
 		BlogsTestUtil.assertEquals(expectedEntry, actualEntry);
 
-		actualEntry = BlogsEntryLocalServiceUtil.getEntry(
+		actualEntry = _blogsEntryLocalService.getEntry(
 			expectedEntry.getGroupId(), urlTitle);
 
 		BlogsTestUtil.assertEquals(expectedEntry, actualEntry);
@@ -927,7 +925,7 @@ public class BlogsEntryLocalServiceTest {
 	public void testGetEntryByGroupAndUrlTitle() throws Exception {
 		BlogsEntry expectedEntry = addEntry(false);
 
-		BlogsEntry actualEntry = BlogsEntryLocalServiceUtil.getEntry(
+		BlogsEntry actualEntry = _blogsEntryLocalService.getEntry(
 			expectedEntry.getGroupId(), expectedEntry.getUrlTitle());
 
 		BlogsTestUtil.assertEquals(expectedEntry, actualEntry);
@@ -990,7 +988,7 @@ public class BlogsEntryLocalServiceTest {
 	@Test
 	public void testGetGroupsEntries() throws Exception {
 		List<BlogsEntry> groupsEntries =
-			BlogsEntryLocalServiceUtil.getGroupsEntries(
+			_blogsEntryLocalService.getGroupsEntries(
 				_user.getCompanyId(), _group.getGroupId(), new Date(),
 				_statusInTrashQueryDefinition);
 
@@ -1000,7 +998,7 @@ public class BlogsEntryLocalServiceTest {
 		addEntry(true);
 
 		List<BlogsEntry> groupsEntriesInTrash =
-			BlogsEntryLocalServiceUtil.getGroupsEntries(
+			_blogsEntryLocalService.getGroupsEntries(
 				_user.getCompanyId(), _group.getGroupId(), new Date(),
 				_statusInTrashQueryDefinition);
 
@@ -1062,7 +1060,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test(expected = EntryTitleException.class)
 	public void testPublishWithBlankTitle() throws Exception {
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), StringPool.BLANK, RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -1070,7 +1068,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test(expected = EntryTitleException.class)
 	public void testPublishWithNullTitle() throws Exception {
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), null, RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -1078,7 +1076,7 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test(expected = EntryTitleException.class)
 	public void testPublishWithoutTitle() throws Exception {
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			_user.getUserId(), StringPool.BLANK, RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -1090,7 +1088,7 @@ public class BlogsEntryLocalServiceTest {
 			SubscriptionLocalServiceUtil.getUserSubscriptionsCount(
 				_user.getUserId());
 
-		BlogsEntryLocalServiceUtil.subscribe(
+		_blogsEntryLocalService.subscribe(
 			_user.getUserId(), _group.getGroupId());
 
 		int actualCount =
@@ -1106,10 +1104,10 @@ public class BlogsEntryLocalServiceTest {
 			SubscriptionLocalServiceUtil.getUserSubscriptionsCount(
 				_user.getUserId());
 
-		BlogsEntryLocalServiceUtil.subscribe(
+		_blogsEntryLocalService.subscribe(
 			_user.getUserId(), _group.getGroupId());
 
-		BlogsEntryLocalServiceUtil.unsubscribe(
+		_blogsEntryLocalService.unsubscribe(
 			_user.getUserId(), _group.getGroupId());
 
 		int actualCount =
@@ -1126,7 +1124,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			urlTitle, RandomTestUtil.randomString(),
@@ -1135,14 +1133,14 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			RandomTestUtil.randomString(), _user.getUserId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			urlTitle, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new Date(), false, false, null, null,
 			null, null, serviceContext);
 
-		entry = BlogsEntryLocalServiceUtil.updateEntry(
+		entry = _blogsEntryLocalService.updateEntry(
 			_user.getUserId(), entry.getEntryId(), entry.getTitle(),
 			entry.getSubtitle(), urlTitle, entry.getDescription(),
 			entry.getContent(), entry.getDisplayDate(), false, false, null,
@@ -1155,7 +1153,7 @@ public class BlogsEntryLocalServiceTest {
 	public void testUpdateEntryResources() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
-		BlogsEntryLocalServiceUtil.updateEntryResources(
+		_blogsEntryLocalService.updateEntryResources(
 			entry, new String[] {ActionKeys.ADD_DISCUSSION}, null);
 	}
 
@@ -1164,7 +1162,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -1172,7 +1170,7 @@ public class BlogsEntryLocalServiceTest {
 
 		String bakedUrlTitle = "///////" + expectedUrlTitle;
 
-		entry = BlogsEntryLocalServiceUtil.updateEntry(
+		entry = _blogsEntryLocalService.updateEntry(
 			_user.getUserId(), entry.getEntryId(), entry.getTitle(),
 			entry.getSubtitle(), bakedUrlTitle, entry.getDescription(),
 			entry.getContent(), entry.getDisplayDate(), false, false, null,
@@ -1188,13 +1186,13 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		String urlTitle = entry.getUrlTitle();
 
-		entry = BlogsEntryLocalServiceUtil.updateEntry(
+		entry = _blogsEntryLocalService.updateEntry(
 			_user.getUserId(), entry.getEntryId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -1209,7 +1207,7 @@ public class BlogsEntryLocalServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group, _user.getUserId());
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -1217,7 +1215,7 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.STATUS_DRAFT);
 
-		entry = BlogsEntryLocalServiceUtil.updateEntry(
+		entry = _blogsEntryLocalService.updateEntry(
 			_user.getUserId(), entry.getEntryId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			serviceContext);
@@ -1229,7 +1227,7 @@ public class BlogsEntryLocalServiceTest {
 	public void testURLTitleIsSavedWhenAddingApprovedEntry() throws Exception {
 		String title = RandomTestUtil.randomString();
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), title, RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _user.getUserId()));
@@ -1262,7 +1260,7 @@ public class BlogsEntryLocalServiceTest {
 
 		serviceContext.setWorkflowAction(WorkflowConstants.STATUS_DRAFT);
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_user.getUserId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -1307,13 +1305,13 @@ public class BlogsEntryLocalServiceTest {
 		Calendar displayDateCalendar = CalendarFactoryUtil.getCalendar(
 			2012, 1, date);
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			userId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), displayDateCalendar.getTime(),
 			serviceContext);
 
 		if (statusInTrash) {
-			entry = BlogsEntryLocalServiceUtil.moveEntryToTrash(userId, entry);
+			entry = _blogsEntryLocalService.moveEntryToTrash(userId, entry);
 		}
 
 		return entry;
@@ -1364,7 +1362,7 @@ public class BlogsEntryLocalServiceTest {
 		}
 
 		List<BlogsEntry> initialEntries =
-			BlogsEntryLocalServiceUtil.getCompanyEntries(
+			_blogsEntryLocalService.getCompanyEntries(
 				_user.getCompanyId(), new Date(), queryDefinition);
 
 		int initialCount = initialEntries.size();
@@ -1373,7 +1371,7 @@ public class BlogsEntryLocalServiceTest {
 		addEntry(true);
 
 		List<BlogsEntry> actualEntries =
-			BlogsEntryLocalServiceUtil.getCompanyEntries(
+			_blogsEntryLocalService.getCompanyEntries(
 				_user.getCompanyId(), new Date(), queryDefinition);
 
 		Assert.assertEquals(
@@ -1392,13 +1390,13 @@ public class BlogsEntryLocalServiceTest {
 			queryDefinition = _statusAnyQueryDefinition;
 		}
 
-		int initialCount = BlogsEntryLocalServiceUtil.getCompanyEntriesCount(
+		int initialCount = _blogsEntryLocalService.getCompanyEntriesCount(
 			_user.getCompanyId(), new Date(), queryDefinition);
 
 		addEntry(false);
 		addEntry(true);
 
-		int actualCount = BlogsEntryLocalServiceUtil.getCompanyEntriesCount(
+		int actualCount = _blogsEntryLocalService.getCompanyEntriesCount(
 			_user.getCompanyId(), new Date(), queryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
@@ -1418,11 +1416,11 @@ public class BlogsEntryLocalServiceTest {
 		List<BlogsEntry> initialEntries = null;
 
 		if (displayDate) {
-			initialEntries = BlogsEntryLocalServiceUtil.getGroupEntries(
+			initialEntries = _blogsEntryLocalService.getGroupEntries(
 				_group.getGroupId(), new Date(), queryDefinition);
 		}
 		else {
-			initialEntries = BlogsEntryLocalServiceUtil.getGroupEntries(
+			initialEntries = _blogsEntryLocalService.getGroupEntries(
 				_group.getGroupId(), queryDefinition);
 		}
 
@@ -1434,11 +1432,11 @@ public class BlogsEntryLocalServiceTest {
 		List<BlogsEntry> actualEntries = null;
 
 		if (displayDate) {
-			actualEntries = BlogsEntryLocalServiceUtil.getGroupEntries(
+			actualEntries = _blogsEntryLocalService.getGroupEntries(
 				_group.getGroupId(), new Date(), queryDefinition);
 		}
 		else {
-			actualEntries = BlogsEntryLocalServiceUtil.getGroupEntries(
+			actualEntries = _blogsEntryLocalService.getGroupEntries(
 				_group.getGroupId(), queryDefinition);
 		}
 
@@ -1462,11 +1460,11 @@ public class BlogsEntryLocalServiceTest {
 		int initialCount = 0;
 
 		if (displayDate) {
-			initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+			initialCount = _blogsEntryLocalService.getGroupEntriesCount(
 				_group.getGroupId(), new Date(), queryDefinition);
 		}
 		else {
-			initialCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+			initialCount = _blogsEntryLocalService.getGroupEntriesCount(
 				_group.getGroupId(), queryDefinition);
 		}
 
@@ -1476,11 +1474,11 @@ public class BlogsEntryLocalServiceTest {
 		int actualCount = 0;
 
 		if (displayDate) {
-			actualCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+			actualCount = _blogsEntryLocalService.getGroupEntriesCount(
 				_group.getGroupId(), new Date(), queryDefinition);
 		}
 		else {
-			actualCount = BlogsEntryLocalServiceUtil.getGroupEntriesCount(
+			actualCount = _blogsEntryLocalService.getGroupEntriesCount(
 				_group.getGroupId(), queryDefinition);
 		}
 
@@ -1498,7 +1496,7 @@ public class BlogsEntryLocalServiceTest {
 		}
 
 		List<BlogsEntry> initialEntries =
-			BlogsEntryLocalServiceUtil.getGroupUserEntries(
+			_blogsEntryLocalService.getGroupUserEntries(
 				_group.getGroupId(), _user.getUserId(), new Date(),
 				queryDefinition);
 
@@ -1508,7 +1506,7 @@ public class BlogsEntryLocalServiceTest {
 		addEntry(true);
 
 		List<BlogsEntry> actualEntries =
-			BlogsEntryLocalServiceUtil.getGroupUserEntries(
+			_blogsEntryLocalService.getGroupUserEntries(
 				_group.getGroupId(), _user.getUserId(), new Date(),
 				queryDefinition);
 
@@ -1528,14 +1526,14 @@ public class BlogsEntryLocalServiceTest {
 			queryDefinition = _statusAnyQueryDefinition;
 		}
 
-		int initialCount = BlogsEntryLocalServiceUtil.getGroupUserEntriesCount(
+		int initialCount = _blogsEntryLocalService.getGroupUserEntriesCount(
 			_group.getGroupId(), _user.getUserId(), new Date(),
 			queryDefinition);
 
 		addEntry(false);
 		addEntry(true);
 
-		int actualCount = BlogsEntryLocalServiceUtil.getGroupUserEntriesCount(
+		int actualCount = _blogsEntryLocalService.getGroupUserEntriesCount(
 			_group.getGroupId(), _user.getUserId(), new Date(),
 			queryDefinition);
 
@@ -1558,7 +1556,7 @@ public class BlogsEntryLocalServiceTest {
 			_organization);
 
 		List<BlogsEntry> initialEntries =
-			BlogsEntryLocalServiceUtil.getOrganizationEntries(
+			_blogsEntryLocalService.getOrganizationEntries(
 				_organization.getOrganizationId(), new Date(), queryDefinition);
 
 		int initialCount = initialEntries.size();
@@ -1567,7 +1565,7 @@ public class BlogsEntryLocalServiceTest {
 		addEntry(_organizationUser.getUserId(), true);
 
 		List<BlogsEntry> actualEntries =
-			BlogsEntryLocalServiceUtil.getOrganizationEntries(
+			_blogsEntryLocalService.getOrganizationEntries(
 				_organization.getOrganizationId(), new Date(), queryDefinition);
 
 		Assert.assertEquals(
@@ -1591,16 +1589,14 @@ public class BlogsEntryLocalServiceTest {
 		_organizationUser = UserTestUtil.addOrganizationOwnerUser(
 			_organization);
 
-		int initialCount =
-			BlogsEntryLocalServiceUtil.getOrganizationEntriesCount(
-				_organization.getOrganizationId(), new Date(), queryDefinition);
+		int initialCount = _blogsEntryLocalService.getOrganizationEntriesCount(
+			_organization.getOrganizationId(), new Date(), queryDefinition);
 
 		addEntry(_organizationUser.getUserId(), false);
 		addEntry(_organizationUser.getUserId(), true);
 
-		int actualCount =
-			BlogsEntryLocalServiceUtil.getOrganizationEntriesCount(
-				_organization.getOrganizationId(), new Date(), queryDefinition);
+		int actualCount = _blogsEntryLocalService.getOrganizationEntriesCount(
+			_organization.getOrganizationId(), new Date(), queryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
 	}
@@ -1668,6 +1664,9 @@ public class BlogsEntryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private final List<BlogsEntry> _blogsEntries = new ArrayList<>();
+
+	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
 
 	@DeleteAfterTestRun
 	private User _creatorUser;

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -20,6 +20,7 @@ import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.blogs.test.util.BlogsTestUtil;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.friendly.url.exception.DuplicateFriendlyURLEntryException;
 import com.liferay.message.boards.constants.MBMessageConstants;
@@ -280,19 +281,11 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddDuplicateAttachmentFileEntry() throws Exception {
-		BlogsEntry entry = addEntry(false);
-
 		String fileName = StringUtil.randomString();
 
-		FileEntry fileEntry1 = _blogsEntryLocalService.addAttachmentFileEntry(
-			entry, entry.getUserId(), fileName,
-			ContentTypes.APPLICATION_OCTET_STREAM,
-			new UnsyncByteArrayInputStream(new byte[0]));
+		FileEntry fileEntry1 = _addAttachmentFileEntry(null, fileName);
 
-		FileEntry fileEntry2 = _blogsEntryLocalService.addAttachmentFileEntry(
-			entry, entry.getUserId(), fileName,
-			ContentTypes.APPLICATION_OCTET_STREAM,
-			new UnsyncByteArrayInputStream(new byte[0]));
+		FileEntry fileEntry2 = _addAttachmentFileEntry(null, fileName);
 
 		Assert.assertNotEquals(
 			fileEntry1.getFileName(), fileEntry2.getFileName());
@@ -620,6 +613,25 @@ public class BlogsEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteAttachmentFileEntry() throws Exception {
+		FileEntry fileEntry = _addAttachmentFileEntry(
+			null, StringUtil.randomString());
+
+		_blogsEntryLocalService.deleteAttachmentFileEntry(
+			fileEntry.getFileEntryId());
+
+		try {
+			_blogsEntryLocalService.getAttachmentFileEntry(
+				fileEntry.getFileEntryId());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(exception instanceof NoSuchFileEntryException);
+		}
+	}
+
+	@Test
 	public void testDeleteDiscussion() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
@@ -648,13 +660,20 @@ public class BlogsEntryLocalServiceTest {
 				BlogsEntry.class.getName(), entry.getEntryId()));
 	}
 
-	@Test(expected = NoSuchEntryException.class)
+	@Test
 	public void testDeleteEntry() throws Exception {
 		BlogsEntry entry = addEntry(false);
 
 		_blogsEntryLocalService.deleteEntry(entry);
 
-		_blogsEntryLocalService.getEntry(entry.getEntryId());
+		try {
+			_blogsEntryLocalService.getEntry(entry.getEntryId());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(exception instanceof NoSuchEntryException);
+		}
 	}
 
 	@Test
@@ -685,6 +704,37 @@ public class BlogsEntryLocalServiceTest {
 		Assert.assertNull(
 			_blogsEntryLocalService.fetchAttachmentsFolder(
 				TestPropsValues.getUserId(), _group.getGroupId()));
+	}
+
+	@Test
+	public void testGetAttachmentFileEntry() throws Exception {
+		FileEntry fileEntry1 = _addAttachmentFileEntry(
+			null, StringUtil.randomString());
+
+		FileEntry fileEntry2 = _blogsEntryLocalService.getAttachmentFileEntry(
+			fileEntry1.getFileEntryId());
+
+		Assert.assertEquals(fileEntry1, fileEntry2);
+	}
+
+	@Test
+	public void testGetAttachmentFileEntryByExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.randomString();
+
+		FileEntry fileEntry1 = _addAttachmentFileEntry(
+			externalReferenceCode, StringUtil.randomString());
+
+		Assert.assertEquals(
+			externalReferenceCode, fileEntry1.getExternalReferenceCode());
+
+		FileEntry fileEntry2 =
+			_blogsEntryLocalService.
+				getAttachmentFileEntryByExternalReferenceCode(
+					externalReferenceCode, fileEntry1.getGroupId());
+
+		Assert.assertEquals(fileEntry1, fileEntry2);
 	}
 
 	@Test
@@ -1599,6 +1649,16 @@ public class BlogsEntryLocalServiceTest {
 			_organization.getOrganizationId(), new Date(), queryDefinition);
 
 		Assert.assertEquals(initialCount + 1, actualCount);
+	}
+
+	private FileEntry _addAttachmentFileEntry(
+			String externalReferenceCode, String fileName)
+		throws Exception {
+
+		return _blogsEntryLocalService.addAttachmentFileEntry(
+			externalReferenceCode, _user.getUserId(), _group.getGroupId(),
+			fileName, ContentTypes.APPLICATION_OCTET_STREAM,
+			new UnsyncByteArrayInputStream(new byte[0]));
 	}
 
 	private MBMessage _addMBMessage(

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
@@ -6,10 +6,12 @@
 package com.liferay.blogs.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.constants.BlogsConstants;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -31,6 +33,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -66,127 +69,60 @@ public class BlogsEntryServiceTest {
 
 		_groupUser = UserTestUtil.addGroupUser(
 			_group, RoleConstants.POWER_USER);
+
+		_permissionChecker = PermissionCheckerFactoryUtil.create(_groupUser);
 	}
 
 	@Test
 	public void testAddEntryWithAddEntryPermission1() throws Exception {
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			TestPropsValues.getCompanyId(), "com.liferay.blogs",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.ADD_ENTRY);
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId());
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(
+			ActionKeys.ADD_ENTRY, BlogsConstants.SERVICE_NAME);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.addEntry(
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null, serviceContext);
+			_addEntry1();
 		}
 	}
 
 	@Test
 	public void testAddEntryWithAddEntryPermission2() throws Exception {
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			TestPropsValues.getCompanyId(), "com.liferay.blogs",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.ADD_ENTRY);
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId());
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(
+			ActionKeys.ADD_ENTRY, BlogsConstants.SERVICE_NAME);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.addEntry(
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null, serviceContext);
+			_addEntry2();
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testAddEntryWithoutAddEntryPermission1() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId());
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.addEntry(
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null, serviceContext);
+			_addEntry1();
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testAddEntryWithoutAddEntryPermission2() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId());
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.addEntry(
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null, serviceContext);
+			_addEntry2();
 		}
 	}
 
 	@Test
 	public void testDeleteEntryWithDeletePermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.DELETE);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(ActionKeys.DELETE, _CLASS_NAME_BLOGS_ENTRY);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
@@ -194,17 +130,10 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testDeleteEntryWithoutDeletePermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
@@ -212,43 +141,14 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetCompanyEntriesWithoutViewPermission() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
@@ -265,51 +165,24 @@ public class BlogsEntryServiceTest {
 	public void testGetCompanyEntriesWithoutViewPermissionAndDisplayDate()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		_addEntry(calendar.getTime());
 
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			calendar = Calendar.getInstance();
 
@@ -331,43 +204,14 @@ public class BlogsEntryServiceTest {
 	public void testGetCompanyEntriesWithoutViewPermissionAndMax()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
@@ -382,27 +226,12 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetCompanyEntriesWithViewPermission() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
@@ -420,35 +249,22 @@ public class BlogsEntryServiceTest {
 	public void testGetCompanyEntriesWithViewPermissionAndDisplayDate()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addEntry(calendar.getTime());
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			calendar = Calendar.getInstance();
 
@@ -471,27 +287,13 @@ public class BlogsEntryServiceTest {
 	public void testGetCompanyEntriesWithViewPermissionAndMax()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		_addEntry();
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
@@ -506,29 +308,19 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetEntriesPrevAndNext() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			serviceContext);
+		BlogsEntry entry3 = _addEntry();
 
 		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry2.getEntryId());
@@ -552,23 +344,15 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetEntriesPrevAndNextWithOnlyNext() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry1.getEntryId());
@@ -591,23 +375,15 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetEntriesPrevAndNextWithOnlyPrev() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry2.getEntryId());
@@ -643,27 +419,18 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		_addEntry(calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addEntry(calendar.getTime(), serviceContext);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.getEntriesPrevAndNext(entry2.getEntryId());
 		}
@@ -681,30 +448,21 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime(), serviceContext);
 
 		serviceContext.setAddGroupPermissions(false);
 		serviceContext.setAddGuestPermissions(false);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addEntry(calendar.getTime(), serviceContext);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 				entry2.getEntryId());
@@ -741,30 +499,21 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		_addEntry(calendar.getTime(), serviceContext);
 
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry3 = _addEntry(calendar.getTime(), serviceContext);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 				entry2.getEntryId());
@@ -788,33 +537,12 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testGetEntryWithoutViewPermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.getEntry(entry.getEntryId());
 		}
@@ -822,33 +550,12 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testGetEntryWithoutViewPermission2() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.getEntry(
 				entry.getGroupId(), entry.getUrlTitle());
@@ -857,17 +564,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetEntryWithViewPermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.getEntry(entry.getEntryId());
 		}
@@ -875,17 +575,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetEntryWithViewPermission2() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.getEntry(
 				entry.getGroupId(), entry.getUrlTitle());
@@ -894,43 +587,14 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetGroupEntriesWithoutViewPermission() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
@@ -947,51 +611,24 @@ public class BlogsEntryServiceTest {
 	public void testGetGroupEntriesWithoutViewPermissionAndDisplayDate()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		_addEntry(calendar.getTime());
 
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			calendar = Calendar.getInstance();
 
@@ -1013,43 +650,14 @@ public class BlogsEntryServiceTest {
 	public void testGetGroupEntriesWithoutViewPermissionAndMax()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		List<Role> roles = _roleLocalService.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			if (RoleConstants.OWNER.equals(role.getName())) {
-				continue;
-			}
-
-			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry2.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_removeViewResourcePermission(entry2);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
@@ -1064,27 +672,12 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetGroupEntriesWithViewPermission() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry1 = _addEntry();
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
@@ -1102,35 +695,22 @@ public class BlogsEntryServiceTest {
 	public void testGetGroupEntriesWithViewPermissionAndDisplayDate()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
-
 		Calendar calendar = Calendar.getInstance();
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry1 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
+		BlogsEntry entry2 = _addEntry(calendar.getTime());
 
 		calendar.add(Calendar.HOUR, 2);
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			calendar.getTime(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addEntry(calendar.getTime());
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			calendar = Calendar.getInstance();
 
@@ -1151,27 +731,13 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testGetGroupEntriesWithViewPermissionAndMax() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId());
+		_addEntry();
 
-		_blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry2 = _addEntry();
+		BlogsEntry entry3 = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
@@ -1186,25 +752,12 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testMoveEntryToTrashWithDeletePermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.DELETE);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(ActionKeys.DELETE, _CLASS_NAME_BLOGS_ENTRY);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
@@ -1212,17 +765,10 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testMoveEntryToTrashWithoutDeletePermission() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
@@ -1230,17 +776,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testOwnerCanDeleteEntry() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry(_groupUser);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
@@ -1248,17 +787,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testOwnerCanMoveEntryToTrash() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry(_groupUser);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
@@ -1266,19 +798,12 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testOwnerCanRestoreEntryFromTrash() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId()));
+		BlogsEntry entry = _addEntry(_groupUser);
 
 		_blogsEntryLocalService.moveEntryToTrash(_groupUser.getUserId(), entry);
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
@@ -1286,29 +811,12 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testOwnerCanUpdateEntry() throws Exception {
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group, _groupUser.getUserId());
-
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(), serviceContext);
-
-		serviceContext = ServiceContextTestUtil.getServiceContext(
-			_group, _groupUser.getUserId());
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry(_groupUser);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.updateEntry(
-				entry.getEntryId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
-				new String[0], RandomTestUtil.randomString(), null, null,
-				serviceContext);
+			_updateEntry(entry.getEntryId());
 		}
 	}
 
@@ -1316,28 +824,15 @@ public class BlogsEntryServiceTest {
 	public void testRestoreEntryFromTrashWithDeletePermission()
 		throws Exception {
 
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
 		_blogsEntryLocalService.moveEntryToTrash(
 			TestPropsValues.getUserId(), entry);
 
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.DELETE);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(ActionKeys.DELETE, _CLASS_NAME_BLOGS_ENTRY);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
@@ -1347,20 +842,13 @@ public class BlogsEntryServiceTest {
 	public void testRestoreEntryFromTrashWithoutDeletePermission()
 		throws Exception {
 
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
 		_blogsEntryLocalService.moveEntryToTrash(
 			TestPropsValues.getUserId(), entry);
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
@@ -1373,11 +861,8 @@ public class BlogsEntryServiceTest {
 		User user = UserTestUtil.addUser(
 			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(user);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				user, permissionChecker)) {
+				user, PermissionCheckerFactoryUtil.create(user))) {
 
 			_blogsEntryService.subscribe(_group.getGroupId());
 		}
@@ -1385,11 +870,8 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testSubscribeEntryWithSubscribePermission() throws Exception {
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.subscribe(_group.getGroupId());
 		}
@@ -1402,11 +884,8 @@ public class BlogsEntryServiceTest {
 		User user = UserTestUtil.addUser(
 			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(user);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				user, permissionChecker)) {
+				user, PermissionCheckerFactoryUtil.create(user))) {
 
 			_blogsEntryService.unsubscribe(_group.getGroupId());
 		}
@@ -1414,11 +893,8 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testUnsubscribeEntryWithSubscribePermission() throws Exception {
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
-
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.unsubscribe(_group.getGroupId());
 		}
@@ -1426,122 +902,148 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testUpdateEntryWithoutUpdatePermission1() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.updateEntry(
-				entry.getEntryId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
-				new String[0], RandomTestUtil.randomString(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group, _groupUser.getUserId()));
+			_updateEntry(entry.getEntryId());
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testUpdateEntryWithoutUpdatePermission2() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		BlogsEntry entry = _addEntry();
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.updateEntry(
-				entry.getEntryId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group, _groupUser.getUserId()));
+			_updateEntry(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testUpdateEntryWithUpdatePermission1() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
-			ServiceContextTestUtil.getServiceContext(
-				_group, TestPropsValues.getUserId()));
+		BlogsEntry entry = _addEntry();
 
-		Role siteMemberRole = _roleLocalService.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
-
-		_resourcePermissionLocalService.addResourcePermission(
-			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.UPDATE);
-
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+		_addResourcePermission(ActionKeys.UPDATE, _CLASS_NAME_BLOGS_ENTRY);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+				_groupUser, _permissionChecker)) {
 
-			_blogsEntryService.updateEntry(
-				entry.getEntryId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
-				new String[0], RandomTestUtil.randomString(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group, _groupUser.getUserId()));
+			_updateEntry(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testUpdateEntryWithUpdatePermission2() throws Exception {
-		BlogsEntry entry = _blogsEntryLocalService.addEntry(
-			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
-			new Date(),
+		BlogsEntry entry = _addEntry();
+
+		_addResourcePermission(ActionKeys.UPDATE, _CLASS_NAME_BLOGS_ENTRY);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_updateEntry(entry.getEntryId());
+		}
+	}
+
+	private BlogsEntry _addEntry() throws Exception {
+		return _addEntry(new Date());
+	}
+
+	private BlogsEntry _addEntry(Date displayDate) throws Exception {
+		return _addEntry(
+			displayDate,
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
+	}
+
+	private BlogsEntry _addEntry(
+			Date displayDate, ServiceContext serviceContext)
+		throws Exception {
+
+		return _blogsEntryLocalService.addEntry(
+			serviceContext.getUserId(), StringUtil.randomString(),
+			RandomTestUtil.randomString(), displayDate, serviceContext);
+	}
+
+	private BlogsEntry _addEntry(User user) throws Exception {
+		return _addEntry(
+			new Date(),
+			ServiceContextTestUtil.getServiceContext(_group, user.getUserId()));
+	}
+
+	private void _addEntry1() throws PortalException {
+		_blogsEntryService.addEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1, 1,
+			1990, 1, 1, true, false, new String[0],
+			RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, _groupUser.getUserId()));
+	}
+
+	private void _addEntry2() throws PortalException {
+		_blogsEntryService.addEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1, 1,
+			1990, 1, 1, true, false, new String[0],
+			RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, _groupUser.getUserId()));
+	}
+
+	private void _addResourcePermission(String actionId, String name)
+		throws Exception {
 
 		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
 		_resourcePermissionLocalService.addResourcePermission(
-			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
-			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
-			siteMemberRole.getRoleId(), ActionKeys.UPDATE);
+			TestPropsValues.getCompanyId(), name, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(_group.getGroupId()), siteMemberRole.getRoleId(),
+			actionId);
+	}
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+	private void _removeViewResourcePermission(BlogsEntry entry)
+		throws Exception {
 
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+		for (Role role :
+				_roleLocalService.getRoles(TestPropsValues.getCompanyId())) {
 
-			_blogsEntryService.updateEntry(
-				entry.getEntryId(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
-				1, 1990, 1, 1, true, false, new String[0],
-				RandomTestUtil.randomString(), null, null,
-				ServiceContextTestUtil.getServiceContext(
-					_group, _groupUser.getUserId()));
+			if (RoleConstants.OWNER.equals(role.getName())) {
+				continue;
+			}
+
+			_resourcePermissionLocalService.removeResourcePermission(
+				TestPropsValues.getCompanyId(),
+				"com.liferay.blogs.model.BlogsEntry",
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(entry.getEntryId()), role.getRoleId(),
+				ActionKeys.VIEW);
 		}
 	}
+
+	private void _updateEntry(long entryId) throws PortalException {
+		_blogsEntryService.updateEntry(
+			entryId, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
+			new String[0], RandomTestUtil.randomString(), null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, _groupUser.getUserId()));
+	}
+
+	private static final String _CLASS_NAME_BLOGS_ENTRY =
+		"com.liferay.blogs.model.BlogsEntry";
 
 	@DeleteAfterTestRun
 	private static Group _group;
 
 	private static User _groupUser;
+	private static PermissionChecker _permissionChecker;
 
 	@Inject
 	private BlogsEntryLocalService _blogsEntryLocalService;

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
@@ -10,13 +10,16 @@ import com.liferay.blogs.constants.BlogsConstants;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.blogs.service.BlogsEntryService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -74,9 +78,42 @@ public class BlogsEntryServiceTest {
 	}
 
 	@Test
+	public void testAddAttachmentFileEntryWithAddEntryPermission()
+		throws Exception {
+
+		_addResourcePermission(
+			ActionKeys.ADD_ENTRY, BlogsConstants.RESOURCE_NAME);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.addAttachmentFileEntry(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				new UnsyncByteArrayInputStream(new byte[0]));
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAddAttachmentFileEntryWithoutAddEntryPermission()
+		throws Exception {
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.addAttachmentFileEntry(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				ContentTypes.APPLICATION_OCTET_STREAM,
+				new UnsyncByteArrayInputStream(new byte[0]));
+		}
+	}
+
+	@Test
 	public void testAddEntryWithAddEntryPermission1() throws Exception {
 		_addResourcePermission(
-			ActionKeys.ADD_ENTRY, BlogsConstants.SERVICE_NAME);
+			ActionKeys.ADD_ENTRY, BlogsConstants.RESOURCE_NAME);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, _permissionChecker)) {
@@ -88,7 +125,7 @@ public class BlogsEntryServiceTest {
 	@Test
 	public void testAddEntryWithAddEntryPermission2() throws Exception {
 		_addResourcePermission(
-			ActionKeys.ADD_ENTRY, BlogsConstants.SERVICE_NAME);
+			ActionKeys.ADD_ENTRY, BlogsConstants.RESOURCE_NAME);
 
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, _permissionChecker)) {
@@ -116,6 +153,37 @@ public class BlogsEntryServiceTest {
 	}
 
 	@Test
+	public void testDeleteAttachmentFileEntryWithDeletePermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		_addResourcePermission(
+			ActionKeys.ADD_ENTRY, BlogsConstants.RESOURCE_NAME);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.deleteAttachmentFileEntry(
+				fileEntry.getFileEntryId());
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testDeleteAttachmentFileEntryWithoutDeletePermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.deleteAttachmentFileEntry(
+				fileEntry.getFileEntryId());
+		}
+	}
+
+	@Test
 	public void testDeleteEntryWithDeletePermission() throws Exception {
 		BlogsEntry entry = _addEntry();
 
@@ -136,6 +204,66 @@ public class BlogsEntryServiceTest {
 				_groupUser, _permissionChecker)) {
 
 			_blogsEntryService.deleteEntry(entry.getEntryId());
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testGetAttachmentFileEntryByExternalReferenceCodeWithoutViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		_removeViewResourcePermission(fileEntry);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.getAttachmentFileEntryByExternalReferenceCode(
+				fileEntry.getExternalReferenceCode(), fileEntry.getGroupId());
+		}
+	}
+
+	@Test
+	public void testGetAttachmentFileEntryByExternalReferenceCodeWithViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.getAttachmentFileEntryByExternalReferenceCode(
+				fileEntry.getExternalReferenceCode(), fileEntry.getGroupId());
+		}
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testGetAttachmentFileEntryWithoutViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		_removeViewResourcePermission(fileEntry);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.getAttachmentFileEntry(
+				fileEntry.getFileEntryId());
+		}
+	}
+
+	@Test
+	public void testGetAttachmentFileEntryWithViewPermission()
+		throws Exception {
+
+		FileEntry fileEntry = _addAttachmentFileEntry();
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, _permissionChecker)) {
+
+			_blogsEntryService.getAttachmentFileEntry(
+				fileEntry.getFileEntryId());
 		}
 	}
 
@@ -948,6 +1076,14 @@ public class BlogsEntryServiceTest {
 		}
 	}
 
+	private FileEntry _addAttachmentFileEntry() throws Exception {
+		return _blogsEntryLocalService.addAttachmentFileEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			new UnsyncByteArrayInputStream(new byte[0]));
+	}
+
 	private BlogsEntry _addEntry() throws Exception {
 		return _addEntry(new Date());
 	}
@@ -1010,6 +1146,20 @@ public class BlogsEntryServiceTest {
 	private void _removeViewResourcePermission(BlogsEntry entry)
 		throws Exception {
 
+		_removeViewResourcePermission(
+			BlogsEntry.class.getName(), entry.getEntryId());
+	}
+
+	private void _removeViewResourcePermission(FileEntry fileEntry)
+		throws Exception {
+
+		_removeViewResourcePermission(
+			DLFileEntry.class.getName(), fileEntry.getFileEntryId());
+	}
+
+	private void _removeViewResourcePermission(String name, long primKey)
+		throws Exception {
+
 		for (Role role :
 				_roleLocalService.getRoles(TestPropsValues.getCompanyId())) {
 
@@ -1018,11 +1168,9 @@ public class BlogsEntryServiceTest {
 			}
 
 			_resourcePermissionLocalService.removeResourcePermission(
-				TestPropsValues.getCompanyId(),
-				"com.liferay.blogs.model.BlogsEntry",
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(entry.getEntryId()), role.getRoleId(),
-				ActionKeys.VIEW);
+				TestPropsValues.getCompanyId(), name,
+				ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(primKey),
+				role.getRoleId(), ActionKeys.VIEW);
 		}
 	}
 

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryServiceTest.java
@@ -7,8 +7,8 @@ package com.liferay.blogs.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.model.BlogsEntry;
-import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
-import com.liferay.blogs.service.BlogsEntryServiceUtil;
+import com.liferay.blogs.service.BlogsEntryLocalService;
+import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -20,8 +20,8 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
-import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -70,10 +70,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testAddEntryWithAddEntryPermission1() throws Exception {
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			TestPropsValues.getCompanyId(), "com.liferay.blogs",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.ADD_ENTRY);
@@ -88,7 +88,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.addEntry(
+			_blogsEntryService.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
 				1, 1990, 1, 1, true, false, new String[0],
@@ -98,10 +98,10 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testAddEntryWithAddEntryPermission2() throws Exception {
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			TestPropsValues.getCompanyId(), "com.liferay.blogs",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.ADD_ENTRY);
@@ -116,7 +116,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.addEntry(
+			_blogsEntryService.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
@@ -137,7 +137,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.addEntry(
+			_blogsEntryService.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
 				1, 1990, 1, 1, true, false, new String[0],
@@ -157,7 +157,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.addEntry(
+			_blogsEntryService.addEntry(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
@@ -168,16 +168,16 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testDeleteEntryWithDeletePermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.DELETE);
@@ -188,13 +188,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.deleteEntry(entry.getEntryId());
+			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testDeleteEntryWithoutDeletePermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -206,7 +206,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.deleteEntry(entry.getEntryId());
+			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
 	}
 
@@ -216,19 +216,19 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -236,7 +236,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -250,7 +250,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 100);
 
@@ -273,23 +273,23 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -297,7 +297,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -317,7 +317,7 @@ public class BlogsEntryServiceTest {
 
 			calendar.add(Calendar.HOUR, 3);
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), calendar.getTime(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -335,19 +335,19 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -355,7 +355,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -369,7 +369,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -386,15 +386,15 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
@@ -404,7 +404,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 100);
 
@@ -428,19 +428,19 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -456,7 +456,7 @@ public class BlogsEntryServiceTest {
 
 			calendar.add(Calendar.HOUR, 3);
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), calendar.getTime(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -475,15 +475,15 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
@@ -493,7 +493,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getCompanyEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getCompanyEntries(
 				TestPropsValues.getCompanyId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -514,23 +514,23 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			serviceContext);
 
-		BlogsEntry[] prevAndNext = BlogsEntryServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry2.getEntryId());
 
 		Assert.assertEquals(
@@ -560,17 +560,17 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
-		BlogsEntry[] prevAndNext = BlogsEntryServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry1.getEntryId());
 
 		Assert.assertNull(
@@ -599,17 +599,17 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
-		BlogsEntry[] prevAndNext = BlogsEntryServiceUtil.getEntriesPrevAndNext(
+		BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
 			entry2.getEntryId());
 
 		Assert.assertEquals(
@@ -643,19 +643,19 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -665,7 +665,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.getEntriesPrevAndNext(entry2.getEntryId());
+			_blogsEntryService.getEntriesPrevAndNext(entry2.getEntryId());
 		}
 	}
 
@@ -681,13 +681,13 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -696,7 +696,7 @@ public class BlogsEntryServiceTest {
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -706,9 +706,8 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntry[] prevAndNext =
-				BlogsEntryServiceUtil.getEntriesPrevAndNext(
-					entry2.getEntryId());
+			BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
+				entry2.getEntryId());
 
 			Assert.assertEquals(
 				StringBundler.concat(
@@ -742,7 +741,7 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -751,13 +750,13 @@ public class BlogsEntryServiceTest {
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 1);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -767,9 +766,8 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntry[] prevAndNext =
-				BlogsEntryServiceUtil.getEntriesPrevAndNext(
-					entry2.getEntryId());
+			BlogsEntry[] prevAndNext = _blogsEntryService.getEntriesPrevAndNext(
+				entry2.getEntryId());
 
 			Assert.assertNull(
 				"The previous entry relative to entry " + entry2.getEntryId() +
@@ -790,13 +788,13 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testGetEntryWithoutViewPermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -804,7 +802,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -818,19 +816,19 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.getEntry(entry.getEntryId());
+			_blogsEntryService.getEntry(entry.getEntryId());
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testGetEntryWithoutViewPermission2() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -838,7 +836,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -852,14 +850,14 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.getEntry(
+			_blogsEntryService.getEntry(
 				entry.getGroupId(), entry.getUrlTitle());
 		}
 	}
 
 	@Test
 	public void testGetEntryWithViewPermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -871,13 +869,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.getEntry(entry.getEntryId());
+			_blogsEntryService.getEntry(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testGetEntryWithViewPermission2() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -889,7 +887,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.getEntry(
+			_blogsEntryService.getEntry(
 				entry.getGroupId(), entry.getUrlTitle());
 		}
 	}
@@ -900,19 +898,19 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -920,7 +918,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -934,7 +932,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 100);
 
@@ -957,23 +955,23 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -981,7 +979,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -1001,7 +999,7 @@ public class BlogsEntryServiceTest {
 
 			calendar.add(Calendar.HOUR, 3);
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), calendar.getTime(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -1019,19 +1017,19 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
+		List<Role> roles = _roleLocalService.getRoles(
 			TestPropsValues.getCompanyId());
 
 		for (Role role : roles) {
@@ -1039,7 +1037,7 @@ public class BlogsEntryServiceTest {
 				continue;
 			}
 
-			ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_resourcePermissionLocalService.removeResourcePermission(
 				TestPropsValues.getCompanyId(),
 				"com.liferay.blogs.model.BlogsEntry",
 				ResourceConstants.SCOPE_INDIVIDUAL,
@@ -1053,7 +1051,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -1070,15 +1068,15 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
@@ -1088,7 +1086,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 100);
 
@@ -1112,19 +1110,19 @@ public class BlogsEntryServiceTest {
 
 		calendar.set(Calendar.YEAR, 2000);
 
-		BlogsEntry entry1 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry1 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
 		calendar.add(Calendar.HOUR, 2);
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			calendar.getTime(), serviceContext);
 
@@ -1140,7 +1138,7 @@ public class BlogsEntryServiceTest {
 
 			calendar.add(Calendar.HOUR, 3);
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), calendar.getTime(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -1157,15 +1155,15 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
 
-		BlogsEntryLocalServiceUtil.addEntry(
+		_blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry2 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry2 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "2", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
-		BlogsEntry entry3 = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry3 = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "3", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
@@ -1175,7 +1173,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			List<BlogsEntry> entries = BlogsEntryServiceUtil.getGroupEntries(
+			List<BlogsEntry> entries = _blogsEntryService.getGroupEntries(
 				_group.getGroupId(), new Date(),
 				WorkflowConstants.STATUS_APPROVED, 2);
 
@@ -1188,16 +1186,16 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testMoveEntryToTrashWithDeletePermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.DELETE);
@@ -1208,13 +1206,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.moveEntryToTrash(entry.getEntryId());
+			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testMoveEntryToTrashWithoutDeletePermission() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -1226,13 +1224,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.moveEntryToTrash(entry.getEntryId());
+			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testOwnerCanDeleteEntry() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -1244,13 +1242,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.deleteEntry(entry.getEntryId());
+			_blogsEntryService.deleteEntry(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testOwnerCanMoveEntryToTrash() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -1262,20 +1260,19 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.moveEntryToTrash(entry.getEntryId());
+			_blogsEntryService.moveEntryToTrash(entry.getEntryId());
 		}
 	}
 
 	@Test
 	public void testOwnerCanRestoreEntryFromTrash() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, _groupUser.getUserId()));
 
-		BlogsEntryLocalServiceUtil.moveEntryToTrash(
-			_groupUser.getUserId(), entry);
+		_blogsEntryLocalService.moveEntryToTrash(_groupUser.getUserId(), entry);
 
 		PermissionChecker permissionChecker =
 			PermissionCheckerFactoryUtil.create(_groupUser);
@@ -1283,7 +1280,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.restoreEntryFromTrash(entry.getEntryId());
+			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
 	}
 
@@ -1293,7 +1290,7 @@ public class BlogsEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, _groupUser.getUserId());
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			_groupUser.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(), serviceContext);
 
@@ -1306,7 +1303,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.updateEntry(
+			_blogsEntryService.updateEntry(
 				entry.getEntryId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
@@ -1319,19 +1316,19 @@ public class BlogsEntryServiceTest {
 	public void testRestoreEntryFromTrashWithDeletePermission()
 		throws Exception {
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		BlogsEntryLocalServiceUtil.moveEntryToTrash(
+		_blogsEntryLocalService.moveEntryToTrash(
 			TestPropsValues.getUserId(), entry);
 
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.DELETE);
@@ -1342,7 +1339,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.restoreEntryFromTrash(entry.getEntryId());
+			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
 	}
 
@@ -1350,13 +1347,13 @@ public class BlogsEntryServiceTest {
 	public void testRestoreEntryFromTrashWithoutDeletePermission()
 		throws Exception {
 
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		BlogsEntryLocalServiceUtil.moveEntryToTrash(
+		_blogsEntryLocalService.moveEntryToTrash(
 			TestPropsValues.getUserId(), entry);
 
 		PermissionChecker permissionChecker =
@@ -1365,7 +1362,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.restoreEntryFromTrash(entry.getEntryId());
+			_blogsEntryService.restoreEntryFromTrash(entry.getEntryId());
 		}
 	}
 
@@ -1382,7 +1379,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				user, permissionChecker)) {
 
-			BlogsEntryServiceUtil.subscribe(_group.getGroupId());
+			_blogsEntryService.subscribe(_group.getGroupId());
 		}
 	}
 
@@ -1394,7 +1391,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.subscribe(_group.getGroupId());
+			_blogsEntryService.subscribe(_group.getGroupId());
 		}
 	}
 
@@ -1411,7 +1408,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				user, permissionChecker)) {
 
-			BlogsEntryServiceUtil.unsubscribe(_group.getGroupId());
+			_blogsEntryService.unsubscribe(_group.getGroupId());
 		}
 	}
 
@@ -1423,13 +1420,13 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.unsubscribe(_group.getGroupId());
+			_blogsEntryService.unsubscribe(_group.getGroupId());
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testUpdateEntryWithoutUpdatePermission1() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -1441,7 +1438,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.updateEntry(
+			_blogsEntryService.updateEntry(
 				entry.getEntryId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
@@ -1453,7 +1450,7 @@ public class BlogsEntryServiceTest {
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testUpdateEntryWithoutUpdatePermission2() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
@@ -1465,7 +1462,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.updateEntry(
+			_blogsEntryService.updateEntry(
 				entry.getEntryId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
@@ -1478,16 +1475,16 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testUpdateEntryWithUpdatePermission1() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.UPDATE);
@@ -1498,7 +1495,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.updateEntry(
+			_blogsEntryService.updateEntry(
 				entry.getEntryId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
@@ -1510,16 +1507,16 @@ public class BlogsEntryServiceTest {
 
 	@Test
 	public void testUpdateEntryWithUpdatePermission2() throws Exception {
-		BlogsEntry entry = BlogsEntryLocalServiceUtil.addEntry(
+		BlogsEntry entry = _blogsEntryLocalService.addEntry(
 			TestPropsValues.getUserId(), "1", RandomTestUtil.randomString(),
 			new Date(),
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		Role siteMemberRole = RoleLocalServiceUtil.getRole(
+		Role siteMemberRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.SITE_MEMBER);
 
-		ResourcePermissionLocalServiceUtil.addResourcePermission(
+		_resourcePermissionLocalService.addResourcePermission(
 			_group.getCompanyId(), "com.liferay.blogs.model.BlogsEntry",
 			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
 			siteMemberRole.getRoleId(), ActionKeys.UPDATE);
@@ -1530,7 +1527,7 @@ public class BlogsEntryServiceTest {
 		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
 				_groupUser, permissionChecker)) {
 
-			BlogsEntryServiceUtil.updateEntry(
+			_blogsEntryService.updateEntry(
 				entry.getEntryId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 1,
@@ -1547,6 +1544,18 @@ public class BlogsEntryServiceTest {
 	private static User _groupUser;
 
 	@Inject
+	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@Inject
+	private BlogsEntryService _blogsEntryService;
+
+	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -14,7 +14,6 @@ import com.liferay.headless.delivery.dto.v1_0.util.ContentValueUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.BlogPostingImageEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.BlogPostingImageResource;
 import com.liferay.portal.kernel.change.tracking.CTAware;
-import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Field;
@@ -30,7 +29,6 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
-import com.liferay.upload.UniqueFileNameProvider;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -54,13 +52,7 @@ public class BlogPostingImageResourceImpl
 	public void deleteBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
-			blogPostingImageId);
-
-		_validate(fileEntry);
-
-		_portletFileRepository.deletePortletFileEntry(
-			fileEntry.getFileEntryId());
+		_blogsEntryService.deleteAttachmentFileEntry(blogPostingImageId);
 	}
 
 	@Override
@@ -72,12 +64,10 @@ public class BlogPostingImageResourceImpl
 			siteId, externalReferenceCode);
 
 		FileEntry fileEntry =
-			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+			_blogsEntryService.getAttachmentFileEntryByExternalReferenceCode(
 				externalReferenceCode, siteId);
 
-		_validate(fileEntry);
-
-		_portletFileRepository.deletePortletFileEntry(
+		_blogsEntryService.deleteAttachmentFileEntry(
 			fileEntry.getFileEntryId());
 	}
 
@@ -85,12 +75,8 @@ public class BlogPostingImageResourceImpl
 	public BlogPostingImage getBlogPostingImage(Long blogPostingImageId)
 		throws Exception {
 
-		FileEntry fileEntry = _portletFileRepository.getPortletFileEntry(
-			blogPostingImageId);
-
-		_validate(fileEntry);
-
-		return _toBlogPostingImage(fileEntry);
+		return _toBlogPostingImage(
+			_blogsEntryService.getAttachmentFileEntry(blogPostingImageId));
 	}
 
 	@Override
@@ -103,13 +89,9 @@ public class BlogPostingImageResourceImpl
 			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		FileEntry fileEntry =
-			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
-				externalReferenceCode, siteId);
-
-		_validate(fileEntry);
-
-		return _toBlogPostingImage(fileEntry);
+		return _toBlogPostingImage(
+			_blogsEntryService.getAttachmentFileEntryByExternalReferenceCode(
+				externalReferenceCode, siteId));
 	}
 
 	@Override
@@ -139,7 +121,7 @@ public class BlogPostingImageResourceImpl
 			},
 			sorts,
 			document -> _toBlogPostingImage(
-				_portletFileRepository.getPortletFileEntry(
+				_blogsEntryService.getAttachmentFileEntry(
 					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
 	}
 
@@ -147,8 +129,6 @@ public class BlogPostingImageResourceImpl
 	public BlogPostingImage postSiteBlogPostingImage(
 			Long siteId, MultipartBody multipartBody)
 		throws Exception {
-
-		Folder folder = _blogsEntryService.addAttachmentsFolder(siteId);
 
 		BinaryFile binaryFile = multipartBody.getBinaryFile("file");
 
@@ -173,28 +153,9 @@ public class BlogPostingImageResourceImpl
 		}
 
 		return _toBlogPostingImage(
-			_portletFileRepository.addPortletFileEntry(
-				externalReferenceCode, siteId, contextUser.getUserId(), null, 0,
-				BlogsConstants.SERVICE_NAME, folder.getFolderId(),
-				binaryFile.getInputStream(),
-				_uniqueFileNameProvider.provide(
-					title,
-					fileName -> _hasFileEntry(
-						siteId, folder.getFolderId(), fileName)),
-				binaryFile.getContentType(), true));
-	}
-
-	private boolean _hasFileEntry(
-		long groupId, long folderId, String fileName) {
-
-		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-			groupId, folderId, fileName);
-
-		if (fileEntry == null) {
-			return false;
-		}
-
-		return true;
+			_blogsEntryService.addAttachmentFileEntry(
+				externalReferenceCode, siteId, title,
+				binaryFile.getContentType(), binaryFile.getInputStream()));
 	}
 
 	private BlogPostingImage _toBlogPostingImage(FileEntry fileEntry)
@@ -219,17 +180,6 @@ public class BlogPostingImageResourceImpl
 		};
 	}
 
-	private void _validate(FileEntry fileEntry) throws Exception {
-		Folder folder = _blogsEntryService.addAttachmentsFolder(
-			fileEntry.getGroupId());
-
-		if (fileEntry.getFolderId() != folder.getFolderId()) {
-			throw new BadRequestException(
-				fileEntry.getFileEntryId() +
-					" does not correspond to a valid blog posting image");
-		}
-	}
-
 	private static final EntityModel _entityModel =
 		new BlogPostingImageEntityModel();
 
@@ -238,11 +188,5 @@ public class BlogPostingImageResourceImpl
 
 	@Reference
 	private DLURLHelper _dlURLHelper;
-
-	@Reference
-	private PortletFileRepository _portletFileRepository;
-
-	@Reference
-	private UniqueFileNameProvider _uniqueFileNameProvider;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38011

This [suggestion](https://github.com/brianchandotcom/liferay-portal/pull/154293#issuecomment-2359233798) comes from Brian Chan.

I'm refactoring the class `BlogsPostingImageResourceImpl` to avoid duplicated logic related to the access of `_portletFileRepository` that already exists in `BlogsEntryLocalServiceImpl`. 

:warning:  NOTE: I don't know if we need to add new permissions for the GET and DELETE methods in `BlogsEntryServiceImpl`.

# How am I fixing it?

Now all the logic is stored in one place: `BlogsEntryLocalServiceImpl`.

# How can you verify that it works?

`cd modules/apps/headless/headless-delivery/headless-delivery-test`
`gw tI --tests BlogPostingImageResourceTest`

`cd modules/apps/blogs/blogs-test`
`gw tI --tests "*testAddAttachmentFileEntryWith*"`
