### PR TITLE
LPD-40849 Underline isn't working in Wiki CKEeditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorCreoleConfigContributor.java
@@ -43,7 +43,7 @@ public class CKEditorCreoleConfigContributor
 
 		jsonObject.put(
 			"allowedContent",
-			"b strong i u hr h1 h2 h3 h4 h5 h6 em ul ol li pre table tr th; " +
+			"b strong i hr h1 h2 h3 h4 h5 h6 em ul ol li pre table tr th; " +
 				"img a[*]");
 
 		Map<String, String> fileBrowserParams =
@@ -95,7 +95,7 @@ public class CKEditorCreoleConfigContributor
 		Map<String, Object> inputEditorTaglibAttributes) {
 
 		return JSONUtil.putAll(
-			toJSONArray("['Bold', 'Italic', 'Underline', '-' ,'RemoveFormat']"),
+			toJSONArray("['Bold', 'Italic', '-' ,'RemoveFormat']"),
 			toJSONArray("['NumberedList', 'BulletedList', '-']"),
 			toJSONArray("['Format']"), toJSONArray("['Link', 'Unlink']"),
 			toJSONArray("['Table', '-','ImageSelector', '-', 'HorizontalRule']")


### PR DESCRIPTION
>[!IMPORTANT]
> This PR needs to be reviewed by Fronted Infra

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40849

Underline isn't working in Wiki CKEditor

# How am I fixing it?

I removed the underling because we accidentally added it in LPS-110019 (12dfaf5).

Before I realized that is included by accident I try to add support to underline in [frontend-editor-ckeditor/.../creole_data_processor.js](../blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_data_processor.js) but apparently, our current parser only supported [Creole 1.0](http://www.wikicreole.org/wiki/Creole1.0).

# How can you verify that it works?

1. Go to Site > Content & Data > Wiki
1. Main > Add a Page

Confirm the underline `U` format button is not in the toolbar.

## Before PR
![image](https://github.com/user-attachments/assets/e620eb1d-6e4d-4495-8a4b-8d3ab261fc85)

## After PR
![image](https://github.com/user-attachments/assets/066817c3-6661-433a-9c6b-4240b185c442)

# Why doesn't this include any test?

We are removing a format button, which doesn't work before the PR.