### PR TITLE
LPD-40841 add PortletContext to mockLiferayPortletRenderRequest to avoid MVCPortlet `null is not a valid include` log message

### DIFF
--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/display/context/test/BlogsViewEntryContentDisplayContextTest.java
@@ -25,6 +25,7 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -49,6 +50,7 @@ import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.test.MockLiferayPortletContext;
 
 import javax.portlet.Portlet;
 import javax.portlet.RenderRequest;
@@ -192,8 +194,17 @@ public class BlogsViewEntryContentDisplayContextTest {
 			new TestMockLiferayPortletRenderRequest(
 				new MockHttpServletRequest());
 
+		String path = "/blogs/view.jsp";
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			MVCRenderConstants.
+				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
+			new MockLiferayPortletContext(path));
+
 		mockLiferayPortletRenderRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		mockLiferayPortletRenderRequest.setParameter("mvcPath", path);
 
 		ReflectionTestUtil.invoke(
 			_portlet, "doDispatch",


### PR DESCRIPTION
LPD-4084 fix BlogsViewEntryContentDisplayContextTest PortalLogAssertorTest#testScanXMLLog:

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-4084

There is a message on the log on the execution of BlogsViewEntryContentDisplayContextTest and we want to prevent it

# How am I fixing it?

Add PortletContext to mockLiferayPortletRenderRequest to avoid MVCPortlet `null is not a valid include` log message

# How can you verify that it works?

Run the included automated tests.


# Commits

LPD-40841 add PortletContext to mockLiferayPortletRenderRequest to avoid MVCPortlet `null is not a valid include` log message