### PR TITLE
LPD-38995 [playwright] Fix test 'Web Content version, status and ID are shown and updated after auto save'

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -591,9 +591,7 @@ autoSaveTest(
 
 		await journalEditArticlePage.fillTitle(title);
 
-		await expect(
-			journalEditArticlePage.changesSavedIndicator
-		).toBeVisible();
+		await journalEditArticlePage.changesSavedIndicator.waitFor();
 
 		await openFieldset(page, 'Basic Information');
 

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -15,6 +15,7 @@ import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
+import {openFieldset} from '../../utils/openFieldset';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 import getDataStructureDefinition from './utils/getDataStructureDefinition';
@@ -594,7 +595,7 @@ autoSaveTest(
 			journalEditArticlePage.changesSavedIndicator
 		).toBeVisible();
 
-		await page.getByRole('link', {name: 'Basic Information'}).click();
+		await openFieldset(page, 'Basic Information');
 
 		await expect(page.getByText('1.0')).toBeVisible();
 
@@ -625,7 +626,7 @@ autoSaveTest(
 			).toBeVisible();
 		}).toPass();
 
-		await page.getByRole('link', {name: 'Basic Information'}).click();
+		await openFieldset(page, 'Basic Information');
 
 		await expect(page.getByText('1.1')).toBeVisible();
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38995

Fix test 'Web Content version, status, and ID are shown and updated after autosave' (journalArticleAutosave.spec.ts) 

# How am I fixing it?

Updating the broken locator and use the new utility openFieldset

# How can you verify that it works?

1. Go to /modules/test/playwright
1. Run npm install (setup)
1. Run npm run `npm run playwright test -- -g @LPD-32874` to run the test


# Before the PR

![image](https://github.com/user-attachments/assets/07d9ded9-01f8-44ad-bf31-6e2233c6ec12)


# After the PR (launched 10 times to avoid flaky results)

```sh
npm run playwright test -- -g @LPD-32874 --repeat-each 10 --reporter list
```

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/4ef8d1ef-5079-4209-9d60-deaf707a29a2">
