### PR TITLE
LPD-38004 Don't execute refetch in the first render

### DIFF
--- a/modules/apps/asset/asset-taglib/package.json
+++ b/modules/apps/asset/asset-taglib/package.json
@@ -20,7 +20,8 @@
 	"scripts": {
 		"build": "node-scripts build",
 		"checkFormat": "node-scripts format --check",
-		"format": "node-scripts format"
+		"format": "node-scripts format",
+		"test": "node-scripts test"
 	},
 	"version": "11.1.3"
 }

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -72,7 +72,7 @@ function AssetVocabulariesCategoriesSelector({
 	const previousInputValue = usePrevious(inputValue);
 
 	useEffect(() => {
-		if (inputValue !== previousInputValue) {
+		if (previousInputValue && inputValue !== previousInputValue) {
 			refetch();
 		}
 

--- a/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {useResource} from '@clayui/data-provider';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import AssetVocabularyCategoriesSelector from '../../src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector';
+
+const DEFAULT_PROPS = {
+	eventName: 'selectCategory',
+	groupIds: [],
+	inputName: '',
+	portletURL: '',
+};
+jest.mock('@clayui/data-provider', () => ({
+	useResource: jest.fn().mockImplementation(() => ({
+		refetch: jest.fn(),
+		resource: [],
+	})),
+}));
+
+describe('AssetVocabularyCategoriesSelector', () => {
+	it('refetch is not called in the first component render', () => {
+		render(<AssetVocabularyCategoriesSelector {...DEFAULT_PROPS} />);
+
+		const {refetch} = useResource();
+
+		expect(refetch).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
LPD-38004 Don't execute refetch in the first render

# What is this trying to solve?

- Calling the refecth function in teh first render is causing the lpp ["Categories not showing up in quick selector for site members"](https://liferay.atlassian.net/browse/LPP-55538)

[Link to ticket](https://liferay.atlassian.net/browse/LPD-38004)

# How am I fixing it?

- Don't execute the refetch when `previousInputValue` has no value, as in the first render it is null.

# How can I test it?

- Execute the unit test 
NOTE: to test the lpp we have to restore the client dump and it's not that easy, so this way to test it is teh fastest one.

CC: @jkappler 