### PR TITLE
LPD-38875 Truncate text values when max length exceeded

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -695,17 +695,20 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 					richTextValues.add(richTextValue);
 
-					if (richTextValue.length() >
-							_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH) {
-
-						richTextValue = richTextValue.substring(
-							0, _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH);
-					}
-
-					truncatedValues.add(richTextValue);
+					truncatedValues.add(_truncate(richTextValue));
 				}
 
 				valuesString = richTextValues.toArray(new String[0]);
+				truncatedValuesString = truncatedValues.toArray(new String[0]);
+			}
+			else if (type.equals(DDMFormFieldTypeConstants.TEXT)) {
+				List<String> truncatedValues = new ArrayList<>(
+					valuesString.length);
+
+				for (String valueString : valuesString) {
+					truncatedValues.add(_truncate(valueString));
+				}
+
 				truncatedValuesString = truncatedValues.toArray(new String[0]);
 			}
 
@@ -784,14 +787,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 			return;
 		}
 
-		if (sortableValueString.length() >
-				_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH) {
-
-			sortableValueString = sortableValueString.substring(
-				0, _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH);
-		}
-
-		document.addKeyword(_getSortableFieldName(name), sortableValueString);
+		document.addKeyword(
+			_getSortableFieldName(name), _truncate(sortableValueString));
 	}
 
 	private void _extractIndexableAttribute(
@@ -964,6 +961,14 @@ public class DDMIndexerImpl implements DDMIndexer {
 	private String[] _toStringArray(Object value) throws PortalException {
 		return ArrayUtil.toStringArray(
 			_jsonFactory.createJSONArray(String.valueOf(value)));
+	}
+
+	private String _truncate(String string) {
+		if (string.length() > _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH) {
+			return string.substring(0, _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH);
+		}
+
+		return string;
 	}
 
 	private static final int _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH =


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38875

Indexing DDM structures may fail when text values exceed the maximum length.  Treat them the same way as rich text fields, truncating the value before sending it to the indexer.

# How can you verify that it works?

This was breaking some of our tests. Run
```
$ cd asset-auto-tagger-opennlp-test && gw testIntegration --tests '*JournalArticleOpenNLPDocumentAssetAutoTaggerTest'
```

The tests will pass, but you should see failures in the logs.  After this fix, the failures no longer occur.