### PR TITLE
LPD-39146 Fix Poshi: add connectSite to the Asset Library

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesForWebContentArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesForWebContentArticle.testcase
@@ -247,6 +247,10 @@ definition {
 
 			PageEditor.publish();
 
+			JSONDepot.connectSite(
+				depotName = "Test Depot Name",
+				groupName = "Test Site Name");
+
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "global");
 
 			NavItem.gotoStructures();


### PR DESCRIPTION
Hi,

I would like to kindly ask to review this PR

Addressing DisplayPageTemplatesForWebContentArticle#PreviewWebContentThroughTheDisplayPageOfSpecificSiteInAssetLibrary Test failure. https://liferay.atlassian.net/browse/LPD-39146.

**Solution**:
The test should connect the asset library to the site before it can be linked to web content.

Thanks in advance!