### PR TITLE
LPD-39367 [Playwright] Fix 'Check alert message of duplicated friendly URL in french'

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -91,7 +91,7 @@ baseTest(
 		tag: '@LPD-32185',
 	},
 	async ({journalEditArticlePage, page, site}) => {
-		await page.goto(`/fr/`);
+		await page.goto('/fr');
 		await journalEditArticlePage.createBasicArticleWithFriendlyURL(
 			site,
 			'Contenu web basique'

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -101,11 +101,11 @@ baseTest(
 			'Contenu web basique'
 		);
 
-		await expect(
-			page
-				.locator('#ToastAlertContainer')
-				.getByText('test', {exact: true})
-		).toBeVisible();
+		await waitForAlert(
+			page,
+			"Avertissement:Les URL simplifiées suivantes ont été modifiées pour garantir l'unicité",
+			{type: 'warning'}
+		);
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -106,6 +106,10 @@ baseTest(
 			"Avertissement:Les URL simplifiées suivantes ont été modifiées pour garantir l'unicité",
 			{type: 'warning'}
 		);
+
+		// change back to english language
+
+		await page.goto('/en');
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -189,7 +189,7 @@ export class JournalEditArticlePage {
 		);
 
 		const title = getRandomString();
-		await fillAndClickOutside(this.page, this.titleInput, title);
+		await this.fillTitle(title);
 		await this.fillFriendlyURL('test');
 
 		await this.publishButton.click();

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -54,7 +54,9 @@ export class JournalEditArticlePage {
 		this.friendlyUrlToggle = page.locator('a[href="#friendlyUrlContent"]');
 		this.historyButton = page.getByLabel('History');
 		this.journalPage = new JournalPage(page);
-		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
+		this.propertiesTab = page.getByRole('tab', {
+			name: /properties|propriétés/i,
+		});
 		this.publishButton = page.locator(
 			'#_com_liferay_journal_web_portlet_JournalPortlet_publishButton'
 		);

--- a/modules/test/playwright/tests/layout-page-template-admin-web/pageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/pageTemplatesAdmin.spec.ts
@@ -270,7 +270,6 @@ test('Create a page based on a page template', async ({
 
 	await pagesAdminPage.addPage({
 		name: layoutTitle,
-		successMessage: 'Success:The page was created successfully.',
 		template: pageTemplateName,
 	});
 


### PR DESCRIPTION
>[!NOTE]
> This PR is built on instead of #5998 simply the logic

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39367

We are trying to fix the test failure `Check alert message of duplicated friendly URL in french`

![image](https://github.com/user-attachments/assets/a567bd76-1ff0-4989-a215-0c0676ae8848)


# How am I fixing it?
My first attempt was to use `data-qa-id` but updating the locator is good enough.
Update the locator to use regex to include FR and use the `this.fillTitle` to wait until the page is ready

# How can you verify that it works?

1. Go to `/modules/test/playwright`
1. Run `npm install` (setup)
1. Run `npm run playwright test -- -g "Check alert message of duplicated friendly URL in french"` to execute the test


# Test launched 10 times test locally to avoid flaky results

<img width="972" alt="image" src="https://github.com/user-attachments/assets/5e7d493e-4ee0-4793-acdc-a236abe389e5">



