### PR TITLE
LPD-38277 Use capital D to validate visibility

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
@@ -353,7 +353,7 @@ definition {
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addEntryWithUploadedCoverImage(
-			coverImageName = "document_1",
+			coverImageName = "Document_1",
 			entryContent = "Blogs Entry Content new",
 			entrySubtitle = "Blogs Entry Subtitle new",
 			entryTitle = "Blogs Entry Title new",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-38277

The failure of the poshi test was because an image was checked for a lower case filename instead of the original upper cased filename