### PR TITLE
LPD-38991 Vocabularies configured at site-level cannot be selected from widget page templates

### DIFF
--- a/modules/apps/asset/asset-taglib-test/build.gradle
+++ b/modules/apps/asset/asset-taglib-test/build.gradle
@@ -3,5 +3,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-taglib")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
+++ b/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
@@ -15,9 +15,13 @@ import com.liferay.asset.taglib.servlet.taglib.AssetCategoriesSelectorTag;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutPrototype;
+import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -30,6 +34,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -64,6 +69,12 @@ public class AssetCategoriesSelectorTagTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_layoutPrototype = _layoutPrototypeLocalService.addLayoutPrototype(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), true,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	@Test
@@ -108,9 +119,13 @@ public class AssetCategoriesSelectorTagTest {
 		assetCategoriesSelectorTag.setClassPK(
 			journalArticle.getResourcePrimKey());
 
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
 		ReflectionTestUtil.setFieldValue(
 			assetCategoriesSelectorTag, "_httpServletRequest",
-			_getMockHttpServletRequest());
+			_getMockHttpServletRequest(themeDisplay));
 
 		List<String[]> categoryIdsTitles = ReflectionTestUtil.invoke(
 			assetCategoriesSelectorTag, "getCategoryIdsTitles",
@@ -142,13 +157,40 @@ public class AssetCategoriesSelectorTagTest {
 			categoryIdsTitle[1]);
 	}
 
-	private HttpServletRequest _getMockHttpServletRequest() {
-		HttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
+	@Test
+	public void testGetGroupIdsWithLayoutPrototype() throws Exception {
+		_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0, 0,
+			RandomTestUtil.randomString(),
+			LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE, 0, true,
+			_layoutPrototype.getLayoutPrototypeId(), 0, 0,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		AssetCategoriesSelectorTag assetCategoriesSelectorTag =
+			new AssetCategoriesSelectorTag();
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		ReflectionTestUtil.setFieldValue(
+			assetCategoriesSelectorTag, "_httpServletRequest",
+			_getMockHttpServletRequest(themeDisplay));
+
+		long[] groupIds = ReflectionTestUtil.invoke(
+			assetCategoriesSelectorTag, "getGroupIds", new Class<?>[0]);
+
+		Assert.assertNotNull(groupIds);
+
+		Assert.assertEquals(_group.getGroupId(), groupIds[0]);
+	}
+
+	private HttpServletRequest _getMockHttpServletRequest(
+		ThemeDisplay themeDisplay) {
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -164,5 +206,15 @@ public class AssetCategoriesSelectorTagTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@DeleteAfterTestRun
+	private LayoutPrototype _layoutPrototype;
+
+	@Inject
+	private LayoutPrototypeLocalService _layoutPrototypeLocalService;
 
 }

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -19,17 +19,24 @@ import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.learn.LearnMessage;
 import com.liferay.learn.LearnMessageUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -280,7 +287,7 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 			if (ArrayUtil.isEmpty(_groupIds)) {
 				return SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						themeDisplay.getScopeGroupId());
+						_getGroupId(themeDisplay.getScopeGroup()));
 			}
 
 			return SiteConnectedGroupGroupProviderUtil.
@@ -452,6 +459,28 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+	}
+
+	private long _getGroupId(Group group) throws PortalException {
+		if (group.isLayoutPrototype()) {
+			LayoutPrototype layoutPrototype =
+				LayoutPrototypeLocalServiceUtil.getLayoutPrototype(
+					group.getClassPK());
+
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				LayoutPageTemplateEntryLocalServiceUtil.
+					fetchFirstLayoutPageTemplateEntry(
+						layoutPrototype.getLayoutPrototypeId());
+
+			if ((layoutPageTemplateEntry != null) &&
+				(layoutPageTemplateEntry.getGroupId() > 0)) {
+
+				group = GroupLocalServiceUtil.getGroup(
+					layoutPageTemplateEntry.getGroupId());
+			}
+		}
+
+		return group.getGroupId();
 	}
 
 	private String _getId() {


### PR DESCRIPTION
Vocabularies configured at site-level cannot be selected from widget page templates

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-38991)

Categories taglib is not working for page templates in a given site, this is because we are using the groupId of the page template, not the ID of the site when retrieving the vocabularies
# How am I fixing it?

Use the correct groupId

# How can you verify that it works?

Run the integration tests, or follow the steps in the ticket
