### PR TITLE
LPD-39083 Ordering by a datetime field in a structure is not possible in the Asset Publisher

### DIFF
--- a/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/model/DDMStructureClassType.java
+++ b/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/model/DDMStructureClassType.java
@@ -111,9 +111,10 @@ public class DDMStructureClassType implements ClassType {
 	}
 
 	private static final String[] _SELECTABLE_DDM_STRUCTURE_FIELDS = {
-		"checkbox", "checkbox_multiple", "date", "ddm-date", "ddm-decimal",
-		"ddm-image", "ddm-integer", "ddm-number", "ddm-text-html", "image",
-		"numeric", "radio", "rich_text", "select", "text", "textarea"
+		"checkbox", "checkbox_multiple", "date", "date_time", "ddm-date",
+		"ddm-decimal", "ddm-image", "ddm-integer", "ddm-number",
+		"ddm-text-html", "image", "numeric", "radio", "rich_text", "select",
+		"text", "textarea"
 	};
 
 	private final long _classTypeId;

--- a/modules/apps/asset/asset-test/build.gradle
+++ b/modules/apps/asset/asset-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:bookmarks:bookmarks-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/model/test/DDMStructureClassTypeTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/model/test/DDMStructureClassTypeTest.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.model.DDMStructureClassType;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class DDMStructureClassTypeTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		DataDefinitionResource.Builder dataDefinitionResourceBuilder =
+			_dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource =
+			dataDefinitionResourceBuilder.user(
+				TestPropsValues.getUser()
+			).build();
+
+		DataDefinition dataDefinition =
+			dataDefinitionResource.postSiteDataDefinitionByContentType(
+				_group.getGroupId(), "journal",
+				DataDefinition.toDTO(
+					StringUtil.read(
+						DDMStructureClassTypeTest.class,
+						"dependencies/data-definition.json")));
+
+		_ddmStructureClassType = new DDMStructureClassType(
+			dataDefinition.getId(), StringUtil.randomString(),
+			_language.getLanguageId(LocaleUtil.US));
+	}
+
+	@Test
+	public void testClassTypeFieldsContainsDateTime() throws Exception {
+		Assert.assertTrue(
+			ListUtil.exists(
+				_ddmStructureClassType.getClassTypeFields(),
+				classTypeField -> Objects.equals(
+					classTypeField.getType(), "date_time")));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	private DDMStructureClassType _ddmStructureClassType;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Language _language;
+
+}

--- a/modules/apps/asset/asset-test/src/testIntegration/resources/com/liferay/asset/model/test/dependencies/data-definition.json
+++ b/modules/apps/asset/asset-test/src/testIntegration/resources/com/liferay/asset/model/test/dependencies/data-definition.json
@@ -1,0 +1,980 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"autocomplete": false,
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataSourceType": "",
+				"dataType": "string",
+				"ddmDataProviderInstanceId": [
+				],
+				"ddmDataProviderInstanceOutput": [
+				],
+				"direction": [
+					"vertical"
+				],
+				"displayStyle": "singleline",
+				"fieldNamespace": "",
+				"fieldReference": "Text",
+				"hideField": false,
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"options": {
+				},
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Text"
+			},
+			"localizable": true,
+			"name": "Text64732942",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataType": "string",
+				"direction": [
+					"vertical"
+				],
+				"displayStyle": "multiline",
+				"fieldNamespace": "",
+				"fieldReference": "TextBox",
+				"hideField": false,
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"objectFieldName": "",
+				"options": {
+				},
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Text Box"
+			},
+			"localizable": true,
+			"name": "Text99999474",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "boolean",
+				"fieldNamespace": "",
+				"fieldReference": "Boolean",
+				"labelAtStructureLevel": true,
+				"objectFieldName": "",
+				"options": {
+				},
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"showAsSwitcher": false,
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": [
+					"false"
+				]
+			},
+			"fieldType": "checkbox",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Boolean"
+			},
+			"localizable": true,
+			"name": "Checkbox24957546",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"alphabeticalOrder": false,
+				"dataSourceType": [
+					"manual"
+				],
+				"dataType": "string",
+				"ddmDataProviderInstanceId": [
+				],
+				"ddmDataProviderInstanceOutput": [
+				],
+				"fieldNamespace": "",
+				"fieldReference": "SelectfromList",
+				"labelAtStructureLevel": true,
+				"multiple": false,
+				"nativeField": false,
+				"options": {
+					"en_US": [
+						{
+							"label": "Option 2",
+							"reference": "Value2",
+							"value": "Option65341849"
+						},
+						{
+							"label": "Option 1",
+							"reference": "Value1",
+							"value": "Option23365180"
+						}
+					]
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "select",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Select from List"
+			},
+			"localizable": true,
+			"name": "Select60136457",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldNamespace": "",
+				"fieldReference": "SingleSelection",
+				"inline": true,
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"options": {
+					"en_US": [
+						{
+							"label": "Option 3",
+							"reference": "Value3",
+							"value": "Option27442039"
+						},
+						{
+							"label": "Option 4",
+							"reference": "Value4",
+							"value": "Option20453846"
+						}
+					]
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "radio",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Single Selection"
+			},
+			"localizable": true,
+			"name": "Radio38512506",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldNamespace": "",
+				"fieldReference": "MultipleSelection",
+				"inline": false,
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"options": {
+					"en_US": [
+						{
+							"label": "Option 1",
+							"reference": "First",
+							"value": "Option56731693"
+						},
+						{
+							"label": "Option 2",
+							"reference": "Second",
+							"value": "Option48850459"
+						}
+					]
+				},
+				"showAsSwitcher": false,
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "checkbox_multiple",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Multiple Selection"
+			},
+			"localizable": true,
+			"name": "CheckboxMultiple73287927",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"columns": {
+					"en_US": [
+						{
+							"label": "Column 1",
+							"reference": "C1",
+							"value": "Option09351750"
+						},
+						{
+							"label": "Column 2",
+							"reference": "C2",
+							"value": "Option49092210"
+						}
+					]
+				},
+				"dataType": "string",
+				"fieldNamespace": "",
+				"fieldReference": "Grid",
+				"rows": {
+					"en_US": [
+						{
+							"label": "Row 1",
+							"reference": "R1",
+							"value": "Option16650028"
+						},
+						{
+							"label": "Row 2",
+							"reference": "R2",
+							"value": "Option17304925"
+						}
+					]
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "grid",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Grid"
+			},
+			"localizable": true,
+			"name": "Grid61627830",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "date",
+				"fieldNamespace": "",
+				"fieldReference": "Date",
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "date",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Date"
+			},
+			"localizable": true,
+			"name": "Date49356527",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"characterOptions": false,
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataType": "integer",
+				"direction": [
+					"vertical"
+				],
+				"fieldNamespace": "",
+				"fieldReference": "Numeric",
+				"hideField": false,
+				"inputMask": false,
+				"inputMaskFormat": {
+					"en_US": ""
+				},
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"numericInputMask": {
+					"en_US": {
+						"append": "",
+						"appendType": "prefix",
+						"decimalPlaces": 2,
+						"symbols": {
+							"decimalSymbol": ".",
+							"thousandsSeparator": "none"
+						}
+					}
+				},
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "numeric",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Numeric"
+			},
+			"localizable": true,
+			"name": "Numeric91272581",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"characterOptions": false,
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataType": "double",
+				"direction": [
+					"vertical"
+				],
+				"fieldNamespace": "",
+				"fieldReference": "Decimal",
+				"hideField": false,
+				"inputMask": false,
+				"inputMaskFormat": {
+					"en_US": ""
+				},
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"numericInputMask": {
+					"en_US": {
+						"append": "",
+						"appendType": "prefix",
+						"decimalPlaces": 2,
+						"symbols": {
+							"decimalSymbol": ".",
+							"thousandsSeparator": "none"
+						}
+					}
+				},
+				"objectFieldName": "",
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "numeric",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Decimal"
+			},
+			"localizable": true,
+			"name": "Numeric55889582",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "image",
+				"fieldNamespace": "",
+				"fieldReference": "Image",
+				"requiredDescription": true,
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "image",
+			"indexType": "text",
+			"indexable": true,
+			"label": {
+				"en_US": "Image"
+			},
+			"localizable": true,
+			"name": "Image58474198",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldNamespace": "",
+				"fieldReference": "RichText",
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "rich_text",
+			"indexType": "text",
+			"indexable": true,
+			"label": {
+				"en_US": "Rich Text"
+			},
+			"localizable": true,
+			"name": "RichText15369611",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"allowGuestUsers": false,
+				"dataType": "document-library",
+				"fieldNamespace": "",
+				"fieldReference": "Upload",
+				"labelAtStructureLevel": true,
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "document_library",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Upload"
+			},
+			"localizable": true,
+			"name": "DocumentLibrary77513015",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldNamespace": "",
+				"fieldReference": "Color",
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "color",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Color"
+			},
+			"localizable": true,
+			"name": "Color34453553",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "journal-article",
+				"fieldNamespace": "",
+				"fieldReference": "WebContent",
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "journal_article",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Web Content"
+			},
+			"localizable": true,
+			"name": "JournalArticle28518732",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "geolocation",
+				"fieldReference": "Geolocation"
+			},
+			"defaultValue": {
+			},
+			"fieldType": "geolocation",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Geolocation"
+			},
+			"localizable": true,
+			"name": "Geolocation35256075",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "link-to-page",
+				"fieldNamespace": "",
+				"fieldReference": "LinktoPage",
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+			},
+			"fieldType": "link_to_layout",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Link to Page"
+			},
+			"localizable": true,
+			"name": "LinkToLayout10347031",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "",
+				"fieldReference": "Separator",
+				"rulesConditionDisabled": true,
+				"style": {
+					"en_US": ""
+				}
+			},
+			"defaultValue": {
+			},
+			"fieldType": "separator",
+			"indexable": false,
+			"label": {
+				"en_US": "Separator"
+			},
+			"localizable": false,
+			"name": "Separator70903507",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "datetime",
+				"fieldReference": "DateAndTime",
+				"objectFieldName": "",
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"rulesActionDisabled": true,
+				"rulesConditionDisabled": true
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "date_time",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Date and Time"
+			},
+			"localizable": false,
+			"name": "DateTime23546209",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Text64732942"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Text99999474"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Checkbox24957546"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Select60136457"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Radio38512506"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"CheckboxMultiple73287927"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Grid61627830"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Date49356527"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Numeric91272581"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Numeric55889582"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Image58474198"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"RichText15369611"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"DocumentLibrary77513015"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Color34453553"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"JournalArticle28518732"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Geolocation35256075"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"LinkToLayout10347031"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Separator70903507"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"DateTime23546209"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "WC Structure Name"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "WC Structure Name"
+	},
+	"storageType": "default"
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39083

It is not possible to sort entries by fields of type "Date and Time" in Asset Publisher.

# How am I fixing it?

By including the field "date_time" in the set of supported field types.

# How can you verify that it works?

Run the included integration test:
```
$ cd asset-test && gw testIntegration --tests '*DDMStructureClassTypeTest'
```