### PR TITLE
LPD-39230 [content-management] Review PR "Allow using directive script-src-attr 'none' by removing inline handlers" (part 2)

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/init.jsp
@@ -16,6 +16,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpComponentsUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,9 +19,19 @@ String widgetURL = ParamUtil.getString(request, "widgetURL");
 			<liferay-ui:message key="share-this-application-on-any-website" />
 		</p>
 
-		<textarea class="col-md-12 lfr-textarea" onClick="this.select();" rows="10">
+		<%
+		String id = StringUtil.randomId();
+		%>
+
+		<textarea class="col-md-12 lfr-textarea" id="<%= id %>" rows="10">
 			<iframe frameborder="0" height="100%" src="<%= HtmlUtil.escapeAttribute(widgetURL) %>" width="100%"></iframe>
 		</textarea>
+
+		<aui:script position="inline">
+			document.getElementById('<%= id %>').onclick = function () {
+				this.select();
+			};
+		</aui:script>
 	</c:when>
 	<c:when test="<%= Validator.isNotNull(netvibesURL) %>">
 		<p>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
@@ -79,7 +79,14 @@ if (layout.isDraftLayout()) {
 						</liferay-util:buffer>
 
 						<aui:field-wrapper label="code">
-							<textarea aria-label="<%= LanguageUtil.get(request, "code") %>" class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" onClick="this.select();" readonly="true"><%= HtmlUtil.escape(textAreaContent) %></textarea>
+							<textarea aria-label="<%= LanguageUtil.get(request, "code") %>" class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" readonly="true"><%= HtmlUtil.escape(textAreaContent) %></textarea>
+
+							<aui:script position="inline">
+								document.getElementById('<portlet:namespace />widgetScript').onclick =
+									function () {
+										this.select();
+									};
+							</aui:script>
 						</aui:field-wrapper>
 
 						<aui:input inlineLabel="right" label='<%= LanguageUtil.format(request, "allow-users-to-add-x-to-any-website", HtmlUtil.escape(portletDisplay.getTitle()), false) %>' labelCssClass="simple-toggle-switch" name="widgetShowAddAppLink" type="toggle-switch" value='<%= GetterUtil.getBoolean(portletPreferences.getValue("lfrWidgetShowAddAppLink", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT) %>' />


### PR DESCRIPTION
Comes from liferay-frontend#4479

Please refer to both https://liferay.atlassian.net/browse/LPD-39123 and https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3245277533/LPD-36188+-+Allow+using+directive+script-src-attr+none+by+removing+inline+handlers to find out the motivation for this PR.
