### PR TITLE
LPD-38591 Update locator to match the URL specific text

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
@@ -46,7 +46,7 @@ definition {
 
 		Type(
 			key_text = "URL",
-			locator1 = "TextInput#ANY",
+			locator1 = "TextInput#ANY_SPECIFIC",
 			value1 = ${entryExternalURL});
 
 		Click(locator1 = "CKEditor#OK_BUTTON");


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-38590

---

The purpose of this PR is to update the locator to match exactly the URL text field. The previous locator along with this [FF removal](https://liferay.atlassian.net/browse/LPD-27491) caused that the text filled by the Acceptance Test LocalFile.ExportImport#DLLinkValidationInWebContent (and some others) were a different one than the expected one. See the screenshots:

This is the new text field "Friendly URL" that is being filled by this [line of code](https://github.com/liferay/liferay-portal/blob/7ac452b0ae2e3d739222fa9a1ff710f8e295ec91/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro#L47)

![image](https://github.com/user-attachments/assets/41549c87-7c42-47f1-98ad-2e098aa60bb1)

instead of filling the desired one:

![image](https://github.com/user-attachments/assets/5e1a0201-31f4-4480-b0f0-7ba3b2f4b98f)
