### PR TITLE
LPD-38714 Remove extra paddings to the loading animation icon

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -58,9 +58,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 				<li class="tbar-item tbar-item-expand">
 					<div class="autofit-row sidebar-section">
 						<div class="autofit-col d-flex flex-row">
-							<div class="inline-item px-6 py-2">
-								<span aria-hidden="true" class="loading-animation"></span>
-							</div>
+							<span aria-hidden="true" class="loading-animation mx-4 my-2"></span>
 
 							<react:component
 								module="{TranslationManager} from journal-web"
@@ -82,10 +80,6 @@ journalEditArticleDisplayContext.setViewAttributes();
 
 						<c:if test="<%= !JournalUtil.isEditDefaultValues(article) %>">
 							<div class="c-ml-2">
-								<div class="inline-item my-5 p-5 w-100">
-									<span aria-hidden="true" class="loading-animation"></span>
-								</div>
-
 								<react:component
 									module="{TranslationOptions} from journal-web"
 									props='<%=


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-38714)

I reduced the margin/paddings for the first loading icon, and removed the second one as it was not useful.


https://github.com/user-attachments/assets/696ffd40-0fc8-4ee1-916a-e801e01d005f



For this case I don't see the need to add any test, it is a visual improvement that is visible to the user only for a second (while the react component is loading) 