### PR TITLE
LPD-40158 FriendlyURL is missing in the default locale if the friendly URL in another language is added

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7431,17 +7431,18 @@ public class JournalArticleLocalServiceImpl
 		Locale defaultLocale, Map<Locale, String> friendlyURLMap,
 		Map<Locale, String> titleMap) {
 
-		for (Map.Entry<Locale, String> friendlyURL :
-				friendlyURLMap.entrySet()) {
+		if (!friendlyURLMap.containsKey(defaultLocale) ||
+			Validator.isNull(friendlyURLMap.get(defaultLocale))) {
 
-			if (Validator.isNotNull(friendlyURL.getValue())) {
-				return friendlyURLMap;
-			}
+			return HashMapBuilder.putAll(
+				friendlyURLMap
+			).put(
+				defaultLocale,
+				_removeTrailingSlashes(titleMap.get(defaultLocale))
+			).build();
 		}
 
-		return HashMapBuilder.put(
-			defaultLocale, _removeTrailingSlashes(titleMap.get(defaultLocale))
-		).build();
+		return friendlyURLMap;
 	}
 
 	private void _copyArticleImages(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -170,6 +170,42 @@ public class JournalArticleLocalServiceTest {
 		_themeDisplay = _getThemeDisplay();
 	}
 
+	@Test
+	public void testAddArticleWithEmptyDefaultLanguageFriendlyURLWithAnotherLanguageFriendlyURL()
+		throws Exception {
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent();
+
+		Locale defaultLocale = _portal.getSiteDefaultLocale(
+			_group.getGroupId());
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		JournalArticle journalArticle = _journalArticleLocalService.addArticle(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), 0, 0,
+			PortalUtil.getClassNameId(JournalArticle.class), StringPool.BLANK,
+			true, 0,
+			HashMapBuilder.put(
+				defaultLocale, "title"
+			).build(),
+			Collections.emptyMap(),
+			HashMapBuilder.put(
+				defaultLocale, ""
+			).put(
+				LocaleUtil.SPAIN, "friendly-url-es"
+			).build(),
+			content, ddmStructure.getStructureId(), null, null, 1, 1, 1965, 0,
+			0, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0,
+			null, null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Map<Locale, String> friendlyURLMap = journalArticle.getFriendlyURLMap();
+
+		Assert.assertNotNull(friendlyURLMap.get(defaultLocale));
+	}
+
 	@Test(expected = DuplicateArticleExternalReferenceCodeException.class)
 	public void testAddArticleWithExistingExternalReferenceCode()
 		throws Exception {


### PR DESCRIPTION
LPD-40158 FriendlyURL is missing in the default locale if the friendly URL in another language is added
# What is this trying to solve?

- Add friendly URL when the URL for the default language is empty but we add a friendly URL to another language

[Link to ticket](https://liferay.atlassian.net/browse/LPD-40158)

# How am I fixing it?

- Before this change, we returned the friendly URL map when there is a friendly URl set, but we didn't verify if the friendly URL for the default language is set, so I add the friendly URL to the default language

# How can I test it?

- Follow the steps in the bug

https://github.com/user-attachments/assets/bc095472-9fb5-4b9c-bcc9-0b4579287486

