### PR TITLE
LPD-37341 Avoid dynamic Liferay.Language.get call

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
@@ -117,7 +117,7 @@ const FileSizeField = ({
 	);
 };
 
-const FileSizePerMimeType = ({
+const FileSizeMimetypes = ({
 	description = Liferay.Language.get('file-size-mime-type-description'),
 	portletNamespace,
 	sizeList: initialSizeList,
@@ -161,7 +161,7 @@ const FileSizePerMimeType = ({
 	);
 };
 
-FileSizePerMimeType.propTypes = {
+FileSizeMimetypes.propTypes = {
 	description: PropTypes.string,
 	portletNamespace: PropTypes.string.isRequired,
 	sizeList: PropTypes.arrayOf(
@@ -172,4 +172,4 @@ FileSizePerMimeType.propTypes = {
 	),
 };
 
-export default FileSizePerMimeType;
+export default FileSizeMimetypes;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
@@ -144,9 +144,7 @@ const FileSizePerMimeType = ({
 
 	return (
 		<>
-			<p className="mb-4 text-3 text-secondary">
-				{Liferay.Language.get(description)}
-			</p>
+			<p className="mb-4 text-3 text-secondary">{description}</p>
 
 			{sizesList.map((item, index) => (
 				<FileSizeField

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/index.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/index.js
@@ -1,6 +1,0 @@
-/**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
- */
-
-export {default as FileSizePerMimeType} from './file-size-limit/FileSizeMimetypes';


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37341

We need to avoid dynamic Liferay.Language.get calls. 
Better name and remove unused export

# How am I fixing it?

Removing the double Liferay.Language.get and, renaming the component to match with filename/export, removing the remove unused export

# How can you verify that it works?

Check the change and verify that all is working as expected:

### Documents and media

1. Go to the Applications menu
2. Control Panel tab
3. Instance / System Settings 
4. Documents and Media 
5. File size Limits
6. Check  **MIME TYPE LIMIT** section

![image](https://github.com/user-attachments/assets/f0c64925-3a39-4288-ac0c-998f62589723)

### Asset Libraries

>[!NOTE]
> Behind feature flag `LPS-114786`

1. Go to the Applications menu
2. Applications tab
3. Asset Libraries
4. Add new Asset library
5. Check  **MIME TYPE LIMIT** section

![image](https://github.com/user-attachments/assets/0e551724-d504-495d-b34b-29dbfff9e4b9)




# Why doesn't this include any test?

It isn't needed, only fix the dynamic Liferay.Language.get call and refactor code to make it more understandable and clean.

