### PR TITLE
LPD-38525

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -92,11 +92,10 @@ export default function UndoRedo({
 	const handleUndo = (newStep) => {
 		const nextStep = history[newStep];
 
-		if (nextStep.selectedLanguageId !== selectedLanguageId) {
-			const selectedLanguageIdInput = document.getElementById(
-				`${portletNamespace}languageId`
-			);
-
+		const selectedLanguageIdInput = document.getElementById(
+			`${portletNamespace}languageId`
+		);
+		if (nextStep.selectedLanguageId !== selectedLanguageIdInput.value) {
 			descriptionInputComponent
 				.get('translatedLanguages')
 				.values()
@@ -109,7 +108,7 @@ export default function UndoRedo({
 							.remove(lang);
 						descriptionInputComponent.removeInputLanguage(lang);
 						descriptionInputComponent._updateTranslationStatus(
-							selectedLanguageId
+							selectedLanguageIdInput.value
 						);
 					}
 				});
@@ -126,7 +125,7 @@ export default function UndoRedo({
 							.remove(lang);
 						friendlyURLInputComponent.removeInputLanguage(lang);
 						friendlyURLInputComponent._updateTranslationStatus(
-							selectedLanguageId
+							selectedLanguageIdInput.value
 						);
 					}
 				});
@@ -141,7 +140,7 @@ export default function UndoRedo({
 							.remove(lang);
 						titleInputComponent.removeInputLanguage(lang);
 						titleInputComponent._updateTranslationStatus(
-							selectedLanguageId
+							selectedLanguageIdInput.value
 						);
 					}
 				});
@@ -163,11 +162,11 @@ export default function UndoRedo({
 	const handleRedo = (newStep) => {
 		const nextStep = history[newStep];
 
-		if (nextStep.selectedLanguageId !== selectedLanguageId) {
-			const selectedLanguageIdInput = document.getElementById(
-				`${portletNamespace}languageId`
-			);
+		const selectedLanguageIdInput = document.getElementById(
+			`${portletNamespace}languageId`
+		);
 
+		if (nextStep.selectedLanguageId !== selectedLanguageIdInput.value) {
 			selectedLanguageIdInput.value = nextStep.selectedLanguageId;
 
 			nextStep.descriptionTranslatedLanguages.map((lang) => {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -541,7 +541,7 @@ export default function UndoRedo({
 							<ClayDropDown.Divider />
 
 							<ClayDropDown.Item
-								disabled={step <= 0}
+								disabled={step === 0}
 								onClick={() => {
 									Liferay.fire('journal:goto', {
 										step: 0,
@@ -563,7 +563,7 @@ export default function UndoRedo({
 				<ClayButtonWithIcon
 					aria-label={Liferay.Language.get('undo-all')}
 					className="btn-monospaced"
-					disabled={history.length <= 1}
+					disabled={step === 0}
 					displayType="secondary"
 					onClick={() => {
 						Liferay.fire('journal:goto', {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -501,6 +501,12 @@ export default function UndoRedo({
 												disabled={step === index}
 												key={index}
 												onClick={() => {
+													Liferay.fire(
+														'journal:goto',
+														{
+															step: index,
+														}
+													);
 													if (index < step) {
 														let i = step;
 														while (i > index) {
@@ -515,13 +521,6 @@ export default function UndoRedo({
 															handleRedo(i);
 														}
 													}
-
-													Liferay.fire(
-														'journal:goto',
-														{
-															step: index,
-														}
-													);
 
 													setActive(false);
 												}}
@@ -545,14 +544,14 @@ export default function UndoRedo({
 							<ClayDropDown.Item
 								disabled={step <= 0}
 								onClick={() => {
-									let i = step;
-									while (i > 0) {
-										i--;
-										handleUndo(0);
-									}
 									Liferay.fire('journal:goto', {
 										step: 0,
 									});
+									let i = step;
+									while (i > 0) {
+										i--;
+										handleUndo(i);
+									}
 									setActive(false);
 								}}
 							>
@@ -568,14 +567,14 @@ export default function UndoRedo({
 					disabled={history.length <= 1}
 					displayType="secondary"
 					onClick={() => {
+						Liferay.fire('journal:goto', {
+							step: 0,
+						});
 						let i = step;
 						while (i > 0) {
 							i--;
 							handleUndo(i);
 						}
-						Liferay.fire('journal:goto', {
-							step: 0,
-						});
 					}}
 					size="sm"
 					symbol="time"

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -434,7 +434,25 @@ autoSaveUndoRedoTest(
 
 		await fillAndClickOutside(page, textField, text);
 
-		await historyButton.click();
+		const translationButton = page.getByLabel('Select a language, current');
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('option', {
+				name: 'Catalan Language: Not',
+			}),
+			trigger: translationButton,
+		});
+
+		await expect(async () => {
+			await journalEditArticlePage.fillTitle(getRandomString());
+
+			await historyButton.click();
+
+			await expect(
+				page.getByRole('menuitem', {name: 'Change Language'})
+			).toBeEnabled();
+		}).toPass();
 
 		await page.getByRole('menuitem', {name: 'Undo All'}).click();
 


### PR DESCRIPTION
[LPD-38525](https://liferay.atlassian.net/browse/LPD-38525)

Issue and solution:
The root cause was the order of the events were fired when going to a specific history step. We need to fire the goto event for data-engine before we handle the undo or redo for the metadataFields. This is important, as if a locale change is happened in the history, Undo or Redo will change the locale, that will also fire an event for data-engine to update it's values. 

Test:
I updated our current test to include a locale change and cover this usecase as well.
Follow ticket description or run 'History button test'

Please review my changes