### PR TITLE
LPD-37804 Incorrect message when deleting vocabulary through option with user with no delete permission

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -85,7 +85,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import javax.portlet.ActionRequest;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -661,13 +660,11 @@ public class AssetCategoriesDisplayContext {
 
 	public List<DropdownItem> getVocabulariesDropdownItems() {
 		LiferayPortletURL deleteVocabulariesURL =
-			_renderResponse.createActionURL();
+			(LiferayPortletURL)_renderResponse.createResourceURL();
 
 		deleteVocabulariesURL.setCopyCurrentRenderParameters(false);
-		deleteVocabulariesURL.setParameter(
-			ActionRequest.ACTION_NAME,
-			"/asset_categories_admin/delete_asset_vocabulary");
-		deleteVocabulariesURL.setParameter("redirect", getDefaultRedirect());
+		deleteVocabulariesURL.setResourceID(
+			"/asset_categories_admin/delete_asset_vocabularies");
 
 		ItemSelector itemSelector =
 			(ItemSelector)_httpServletRequest.getAttribute(
@@ -685,6 +682,7 @@ public class AssetCategoriesDisplayContext {
 				dropdownItem.putData("action", "deleteVocabularies");
 				dropdownItem.putData(
 					"deleteVocabulariesURL", deleteVocabulariesURL.toString());
+				dropdownItem.putData("redirectURL", getDefaultRedirect());
 				dropdownItem.putData(
 					"viewVocabulariesURL",
 					String.valueOf(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/DeleteAssetVocabulariesMVCResourceCommand.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/DeleteAssetVocabulariesMVCResourceCommand.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.admin.web.internal.portlet.action;
+
+import com.liferay.asset.categories.admin.web.constants.AssetCategoriesAdminPortletKeys;
+import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Diego Hu
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + AssetCategoriesAdminPortletKeys.ASSET_CATEGORIES_ADMIN,
+		"mvc.command.name=/asset_categories_admin/delete_asset_vocabularies"
+	},
+	service = MVCResourceCommand.class
+)
+public class DeleteAssetVocabulariesMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		boolean hasError = false;
+
+		for (long deleteVocabularyId :
+				ParamUtil.getLongValues(resourceRequest, "rowIds")) {
+
+			try {
+				_assetVocabularyService.deleteVocabulary(deleteVocabularyId);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+
+				hasError = true;
+			}
+		}
+
+		if (hasError) {
+			jsonObject.put(
+				"errorMessage",
+				_language.get(
+					_portal.getHttpServletRequest(resourceRequest),
+					"one-or-more-entries-could-not-be-deleted"));
+		}
+		else {
+			jsonObject.put("success", Boolean.TRUE);
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DeleteAssetVocabulariesMVCResourceCommand.class);
+
+	@Reference
+	private AssetVocabularyService _assetVocabularyService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/DeleteAssetVocabularyMVCActionCommand.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/DeleteAssetVocabularyMVCActionCommand.java
@@ -39,14 +39,6 @@ public class DeleteAssetVocabularyMVCActionCommand
 
 		if (vocabularyId > 0) {
 			_assetVocabularyService.deleteVocabulary(vocabularyId);
-
-			return;
-		}
-
-		for (long deleteVocabularyId :
-				ParamUtil.getLongValues(actionRequest, "rowIds")) {
-
-			_assetVocabularyService.deleteVocabulary(deleteVocabularyId);
 		}
 	}
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -8,6 +8,7 @@ import {
 	navigate,
 	objectToFormData,
 	openSelectionModal,
+	openToast,
 } from 'frontend-js-web';
 
 import openDeleteVocabularyModal from './openDeleteVocabularyModal';
@@ -35,7 +36,33 @@ const ACTIONS = {
 										.join(','),
 								}),
 								method: 'POST',
-							}).then((response) => navigate(response.url));
+							})
+								.then((response) => {
+									if (response.ok) {
+										return response.json();
+									}
+									else {
+										showErorMessage();
+									}
+								})
+								.then((data) => {
+									if (data.success) {
+										navigate(itemData.redirectURL);
+
+										openToast({
+											message: Liferay.Language.get(
+												'your-request-completed-successfully'
+											),
+											type: 'success',
+										});
+									}
+									else {
+										showErorMessage(data.errorMessage);
+									}
+								})
+								.catch(() => {
+									showErorMessage();
+								});
 						},
 					});
 				}
@@ -44,6 +71,15 @@ const ACTIONS = {
 			url: itemData.viewVocabulariesURL,
 		});
 	},
+};
+
+const showErorMessage = (errorMessage) => {
+	openToast({
+		message:
+			errorMessage ||
+			Liferay.Language.get('an-unexpected-error-occurred'),
+		type: 'danger',
+	});
 };
 
 export default function propsTransformer({

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/portlet/action/test/DeleteAssetVocabulariesMVCResourceCommandTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/internal/portlet/action/test/DeleteAssetVocabulariesMVCResourceCommandTest.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyService;
+import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Diego hu
+ */
+@RunWith(Arquillian.class)
+public class DeleteAssetVocabulariesMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_assetVocabulary = AssetTestUtil.addVocabulary(_group.getGroupId());
+	}
+
+	@Test
+	public void testServeResourceWithoutPermission() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		JSONObject jsonObject = _serveResource(
+			_getMockLiferayResourceRequest(), user);
+
+		Assert.assertEquals(
+			_language.get(
+				LocaleUtil.US, "one-or-more-entries-could-not-be-deleted"),
+			jsonObject.get("errorMessage"));
+	}
+
+	@Test
+	public void testServeResourceWithPermission() throws Exception {
+		User user = UserTestUtil.addCompanyAdminUser(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		JSONObject jsonObject = _serveResource(
+			_getMockLiferayResourceRequest(), user);
+
+		Assert.assertTrue(jsonObject.getBoolean("success"));
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest() {
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"rowIds", String.valueOf(_assetVocabulary.getVocabularyId()));
+
+		mockLiferayResourceRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+
+		return mockLiferayResourceRequest;
+	}
+
+	private JSONObject _serveResource(
+			MockLiferayResourceRequest mockLiferayResourceRequest, User user)
+		throws Exception {
+
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(user);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				user, permissionChecker)) {
+
+			_mvcResourceCommand.serveResource(
+				mockLiferayResourceRequest, mockLiferayResourceResponse);
+
+			ByteArrayOutputStream byteArrayOutputStream =
+				(ByteArrayOutputStream)
+					mockLiferayResourceResponse.getPortletOutputStream();
+
+			return JSONFactoryUtil.createJSONObject(
+				byteArrayOutputStream.toString());
+		}
+		finally {
+			UserLocalServiceUtil.deleteUser(user);
+		}
+	}
+
+	private AssetVocabulary _assetVocabulary;
+
+	@Inject
+	private AssetVocabularyService _assetVocabularyService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Language _language;
+
+	@Inject(
+		filter = "mvc.command.name=/asset_categories_admin/delete_asset_vocabularies"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private Portal _portal;
+
+}


### PR DESCRIPTION
LPD-37804 Incorrect message when deleting vocabulary through option with user with no delete permission

# What is this trying to solve?
- When an user does not have the permissions to delete a vocabulary, the message that appears is wrong, it appears a success message instead of an error message

[Link to ticket](https://liferay.atlassian.net/browse/LPD-37804)

# How am I fixing it?
- I'm creating a resource command that controls the deletion of the vocabularies and returns a success or an error state

# How can I test it?
- Follow the steps in the bug 

https://github.com/user-attachments/assets/72889064-c7a9-4607-ae84-59ea2634d1ad


