### PR TITLE
LPD-39085 MB: can cancel and reply again

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/BaseEditor.js
@@ -80,6 +80,19 @@ const BaseEditor = forwardRef(
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, []);
 
+		const destroy = useCallback(() => {
+			console.log('destroy');
+			const editor = editorRef.current.editor;
+
+			if (editor) {
+				editor.instanceReady = false;
+
+				editor.destroy();
+
+				window[name] = null;
+			}
+		}, [name]);
+
 		const getHTML = useCallback(() => {
 			let data = contents;
 
@@ -126,6 +139,7 @@ const BaseEditor = forwardRef(
 
 		useEffect(() => {
 			window[name] = {
+				destroy,
 				getHTML,
 				getText() {
 					return contents;

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
@@ -250,10 +250,10 @@ class MBPortlet {
 		const bodyInput = document.getElementById(`${namespace}body`);
 
 		if (replyToMessageId) {
-			bodyInput.value =
-				window[
-					`${namespace}replyMessageBody${replyToMessageId}`
-				].getHTML();
+
+			const editorName =`${namespace}replyMessageBody${replyToMessageId}`;
+
+			bodyInput.value = window[editorName].getHTML();
 
 			submitForm(
 				document[`${namespace}addQuickReplyFm${replyToMessageId}`]

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -59,6 +59,20 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		);
 
 		if (addQuickReplyContainer) {
+			var editorName = '<portlet:namespace />replyMessageBody' + messageId;
+
+			if (window[editorName]) {
+				addQuickReplyContainer.classList.remove('hide');
+				addQuickReplyContainer.scrollIntoView(true);
+
+				Liferay.Util.toggleDisabled(
+					'#<portlet:namespace />replyMessageButton' + messageId,
+					true
+				);
+
+				return;
+			}
+
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/message_boards/get_edit_message_quick" var="editMessageQuickURL">
 				<portlet:param name="redirect" value="<%= currentURL %>" />
 			</liferay-portlet:resourceURL>
@@ -103,9 +117,6 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 					if (parentMessageIdInput) {
 						parentMessageIdInput.value = messageId;
 					}
-
-					var editorName =
-						'<portlet:namespace />replyMessageBody' + messageId;
 
 					Liferay.componentReady(editorName).then((editor) => {
 						editor.focus();

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -61,18 +61,6 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 		if (addQuickReplyContainer) {
 			var editorName = '<portlet:namespace />replyMessageBody' + messageId;
 
-			if (window[editorName]) {
-				addQuickReplyContainer.classList.remove('hide');
-				addQuickReplyContainer.scrollIntoView(true);
-
-				Liferay.Util.toggleDisabled(
-					'#<portlet:namespace />replyMessageButton' + messageId,
-					true
-				);
-
-				return;
-			}
-
 			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/message_boards/get_edit_message_quick" var="editMessageQuickURL">
 				<portlet:param name="redirect" value="<%= currentURL %>" />
 			</liferay-portlet:resourceURL>
@@ -103,6 +91,10 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 					return response.text();
 				})
 				.then((response) => {
+					if (window[editorName]) {
+						window[editorName].destroy();
+					}
+
 					addQuickReplyContainer.innerHTML = response;
 
 					Liferay.Util.runScriptsInElement(addQuickReplyContainer);
@@ -143,6 +135,12 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 
 		if (addQuickReplyContainer) {
 			addQuickReplyContainer.classList.add('hide');
+		}
+
+		var editorName = '<portlet:namespace />replyMessageBody' + messageId;
+
+		if (window[editorName]) {
+			window[editorName].destroy();
 		}
 
 		Liferay.Util.toggleDisabled(

--- a/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {messageBoardsPagesTest} from '../../fixtures/messageBoardsTest';
+import getRandomString from '../../utils/getRandomString';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	messageBoardsPagesTest,
+	loginTest()
+);
+
+test(
+	'Can reply, cancel and reply again to a thread',
+	{
+		tag: '@LPD-39085',
+	},
+	async ({messageBoardsEditThreadPage, page, site}) => {
+		await messageBoardsEditThreadPage.goto(site.friendlyUrlPath);
+
+		const mbTitle = getRandomString();
+
+		await messageBoardsEditThreadPage.publishNewBasicThread(
+			mbTitle,
+			site.friendlyUrlPath
+		);
+
+		await page.getByRole('button', { name: 'Reply' }).click();
+
+		await expect(messageBoardsEditThreadPage.bodyTextBox).toBeVisible();
+
+		await page.getByRole('button', { name: 'Cancel' }).click();
+
+		await page.getByRole('button', { name: 'Reply' }).click();
+
+		await expect(messageBoardsEditThreadPage.bodyTextBox).toBeVisible();
+	}
+);


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-39085)
The message "body" of Message Boards is not displayed after a Cancel

# How am I fixing it
The cancel button just hide the container, but the CKEditor is not removed. Reply was always creating it and executing the scripts. Thus, when reply is clicked, I decided to check if an editor already exists and avoid all these creation, and just show the section. 

# How can you verify it works: 
You can follow the steps on the issue, or just run `npm run playwright -- test -g 'LPD-39085' --reporter list`

```
npm run playwright -- test -g 'LPD-39085' --reporter list --repeat-each=5

> @liferay/playwright@1.0.0 playwright
> playwright "test" "-g" "LPD-39085" "--reporter" "list" "--repeat-each=5"


Running 5 tests using 1 worker

  ✓  1 [message-boards-web] › message-boards-web/mbThread.spec.ts:21:1 › Can reply, cancel and reply again to a thread (39.6s)
  ✓  2 [message-boards-web] › message-boards-web/mbThread.spec.ts:21:1 › Can reply, cancel and reply again to a thread (29.1s)
  ✓  3 [message-boards-web] › message-boards-web/mbThread.spec.ts:21:1 › Can reply, cancel and reply again to a thread (25.9s)
  ✓  4 [message-boards-web] › message-boards-web/mbThread.spec.ts:21:1 › Can reply, cancel and reply again to a thread (25.9s)
  ✓  5 [message-boards-web] › message-boards-web/mbThread.spec.ts:21:1 › Can reply, cancel and reply again to a thread (32.5s)

  5 passed (2.9m)
```
