### PR TITLE
LPD-39274 Check if parent group has enabled to share the content with child site

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 6.0.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/group/provider/SiteConnectedGroupGroupProvider.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/group/provider/SiteConnectedGroupGroupProvider.java
@@ -23,10 +23,19 @@ public interface SiteConnectedGroupGroupProvider {
 		throws PortalException;
 
 	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
-			long groupId, boolean ddmStructuresAvailable)
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException;
+
+	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled,
+			boolean ddmStructuresAvailable)
 		throws PortalException;
 
 	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(long[] groupIds)
+		throws PortalException;
+
+	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
 		throws PortalException;
 
 }

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/util/SiteConnectedGroupGroupProviderUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/util/SiteConnectedGroupGroupProviderUtil.java
@@ -52,7 +52,7 @@ public class SiteConnectedGroupGroupProviderUtil {
 	}
 
 	public static long[] getCurrentAndAncestorSiteAndDepotGroupIds(
-			long groupId, boolean ddmStructuresAvailable)
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
 		throws PortalException {
 
 		SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider =
@@ -61,7 +61,22 @@ public class SiteConnectedGroupGroupProviderUtil {
 
 		return siteConnectedGroupGroupProvider.
 			getCurrentAndAncestorSiteAndDepotGroupIds(
-				groupId, ddmStructuresAvailable);
+				groupId, checkContentSharingWithChildrenEnabled);
+	}
+
+	public static long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled,
+			boolean ddmStructuresAvailable)
+		throws PortalException {
+
+		SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider =
+			_siteConnectedGroupGroupProviderUtil.
+				_getSiteConnectedGroupGroupProvider();
+
+		return siteConnectedGroupGroupProvider.
+			getCurrentAndAncestorSiteAndDepotGroupIds(
+				groupId, checkContentSharingWithChildrenEnabled,
+				ddmStructuresAvailable);
 	}
 
 	public static long[] getCurrentAndAncestorSiteAndDepotGroupIds(
@@ -74,6 +89,19 @@ public class SiteConnectedGroupGroupProviderUtil {
 
 		return siteConnectedGroupGroupProvider.
 			getCurrentAndAncestorSiteAndDepotGroupIds(groupIds);
+	}
+
+	public static long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		SiteConnectedGroupGroupProvider siteConnectedGroupGroupProvider =
+			_siteConnectedGroupGroupProviderUtil.
+				_getSiteConnectedGroupGroupProvider();
+
+		return siteConnectedGroupGroupProvider.
+			getCurrentAndAncestorSiteAndDepotGroupIds(
+				groupIds, checkContentSharingWithChildrenEnabled);
 	}
 
 	private SiteConnectedGroupGroupProviderUtil() {

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/group/provider/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/group/provider/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/util/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/group/provider/SiteConnectedGroupGroupProviderImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/group/provider/SiteConnectedGroupGroupProviderImpl.java
@@ -57,8 +57,17 @@ public class SiteConnectedGroupGroupProviderImpl
 	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(long groupId)
 		throws PortalException {
 
+		return getCurrentAndAncestorSiteAndDepotGroupIds(groupId, false);
+	}
+
+	@Override
+	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
 		return ArrayUtil.append(
-			_portal.getCurrentAndAncestorSiteGroupIds(groupId),
+			_portal.getCurrentAndAncestorSiteGroupIds(
+				groupId, checkContentSharingWithChildrenEnabled),
 			ListUtil.toLongArray(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
 					groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
@@ -67,11 +76,13 @@ public class SiteConnectedGroupGroupProviderImpl
 
 	@Override
 	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
-			long groupId, boolean ddmStructuresAvailable)
+			long groupId, boolean checkContentSharingWithChildrenEnabled,
+			boolean ddmStructuresAvailable)
 		throws PortalException {
 
 		return ArrayUtil.append(
-			_portal.getCurrentAndAncestorSiteGroupIds(groupId),
+			_portal.getCurrentAndAncestorSiteGroupIds(
+				groupId, checkContentSharingWithChildrenEnabled),
 			ListUtil.toLongArray(
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
 					groupId, ddmStructuresAvailable, QueryUtil.ALL_POS,
@@ -83,6 +94,14 @@ public class SiteConnectedGroupGroupProviderImpl
 	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(long[] groupIds)
 		throws PortalException {
 
+		return getCurrentAndAncestorSiteAndDepotGroupIds(groupIds, false);
+	}
+
+	@Override
+	public long[] getCurrentAndAncestorSiteAndDepotGroupIds(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
 		List<DepotEntry> depotEntries = new ArrayList<>();
 
 		for (long groupId : groupIds) {
@@ -92,7 +111,8 @@ public class SiteConnectedGroupGroupProviderImpl
 		}
 
 		return ArrayUtil.append(
-			_portal.getCurrentAndAncestorSiteGroupIds(groupIds),
+			_portal.getCurrentAndAncestorSiteGroupIds(
+				groupIds, checkContentSharingWithChildrenEnabled),
 			ListUtil.toLongArray(depotEntries, DepotEntry::getGroupId));
 	}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewMoreMenuItemsDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewMoreMenuItemsDisplayContext.java
@@ -146,7 +146,7 @@ public class DLViewMoreMenuItemsDisplayContext {
 				themeDisplay.getCompanyId(), folderId,
 				SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						themeDisplay.getScopeGroupId(), true),
+						themeDisplay.getScopeGroupId(), false, true),
 				displayTerms.getKeywords(), includeBasicFileEntryType,
 				_inherited, searchContainer.getStart(),
 				searchContainer.getEnd()),
@@ -154,7 +154,7 @@ public class DLViewMoreMenuItemsDisplayContext {
 				themeDisplay.getCompanyId(), folderId,
 				SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						themeDisplay.getScopeGroupId(), true),
+						themeDisplay.getScopeGroupId(), false, true),
 				displayTerms.getKeywords(), includeBasicFileEntryType,
 				_inherited));
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/collection/provider/DLFileEntryTypeRelatedInfoCollectionProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/collection/provider/DLFileEntryTypeRelatedInfoCollectionProvider.java
@@ -144,7 +144,7 @@ public class DLFileEntryTypeRelatedInfoCollectionProvider
 				ArrayUtil.contains(
 					SiteConnectedGroupGroupProviderUtil.
 						getCurrentAndAncestorSiteAndDepotGroupIds(
-							serviceContext.getScopeGroupId(), true),
+							serviceContext.getScopeGroupId(), false, true),
 					_dlFileEntryType.getGroupId())) {
 
 				return true;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
@@ -199,7 +199,7 @@ public class FileEntryInfoItemFormVariationsProvider
 		throws PortalException {
 
 		return SiteConnectedGroupGroupProviderUtil.
-			getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true);
+			getCurrentAndAncestorSiteAndDepotGroupIds(groupId, false, true);
 	}
 
 	private DLFileEntryType _getDLFileEntryTypeByFileEntryTypeKey(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDLObjectsMVCActionCommand.java
@@ -269,7 +269,7 @@ public class CopyDLObjectsMVCActionCommand extends BaseMVCActionCommand {
 
 		long[] groupIds =
 			_siteConnectedGroupGroupProvider.
-				getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true);
+				getCurrentAndAncestorSiteAndDepotGroupIds(groupId, false, true);
 
 		if (ArrayUtil.isEmpty(groupIds)) {
 			return DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT;
@@ -301,7 +301,7 @@ public class CopyDLObjectsMVCActionCommand extends BaseMVCActionCommand {
 
 		long[] groupIds =
 			_siteConnectedGroupGroupProvider.
-				getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true);
+				getCurrentAndAncestorSiteAndDepotGroupIds(groupId, false, true);
 
 		if (ArrayUtil.isEmpty(groupIds) ||
 			!ArrayUtil.contains(groupIds, folder.getGroupId())) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java
@@ -435,7 +435,8 @@ public class MenuItemProvider {
 		try {
 			return _dlFileEntryTypeService.getFolderFileEntryTypes(
 				_siteConnectedGroupGroupProvider.
-					getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true),
+					getCurrentAndAncestorSiteAndDepotGroupIds(
+						groupId, false, true),
 				folderId, inherited);
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMStructureItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMStructureItemSelectorViewDescriptor.java
@@ -129,7 +129,7 @@ public class DDMStructureItemSelectorViewDescriptor
 			groupIds =
 				SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_themeDisplay.getScopeGroupId(), true);
+						_themeDisplay.getScopeGroupId(), false, true);
 		}
 		else {
 			groupIds = new long[] {_themeDisplay.getScopeGroupId()};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMTemplateItemSelectorViewDescriptor.java
@@ -113,7 +113,7 @@ public class DDMTemplateItemSelectorViewDescriptor
 		long[] groupIds =
 			SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId(), true);
+					_themeDisplay.getScopeGroupId(), false, true);
 
 		ddmTemplateSearchContainer.setResultsAndTotal(
 			() -> DDMTemplateServiceUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -784,7 +784,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 					_dlFileEntryTypeLocalService.getFolderFileEntryTypes(
 						_siteConnectedGroupGroupProvider.
 							getCurrentAndAncestorSiteAndDepotGroupIds(
-								groupId, true),
+								groupId, false, true),
 						documentFolderId, true)) {
 
 				if (name.equals(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -324,7 +324,8 @@ public class JournalArticleModelValidator
 		List<DDMStructure> folderDDMStructures =
 			_journalFolderLocalService.getDDMStructures(
 				_siteConnectedGroupGroupProvider.
-					getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true),
+					getCurrentAndAncestorSiteAndDepotGroupIds(
+						groupId, false, true),
 				folderId, restrictionType);
 
 		for (DDMStructure folderDDMStructure : folderDDMStructures) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
@@ -32,10 +32,15 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.sites.kernel.util.Sites;
+
+import javax.portlet.PortletPreferences;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -209,6 +214,57 @@ public class JournalArticleLayoutDisplayPageProviderTest {
 		Assert.assertNotNull(
 			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
 				_group.getGroupId(), _journalArticle.getUrlTitle()));
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProviderParentJournalArticleContentSharingWithChildrenDisabled()
+		throws Exception {
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			_group.getCompanyId());
+
+		try {
+			portletPreferences.setValue(
+				PropsKeys.SITES_CONTENT_SHARING_WITH_CHILDREN_ENABLED,
+				String.valueOf(Sites.CONTENT_SHARING_WITH_CHILDREN_DISABLED));
+
+			Group childGroup = GroupTestUtil.addGroupToCompany(
+				_group.getCompanyId(), _group.getGroupId());
+
+			Assert.assertNull(
+				_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					childGroup.getGroupId(), _journalArticle.getUrlTitle()));
+		}
+		finally {
+			portletPreferences.reset(
+				PropsKeys.SITES_CONTENT_SHARING_WITH_CHILDREN_ENABLED);
+		}
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProviderParentJournalArticleContentSharingWithChildrenEnabledByDefault()
+		throws Exception {
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			_group.getCompanyId());
+
+		try {
+			portletPreferences.setValue(
+				PropsKeys.SITES_CONTENT_SHARING_WITH_CHILDREN_ENABLED,
+				String.valueOf(
+					Sites.CONTENT_SHARING_WITH_CHILDREN_ENABLED_BY_DEFAULT));
+
+			Group childGroup = GroupTestUtil.addGroupToCompany(
+				_group.getCompanyId(), _group.getGroupId());
+
+			Assert.assertNotNull(
+				_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+					childGroup.getGroupId(), _journalArticle.getUrlTitle()));
+		}
+		finally {
+			portletPreferences.reset(
+				PropsKeys.SITES_CONTENT_SHARING_WITH_CHILDREN_ENABLED);
+		}
 	}
 
 	@FeatureFlags("LPD-11147")

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMStructuresDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMStructuresDisplayContext.java
@@ -88,7 +88,7 @@ public class JournalDDMStructuresDisplayContext {
 			groupIds =
 				SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_themeDisplay.getScopeGroupId(), true);
+						_themeDisplay.getScopeGroupId(), false, true);
 		}
 
 		long[] structureGroupIds = groupIds;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
@@ -126,7 +126,7 @@ public class JournalDDMTemplateDisplayContext {
 			groupIds =
 				SiteConnectedGroupGroupProviderUtil.
 					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_themeDisplay.getScopeGroupId(), true);
+						_themeDisplay.getScopeGroupId(), false, true);
 		}
 
 		long[] templateGroupIds = groupIds;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -522,7 +522,7 @@ public class JournalDisplayContext {
 		_ddmStructures = JournalFolderServiceUtil.getDDMStructures(
 			SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId(), true),
+					_themeDisplay.getScopeGroupId(), false, true),
 			getFolderId(), restrictionType);
 
 		if (_journalWebConfiguration.journalBrowseByStructuresSortedByName()) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
@@ -98,7 +98,7 @@ public class JournalViewMoreMenuItemsDisplayContext {
 		long[] currentAndAncestorSiteAndDepotGroupIds =
 			SiteConnectedGroupGroupProviderUtil.
 				getCurrentAndAncestorSiteAndDepotGroupIds(
-					_themeDisplay.getScopeGroupId(), true);
+					_themeDisplay.getScopeGroupId(), false, true);
 
 		searchContainer.setResultsAndTotal(
 			() -> {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/DDMStructureRelatedInfoCollectionProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/DDMStructureRelatedInfoCollectionProvider.java
@@ -118,7 +118,7 @@ public class DDMStructureRelatedInfoCollectionProvider
 			if (ArrayUtil.contains(
 					SiteConnectedGroupGroupProviderUtil.
 						getCurrentAndAncestorSiteAndDepotGroupIds(
-							serviceContext.getScopeGroupId(), true),
+							serviceContext.getScopeGroupId(), false, true),
 					_ddmStructure.getGroupId())) {
 
 				return true;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormVariationsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormVariationsProvider.java
@@ -155,7 +155,7 @@ public class JournalArticleInfoItemFormVariationsProvider
 		throws PortalException {
 
 		return SiteConnectedGroupGroupProviderUtil.
-			getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true);
+			getCurrentAndAncestorSiteAndDepotGroupIds(groupId, false, true);
 	}
 
 	@Reference

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -154,7 +154,7 @@ public class JournalArticleLayoutDisplayPageProvider
 
 		for (long connectedGroupId :
 				siteConnectedGroupGroupProvider.
-					getCurrentAndAncestorSiteAndDepotGroupIds(groupId)) {
+					getCurrentAndAncestorSiteAndDepotGroupIds(groupId, true)) {
 
 			JournalArticle article = null;
 


### PR DESCRIPTION
LPD-39274 A child site is displaying Web Content from the parent site, despite the configuration being set to prevent this

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39274

On the case that the parent do not allow child site to access their content we should check it.

# How am I fixing it?

On the method that obtains the connected groups to accesing the article, pass a new parameter to check if we are allowed to see the parent content. For this we need new methods to pass the boolean to the portalImpl method.

# How can you verify that it works?

Run the included automated tests.


# Commits

- **LPD-39274 on the Site Connected Group Provider, add methods to check if between the ancestors we have the property Content Sharing With Children Enabled**
- **LPD-39274 baseline**
- **LPD-39274 add the new parameter on the methods as false when needed**
- **LPD-39274 check if accessing the article we have the content Sharing With Children Enabled**
- **LPD-39274 add test to check that the journal articles is shown or not depends on the property SITES_CONTENT_SHARING_WITH_CHILDREN_ENABLED**
