### PR TITLE
LPD-38520 | Wiki page userName does not match userId after changing parent

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_iterator.jsp
@@ -199,7 +199,7 @@ for (int i = 0; i < pages.size(); i++) {
 	// User
 
 	if (!curWikiPage.isNew()) {
-		row.addText(HtmlUtil.escape(PortalUtil.getUserName(curWikiPage)), rowURL);
+		row.addText(HtmlUtil.escape(curWikiPage.getUserName()), rowURL);
 	}
 	else {
 		row.addText(StringPool.BLANK);


### PR DESCRIPTION
Additional commit for the first pull. Found one more location with the wrong displaying.

----

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-38520

### How am I fixing it?
~~The _udate method used the old userId I fixed it by using the received userId.~~

To avoid breaking https://liferay.atlassian.net/browse/LPS-148306 I reverted my changes and instead changed the view_page.jsp,
there was a mismatch between the descriptive and list views.
[view_pages.jsp#L207(descriptive)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp#L207)
[view_pages.jsp#L254(list)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/view_pages.jsp#L254)
The difference was that the list view used the userId from the curPage while the descriptive used the userName from the curPage. Before LPS-148306 this was not an issue but after the id and the userName can be different.
There is an integration test for the backend use case so I did not make a test for this change as it should have been part of the original LPS.

### How can you verify that it works?

To test run:
`gw testIntegration --tests WikiPageLocalServiceTest.testUpdatePagePreservesOriginalOwner`

Or manually test based on the LPD steps

original pull: https://github.com/liferay-content-management/liferay-portal/pull/5951
