### PR TITLE
LPD-39703 Editing a Web Content in a Web Content Display displays 2 success messages

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -6,8 +6,7 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext" %><%@
 page import="com.liferay.journal.content.web.internal.servlet.taglib.PortletHeaderActionDropdownItemsProvider" %><%@

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -7,8 +7,6 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<liferay-ui:success key='<%= portletDisplay.getId() + "requestProcessed" %>' message="your-request-completed-successfully" />
-
 <div class="visible-interaction">
 
 	<%


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-39703

### How am I fixing it?
I avoided the double success message by removing the burned in one from the portlet_header.

### How can you verify that it works?

To test run:
~`npm run test -- test -g "LPD-39703" `~

----

Resent without the test case based on https://github.com/liferay-content-management/liferay-portal/pull/6017#issuecomment-2426429131