### PR TITLE
LPD-39667 Fix tests ImageEditor#CanSaveResizedImage and ImageEditor#CanSaveResizedImagePreview

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
@@ -172,7 +172,7 @@
 
 <tr>
 	<td>DOCUMENT_EXTRACTED_METADATA_FIELD</td>
-	<td>//div[@role="tablist"][contains(.,'Metadata')]//label[contains(.,'${key_metadataLabel}')]/../../div[contains(.,'${key_metadataData}')]</td>
+	<td>//div[contains(@class,'panel-group')][contains(.,'Metadata')]//label[contains(.,'${key_metadataLabel}')]/../../div[contains(.,'${key_metadataData}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39667

These POSHI tests are failing:

* ImageEditor#CanSaveResizedImage
* ImageEditor#CanSaveResizedImagePreview

# How am I fixing it?

In [LPD-39202](https://github.com/liferay/liferay-portal/commit/1e1aca8135f8224dee2dd2b25e778af829ff2a3b) the panel group has been changed, so I've fixed the locator.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=ImageEditor#CanSaveResizedImage`
`ant -f build-test.xml run-selenium-test -Dtest.class=ImageEditor#CanSaveResizedImagePreview`