### PR TITLE
LPD-40576 [playwright] Fix test 'Translation is removed when using Undo and restored when using Redo'

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -286,7 +286,7 @@ autoSaveTest(
 	async ({journalEditArticlePage, page, site}) => {
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-		await journalEditArticlePage.fillTitle(getRandomString());
+		await journalEditArticlePage.fillContent(getRandomString());
 
 		const translationButton = page.getByLabel('Select a language, current');
 
@@ -298,7 +298,7 @@ autoSaveTest(
 			trigger: translationButton,
 		});
 
-		await journalEditArticlePage.fillTitle(getRandomString());
+		await journalEditArticlePage.fillContent(getRandomString());
 
 		await clickAndExpectToBeVisible({
 			autoClick: false,

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -293,7 +293,7 @@ autoSaveTest(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('option', {
-				name: 'Catalan Language: Not',
+				name: 'Catalan Language: Not Translated',
 			}),
 			trigger: translationButton,
 		});
@@ -313,7 +313,7 @@ autoSaveTest(
 		await clickAndExpectToBeVisible({
 			autoClick: false,
 			target: page.getByRole('option', {
-				name: 'Catalan Language: Not',
+				name: 'Catalan Language: Not Translated',
 			}),
 			trigger: translationButton,
 		});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40576

Fix the test because is working manually

# How am I fixing it?

Using fillContent instead of fillTitle to test the undo/redo translation.


# How can you verify that it works?

1. Go to `/modules/test/playwright`
1. Run `npm install (setup)`
1. Run npm run `npm run playwright test -- -g "Translation is removed when using Undo and restored when using Redo"` to run the test

# Test launched 10 times test locally to avoid flaky results
![image](https://github.com/user-attachments/assets/02aef7cc-d01a-47b6-8f6e-0beb641296e3)
