### PR TITLE
LPD-37088 Fix test after wordsmith (follow up)

### DIFF
--- a/modules/apps/notifications/notifications-web/src/test/java/com/liferay/notifications/web/internal/portlet/NotificationsPortletTest.java
+++ b/modules/apps/notifications/notifications-web/src/test/java/com/liferay/notifications/web/internal/portlet/NotificationsPortletTest.java
@@ -137,9 +137,9 @@ public class NotificationsPortletTest {
 		return String.format(
 			"No user notification definition found for class name ID %d, " +
 				"notification type %d, and portlet %s",
-			userNotificationDelivery.getPortletId(),
 			userNotificationDelivery.getClassNameId(),
-			userNotificationDelivery.getNotificationType());
+			userNotificationDelivery.getNotificationType(),
+			userNotificationDelivery.getPortletId());
 	}
 
 	private MockLiferayPortletActionRequest


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37088

The NotificationsPortlet test is failing because of a wrongly applied wordsmith in this [commit](https://github.com/brianchandotcom/liferay-portal/commit/f46affb4e96ca8653920af916408e7f3b8530824)

# How am I fixing it?

Changing `String.format` parameters order.

# How can you verify that it works?

`cd modules/apps/notifications/notifications-web`
`gw test --tests NotificationsPortletTest`
