### PR TITLE
Cannot add linebreaks in Message Boards with BBCode format

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -434,7 +434,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		body = SanitizerUtil.sanitize(
 			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
-			messageId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, body,
+			messageId, "text/" + format, Sanitizer.MODE_ALL, body,
 			HashMapBuilder.<String, Object>put(
 				"discussion",
 				() -> {
@@ -2801,7 +2801,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		body = SanitizerUtil.sanitize(
 			message.getCompanyId(), message.getGroupId(), userId,
-			MBMessage.class.getName(), messageId, ContentTypes.TEXT_HTML,
+			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
 			Sanitizer.MODE_ALL, body,
 			HashMapBuilder.<String, Object>put(
 				"discussion", message.isDiscussion()

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -89,6 +89,25 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
+	public void testAddBBCodeSubjectWithLineBreakInBodyInBBCode()
+		throws Exception {
+
+		String subject = "<u>subject</u>";
+		String body = "a\nbc";
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+
+		MBMessage message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, "bbcode", inputStreamOVPs, false, 0.0, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(body, message.getBody());
+	}
+
+	@Test
 	public void testAddHtmlSubjectWithEmptyBodyMessage() throws Exception {
 		String subject = "<u>subject</u>";
 		String body = StringPool.BLANK;


### PR DESCRIPTION
[Link to issue ](https://liferay.atlassian.net/browse/LPD-39135) Cannot add linebreaks in Message Boards with BBCode format

# How am I fixing it. 
This bug was introduced by https://github.com/brianchandotcom/liferay-portal/pull/141654/files. I am reverting the change and checking that there is currently no XSS issue by running these functional tests: 
- MBThread#CannotPublishThreadWithTagContainingJavaScript
- MBThread#CanViewBBCodeNoXSSWithRemoteServices
- MBThread#JavascriptIsNotExecutedInBBCodeBody
- MBThread#JavascriptIsNotExecutedInHTMLBody

Also I have added a playwright test to cover that linebreaks can be added in BBCode (the default configuration)


![Screenshot 2024-10-14 at 13 49 19](https://github.com/user-attachments/assets/596623f8-b600-43ea-b8a4-eaad79b5f838)
