### PR TITLE
LPD-40544 Fix test DepotSharing#CanShareSameDocumentByDifferentUsers

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSharing.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSharing.testcase
@@ -26,6 +26,10 @@ definition {
 		JSONDepot.addDepot(
 			depotDescription = "This is the description of a depot",
 			depotName = "Test Depot Name");
+
+		JSONDepot.connectSite(
+			depotName = "Test Depot Name",
+			groupName = "Guest");
 	}
 
 	tearDown {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40544

This test is failing: `DepotSharing#CanShareSameDocumentByDifferentUsers`

* A user cannot see the shared item.

# How am I fixing it?

Added missing connection between Asset Library and Site.

# How can you verify that it works?

Run `ant -f build-test.xml run-selenium-test -Dtest.class=DepotSharing#CanShareSameDocumentByDifferentUsers`
