### PR TITLE
LPD-38568 Workaround to enable deprecation feature flag LPD-35013

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotCategorySiteIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotCategorySiteIntegration.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Depot";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "Site Name");
 

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Item Selector";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowUsecase.testcase
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowUsecase.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-bpm"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Workflow";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowWiki.testcase
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/tests/WorkflowWiki.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-bpm"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "Wiki";
 	property testray.main.component.name = "Workflow";
@@ -15,6 +16,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		Navigator.openURL();
 

--- a/modules/apps/ratings/ratings-test/src/testFunctional/tests/Ratings.testcase
+++ b/modules/apps/ratings/ratings-test/src/testFunctional/tests/Ratings.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Ratings";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
@@ -37,6 +37,24 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro enableWiki() {
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Instance Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Feature Flags",
+			configurationName = "Deprecation",
+			configurationScope = "Virtual Instance Scope");
+
+		Check.checkToggleSwitch(
+			locator1 = "FeatureFlag#TOGGLE_ROW",
+			title_row = "Wiki",
+			toggle_state = "Disabled");
+	}
+
+	@summary = "Default summary"
 	macro subscribeToNodeCP(wikiNodeName = null) {
 		var key_wikiNodeName = ${wikiNodeName};
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/customfields/cpcustomfields/CPCustomfields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/customfields/cpcustomfields/CPCustomfields.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-core-infra"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Custom Fields";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/gdpr/GDPR.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/gdpr/GDPR.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-commerce"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true${line.separator}jsonws.web.service.paths.excludes=";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false${line.separator}jsonws.web.service.paths.excludes=";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Personal Data";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/ClassicSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/ClassicSearch.testcase
@@ -1,10 +1,11 @@
 @component-name = "portal-search"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
 	property osgi.module.configuration.file.names = "com.liferay.portal.search.web.internal.configuration.SearchWebConfiguration.config";
 	property osgi.module.configurations = "classicSearchPortletInFrontPage=\"true\"";
-	property portal.release = "true";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.suite.search.engine = "elasticsearch7,solr";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Web Search";
@@ -13,6 +14,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-search"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.suite.search.engine = "elasticsearch7";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Web Search";
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SolrSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SolrSearch.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-search"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.suite.search.engine = "solr";
 	property portal.upstream = "true";
 	property solr.enabled = "true";
@@ -12,6 +13,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/antisamy/AntiSamy.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/antisamy/AntiSamy.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "AntiSamy";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "false";
 	property testray.main.component.name = "XSS";
@@ -12,6 +13,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/SemanticSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/SemanticSearch.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-search"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.suite.search.engine = "elasticsearch7";
 	property portal.upstream = "true";
 	property test.run.environment = "EE";
@@ -12,6 +13,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SimilarResults.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/elasticsearch/SimilarResults.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-search-ee"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.suite.search.engine = "elasticsearch7";
 	property portal.upstream = "true";
 	property test.run.environment = "EE";
@@ -12,6 +13,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/mentions/MentionsWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/mentions/MentionsWiki.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "default.layout.template.id=1_column${line.separator}feature.flag.LPD-35013=true${line.separator}jsonws.web.service.paths.excludes=";
-	property portal.release = "true";
+	property custom.properties = "default.layout.template.id=1_column${line.separator}feature.flag.LPD-35013=false${line.separator}jsonws.web.service.paths.excludes=";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "Wiki";
 	property testray.main.component.name = "Mentions";
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiDisplayWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiDisplayWidget.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiEntry.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiLocalization.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiNotifications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiNotifications.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "default.layout.template.id=1_column${line.separator}feature.flag.LPD-35013=true${line.separator}jsonws.web.service.paths.excludes=";
+	property custom.properties = "default.layout.template.id=1_column${line.separator}feature.flag.LPD-35013=false{line.separator}jsonws.web.service.paths.excludes=";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "Notifications";
 	property testray.main.component.name = "Wiki";
@@ -15,6 +16,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPage.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPermissions.testcase
@@ -1,9 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "Roles";
 	property testray.main.component.name = "Wiki";
@@ -12,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiSearch.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiSearch.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiStaging.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
 	property portal.acceptance = "true";
-	property portal.release = "true";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiUpgrade.testcase
@@ -1,9 +1,10 @@
 @component-name = "portal-upgrades"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
+	property custom.properties = "feature.flag.LPD-35013=false";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
-	property portal.release = "true";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property test.liferay.virtual.instance = "false";
@@ -17,6 +18,8 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		AssertLocation(value1 = "${portalURL}/web/guest?SM_USER=test@liferay.com");
+
+		WikiPortlet.enableWiki();
 
 		SearchAdministration.executeReindex();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiWidget.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "WYSIWYG";
 	property testray.main.component.name = "User Interface";
@@ -13,6 +14,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "WYSIWYG Site Name");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsWiki.testcase
@@ -15,22 +15,7 @@ definition {
 
 		User.firstLoginPG();
 
-		task ("Enable Wiki") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Configuration",
-				panel = "Control Panel",
-				portlet = "Instance Settings");
-
-			SystemSettings.gotoConfiguration(
-				configurationCategory = "Feature Flags",
-				configurationName = "Deprecation",
-				configurationScope = "Virtual Instance Scope");
-
-			Check.checkToggleSwitch(
-				locator1 = "FeatureFlag#TOGGLE_ROW",
-				title_row = "Wiki",
-				toggle_state = "Disabled");
-		}
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/socialnetworking/socialactivity/SocialActivity.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/socialnetworking/socialactivity/SocialActivity.testcase
@@ -1,8 +1,9 @@
 @component-name = "portal-content-management"
 definition {
 
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Social Networking";
 
@@ -10,6 +11,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 	}
 
 	tearDown {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Staging";
 
@@ -13,6 +14,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Staging";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Asset Publisher Widget";
 
@@ -14,6 +15,10 @@ definition {
 
 		task ("Sign in") {
 			User.firstLoginPG();
+		}
+
+		task ("Enable wiki") {
+			WikiPortlet.enableWiki();
 		}
 
 		task ("Add a site") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/TagsUseCase.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.component.names = "Tags";
 	property testray.main.component.name = "Tags";
@@ -13,6 +14,8 @@ definition {
 			TestCase.setUpPortalInstance();
 
 			User.firstLoginPG();
+
+			WikiPortlet.enableWiki();
 		}
 
 		task ("Add a site") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/trash/RecycleBin.testcase
@@ -2,8 +2,9 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=true";
-	property portal.release = "true";
+	property custom.properties = "feature.flag.LPD-35013=false";
+	property osgi.modules.includes = "wiki";
+	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Recycle Bin";
 
@@ -11,6 +12,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		WikiPortlet.enableWiki();
 
 		HeadlessSite.addSite(siteName = "Site Name");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38568

We have an issue to enable a deprecation feature flag using feature.flag.LPD-35013=true, see this slack thread: https://liferay.slack.com/archives/CD7939WBE/p1728060218920649?thread_ts=1727435003.757549&cid=CD7939WBE. There is an story to made deprecation enable  works, see: https://liferay.atlassian.net/browse/LPD-4283.

Meanwhile we need wiki tests working. So, with this PR we are adding a workaround to enable deprecation feature flag LPD-35013.

# How am I fixing it?

Add a Wiki macro inside WikiPortlet in order to enable wiki, and add these properties for the testcase file:

property custom.properties = "feature.flag.LPD-35013=false";
property osgi.modules.includes = "wiki";
property portal.release = "false";

# How can you verify that it works?

See in the execution that wiki tests and other tests related with wiki macros are working.