### PR TITLE
LPD-39287 Change ASTERISK_DATE_FIELD icon path, remove span

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Icon.path
@@ -62,7 +62,7 @@
 </tr>
 <tr>
 	<td>ASTERISK_DATE_FIELD</td>
-	<td>//label[contains(.,'${key_fieldFieldLabel}')]//span[*[name()='svg'][contains(@class,'icon-asterisk')]] | //label[contains(.,'${key_fieldFieldLabel}')]//span[contains(.,'*')]</td>
+	<td>//label[contains(.,'${key_fieldFieldLabel}')]//*[name()='svg'][contains(@class,'lexicon-icon-asterisk')] | //label[contains(.,'${key_fieldFieldLabel}')]//span[contains(.,'*')] | //span[contains(@class, 'ddm-label-required') and contains(@class, 'reference-mark')]//*[name()='svg'][contains(@class,'lexicon-icon-asterisk')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi,
May I ask to review this PR?

This is for https://liferay.atlassian.net/browse/LPD-39287.

**Rootcause**: Asterisk Icon changed, probably <span> was removed.

**Solution**: appended an OR section to the locator to get without span.

Thank you in advance!