### PR TITLE
LPD-40156 We should check if the toggle switch is already checked or not in WikiPortlet.macro's enableWiki()

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiPortlet.macro
@@ -48,10 +48,14 @@ definition {
 			configurationName = "Deprecation",
 			configurationScope = "Virtual Instance Scope");
 
-		Check.checkToggleSwitch(
-			locator1 = "FeatureFlag#TOGGLE_ROW",
-			title_row = "Wiki",
-			toggle_state = "Disabled");
+		if (IsElementPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = "Wiki", toggle_state = "Disabled")) {
+			Check.checkToggleSwitch(
+				locator1 = "FeatureFlag#TOGGLE_ROW",
+				title_row = "Wiki",
+				toggle_state = "Disabled");
+		}
+
+		Navigator.openURL();
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40156

Some staging tests are being affected by enable wiki macro like [this one](https://liferay.atlassian.net/browse/LPD-39489?atlOrigin=eyJpIjoiZTU4YzdmYjhiNjM0NGQwNDkxZGVjZGIxMjAyMGFlZWEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ). So this PR is to tmprove enable wiki macro in order to take into account some use cases when:

1. We are calling to enable wiki twice
2. We need to be in the home page 

# How am I fixing it?

Check if there is a disabled wiki feature flag to enable it and go back to home page

# How can you verify that it works?

No test needed because this is to improve our tests. Execute ci:test:headless-functional to see if this change fix this [staging issue.](https://liferay.atlassian.net/browse/LPD-39489?atlOrigin=eyJpIjoiZTU4YzdmYjhiNjM0NGQwNDkxZGVjZGIxMjAyMGFlZWEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
