### PR TITLE
LPD-38760 Cannot display image added through the item selector to a blogs entry

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,10 +25,6 @@
 			max-width: 100%;
 		}
 
-		img[data-cke-saved-src]:not([data-fileentryid]) {
-			visibility: hidden;
-		}
-
 		.cover-image-container {
 			background-position: center;
 			background-repeat: no-repeat;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38760

An image inserted into a Blog entry from the URL tab of the image selector is not visible.

# How am I fixing it?

Removing an entry added to the CSS when this bug was fixed: 

* Jira issue: [Copy and pasted images appear twice in blogs entry alloy editor](https://liferay.atlassian.net/browse/LPS-195447) 
* PR: [LPS-195447 Remove image added by ckeditor](https://github.com/liferay-frontend/liferay-portal/pull/3680/commits/77826f3b24e5f52a4c8a2d6270f5b6fdf7dc9e9a)

I've manually checked that reverting this change didn't make the old bug to reproduce.

# How can you verify that it works?

Run POSHI test:
`ant -f build-test.xml run-selenium-test -Dtest.class=ItemSelector#CanAddBlogsImageViaURL`
