### PR TITLE
LPD-38270 We can select for preview of web content in Asset Libraries through not connected sites' display page templates

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -52,6 +52,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -224,6 +225,46 @@ public class JournalEditArticleDisplayContext {
 
 				siteItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 					new URLItemSelectorReturnType());
+
+				Group scopeGroup = _groupLocalService.getGroup(getGroupId());
+
+				if (scopeGroup.isDepot()) {
+					List<Long> connectedGroupIds = TransformUtil.transform(
+						_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+							_depotEntryLocalService.getDepotEntry(
+								scopeGroup.getClassPK())),
+						DepotEntryGroupRel::getGroupId);
+
+					long[] excludedGroupsIds = null;
+
+					if (ListUtil.isNotEmpty(connectedGroupIds)) {
+						excludedGroupsIds = TransformUtil.transformToLongArray(
+							_groupLocalService.getGroups(
+								_themeDisplay.getCompanyId(),
+								GroupConstants.ANY_PARENT_GROUP_ID, true,
+								QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+							group -> {
+								if (!connectedGroupIds.contains(
+										group.getGroupId())) {
+
+									return group.getGroupId();
+								}
+
+								return null;
+							});
+					}
+					else {
+						excludedGroupsIds = TransformUtil.transformToLongArray(
+							_groupLocalService.getGroups(
+								_themeDisplay.getCompanyId(),
+								GroupConstants.ANY_PARENT_GROUP_ID, true,
+								QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+							Group::getGroupId);
+					}
+
+					siteItemSelectorCriterion.setExcludedGroupIds(
+						excludedGroupsIds);
+				}
 
 				return String.valueOf(
 					_itemSelector.getItemSelectorURL(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -9,6 +9,9 @@ import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.item.selector.criterion.AssetDisplayPageSelectorCriterion;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalServiceUtil;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.form.renderer.constants.DDMFormRendererConstants;
 import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
@@ -68,6 +71,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
@@ -118,11 +122,17 @@ public class JournalEditArticleDisplayContext {
 
 	public JournalEditArticleDisplayContext(
 		HttpServletRequest httpServletRequest,
-		LiferayPortletResponse liferayPortletResponse, JournalArticle article) {
+		LiferayPortletResponse liferayPortletResponse, JournalArticle article,
+		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService) {
 
 		_httpServletRequest = httpServletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_article = article;
+		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
+		_groupLocalService = groupLocalService;
 
 		_itemSelector = (ItemSelector)httpServletRequest.getAttribute(
 			ItemSelector.class.getName());
@@ -224,45 +234,65 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"sites",
 			() -> {
-				RecentGroupManager recentGroupManager =
-					RecentGroupManagerUtil.getRecentGroupManager();
+				Group scopeGroup = _groupLocalService.getGroup(getGroupId());
 
-				List<Group> recentGroups = ListUtil.subList(
-					recentGroupManager.getRecentGroups(_httpServletRequest), 0,
-					_MAX_SITES);
+				List<Group> groups;
 
-				JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+				int max = _MAX_SITES;
 
-				for (Group group : recentGroups) {
-					if (group.isCompany()) {
-						continue;
+				if (scopeGroup.isDepot()) {
+					groups = _groupLocalService.getGroups(
+						TransformUtil.transformToLongArray(
+							_depotEntryGroupRelLocalService.
+								getDepotEntryGroupRels(
+									_depotEntryLocalService.getDepotEntry(
+										scopeGroup.getClassPK())),
+							DepotEntryGroupRel::getGroupId));
+				}
+				else {
+					RecentGroupManager recentGroupManager =
+						RecentGroupManagerUtil.getRecentGroupManager();
+
+					List<Group> recentGroups = ListUtil.subList(
+						recentGroupManager.getRecentGroups(_httpServletRequest),
+						0, _MAX_SITES);
+
+					JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+					for (Group group : recentGroups) {
+						if (group.isCompany()) {
+							continue;
+						}
+
+						jsonArray.put(
+							JSONUtil.put(
+								"groupId", group.getGroupId()
+							).put(
+								"name",
+								group.getDescriptiveName(
+									_themeDisplay.getLocale())
+							));
 					}
 
-					jsonArray.put(
-						JSONUtil.put(
-							"groupId", group.getGroupId()
-						).put(
-							"name",
-							group.getDescriptiveName(_themeDisplay.getLocale())
-						));
+					if (recentGroups.size() == _MAX_SITES) {
+						return jsonArray;
+					}
+
+					max = _MAX_SITES - recentGroups.size();
+
+					groups = GroupServiceUtil.getGroups(
+						_themeDisplay.getCompanyId(),
+						GroupConstants.DEFAULT_PARENT_GROUP_ID, true);
 				}
 
-				if (recentGroups.size() == _MAX_SITES) {
-					return jsonArray;
-				}
-
-				int max = _MAX_SITES - recentGroups.size();
-
-				List<Group> groups = GroupServiceUtil.getGroups(
-					_themeDisplay.getCompanyId(),
-					GroupConstants.DEFAULT_PARENT_GROUP_ID, true);
+				JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 				for (Group group : groups) {
 					if (max < 0) {
 						break;
 					}
 
-					if (recentGroups.contains(group) || group.isCompany()) {
+					if (group.isCompany()) {
 						continue;
 					}
 
@@ -287,6 +317,15 @@ public class JournalEditArticleDisplayContext {
 						ActionKeys.VIEW)) {
 
 					return 0;
+				}
+
+				Group scopeGroup = _groupLocalService.getGroup(getGroupId());
+
+				if (scopeGroup.isDepot()) {
+					return _depotEntryGroupRelLocalService.
+						getDepotEntryGroupRelsCount(
+							_depotEntryLocalService.getDepotEntry(
+								scopeGroup.getClassPK()));
 				}
 
 				int groupsCount = GroupServiceUtil.getGroupsCount(
@@ -1754,11 +1793,15 @@ public class JournalEditArticleDisplayContext {
 	private String _ddmTemplateKey;
 	private String _defaultArticleLanguageId;
 	private LayoutPageTemplateEntry _defaultLayoutPageTemplateEntry;
+	private final DepotEntryGroupRelLocalService
+		_depotEntryGroupRelLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
 	private Integer _displayPageType;
 	private Long _folderId;
 	private String _folderName;
 	private String _friendlyURLDuplicatedWarningMessage;
 	private Long _groupId;
+	private final GroupLocalService _groupLocalService;
 	private final HttpServletRequest _httpServletRequest;
 	private Long _inheritedWorkflowDDMStructuresFolderId;
 	private final ItemSelector _itemSelector;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditArticleMVCRenderCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/EditArticleMVCRenderCommand.java
@@ -5,11 +5,14 @@
 
 package com.liferay.journal.web.internal.portlet.action;
 
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.web.internal.display.context.JournalEditArticleDisplayContext;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -48,7 +51,9 @@ public class EditArticleMVCRenderCommand implements MVCRenderCommand {
 				new JournalEditArticleDisplayContext(
 					httpServletRequest,
 					_portal.getLiferayPortletResponse(renderResponse),
-					ActionUtil.getArticle(httpServletRequest)));
+					ActionUtil.getArticle(httpServletRequest),
+					_depotEntryGroupRelLocalService, _depotEntryLocalService,
+					_groupLocalService));
 
 			return "/edit_article.jsp";
 		}
@@ -68,6 +73,15 @@ public class EditArticleMVCRenderCommand implements MVCRenderCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditArticleMVCRenderCommand.class);
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
@@ -85,7 +85,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			_UNEXPECTED_FOLDER_NAME_MESSAGE, expectedResult,
@@ -120,7 +121,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			_UNEXPECTED_FOLDER_NAME_MESSAGE, expectedResult,
@@ -176,7 +178,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			_UNEXPECTED_FOLDER_NAME_MESSAGE, expectedResult,
@@ -224,7 +227,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			_UNEXPECTED_FOLDER_NAME_MESSAGE, expectedResult,
@@ -247,7 +251,8 @@ public class JournalEditArticleDisplayContextTest {
 	public void testIsShowSelectFolderAddActionFalseParamValue() {
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Mockito.when(
 			_httpServletRequest.getParameter("showSelectFolder")
@@ -269,7 +274,8 @@ public class JournalEditArticleDisplayContextTest {
 	public void testIsShowSelectFolderAddActionMissingParam() {
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Mockito.when(
 			_httpServletRequest.getParameter("showSelectFolder")
@@ -291,7 +297,8 @@ public class JournalEditArticleDisplayContextTest {
 	public void testIsShowSelectFolderAddActionTrueParamValue() {
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Mockito.when(
 			_httpServletRequest.getParameter("showSelectFolder")
@@ -313,7 +320,8 @@ public class JournalEditArticleDisplayContextTest {
 	public void testIsShowSelectFolderEditActionDoesntMatterParamValue() {
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, _journalArticle);
+				_httpServletRequest, _liferayPortletResponse, _journalArticle,
+				null, null, null);
 
 		Assert.assertFalse(
 			_journalEditArticleDisplayContext.isShowSelectFolder());
@@ -329,7 +337,8 @@ public class JournalEditArticleDisplayContextTest {
 	public void testShowSelectFolderValueIsCached() {
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Mockito.when(
 			_httpServletRequest.getParameter("showSelectFolder")
@@ -397,7 +406,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, journalArticle);
+				_httpServletRequest, _liferayPortletResponse, journalArticle,
+				null, null, null);
 
 		Assert.assertEquals(
 			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
@@ -421,7 +431,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			defaultLanguageId,
@@ -453,7 +464,8 @@ public class JournalEditArticleDisplayContextTest {
 
 		_journalEditArticleDisplayContext =
 			new JournalEditArticleDisplayContext(
-				_httpServletRequest, _liferayPortletResponse, null);
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
 
 		Assert.assertEquals(
 			LocaleUtil.toLanguageId(LocaleUtil.UK),

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesForWebContentArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesForWebContentArticle.testcase
@@ -509,6 +509,10 @@ definition {
 		task ("When the site designer creates a web content in an Asset Library") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
+			JSONDepot.connectSite(
+				depotName = "Test Depot Name",
+				groupName = "Test Site Name");
+
 			DepotNavigator.openDepotWebContentAdmin(depotName = "Test Depot Name");
 
 			WebContentNavigator.gotoAddCP();


### PR DESCRIPTION
# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-37464)

We can select for preview of web content in Asset Libraries through not connected sites' display page templates. So , we have to do not show not connected site's. 

# How am I fixing it?

Get connected site's and and display them both in the list and in the site selector and do not show those not connected.

# How can you verify that it works?

Follow the steps in the ticket or execute updated poshi test.