### PR TITLE
LPD-39703 Editing a Web Content in a Web Content Display displays 2 success messages

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -6,8 +6,7 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext" %><%@
 page import="com.liferay.journal.content.web.internal.servlet.taglib.PortletHeaderActionDropdownItemsProvider" %><%@

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -7,8 +7,6 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<liferay-ui:success key='<%= portletDisplay.getId() + "requestProcessed" %>' message="your-request-completed-successfully" />
-
 <div class="visible-interaction">
 
 	<%

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -205,6 +205,49 @@ baseTest(
 );
 
 baseTest(
+	'Only 1 Success Popup shows on web content display content edit',
+	{
+		tag: '@LPD-39703',
+	},
+	async ({
+		journalEditArticlePage,
+		page,
+		pagesAdminPage,
+		site,
+		widgetPagePage,
+	}) => {
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+
+		const name = 'widgetPage';
+		await pagesAdminPage.addWidgetPage({name});
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+		await page.getByLabel(name, {exact: true}).click();
+
+		await widgetPagePage.addPortlet('Web Content Display');
+
+		await page
+			.getByTestId('addButton')
+			.getByRole('button', {name: 'Add'})
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Basic Web Content'}).click();
+
+		await journalEditArticlePage.fillTitle('testArticle');
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await expect(page.getByRole('heading', {name})).toBeVisible();
+
+		await page.getByText('Success:Your request').first().isVisible();
+
+		await page.waitForTimeout(100);
+
+		expect(await page.getByText('Success:Your request').count()).toBe(1);
+	}
+);
+
+baseTest(
 	'Navigate in ddm template selector',
 	{
 		tag: '@LPD-36441',


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-39703

### How am I fixing it?
I avoided the double success message by removing the burned in one from the portlet_header.

### How can you verify that it works?

To test run:
`npm run test -- test -g "LPD-39703" `