### PR TITLE
LPD-39797 A Select from List field shows a list with an empty string even when no options are selected

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -491,10 +491,14 @@ public class JournalTransformer {
 			while (iterator.hasNext()) {
 				Element optionElement = iterator.next();
 
-				dataJSONArray.put(optionElement.getData());
+				if (Validator.isNotNull(optionElement.getData())) {
+					dataJSONArray.put(optionElement.getData());
+				}
 			}
 
-			data = JSONUtil.toString(dataJSONArray);
+			if (dataJSONArray.length() != 0) {
+				data = JSONUtil.toString(dataJSONArray);
+			}
 		}
 
 		if (dynamicContentElement != null) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -174,6 +174,7 @@ public class JournalTransformerTest {
 	@Test
 	public void testCreateTemplateNode() throws Exception {
 		_testCreateTemplateNodeDocumentLibraryDDMFormField();
+		_testCreateTemplateNodeSelectTypeDDMFormFieldWithNoOptions();
 		_testCreateTemplateNodeSelectTypeDDMFormFieldWithOptions();
 		_testCreateTemplateNodeSelectTypeDDMFormFieldWithoutOptions();
 	}
@@ -733,6 +734,40 @@ public class JournalTransformerTest {
 		Assert.assertEquals(
 			jsonObject.getString("groupId"),
 			templateNode.getAttribute("groupId"));
+	}
+
+	private void _testCreateTemplateNodeSelectTypeDDMFormFieldWithNoOptions() {
+		DDMFormField ddmFormField = new DDMFormField(
+			"name", DDMFormFieldTypeConstants.SELECT);
+
+		ddmFormField.setDataType("string");
+		ddmFormField.setMultiple(true);
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		rootElement.addElement("dynamic-content");
+
+		TemplateNode templateNode = ReflectionTestUtil.invoke(
+			_journalTransformer, "_createTemplateNode",
+			new Class<?>[] {
+				DDMFormField.class, Element.class, Locale.class,
+				ThemeDisplay.class
+			},
+			ddmFormField, rootElement, LocaleUtil.getDefault(),
+			new ThemeDisplay());
+
+		Assert.assertTrue(MapUtil.isEmpty(templateNode.getAttributes()));
+		Assert.assertEquals(StringPool.BLANK, templateNode.getData());
+		Assert.assertEquals("name", templateNode.getName());
+		Assert.assertEquals("select", templateNode.getType());
+
+		List<String> options = templateNode.getOptions();
+
+		Assert.assertEquals(options.toString(), 0, options.size());
+
+		Assert.assertTrue(MapUtil.isEmpty(templateNode.getOptionsMap()));
 	}
 
 	private void _testCreateTemplateNodeSelectTypeDDMFormFieldWithOptions() {


### PR DESCRIPTION
LPD-39797 A Select from List field shows a list with an empty string even when no options are selected

# What is this trying to solve?

- Select from list field shows an empty string when there is no option selected in Web Content Display

[Link to ticket](https://liferay.atlassian.net/browse/LPD-39797)

# How am I fixing it?

- The data is shown like `"[""]"`, the "" inside the brackets are added within the `optionElement.getData()` so the ifrst step is to not add it to `dataJSONArray` when is empty. Then the "[]" is added when we create `dataJSONArray`, so what I did is to not add it to the `data` when is empty

# How can I test it?

- Follow the steps in the bug and execute integration test
![image](https://github.com/user-attachments/assets/1b5fd7f4-8cad-4d8a-98b0-302ca0b511c2)
