### PR TITLE
LPD-39077 Fix KBDisplayWidget#CanViewCustomFriendlyURL and KBDisplayWidget#CanViewDefaultFriendlyURL

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBDisplayWidget.testcase
@@ -623,7 +623,7 @@ definition {
 		for (var num : list "1,2") {
 			KBDisplayWidget.gotoViaKBDisplayPG(kbArticleTitle = "KB Article Title${num}");
 
-			AssertLocation(value1 = "${portalURL}/web/guest/knowledge-base-display-page/-/knowledge_base/custom-friendly-url${num}");
+			AssertLocation(value1 = "${portalURL}/web/guest/knowledge-base-display-page/-/knowledge_base/custom-friendly-url${num}?_com_liferay_knowledge_base_web_portlet_DisplayPortlet_urlTitle=custom-friendly-url${num}");
 		}
 	}
 
@@ -644,7 +644,7 @@ definition {
 		for (var num : list "1,2") {
 			KBDisplayWidget.gotoViaKBDisplayPG(kbArticleTitle = "KB Article Title${num}");
 
-			AssertLocation(value1 = "${portalURL}/web/guest/knowledge-base-display-page/-/knowledge_base/kb-article-title${num}");
+			AssertLocation(value1 = "${portalURL}/web/guest/knowledge-base-display-page/-/knowledge_base/kb-article-title${num}?_com_liferay_knowledge_base_web_portlet_DisplayPortlet_urlTitle=kb-article-title${num}");
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39077

The 2 POSHI tests are failing because the expected URL is different.

# How am I fixing it?

I've just added the missing parameter in the URL.

# How can you verify that it works?

Run POSHI tests:

* `ant -f build-test.xml run-selenium-test -Dtest.class=KBDisplayWidget#CanViewDefaultFriendlyURL`
* `ant -f build-test.xml run-selenium-test -Dtest.class=KBDisplayWidget#CanViewCustomFriendlyURL`

Note: the tests in local are still failing, only because in CI the URL expects this additional path: `/web/guest` . I don't know how to add it in local.