### PR TITLE
LPD-39468 Back icon in notifications

### DIFF
--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -50,14 +50,14 @@ if (Validator.isNotNull(backURL)) {
 				add(
 					navigationItem -> {
 						navigationItem.setActive(!actionRequired);
-						navigationItem.setHref(renderResponse.createRenderURL(), "actionRequired", StringPool.FALSE);
+						navigationItem.setHref(renderResponse.createRenderURL(), "actionRequired", StringPool.FALSE, "backURL", currentURL);
 						navigationItem.setLabel(LanguageUtil.format(httpServletRequest, "notifications-list-x", UserNotificationEventLocalServiceUtil.getDeliveredUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, false)));
 					});
 
 				add(
 					navigationItem -> {
 						navigationItem.setActive(actionRequired);
-						navigationItem.setHref(renderResponse.createRenderURL(), "actionRequired", StringPool.TRUE);
+						navigationItem.setHref(renderResponse.createRenderURL(), "actionRequired", StringPool.TRUE, "backURL", currentURL);
 						navigationItem.setLabel(LanguageUtil.format(httpServletRequest, "requests-list-x", String.valueOf(UserNotificationEventLocalServiceUtil.getArchivedUserNotificationEventsCount(themeDisplay.getUserId(), UserNotificationDeliveryConstants.TYPE_WEBSITE, true, true, false))));
 					});
 			}

--- a/modules/apps/notifications/notifications-web/test.properties
+++ b/modules/apps/notifications/notifications-web/test.properties
@@ -2,7 +2,7 @@
 ## Relevant
 ##
 
-    playwright.test.project[playwright-js-tomcat90-mysql57][relevant][notifications-web-rule]=notification-web
+    playwright.test.project[playwright-js-tomcat90-mysql57][relevant][notifications-web-rule]=notifications-web
 
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*][relevant][notifications-web-rule]=\
         (testray.component.names == "Notifications") AND \

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -51,6 +51,7 @@ import {config as loginWebConfig} from './tests/login-web/config';
 import {config as messageBoardsWebConfig} from './tests/message-boards-web/config';
 import {config as nestedPortletsWebConfig} from './tests/nested-portlets-web/config';
 import {config as notificationWebConfig} from './tests/notification-web/config';
+import {config as notificationsWebConfig} from './tests/notifications-web/config';
 import {config as objectWebConfig} from './tests/object-web/config';
 import {config as openIdLinkConfig} from './tests/openid-link/config';
 import {config as osbFaroWebConfig} from './tests/osb-faro-web/config';
@@ -149,6 +150,7 @@ export default defineConfig({
 		messageBoardsWebConfig,
 		nestedPortletsWebConfig,
 		notificationWebConfig,
+		notificationsWebConfig,
 		objectWebConfig,
 		openIdLinkConfig,
 		osbFaroWebConfig,

--- a/modules/test/playwright/tests/notifications-web/config.ts
+++ b/modules/test/playwright/tests/notifications-web/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'notifications-web',
+	testDir: 'tests/notifications-web',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/notifications-web/fixtures/notificationsPagesTest.ts
+++ b/modules/test/playwright/tests/notifications-web/fixtures/notificationsPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {NotificationsPage} from '../pages/NotificationsPage';
+
+const notificationsPagesTest = test.extend<{
+	notificationsPage: NotificationsPage;
+}>({
+	notificationsPage: async ({page}, use) => {
+		await use(new NotificationsPage(page));
+	},
+});
+
+export {notificationsPagesTest};

--- a/modules/test/playwright/tests/notifications-web/notifications.spec.ts
+++ b/modules/test/playwright/tests/notifications-web/notifications.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../fixtures/loginTest';
+import {notificationsPagesTest} from './fixtures/notificationsPagesTest';
+
+const test = mergeTests(loginTest(), notificationsPagesTest);
+
+test(
+	'Back button is present while navigating between tabs',
+	{
+		tag: '@LPD-39468',
+	},
+	async ({notificationsPage}) => {
+		await notificationsPage.goto();
+
+		await expect(notificationsPage.backButton).toBeVisible();
+
+		await notificationsPage.requestsTab.click();
+
+		await expect(notificationsPage.backButton).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/notifications-web/pages/NotificationsPage.ts
+++ b/modules/test/playwright/tests/notifications-web/pages/NotificationsPage.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class NotificationsPage {
+	readonly page: Page;
+
+	readonly backButton: Locator;
+	readonly requestsTab: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.backButton = this.page.getByRole('link', {
+			name: 'Return to Full Page',
+		});
+		this.requestsTab = this.page.getByRole('link', {
+			name: 'Requests List (0)',
+		});
+	}
+
+	async goto() {
+		await this.page.getByLabel('Test Test User Profile').click();
+		await this.page.getByRole('menuitem', {name: 'Notifications'}).click();
+	}
+}

--- a/modules/test/playwright/tests/notifications-web/test.properties
+++ b/modules/test/playwright/tests/notifications-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Notifications

--- a/test.properties
+++ b/test.properties
@@ -4525,6 +4525,7 @@
         knowledge-base-web,\
         locked-items-web,\
         message-boards-web,\
+        notifications-web,\
         questions-web,\
         wiki-web
 


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-39468)
Back button disappears when clicking Notifications/Requests List on Notifications

# How did I fix it
I added the back url as a parameter to the link for the tabs, thus always is a back button

![Screenshot 2024-10-16 at 11 50 22](https://github.com/user-attachments/assets/f7b682f6-f458-42d8-ad16-fff49b71aaa1)

# How can you test it
Follow the steps described in the issue, or run `npm run playwright -- test -g 'LPD-39468' --reporter list`
```
npm run playwright -- test -g 'LPD-39468' --reporter list --repeat-each=5

> @liferay/playwright@1.0.0 playwright
> playwright "test" "-g" "LPD-39468" "--reporter" "list" "--repeat-each=5"


Running 5 tests using 1 worker

  ✓  1 [notifications-web] › notifications-web/notifications.spec.ts:18:1 › Back button is present while navigating between tabs (39.1s)
  ✓  2 [notifications-web] › notifications-web/notifications.spec.ts:18:1 › Back button is present while navigating between tabs (26.7s)
  ✓  3 [notifications-web] › notifications-web/notifications.spec.ts:18:1 › Back button is present while navigating between tabs (17.4s)
  ✓  4 [notifications-web] › notifications-web/notifications.spec.ts:18:1 › Back button is present while navigating between tabs (20.0s)
  ✓  5 [notifications-web] › notifications-web/notifications.spec.ts:18:1 › Back button is present while navigating between tabs (19.4s)

  5 passed (2.6m)
```
