### PR TITLE
LPD-37998 Documents and Document Folders can be Moved between sites

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/FolderItemSelectorURLProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/FolderItemSelectorURLProvider.java
@@ -70,7 +70,7 @@ public class FolderItemSelectorURLProvider {
 		folderItemSelectorCriterion.setRepositoryId(repositoryId);
 		folderItemSelectorCriterion.setSelectedFolderId(parentFolderId);
 		folderItemSelectorCriterion.setSelectedRepositoryId(repositoryId);
-		folderItemSelectorCriterion.setShowGroupSelector(true);
+		folderItemSelectorCriterion.setShowGroupSelector(false);
 		folderItemSelectorCriterion.setShowMountFolder(false);
 
 		return String.valueOf(

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -31,6 +31,34 @@ const test = mergeTests(
 );
 
 test(
+	'Check FileEntry cannot be moved to an other site',
+	{
+		tag: '@LPD-32483',
+	},
+	async ({documentLibraryEditFilePage, documentLibraryPage, page}) => {
+		const title = getRandomString();
+
+		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(
+			title
+		);
+
+		await documentLibraryPage.selectFileEntry(title);
+
+		await page.getByRole('button', {name: 'Move'}).nth(0).click();
+
+		const iframe = page.frameLocator(
+			'iframe[title="Select Destination Folder for 1 Item"]'
+		);
+
+		await expect(iframe.getByRole('link', {name: 'Home'})).toBeVisible();
+
+		await expect(
+			iframe.getByText('Sites and Libraries')
+		).not.toBeAttached();
+	}
+);
+
+test(
 	'Check order by Relevance in Search of DL',
 	{
 		tag: '@LPD-32481',


### PR DESCRIPTION


# What is this trying to solve?
[LPD-37998 Documents and Document Folders can be Moved between sites](https://liferay.atlassian.net/browse/LPD-37998)

Documents and Document Folders can be moved between sites, but this action does not handle dependencies like Document Types, breaking Documents in the process.

# How am I fixing it?
By disabling the option to move Documents and Document Folders between sites.

# How can you verify that it works?
"Run the included automated tests."

Cheers,
Balázs