### PR TITLE
LPD-39007 Use correct URL

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -407,11 +407,8 @@ public class UIItemsBuilder {
 
 	public DropdownItem createHistoryDropdownItem() {
 		return DropdownItemBuilder.setHref(
-			PortletURLBuilder.create(
-				_getRenderURL("/document_library/view_file_entry_history")
-			).setBackURL(
-				_getCurrentURL()
-			).buildPortletURL()
+			_getControlPanelRenderURL(
+				"/document_library/view_file_entry_history", _getCurrentURL())
 		).setIcon(
 			"date-time"
 		).setKey(


### PR DESCRIPTION
Clicking "View History" from Documents and Media portlet leads to empty page

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-39007)

Code was using an incorrect URL and redirecting to a non existing page

# How am I fixing it?

Use correct URL

# Why doesn't this include any test?

We already have a poshi test for this at control panel level