### PR TITLE
LPD-38758 translate shows the duplicate fields - playwright test

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
@@ -434,61 +434,6 @@ definition {
 			title = "Translation of WC WebContent Title to ja-JP");
 	}
 
-	@description = "This test covers LPS-142169. It ensures that translate side by side shows the duplicate fields."
-	@priority = 4
-	test CanViewDuplicateFields {
-		property portal.release = "quarantine";
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		NavItem.gotoStructures();
-
-		WebContentStructures.addCP(
-			structureDescription = "WC Structure Description",
-			structureName = "WC Structure Name");
-
-		DataEngine.addField(
-			fieldFieldLabel = "Text",
-			fieldName = "Text");
-
-		DataEngine.toggleFieldRepeatable(fieldFieldLabel = "Text");
-
-		WebContentStructures.saveCP(structureName = "WC Structure Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		NavItem.gotoTemplates();
-
-		WebContentTemplates.addCP(
-			structureName = "WC Structure Name",
-			templateDescription = "WC Template Description",
-			templateName = "WC Template Name");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-		WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-		WebContent.addWithStructureCP(
-			description = "WC WebContent Description",
-			duplicateField = "true",
-			webContentText = "Text",
-			webContentTitle = "WC WebContent Title");
-
-		PortletEntry.publish();
-
-		Translations.gotoTranslate(webContentTitle = "WC WebContent Title");
-
-		Translations.viewBaseFields(
-			webContentDescription = "WC WebContent Description",
-			webContentText = "Text",
-			webContentTitle = "WC WebContent Title");
-
-		Translations.viewBaseFields(
-			webContentDescription = "WC WebContent Description",
-			webContentText = "Text Duplicate Field",
-			webContentTitle = "WC WebContent Title");
-	}
-
 	@description = "This ensures that translate side by side shows the latest values after editing the web content article."
 	@priority = 5
 	@refactordone

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -658,6 +658,42 @@ baseTest(
 		await waitForAlert(page);
 	}
 );
+baseTest(
+	'It ensures that translate side by side shows the duplicate fields',
+	{
+		tag: '@LPS-142169',
+	},
+	async ({apiHelpers, journalEditArticlePage, journalPage, page, site}) => {
+		const localizableFieldName = 'Text5678';
+		const structureName = 'Structure 1';
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [{name: localizableFieldName, repeatable: true}],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		const title = getRandomString();
+		await journalEditArticlePage.createArticleWithDuplicatedField(
+			structureName,
+			site,
+			title
+		);
+
+		await journalPage.goToJournalArticleAction('Translate', title);
+
+		const duplicateFields = page.locator(
+			'[id^="_com_liferay_translation_web_internal_portlet_TranslationPortlet_infoField--DDMStructure_Text"]'
+		);
+
+		await duplicateFields.first().waitFor({state: 'visible'});
+
+		expect(duplicateFields.nth(0)).toBeVisible();
+		expect(duplicateFields.nth(1)).toBeVisible();
+	}
+);
 
 baseTest(
 	'This is a test for reset translations button in web content',

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -20,6 +20,7 @@ export class JournalEditArticlePage {
 	readonly clearButton: Locator;
 	readonly content: Locator;
 	readonly defaultTemplateButton: Locator;
+	readonly duplicateButton: Locator;
 	readonly friendlyURLInput: Locator;
 	readonly friendlyUrlToggle: Locator;
 	readonly historyButton: Locator;
@@ -46,7 +47,7 @@ export class JournalEditArticlePage {
 		this.defaultTemplateButton = page.getByRole('button', {
 			name: 'Default Template',
 		});
-
+		this.duplicateButton = page.getByLabel('Add Duplicate Field Text');
 		this.friendlyURLInput = page.locator(
 			'#_com_liferay_journal_web_portlet_JournalPortlet_friendlyURL'
 		);
@@ -202,6 +203,39 @@ export class JournalEditArticlePage {
 			this.page,
 			`Success:${articleTitle} was created successfully.`
 		);
+	}
+	async createArticleWithDuplicatedField(
+		structureName: string,
+		site?: Site,
+		title?: string
+	) {
+		await this.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+
+		await fillAndClickOutside(
+			this.page,
+			this.titleInput,
+			title || getRandomString()
+		);
+
+		const field = this.page.locator(
+			'input[id^="_com_liferay_journal_web_portlet_JournalPortlet_ddm$$Text"]'
+		);
+
+		await fillAndClickOutside(this.page, field, 'Text Field');
+
+		await this.duplicateButton.click();
+
+		await this.page
+			.locator(
+				'input[id^="_com_liferay_journal_web_portlet_JournalPortlet_ddm$$Text"]'
+			)
+			.nth(1)
+			.fill('Duplicated Text Field');
+
+		await this.publishButton.click();
 	}
 
 	async fillTitle(title: string) {


### PR DESCRIPTION
Hi,
May I ask to review this PR .

Is it for https://liferay.atlassian.net/browse/LPD-38758. 

Solution: created TranslationsInterface#CanViewDuplicateFields test in playwright.

The issue was with the button to create the duplicated field. It is working in PW if we click outside first.

Removed the Poshi test as well.

Thank you!