### PR TITLE
LPD-38819 Honoring the configuration when calling a file without permissions

### DIFF
--- a/modules/apps/portal/portal-webserver-test/bnd.bnd
+++ b/modules/apps/portal/portal-webserver-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Webserver Test
+Bundle-SymbolicName: com.liferay.portal.webserver.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal/portal-webserver-test/build.gradle
+++ b/modules/apps/portal/portal-webserver-test/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
+++ b/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2024-09
+ */
+
+package com.liferay.portal.webserver.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.webserver.WebServerServlet;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+public class WebServerServletTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_user = UserLocalServiceUtil.getGuestUser(_group.getCompanyId());
+	}
+
+	@Test
+	public void testWebServerServletResponseWhenGuestAndAuthLoginIsDisabled()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.login.web.internal.configuration." +
+						"AuthLoginConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"promptEnabled", false
+					).build())) {
+
+			_testWebServerServletResponse(HttpServletResponse.SC_NOT_FOUND);
+		}
+	}
+
+	@Test
+	public void testWebServerServletResponseWhenGuestAndAuthLoginIsEnabled()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.login.web.internal.configuration." +
+						"AuthLoginConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"promptEnabled", true
+					).build())) {
+
+			_testWebServerServletResponse(
+				HttpServletResponse.SC_MOVED_TEMPORARILY);
+		}
+	}
+
+	private void _removeResourcePermission(
+			long fileEntryId, String roleName, String actionId)
+		throws Exception {
+
+		Role guestRole = RoleLocalServiceUtil.getRole(
+			_group.getCompanyId(), roleName);
+
+		ResourcePermissionLocalServiceUtil.removeResourcePermission(
+			_group.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(fileEntryId),
+			guestRole.getRoleId(), actionId);
+	}
+
+	private void _testWebServerServletResponse(int status) throws Exception {
+		User guestUser = UserLocalServiceUtil.getGuestUser(
+			_group.getCompanyId());
+
+		Repository repository = _repositoryLocalService.addRepository(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			PortalUtil.getClassNameId(LiferayRepository.class.getName()),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			PortletKeys.BACKGROUND_TASK, StringPool.BLANK,
+			PortletKeys.BACKGROUND_TASK, new UnicodeProperties(), true,
+			ServiceContextTestUtil.getServiceContext());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		Folder folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), repository.getRepositoryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			serviceContext);
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), repository.getRepositoryId(),
+			folder.getFolderId(), RandomTestUtil.randomString() + ".txt",
+			ContentTypes.TEXT_PLAIN, TestDataConstants.TEST_BYTE_ARRAY, null,
+			null, null, serviceContext);
+
+		_removeResourcePermission(
+			fileEntry.getFileEntryId(), RoleConstants.OWNER,
+			ActionKeys.DOWNLOAD);
+		_removeResourcePermission(
+			fileEntry.getFileEntryId(), RoleConstants.SITE_MEMBER,
+			ActionKeys.DOWNLOAD);
+		_removeResourcePermission(
+			fileEntry.getFileEntryId(), RoleConstants.GUEST,
+			ActionKeys.DOWNLOAD);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, guestUser);
+		mockHttpServletRequest.setRequestURI(
+			StringBundler.concat(
+				"/", repository.getRepositoryId(), "/", fileEntry.getUuid()));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_webServerServlet.service(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(status, mockHttpServletResponse.getStatus());
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLURLHelper _dlURLHelper;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
+
+	private User _user;
+	private final WebServerServlet _webServerServlet = new WebServerServlet();
+
+}

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.login.AuthLoginGroupSettingsUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
@@ -1606,9 +1607,23 @@ public class WebServerServlet extends HttpServlet {
 			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 				FileEntry.class.getName());
 
-		fileEntryModelResourcePermission.check(
-			permissionChecker, fileEntry.getFileEntryId(),
-			_getActionId(httpServletRequest));
+		try {
+			fileEntryModelResourcePermission.check(
+				permissionChecker, fileEntry.getFileEntryId(),
+				_getActionId(httpServletRequest));
+		}
+		catch (PortalException portalException) {
+			User user = permissionChecker.getUser();
+
+			if (user.isGuestUser() &&
+				!AuthLoginGroupSettingsUtil.isPromptEnabled(
+					fileEntry.getGroupId())) {
+
+				throw new NoSuchFileEntryException(portalException);
+			}
+
+			throw portalException;
+		}
 
 		FileVersion fileVersion = fileEntry.getFileVersion();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMPermissions.testcase
@@ -1396,48 +1396,6 @@ definition {
 			value1 = "You do not have the required permissions.");
 	}
 
-	@description = "This is a test for LPS-136852. It checks that a guest cannot access a folder image without permissions."
-	@priority = 4
-	test GuestCannotAccessFolderImageThroughURLWithoutPermissions {
-		property portal.upstream = "true";
-
-		JSONFolder.addFolder(
-			dmFolderDescription = "DM Folder Description",
-			dmFolderName = "DM Folder Name",
-			groupName = "Guest",
-			guestPermissions = "false");
-
-		JSONDocument.addFileWithUploadedFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			folderName = "DM Folder Name",
-			groupName = "Guest",
-			mimeType = "image/jpeg",
-			sourceFileName = "Document_1.jpg");
-
-		DMNavigator.openToFolderInAdmin(
-			dmFolderName = "DM Folder Name",
-			groupName = "Guest",
-			siteURLKey = "guest");
-
-		DMNavigator.gotoDocumentPermissionsCP(dmDocumentTitle = "DM Document Title");
-
-		PermissionsInline.addOrRemoveAnyPermissionsFromSpecificRole(
-			addOrRemoveViewPermission = "Remove",
-			permissionsKeyList = "INLINE_PERMISSIONS_DOWNLOAD_CHECKBOX",
-			roleTitle = "Guest");
-
-		var dmDocumentURL = JSONDocument.getLatestVersionURL(
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Guest");
-
-		User.logoutPG();
-
-		Navigator.openSpecificURL(url = ${dmDocumentURL});
-
-		User.viewLoginPG();
-	}
-
 	@description = "This is a test for LPS-136833. It checks that a guest cannot add a document in a folder without permissions."
 	@priority = 3
 	test GuestCannotAddDocumentInFolder {


### PR DESCRIPTION
# What is this trying to solve?

[{[url](https://liferay.atlassian.net/browse/LPD-38819)}](https://liferay.atlassian.net/browse/LPD-38819)

Current behavior of WebServerServlet is not honoring the prompt configuration

# How am I fixing it?

Checking this configuration to avoid showing the page when this is configured this way

# How can you verify that it works?

Run the included automated tests.