### PR TITLE
LPD-37464 Inherit locale in web content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -38,6 +38,7 @@ import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
+import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalFolderPermission;
 import com.liferay.journal.web.internal.util.RecentGroupManagerUtil;
@@ -126,6 +127,9 @@ public class JournalEditArticleDisplayContext {
 
 		_itemSelector = (ItemSelector)httpServletRequest.getAttribute(
 			ItemSelector.class.getName());
+		_journalWebConfiguration =
+			(JournalWebConfiguration)httpServletRequest.getAttribute(
+				JournalWebConfiguration.class.getName());
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -1474,19 +1478,32 @@ public class JournalEditArticleDisplayContext {
 	private String _getDDMStructureDefaultLanguageId() {
 		DDMStructure ddmStructure = getDDMStructure();
 
-		if (ddmStructure != null) {
-			try {
-				JournalArticle ddmStructureJournalArticle =
-					JournalArticleServiceUtil.getArticle(
-						ddmStructure.getGroupId(), DDMStructure.class.getName(),
-						ddmStructure.getStructureId());
+		if (!_journalWebConfiguration.changeableDefaultLanguage() ||
+			(ddmStructure == null)) {
 
-				return ddmStructureJournalArticle.getDefaultLanguageId();
+			return null;
+		}
+
+		try {
+			JournalArticle ddmStructureJournalArticle =
+				JournalArticleServiceUtil.getArticle(
+					ddmStructure.getGroupId(), DDMStructure.class.getName(),
+					ddmStructure.getStructureId());
+
+			String defaultLanguageId =
+				ddmStructureJournalArticle.getDefaultLanguageId();
+
+			List<String> availableLocales = TransformUtil.transform(
+				getAvailableLocales(),
+				availableLocale -> LocaleUtil.toLanguageId(availableLocale));
+
+			if (availableLocales.contains(defaultLanguageId)) {
+				return defaultLanguageId;
 			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
-				}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
 			}
 		}
 
@@ -1762,6 +1779,7 @@ public class JournalEditArticleDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private Long _inheritedWorkflowDDMStructuresFolderId;
 	private final ItemSelector _itemSelector;
+	private final JournalWebConfiguration _journalWebConfiguration;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private Boolean _neverExpire;
 	private Boolean _neverReview;

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
@@ -5,11 +5,15 @@
 
 package com.liferay.journal.web.internal.display.context;
 
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
+import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.portal.kernel.bean.BeanProperties;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -26,14 +30,20 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
 import javax.servlet.http.HttpServletRequest;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -73,6 +83,12 @@ public class JournalEditArticleDisplayContextTest {
 		portalUtil.setPortal(_portal);
 	}
 
+	@After
+	public void tearDown() {
+		_ddmStructureLocalServiceUtilMockedStatic.close();
+		_journalArticleServiceUtilMockedStatic.close();
+	}
+
 	@Test
 	public void testFolderNameValueIsCached() {
 		String expectedResult = "Home translation";
@@ -104,6 +120,10 @@ public class JournalEditArticleDisplayContextTest {
 	@Test
 	public void testGetDefaultArticleLanguageId() throws PortalException {
 		_testGetDefaultArticleLanguageIdFromArticle();
+		_testGetDefaultArticleLanguageIdWithChangeableDefaultLanguageAndAvailableLocale(
+			LocaleUtil.US, LocaleUtil.UK);
+		_testGetDefaultArticleLanguageIdWithChangeableDefaultLanguageAndAvailableLocale(
+			LocaleUtil.CHINA, LocaleUtil.CHINA);
 		_testGetDefaultArticleLanguageIdWithParameter();
 		_testGetDefaultArticleLanguageIdWithUnavailableLocale();
 	}
@@ -404,6 +424,109 @@ public class JournalEditArticleDisplayContextTest {
 			_journalEditArticleDisplayContext.getDefaultArticleLanguageId());
 	}
 
+	private void
+			_testGetDefaultArticleLanguageIdWithChangeableDefaultLanguageAndAvailableLocale(
+				Locale availableLocale, Locale expectedLocale)
+		throws PortalException {
+
+		JournalArticle journalArticle = Mockito.mock(JournalArticle.class);
+
+		Mockito.when(
+			journalArticle.getArticleId()
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			journalArticle.getDefaultLanguageId()
+		).thenReturn(
+			LocaleUtil.toLanguageId(LocaleUtil.CHINA)
+		);
+
+		long ddmStructureId = RandomTestUtil.randomLong();
+
+		DDMStructure ddmStructure = Mockito.mock(DDMStructure.class);
+
+		Mockito.when(
+			ddmStructure.getStructureId()
+		).thenReturn(
+			ddmStructureId
+		);
+
+		Mockito.when(
+			DDMStructureLocalServiceUtil.fetchStructure(ddmStructureId)
+		).thenReturn(
+			ddmStructure
+		);
+
+		Mockito.when(
+			JournalArticleServiceUtil.getArticle(
+				ddmStructure.getGroupId(), DDMStructure.class.getName(),
+				ddmStructure.getStructureId())
+		).thenReturn(
+			journalArticle
+		);
+
+		JournalWebConfiguration journalWebConfiguration = Mockito.mock(
+			JournalWebConfiguration.class);
+
+		Mockito.when(
+			journalWebConfiguration.changeableDefaultLanguage()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(
+				JournalWebConfiguration.class.getName())
+		).thenReturn(
+			journalWebConfiguration
+		);
+
+		Mockito.when(
+			_httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_themeDisplay
+		);
+
+		Mockito.when(
+			_httpServletRequest.getParameter("ddmStructureId")
+		).thenReturn(
+			String.valueOf(ddmStructureId)
+		);
+
+		Mockito.when(
+			_httpServletRequest.getParameter("defaultLanguageId")
+		).thenReturn(
+			null
+		);
+
+		Set<Locale> availableLocales = new HashSet<>();
+
+		availableLocales.add(availableLocale);
+
+		Mockito.when(
+			_language.getAvailableLocales(Mockito.anyLong())
+		).thenReturn(
+			availableLocales
+		);
+
+		Mockito.when(
+			_language.isAvailableLocale(
+				0, LocaleUtil.toLanguageId(LocaleUtil.CHINA))
+		).thenReturn(
+			true
+		);
+
+		_journalEditArticleDisplayContext =
+			new JournalEditArticleDisplayContext(
+				_httpServletRequest, _liferayPortletResponse, journalArticle);
+
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(expectedLocale),
+			_journalEditArticleDisplayContext.getDefaultArticleLanguageId());
+	}
+
 	private void _testGetDefaultArticleLanguageIdWithParameter() {
 		String defaultLanguageId = RandomTestUtil.randomString();
 
@@ -465,10 +588,16 @@ public class JournalEditArticleDisplayContextTest {
 
 	private final BeanProperties _beanProperties = Mockito.mock(
 		BeanProperties.class);
+	private final MockedStatic<DDMStructureLocalServiceUtil>
+		_ddmStructureLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			DDMStructureLocalServiceUtil.class);
 	private final HttpServletRequest _httpServletRequest = Mockito.mock(
 		HttpServletRequest.class);
 	private final JournalArticle _journalArticle = Mockito.mock(
 		JournalArticle.class);
+	private final MockedStatic<JournalArticleServiceUtil>
+		_journalArticleServiceUtilMockedStatic = Mockito.mockStatic(
+			JournalArticleServiceUtil.class);
 	private JournalEditArticleDisplayContext _journalEditArticleDisplayContext;
 	private final JournalFolderLocalService _journalFolderLocalService =
 		Mockito.mock(JournalFolderLocalService.class);


### PR DESCRIPTION
Default locale creating a web content 

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-37464)

The locale is overriden by the default values of a structure when creating a web content from a structure from global in another site

# How am I fixing it?

When we changed the behaviour because of PTR-3728, we didn't think about inherited structures, it should have only applied when enabling the configuration and for the same site

# How can you verify that it works?

Follow the steps in the ticket or execute the unit test