### PR TITLE
LPD-39017 Fix flaky test DMFileEntry#CanDownloadWithSpecialCharactersInTitle

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -898,10 +898,10 @@ definition {
 		var downloadedFile = FileUtil.exists("${tempDir}/${fileName}");
 
 		if (${downloadedFile} == "true") {
-			echo("This is a correct file name.");
+			echo("There is a file named ${fileName} in temp folder ${tempDir}");
 		}
 		else {
-			fail("FAIL!");
+			fail("There is no file named ${fileName} in temp folder ${tempDir}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -1446,6 +1446,8 @@ definition {
 
 		DMDocument.downloadPG(dmDocumentTitle = "/D/M/@!# Title");
 
+		DownloadTempFile();
+
 		DMDocument.assertFileNameFromTempFolder(fileName = "Document_1.doc");
 	}
 
@@ -1815,6 +1817,8 @@ definition {
 		Navigator.gotoPage(pageName = "Documents and Media Page");
 
 		DMDocument.downloadPG(dmDocumentTitle = "Document_3.doc");
+
+		DownloadTempFile();
 
 		DMDocument.assertFileNameFromTempFolder(fileName = "Document_3.doc");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39017

There is a flaky a test that some times doesn't find a downloaded file.

# How am I fixing it?

I'm applying the same solution done [here](https://github.com/brianchandotcom/liferay-portal/pull/132759/commits/ff6e0b8589e652c4c9d7db9472fde07cd7d723d1) where a pause is added after the download. This solution has been applied in other places too.

# How can you verify that it works?

Run POSHI test: `ant -f build-test.xml run-selenium-test -Dtest.class=DMFileEntry#CanDownloadWithSpecialCharactersInTitle`
