### PR TITLE
LPD-39302 Update locator due to changes in UI for Web Content articles

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -2082,7 +2082,7 @@ definition {
 
 	@summary = "Default summary"
 	macro viewAvailableLanguages(availableLanguageList = null, unavailableLanguageList = null) {
-		Click(locator1 = "Button#LOCALIZATION_GENERIC");
+		Click(locator1 = "Button#LOCALIZATION_TRANSLATED");
 
 		for (var availableLanguage : list ${availableLanguageList}) {
 			AssertElementPresent(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39302

# How am I fixing it?

The localization button was changed as part of https://liferay.atlassian.net/browse/LPD-35921. This updates the locator in order to find the button again. This macro is only used in one place and looks to be safe to update.

I'm sending this through your team since its a Journal macro but this is fixing a test failure within Site Management.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#ViewPortletInteractWithLocalization`