### PR TITLE
LPD-40531 RELEASE BLOCKER: WC publish button disabled after required fields errors

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -343,6 +343,8 @@ export default function _JournalPortlet({
 				}
 			}
 		);
+
+		lockHolder.lock?.unlock();
 	};
 
 	const handleResetValuesButtonClick = (event) => {

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -737,3 +737,27 @@ autosaveWithoutPermissionsTest(
 		await expect(page.getByTitle(articleTitle)).toBeVisible();
 	}
 );
+
+autosaveWithoutPermissionsTest(
+	'Web Content publish button is enabled after required error messages appear',
+	{
+		tag: '@LPD-40531',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const articleTitle = 'Web Content Title';
+
+		await journalEditArticlePage.publishButton.click();
+
+		await expect(
+			page.getByText('The Title field is required.')
+		).toBeVisible();
+
+		await journalEditArticlePage.fillTitle(articleTitle);
+
+		await journalEditArticlePage.publishButton.click();
+
+		await expect(page.getByTitle(articleTitle)).toBeVisible();
+	}
+);


### PR DESCRIPTION
[Link to ticket ](https://liferay.atlassian.net/browse/LPD-40531) Publish button is disabled when publishing WC without title

> If we publish a WC with no title, the publish button is disabled even if we fill the title

# How I am fixing it
As soon as publish button is clicked, lock is activated (thus, publish button disabled), and in theory when the form is submitted, it is unlocked. This was introduced in https://github.com/liferay-content-management/liferay-portal/pull/5424/commits/42fef9803849f437f7878978746fea2b00f02d30
The problem is that when required fields are empty, the form is not submitted. I haven't found any conditional to unlock jut in that case, so I decided to unlock directly for all the cases. 

# How can be tested
You can follow the steps on the issue, or run `npm run playwright -- test -g 'LPD-40531' --reporter list`

```
npm run playwright -- test -g 'LPD-40531' --reporter list --repeat-each=5

> @liferay/playwright@1.0.0 playwright
> playwright "test" "-g" "LPD-40531" "--reporter" "list" "--repeat-each=5"


Running 5 tests using 1 worker

  ✓  1 [journal-web] › journal-web/journalArticleAutosave.spec.ts:741:1 › Web Content publish button is enabled after required error messages appear (31.1s)
  ✓  2 [journal-web] › journal-web/journalArticleAutosave.spec.ts:741:1 › Web Content publish button is enabled after required error messages appear (21.5s)
  ✓  3 [journal-web] › journal-web/journalArticleAutosave.spec.ts:741:1 › Web Content publish button is enabled after required error messages appear (21.4s)
  ✓  4 [journal-web] › journal-web/journalArticleAutosave.spec.ts:741:1 › Web Content publish button is enabled after required error messages appear (22.7s)
  ✓  5 [journal-web] › journal-web/journalArticleAutosave.spec.ts:741:1 › Web Content publish button is enabled after required error messages appear (23.9s)

  5 passed (2.3m)
```


