### PR TITLE
LPD-39505 Add playwright test to View Selected Web Content With Geolocation Field

### DIFF
--- a/modules/test/playwright/tests/journal-web/config.ts
+++ b/modules/test/playwright/tests/journal-web/config.ts
@@ -7,6 +7,7 @@ export const config = {
 	name: 'journal-web',
 	testDir: 'tests/journal-web',
 	use: {
+		permissions: ['geolocation'],
 		testIdAttribute: 'data-qa-id',
 	},
 };

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -10,6 +10,7 @@ import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest'
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageViewModePagesTest} from '../../fixtures/pageViewModePagesTest';
 import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
@@ -49,6 +50,7 @@ const baseTest = mergeTests(
 	isolatedSiteTest,
 	journalPagesTest,
 	loginTest(),
+	pageEditorPagesTest,
 	pageViewModePagesTest,
 	pagesAdminPagesTest,
 	workflowPagesTest
@@ -90,6 +92,13 @@ const translationAndAutosaveTest = mergeTests(
 	})
 );
 
+const geoLocationTest = mergeTests(
+	baseTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	})
+);
+
 const privateContentIconTest = mergeTests(baseTest);
 
 baseTest(
@@ -117,6 +126,83 @@ baseTest(
 		// change back to english language
 
 		await page.goto('/en');
+	}
+);
+
+geoLocationTest(
+	'View Selected Web Content With Geolocation Field',
+	{
+		tag: '@LPS-101248',
+	},
+	async ({
+		apiHelpers,
+		context,
+		journalEditArticlePage,
+		journalEditTemplatePage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		const fieldName = 'Geolocation';
+		const structureName = 'Test Structure';
+		const templateName = 'Test Template';
+		const contentTitle = 'Test Web Content';
+
+		const coords = {latitude: 47.526642, longitude: 19.046394};
+		await context.setGeolocation(coords);
+
+		const dataDefinition = getDataStructureDefinition({
+			defaultLanguageId: 'en_US',
+			fields: [
+				{
+					dataType: 'geolocation',
+					fieldType: 'geolocation',
+					name: fieldName,
+					repeatable: false,
+				},
+			],
+			name: structureName,
+		});
+
+		await apiHelpers.dataEngine.createStructure(site.id, dataDefinition);
+
+		await journalEditTemplatePage.createTemplate({
+			fields: [fieldName],
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+			title: templateName,
+		});
+
+		await journalEditArticlePage.goto({
+			siteUrl: site.friendlyUrlPath,
+			structureName,
+		});
+		await journalEditArticlePage.fillTitle(contentTitle);
+		await expect(page.locator('div[id^="map_"]')).toBeVisible();
+		await journalEditArticlePage.publishButton.click();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+		await pageEditorPage.addFragment('Content Display', 'Content Display');
+
+		await pageEditorPage.selectItemMappingButton.click();
+
+		await page
+			.frameLocator('iframe[title="Select"]')
+			.getByRole('menuitem', {name: 'Web Content'})
+			.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: false,
+			target: page.locator("div[id*='Geolocation']"),
+			trigger: page
+				.frameLocator('iframe[title="Select"]')
+				.getByText(contentTitle),
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditTemplatePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditTemplatePage.ts
@@ -5,7 +5,6 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
@@ -13,7 +12,6 @@ import {JournalTemplatesPage} from './JournalTemplatesPage';
 
 export class JournalEditTemplatePage {
 	readonly page: Page;
-
 	readonly basicInformation: Locator;
 	readonly elementsButton: Locator;
 	readonly journalTemplatesPage: JournalTemplatesPage;
@@ -81,13 +79,17 @@ export class JournalEditTemplatePage {
 		}
 
 		await this.page
-			.getByRole('button', {name: 'Save', exact: true})
+			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 	}
 	async selectStructure(structureName: string) {
 		await openFieldset(this.page, 'Basic Information');
 
 		await this.selectStructureButton.click();
+		await this.page
+			.frameLocator('iframe[title="Select Structure"]')
+			.getByRole('cell', {name: 'Title'})
+			.waitFor();
 		await this.page
 			.frameLocator('iframe[title="Select Structure"]')
 			.getByRole('cell', {name: structureName})

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditTemplatePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditTemplatePage.ts
@@ -5,6 +5,10 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import fillAndClickOutside from '../../../utils/fillAndClickOutside';
+import getRandomString from '../../../utils/getRandomString';
+import {openFieldset} from '../../../utils/openFieldset';
 import {JournalTemplatesPage} from './JournalTemplatesPage';
 
 export class JournalEditTemplatePage {
@@ -13,6 +17,9 @@ export class JournalEditTemplatePage {
 	readonly basicInformation: Locator;
 	readonly elementsButton: Locator;
 	readonly journalTemplatesPage: JournalTemplatesPage;
+	readonly propertiesTab: Locator;
+	readonly selectStructureButton: Locator;
+	readonly titleInput: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -22,21 +29,68 @@ export class JournalEditTemplatePage {
 		});
 		this.elementsButton = page.getByTitle('Elements', {exact: true});
 		this.journalTemplatesPage = new JournalTemplatesPage(page);
+		this.propertiesTab = page.getByRole('heading', {name: 'Properties'});
+		this.selectStructureButton = page.getByRole('button', {
+			name: 'Select Structure',
+		});
+		this.titleInput = page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_name'
+		);
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
-		await this.journalTemplatesPage.goto(siteUrl);
-		await this.journalTemplatesPage.goToCreateNewTemplate();
+		await this.journalTemplatesPage.goToCreateNewTemplate(siteUrl);
 
 		// Do it twice so we decrease flakiness
 
-		await this.journalTemplatesPage.goto(siteUrl);
-		await this.journalTemplatesPage.goToCreateNewTemplate();
+		await this.journalTemplatesPage.goToCreateNewTemplate(siteUrl);
 
 		await this.basicInformation.waitFor();
 	}
 
 	async gotoElements() {
 		await this.elementsButton.click();
+	}
+
+	async fillTitle(title: string) {
+		await this.propertiesTab.waitFor();
+		await fillAndClickOutside(this.page, this.titleInput, title);
+	}
+
+	async createTemplate({
+		fields = [],
+		siteUrl,
+		structureName,
+		title,
+	}: {
+		fields?: string[];
+		siteUrl?: Site['friendlyUrlPath'];
+		structureName?: string;
+		title?: string;
+	} = {}) {
+		await this.goto(siteUrl);
+		await this.fillTitle(title || getRandomString());
+		if (structureName) {
+			await this.selectStructure(structureName);
+		}
+		if (fields) {
+			await this.elementsButton.click();
+			for (const field of fields) {
+				await this.page.getByRole('button', {name: field}).click();
+			}
+		}
+
+		await this.page
+			.getByRole('button', {name: 'Save', exact: true})
+			.click();
+	}
+	async selectStructure(structureName: string) {
+		await openFieldset(this.page, 'Basic Information');
+
+		await this.selectStructureButton.click();
+		await this.page
+			.frameLocator('iframe[title="Select Structure"]')
+			.getByRole('cell', {name: structureName})
+			.click();
 	}
 }

--- a/modules/test/playwright/tests/journal-web/pages/JournalTemplatesPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalTemplatesPage.ts
@@ -26,8 +26,8 @@ export class JournalTemplatesPage {
 		);
 	}
 
-	async goToCreateNewTemplate() {
-		await this.goto();
+	async goToCreateNewTemplate(siteUrl?: Site['friendlyUrlPath']) {
+		await this.goto(siteUrl);
 		await this.newButton.click();
 	}
 }

--- a/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
+++ b/modules/test/playwright/tests/journal-web/utils/getDataStructureDefinition.ts
@@ -10,7 +10,8 @@ interface Props {
 }
 
 interface Field {
-	fieldType?: 'journal_article' | 'select' | 'text';
+	dataType?: string;
+	fieldType?: 'geolocation' | 'journal_article' | 'select' | 'text';
 	localizable?: boolean;
 	name: string;
 	options?: Options;
@@ -27,6 +28,7 @@ export default function getDataStructureDefinition({
 		availableLanguageIds: [defaultLanguageId],
 		dataDefinitionFields: fields.map(
 			({
+				dataType,
 				fieldType = 'text',
 				localizable = true,
 				name: fieldName,
@@ -36,7 +38,7 @@ export default function getDataStructureDefinition({
 			}) => {
 				return {
 					customProperties: {
-						dataType: 'string',
+						dataType,
 						displayStyle: 'singleline',
 						fieldReference: fieldName,
 						options,

--- a/modules/test/playwright/types/data-definition.d.ts
+++ b/modules/test/playwright/types/data-definition.d.ts
@@ -16,13 +16,13 @@ type DataDefinition = {
 
 type DefinitionField = {
 	customProperties: {
-		dataType: 'string';
+		dataType: string;
 		displayStyle: 'singleline' | 'multiline';
 		fieldReference: string;
 		options?: Options;
 	};
 	defaultValue: {[keys: string]: string};
-	fieldType: 'journal_article' | 'select' | 'text';
+	fieldType: 'geolocation' | 'journal_article' | 'select' | 'text';
 	indexType: 'keyword' | 'text' | 'none';
 	label: {[keys: string]: string};
 	localizable: boolean;

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/contentdisplay/ContentDisplayWithWebContentTemplate.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/contentdisplay/ContentDisplayWithWebContentTemplate.testcase
@@ -518,66 +518,6 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-101248. Display web content with Geolocation field in Content Display."
-	@priority = 3
-	test ViewSelectedWebContentWithGeolocationField {
-		task ("Add a web content structure with a Geolocation field") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			NavItem.gotoStructures();
-
-			WebContentStructures.addCP(structureName = "WC Structure Name");
-
-			DataEngine.addField(
-				fieldFieldLabel = "Geolocation",
-				fieldName = "Geolocation");
-
-			WebContentStructures.saveCP();
-		}
-
-		task ("Add a template for new structure") {
-			WebContentNavigator.gotoManageTemplatesViaStructures(structureName = "WC Structure Name");
-
-			WebContentTemplates.addCP(
-				templateFieldNames = "Geolocation",
-				templateName = "WC Template Name");
-		}
-
-		task ("Add a web content based on new structure") {
-			NavItem.click(navItem = "Web Content");
-
-			WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-			WebContent.addWithStructureCP(webContentTitle = "Web Content Title");
-
-			PortletEntry.publish();
-		}
-
-		task ("Add a Content Display to a content page") {
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Content Page Name",
-				siteName = "Test Site Name");
-
-			PageEditor.addFragment(
-				collectionName = "Content Display",
-				fragmentName = "Content Display");
-		}
-
-		task ("Select the web content and template in Content Display") {
-			PageEditor.editContentDisplay(
-				fragmentName = "Content Display",
-				template = "WC Template Name",
-				webcontent = "true",
-				webContentTitle = "Web Content Title");
-		}
-
-		task ("View the Geolocation field is shown in Content Display") {
-			AssertVisible(
-				key_content = "//div[contains(@id,'Geolocation')]",
-				locator1 = "WCD#WEB_CONTENT_CONTENT_ANY");
-		}
-	}
-
 	@description = "This is a test for LPS-101248. Display web content with Grid field in Content Display."
 	@priority = 3
 	test ViewSelectedWebContentWithGridField {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -637,52 +637,6 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 		}
 	}
 
-	@description = "This is a use case for LPS-130033. Display web content with Geolocation field in Web Content Display."
-	@priority = 4
-	test DisplayWebContentWithGeolocationField {
-		task ("Add a web content structure with a Geolocation field") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			NavItem.gotoStructures();
-
-			WebContentStructures.addCP(structureName = "WC Structure Name");
-
-			DataEngine.addField(
-				fieldFieldLabel = "Geolocation",
-				fieldName = "Geolocation");
-
-			WebContentStructures.saveCP();
-		}
-
-		task ("Add a web content based on new structure") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-			WebContent.addWithStructureCP(webContentTitle = "Web Content Title");
-
-			PortletEntry.publish();
-		}
-
-		task ("Select the web content in Web Content Display") {
-			Navigator.gotoSitePage(
-				pageName = "Test Page Name",
-				siteName = "Test Site Name");
-
-			WebContentDisplayPortlet.selectWebContent(webContentTitle = "Web Content Title");
-
-			IFrame.closeFrame();
-		}
-
-		task ("View the web content is shown in Web Content Display") {
-			Portlet.viewTitle(portletName = "Web Content Title");
-
-			AssertVisible(
-				key_content = "//div[contains(@id,'Geolocation')]",
-				locator1 = "WCD#WEB_CONTENT_CONTENT_ANY");
-		}
-	}
-
 	@description = "Can edit a web content template via Web Content Display."
 	@priority = 4
 	test EditTemplate {


### PR DESCRIPTION
Cannot edit structure key when disabling configuration

What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39805, 
https://liferay.atlassian.net/browse/LPD-39805

The geolocation field properly displayed in a web content display



How am I fixing it?

moved the test to the playwright, the 2 tests could be merged into one.

How can you verify that it works?
Run the tests locally