### PR TITLE
LPD-39218 Validate allowed DL File Extensions in MB

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandler.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandler.java
@@ -41,10 +41,14 @@ public abstract class BaseMBUploadFileEntryHandler
 			(ThemeDisplay)uploadPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		String fileName = _getFileName(uploadPortletRequest);
+
+		_dlValidator.validateFileExtension(fileName);
+
+		String contentType = _getContentType(uploadPortletRequest);
+
 		_dlValidator.validateFileSize(
-			themeDisplay.getScopeGroupId(),
-			uploadPortletRequest.getFileName(getParameterName()),
-			uploadPortletRequest.getContentType(getParameterName()),
+			themeDisplay.getScopeGroupId(), fileName, contentType,
 			uploadPortletRequest.getSize(getParameterName()));
 
 		long categoryId = ParamUtil.getLong(uploadPortletRequest, "categoryId");
@@ -55,9 +59,8 @@ public abstract class BaseMBUploadFileEntryHandler
 			return _mbMessageService.addTempAttachment(
 				themeDisplay.getScopeGroupId(), categoryId,
 				MBMessageConstants.TEMP_FOLDER_NAME,
-				TempFileEntryUtil.getTempFileName(
-					_getFileName(uploadPortletRequest)),
-				inputStream, _getContentType(uploadPortletRequest));
+				TempFileEntryUtil.getTempFileName(fileName), inputStream,
+				contentType);
 		}
 	}
 

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/MBUploadFileEntryHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/MBUploadFileEntryHandlerTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.web.internal.upload;
+
+import com.liferay.document.library.kernel.exception.FileExtensionException;
+import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.message.boards.service.MBMessageService;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roberto Díaz
+ */
+public class MBUploadFileEntryHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test(expected = FileExtensionException.InvalidExtension.class)
+	public void testTestMBUploadFileEntryHandlerValidatesFileExtension()
+		throws Exception {
+
+		Mockito.doThrow(
+			FileExtensionException.InvalidExtension.class
+		).when(
+			_dlValidator
+		).validateFileExtension(
+			Mockito.anyString()
+		);
+
+		TestMBUploadFileEntryHandler testMBUploadFileEntryHandler =
+			new TestMBUploadFileEntryHandler(_dlValidator, _mbMessageService);
+
+		Mockito.when(
+			_uploadPortletRequest.getFileName(Mockito.anyString())
+		).thenReturn(
+			"TestFileName"
+		);
+
+		testMBUploadFileEntryHandler.upload(_uploadPortletRequest);
+	}
+
+	private final DLValidator _dlValidator = Mockito.mock(DLValidator.class);
+	private final MBMessageService _mbMessageService = Mockito.mock(
+		MBMessageService.class);
+	private final UploadPortletRequest _uploadPortletRequest = Mockito.mock(
+		UploadPortletRequest.class);
+
+	private static class TestMBUploadFileEntryHandler
+		extends BaseMBUploadFileEntryHandler {
+
+		public TestMBUploadFileEntryHandler(
+			DLValidator dlValidator, MBMessageService mbMessageService) {
+
+			super(dlValidator, mbMessageService);
+		}
+
+		@Override
+		protected String getParameterName() {
+			return "file";
+		}
+
+	}
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39218

Avoid let users add any extension type as MB attachment.

# How am I fixing it?

Adding a validation to limit the allowed MB attachments extensions based in DL limitations

# How can you verify that it works?

Run the included automated tests.