### PR TITLE
LPD-40116  on this case the friendlyURLPosition should match with the one with # because can be mixed

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -845,10 +845,10 @@ public class DLReferencesExportImportContentProcessor
 					"[$dl-reference=" + path + "$,$include-uuid=true$]";
 
 				if (content.startsWith("[#dl-reference=", endPos)) {
-					if (content.contains("include-friendly-url=true")) {
-						int friendlyURLPosition = content.indexOf(
-							"#,#include-friendly-url=true", beginPos);
+					int friendlyURLPosition = content.indexOf(
+						"#,#include-friendly-url=true", beginPos);
 
+					if (friendlyURLPosition != -1) {
 						endPos = friendlyURLPosition + 2;
 					}
 					else {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -869,6 +869,57 @@ public class DefaultExportImportContentProcessorTest {
 		portalUtil.setPortal(new PortalImpl());
 	}
 
+	@Test
+	public void testReplaceExportContentReferencesWithFileEntryInTrash()
+		throws Exception {
+
+		String content = _replaceParameters(
+			_getContent("journal-content.xml"), _fileEntry);
+
+		FileEntry deletedFileEntry = DLAppLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		content = StringUtil.replace(
+			content,
+			new String[] {
+				"[$GROUP_ID_DELETED$]", "[$TITLE_DELETED$]", "[$UUID_DELETED$]"
+			},
+			new String[] {
+				String.valueOf(deletedFileEntry.getGroupId()),
+				deletedFileEntry.getTitle(), deletedFileEntry.getUuid()
+			});
+
+		_referrerStagedModel = JournalTestUtil.addArticle(
+			_stagingGroup.getGroupId(), RandomTestUtil.randomString(), content);
+
+		DLAppHelperLocalServiceUtil.moveFileEntryToTrash(
+			TestPropsValues.getUserId(), deletedFileEntry);
+
+		Element referrerStagedModelElement =
+			_portletDataContextExport.getExportDataElement(
+				_referrerStagedModel);
+
+		String referrerStagedModelPath = ExportImportPathUtil.getModelPath(
+			_referrerStagedModel);
+
+		referrerStagedModelElement.addAttribute(
+			"path", referrerStagedModelPath);
+
+		content = _exportImportContentProcessor.replaceExportContentReferences(
+			_portletDataContextExport, _referrerStagedModel, content, true,
+			true);
+
+		_portletDataContextImport.setScopeGroupId(_fileEntry.getGroupId());
+
+		_exportImportContentProcessor.replaceImportContentReferences(
+			_portletDataContextImport, _referrerStagedModel, content);
+	}
+
 	private Layout _addMultiLocaleLayout(Group group, boolean privateLayout)
 		throws Exception {
 
@@ -1162,8 +1213,9 @@ public class DefaultExportImportContentProcessorTest {
 				"[$EXTERNAL_GROUP_FRIENDLY_URL$]",
 				"[$EXTERNAL_PRIVATE_LAYOUT_FRIENDLY_URL$]",
 				"[$EXTERNAL_PUBLIC_LAYOUT_FRIENDLY_URL$]",
-				"[$FILE_ENTRY_FRIENDLY_URL$]", "[$FRIENDLY_URL_SEPARATOR$]",
-				"[$GROUP_FRIENDLY_URL$]", "[$GROUP_ID$]", "[$GROUP_NAME$]",
+				"[$FILE_ENTRY_FRIENDLY_URL$]", "[$FILE_NAME$]",
+				"[$FRIENDLY_URL_SEPARATOR$]", "[$GROUP_FRIENDLY_URL$]",
+				"[$GROUP_ID$]", "[$GROUP_NAME$]",
 				"[$GROUP_PRIVATE_PAGES_VIRTUAL_HOST$]",
 				"[$GROUP_PUBLIC_PAGES_VIRTUAL_HOST$]", "[$IMAGE_ID$]",
 				"[$LIVE_GROUP_FRIENDLY_URL$]", "[$LIVE_GROUP_ID$]",
@@ -1191,7 +1243,8 @@ public class DefaultExportImportContentProcessorTest {
 				_externalPublicLayout.getFriendlyURL(),
 				FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
 					fileEntry.getTitle()),
-				Portal.FRIENDLY_URL_SEPARATOR, _stagingGroup.getFriendlyURL(),
+				fileEntry.getFileName(), Portal.FRIENDLY_URL_SEPARATOR,
+				_stagingGroup.getFriendlyURL(),
 				String.valueOf(fileEntry.getGroupId()),
 				StringUtil.removeFirst(
 					_stagingGroup.getFriendlyURL(), StringPool.SLASH),
@@ -1430,7 +1483,10 @@ public class DefaultExportImportContentProcessorTest {
 	private PortletDataContext _portletDataContextExport;
 	private PortletDataContext _portletDataContextImport;
 	private StagedModel _referrerStagedModel;
+
+	@DeleteAfterTestRun
 	private Group _stagingGroup;
+
 	private Layout _stagingPrivateLayout;
 	private Layout _stagingPublicLayout;
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/journal-content.xml
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/journal-content.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="content" index-type="text" instance-id="96ZM5men" name="content" type="rich_text">
+		<dynamic-content language-id="en_US">
+			<![CDATA[
+				<img alt="" data-fileentryid="[$IMAGE_ID$]" src="/documents/d/[$GROUP_NAME$]/[$FILE_ENTRY_FRIENDLY_URL$]" />&nbsp;
+				<br />
+				<a href="/documents/[$GROUP_ID_DELETED$]/0/[$TITLE_DELETED$]/[$UUID_DELETED$]">UUID</a>
+			]]>
+		</dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
LPD-40116 Importation fails when on a web content with 2 links with ONE of the on trash

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40116

On some cases,  the importation and exportation fails, it happens when the links are mixed AND the old one, the one inserted with the UUID, the file is on the trash.

# How am I fixing it?

As the filters can be mixed we should check the exact characteres to find.

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-40116 add test to test the behavior on the importation and exportation when the links are mixed AND the old one, the one inserted with the UUID is on the trash.**
- **LPD-40116 on this case the friendlyURLPosition should match with the one with # because can be mixed**
