### PR TITLE
LPD-39151 Fix flaky test SharingDLViewFileVersionDisplayContextTest

### DIFF
--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
@@ -214,7 +214,9 @@ public class SharingDLViewFileVersionDisplayContextTest {
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
-	@Inject
+	@Inject(
+		filter = "component.name=com.liferay.sharing.document.library.internal.display.context.SharingDLDisplayContextFactory"
+	)
 	private DLDisplayContextFactory _dlDisplayContextFactory;
 
 	@Inject


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39151

The integration test `SharingDLViewFileVersionDisplayContextTest` is flaky.

# How am I fixing it?

There are different `DLDisplayContextFactory` implementations but the test is not specifying any. I've tested that removing the desired implementation `SharingDLDisplayContextFactory` makes the test using a different one which makes the test to fail.

Now I've specified the implementation to use.

# How can you verify that it works?

The test still works:

`cd modules/apps/sharing/sharing-document-library-test`
`gw tI --tests SharingDLViewFileVersionDisplayContextTest`
