### PR TITLE
LPD-40404 GIF preview and thumbnail is never displayed, even with Gifsicle enabled

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
@@ -62,7 +62,7 @@ public class AMGIFImageScaler implements AMImageScaler {
 
 			Future<Map.Entry<byte[], byte[]>> collectorFuture =
 				ProcessUtil.execute(
-					CollectorOutputProcessor.INSTANCE, "gifsicle",
+					CollectorOutputProcessor.INSTANCE, "gifsicle", "--careful",
 					"--resize-fit",
 					_getResizeFitValues(amImageConfigurationEntry), "--output",
 					"-", file.getAbsolutePath());


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-40404

Certain gifs in windows fail to generate a preview and throw an error during rendering.

# How am I fixing it?
Adding the --careful flag to the gifsicle process invocation fixes the issue.

# How can you verify that it works?
Follow the steps in LPD-40404 on a Windows system

# Why doesn't this include any test?
Since this is a Windows specific issue, we do not have a way to add automated tests