### PR TITLE
LPD-40430 Fix playwright "Info message appears when autosave is failed due to missing required fields"

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -176,12 +176,6 @@ autoSaveTest(
 		);
 
 		await expect(errorIndicator).toBeVisible();
-
-		await expect(
-			page.getByText(
-				'Please ensure all mandatory fields are completed to enable autosave.'
-			)
-		).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
The autosave message was changed recently, but I don't think the message is relevant, just the lock indicator. 

@NemethNorbert please review. 

```
Running 1 test using 1 worker

  ✓  1 [journal-web] › journal-web/journalArticleAutosave.spec.ts:148:1 › Info message appears when autosave is failed due to missing required fields (32.3s)

  Slow test file: [journal-web] › journal-web/journalArticleAutosave.spec.ts (32.3s)
  Consider splitting slow test files to speed up parallel execution
  1 passed (37.6s)
```