### PR TITLE
LPD-38870 Skip test if not properly configured

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -37,6 +38,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -47,6 +49,7 @@ import java.util.Dictionary;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -65,9 +68,15 @@ public class DLOpenerGoogleDriveManagerTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE,
 			SynchronousDestinationTestRule.INSTANCE);
+
+	public static void assume() {
+		Assume.assumeTrue(Validator.isNotNull(_getGoogleDriveClientId()));
+		Assume.assumeTrue(Validator.isNotNull(_getGoogleDriveClientSecret()));
+		Assume.assumeTrue(Validator.isNotNull(_getGoogleDriveRefreshToken()));
+	}
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -247,6 +256,18 @@ public class DLOpenerGoogleDriveManagerTest {
 		Assert.assertFalse(_isGoogleDriveFile(_addFileEntry()));
 	}
 
+	private static String _getGoogleDriveClientId() {
+		return PropsUtil.get("google.drive.integration.client.id.1");
+	}
+
+	private static String _getGoogleDriveClientSecret() {
+		return PropsUtil.get("google.drive.integration.client.secret.1");
+	}
+
+	private static String _getGoogleDriveRefreshToken() {
+		return PropsUtil.get("google.drive.integration.client.refresh.token.1");
+	}
+
 	private FileEntry _addFileEntry() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_company.getGroupId());
@@ -282,18 +303,6 @@ public class DLOpenerGoogleDriveManagerTest {
 			_http.URLtoString(options));
 
 		return jsonObject.getString("access_token");
-	}
-
-	private String _getGoogleDriveClientId() {
-		return PropsUtil.get("google.drive.integration.client.id.1");
-	}
-
-	private String _getGoogleDriveClientSecret() {
-		return PropsUtil.get("google.drive.integration.client.secret.1");
-	}
-
-	private String _getGoogleDriveRefreshToken() {
-		return PropsUtil.get("google.drive.integration.client.refresh.token.1");
 	}
 
 	private boolean _isGoogleDriveFile(FileEntry fileEntry) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38870

The tests always fail locally, as it assumes Google Drive creds will be available in system properties.

Note that the fix for this same test in the CI was sent in https://liferay.atlassian.net/browse/LRCI-4722. It is expected for the test to fail in the CI until that PR is merged.

# How am I fixing it?

By skipping the test if not propertly configured.

# How can you verify that it works?

Run the test with no configuration and see it pass.