### PR TITLE
LPD-39570 MB showing empty page when changing page size

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/DefaultMBListDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/DefaultMBListDisplayContext.java
@@ -7,9 +7,7 @@ package com.liferay.message.boards.web.internal.display.context;
 
 import com.liferay.message.boards.constants.MBPortletKeys;
 import com.liferay.message.boards.display.context.MBListDisplayContext;
-import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
-import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBCategoryServiceUtil;
 import com.liferay.message.boards.service.MBThreadServiceUtil;
 import com.liferay.message.boards.settings.MBGroupServiceSettings;
@@ -132,29 +130,18 @@ public class DefaultMBListDisplayContext implements MBListDisplayContext {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		int status = WorkflowConstants.STATUS_APPROVED;
-
-		PermissionChecker permissionChecker =
-			themeDisplay.getPermissionChecker();
-
-		if (permissionChecker.isContentReviewer(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId())) {
-
-			status = WorkflowConstants.STATUS_ANY;
-		}
-
-		QueryDefinition<MBCategory> queryDefinition = new QueryDefinition<>(
-			status, themeDisplay.getUserId(), true, searchContainer.getStart(),
-			searchContainer.getEnd(), searchContainer.getOrderByComparator());
+		int status = _getStatus(themeDisplay);
 
 		try {
 			searchContainer.setResultsAndTotal(
 				() -> MBCategoryServiceUtil.getCategories(
 					themeDisplay.getScopeGroupId(), _categoryId,
-					queryDefinition),
+					_getQueryDefinition(
+						searchContainer, status, themeDisplay.getUserId())),
 				MBCategoryServiceUtil.getCategoriesCount(
 					themeDisplay.getScopeGroupId(), _categoryId,
-					queryDefinition));
+					_getQueryDefinition(
+						searchContainer, status, themeDisplay.getUserId())));
 		}
 		catch (Throwable throwable) {
 			throw new PortalException(throwable);
@@ -282,31 +269,19 @@ public class DefaultMBListDisplayContext implements MBListDisplayContext {
 			}
 		}
 		else {
-			int status = WorkflowConstants.STATUS_APPROVED;
-
-			PermissionChecker permissionChecker =
-				themeDisplay.getPermissionChecker();
-
-			if (permissionChecker.isContentReviewer(
-					themeDisplay.getCompanyId(),
-					themeDisplay.getScopeGroupId())) {
-
-				status = WorkflowConstants.STATUS_ANY;
-			}
-
-			QueryDefinition<MBThread> queryDefinition = new QueryDefinition<>(
-				status, themeDisplay.getUserId(), true,
-				searchContainer.getStart(), searchContainer.getEnd(),
-				searchContainer.getOrderByComparator());
+			int status = _getStatus(themeDisplay);
 
 			try {
 				searchContainer.setResultsAndTotal(
 					() -> MBThreadServiceUtil.getThreads(
 						themeDisplay.getScopeGroupId(), _categoryId,
-						queryDefinition),
+						_getQueryDefinition(
+							searchContainer, status, themeDisplay.getUserId())),
 					MBThreadServiceUtil.getThreadsCount(
 						themeDisplay.getScopeGroupId(), _categoryId,
-						queryDefinition));
+						_getQueryDefinition(
+							searchContainer, status,
+							themeDisplay.getUserId())));
 			}
 			catch (Throwable throwable) {
 				throw new PortalException(throwable);
@@ -344,6 +319,27 @@ public class DefaultMBListDisplayContext implements MBListDisplayContext {
 				MBPortletKeys.MESSAGE_BOARDS, "threadEntriesDelta",
 				String.valueOf(threadEntriesDelta));
 		}
+	}
+
+	private QueryDefinition _getQueryDefinition(
+		SearchContainer searchContainer, int status, long userId) {
+
+		return new QueryDefinition<>(
+			status, userId, true, searchContainer.getStart(),
+			searchContainer.getEnd(), searchContainer.getOrderByComparator());
+	}
+
+	private int _getStatus(ThemeDisplay themeDisplay) {
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		if (permissionChecker.isContentReviewer(
+				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId())) {
+
+			return WorkflowConstants.STATUS_ANY;
+		}
+
+		return WorkflowConstants.STATUS_APPROVED;
 	}
 
 	private boolean _isShowRecentPosts(String mvcRenderCommandName) {

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -178,3 +178,40 @@ test('LPD-37727 Change delta to a higher value when on last page', async ({
 		page.getByRole('link', {name: /Thread with headline #\d+/})
 	).toHaveCount(5);
 });
+
+test('LPD-39570 Change delta to a higher value when on last page', async ({
+	apiHelpers,
+	messageBoardsWidgetPage,
+	page,
+	site,
+}) => {
+	for (let i = 0; i < 5; i++) {
+		await apiHelpers.headlessDelivery.postMessageBoardThread({
+			articleBody: getRandomString(),
+			headline: 'Thread with headline #' + i,
+			siteId: site.id,
+		});
+	}
+
+	await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
+
+	await page.getByLabel('Items per Page').click();
+	await page.getByRole('option', {name: /4\s+Entries per Page/}).click();
+
+	await expect(
+		page.getByRole('link', {name: /Thread with headline #\d+/})
+	).toHaveCount(4);
+
+	await page.getByRole('link', {name: /Page\s+2/}).click();
+
+	await expect(
+		page.getByRole('link', {name: /Thread with headline #\d+/})
+	).toHaveCount(1);
+
+	await page.getByLabel('Items per Page').click();
+	await page.getByRole('option', {name: /8\s+Entries per Page/}).click();
+
+	await expect(
+		page.getByRole('link', {name: /Thread with headline #\d+/})
+	).toHaveCount(5);
+});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39570

When on the last page, changing the page size to a value that would leave the current page empty (but still show results in previous pages) will result in an empty page.

This is another instance of https://liferay.atlassian.net/browse/LPD-37727 (already fixed).

# How am I fixing it?

The `SearchContainer#setResultsAndTotal` method already handles this situation, but it does it by mutating the search container based on the `total` value and the page size.  In order for the query to get the correct start/end values, it needs to create the `QueryDefinition` /after/ the search container has been updated.  Here, I'm delaying the creation of the query definition until the last possible moment -- inside the supplier.

# How can you verify that it works?

Run the included playwright test:
```
$ npm run playwright -- test -g LPD-39570 --reporter list

> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-39570 --reporter list


Running 1 test using 1 worker

  ✓  1 [message-boards-web] › message-boards-web/message-boards-web.spec.ts:182:1 › LPD-39570 Change delta to a higher value when on last page (15.1s)
  Slow test file: [message-boards-web] › message-boards-web/message-boards-web.spec.ts (15.1s)
  Consider splitting slow test files to speed up parallel execution
  1 passed (17.8s)
```