### PR TITLE
LPD-39822 deepL supported Language codes are in uppercase so getLanguageCode must be uppercased

### DIFF
--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -73,8 +73,8 @@ public class DeepLTranslator extends BaseTranslator {
 		List<String> supportedLanguageCodes = _getSupportedLanguageCodes(
 			deepLTranslatorConfiguration);
 
-		String targetLanguageCode = getLanguageCode(
-			translatorPacket.getTargetLanguageId());
+		String targetLanguageCode = StringUtil.toUpperCase(
+			getLanguageCode(translatorPacket.getTargetLanguageId()));
 
 		if (!supportedLanguageCodes.contains(targetLanguageCode)) {
 			throw new TranslatorException(
@@ -88,7 +88,8 @@ public class DeepLTranslator extends BaseTranslator {
 		Map<String, String> translatedFieldsMap = _translate(
 			deepLTranslatorConfiguration, translatorPacket.getFieldsMap(),
 			translatorPacket.getHTMLMap(),
-			getLanguageCode(translatorPacket.getSourceLanguageId()),
+			StringUtil.toUpperCase(
+				getLanguageCode(translatorPacket.getSourceLanguageId())),
 			targetLanguageCode);
 
 		return new TranslatorPacket() {

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -80,7 +80,7 @@ public class DeepLTranslator extends BaseTranslator {
 			throw new TranslatorException(
 				StringBundler.concat(
 					"Target language code ", targetLanguageCode,
-					" is not among the supported langauge codes: ",
+					" is not among the supported language codes: ",
 					StringUtil.merge(
 						supportedLanguageCodes, StringPool.COMMA_AND_SPACE)));
 		}


### PR DESCRIPTION
LPD-39822 DeepL translation language code is not properly decoded

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39822

On 359276131517c35a50973532f8c345a2486403c1 we generalize the method but we missed that DeepL need that the language is on uppercase, so we should fix it.

# How am I fixing it?

Convert the data that comes from BaseTranslator to uppercase on the case of DeepL translator

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-39822
1. Enable the "deepL" configuration 
2. Create new content in the default DXP site and publish 
3. In the content "context menu" click on "Translate" 
4. Select the desired "to" language, e.g. German, and click on the "Auto Translate" button. An error appears on the screen 

# Why doesn't this include any test?

DeepL is not supported by CI and the behaviour fixed is translator dependant



# Commits


- **LPD-39822 deepL supported Language codes are in uppercase so getLanguageCode must be uppercased**
- **LPD-39822 typo**
