### PR TITLE
LPD-38754 show tailored message when failing because friendlyURL with trailing slash

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -40,6 +40,7 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalService;
+import com.liferay.friendly.url.exception.FriendlyURLLocalizationUrlTitleException;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.exception.ArticleFriendlyURLException;
@@ -178,6 +179,20 @@ public class JournalArticleLocalServiceTest {
 			article.getExternalReferenceCode(), _group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			article.getArticleId(), true);
+	}
+
+	@Test(
+		expected = FriendlyURLLocalizationUrlTitleException.MustNotHaveTrailingSlash.class
+	)
+	public void testAddArticleWithURLWithStartingSlashThrowsMustNotHaveTrailingSlashException()
+		throws Exception {
+
+		JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			HashMapBuilder.put(
+				_portal.getSiteDefaultLocale(_group), "test/"
+			).build());
 	}
 
 	@Test

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article_exceptions.jspf
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article_exceptions.jspf
@@ -69,6 +69,7 @@
 	<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(fileSizeException.getMaxSize(), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
+<liferay-ui:error exception="<%= FriendlyURLLocalizationUrlTitleException.MustNotHaveTrailingSlash.class %>" message="please-enter-a-friendly-url-that-does-not-end-with-a-slash" />
 <liferay-ui:error exception="<%= InvalidDDMStructureException.class %>" message="the-structure-you-selected-is-not-valid-for-this-folder" />
 
 <liferay-ui:error exception="<%= LiferayFileItemException.class %>">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -59,6 +59,7 @@ page import="com.liferay.dynamic.data.mapping.service.DDMStorageLinkLocalService
 page import="com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil" %><%@
 page import="com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil" %><%@
 page import="com.liferay.exportimport.kernel.exception.ExportImportContentValidationException" %><%@
+page import="com.liferay.friendly.url.exception.FriendlyURLLocalizationUrlTitleException" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList" %><%@
 page import="com.liferay.frontend.taglib.form.navigator.constants.FormNavigatorConstants" %><%@
 page import="com.liferay.journal.configuration.JournalFileUploadsConfiguration" %><%@

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -112,6 +112,30 @@ baseTest(
 );
 
 baseTest(
+	'Check error message on invalid friendly URL',
+	{
+		tag: '@LPD-38754',
+	},
+	async ({journalEditArticlePage, site}) => {
+		await journalEditArticlePage.journalPage.goto(site.friendlyUrlPath);
+		await journalEditArticlePage.journalPage.goToCreateArticle();
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.fillTitle(title);
+		await journalEditArticlePage.fillFriendlyURL(title + '/' || 'test');
+		await journalEditArticlePage.publishButton.waitFor();
+		await journalEditArticlePage.publishButton.click();
+
+		await expect(
+			journalEditArticlePage.alertErrorMessage.getByText(
+				'Please enter a friendly URL that does not end with a slash'
+			)
+		).toBeVisible();
+	}
+);
+
+baseTest(
 	'Select web content display template with the Preview feature',
 	{
 		tag: '@LPD-31427',

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -117,8 +117,7 @@ baseTest(
 		tag: '@LPD-38754',
 	},
 	async ({journalEditArticlePage, site}) => {
-		await journalEditArticlePage.journalPage.goto(site.friendlyUrlPath);
-		await journalEditArticlePage.journalPage.goToCreateArticle();
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
 		const title = getRandomString();
 

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -31,9 +31,13 @@ export class JournalEditArticlePage {
 	readonly submitForWorkflowButton: Locator;
 	readonly titleInput: Locator;
 	readonly undoButton: Locator;
+	readonly alertErrorMessage: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+		this.alertErrorMessage = page.locator(
+			'div.article-content-content >> div.alert-danger'
+		);
 		this.changesSavedIndicator = page.locator(
 			'#_com_liferay_journal_web_portlet_JournalPortlet_changesSavedIndicator'
 		);


### PR DESCRIPTION
LPD-38754 generic message publishing WC with friendly URL ending on slash

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38754

When a user introduces a friendlyURL with a trailing slash, a generic error is shown

# How am I fixing it?

Adding more context to the error on the web content creation/edition

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-38754 add the specific message on the journal article creation when we add a friendly url ending with a slash**
- **LPD-38754 add integration test to check that if adding a wc with explicit url with trailing slash and exception must be thrown**
- **LPD-38754 add test to check the message when trying to create a WC article with a friendlyURL with trailing slash**
