### PR TITLE
LPD-40999 Change ownership of Asset Publisher from Page Management to Content Management

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,11 +19,11 @@ modules/apps/asset/asset-display-page-test    @liferay-page-management
 modules/apps/asset/asset-display-web    @liferay-page-management
 modules/apps/asset/asset-info-display-api    @liferay-page-management
 modules/apps/asset/asset-info-display-impl    @liferay-page-management
-modules/apps/asset/asset-publisher-web    @liferay-page-management
-modules/apps/asset/asset-publisher-api    @liferay-page-management
-modules/apps/asset/asset-publisher-layout-prototype    @liferay-page-management
-modules/apps/asset/asset-publisher-test    @liferay-page-management
-modules/apps/asset/asset-publisher-web    @liferay-page-management
+modules/apps/asset/asset-publisher-web    @liferay-content-management
+modules/apps/asset/asset-publisher-api    @liferay-content-management
+modules/apps/asset/asset-publisher-layout-prototype    @liferay-content-management
+modules/apps/asset/asset-publisher-test    @liferay-content-management
+modules/apps/asset/asset-publisher-web    @liferay-content-management
 modules/apps/batch-engine/    @liferay-headless
 modules/apps/batch-planner/    @liferay-headless
 modules/apps/bean-portlet/

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisher.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisher.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-page-management"
+@component-name = "portal-content-management"
 definition {
 
 	property ci.retries.disabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-page-management"
+@component-name = "portal-content-management"
 definition {
 
 	property ci.retries.disabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherWithXSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherWithXSS.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-page-management"
+@component-name = "portal-content-management"
 definition {
 
 	property ci.retries.disabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/relatedassets/RelatedAssets.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/relatedassets/RelatedAssets.testcase
@@ -1,4 +1,4 @@
-@component-name = "page-management"
+@component-name = "portal-content-management"
 definition {
 
 	property ci.retries.disabled = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/misc/mostviewedassets/MostViewedAssetsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/misc/mostviewedassets/MostViewedAssetsUpgrade.testcase
@@ -1,4 +1,4 @@
-@component-name = "page-management"
+@component-name = "portal-content-management"
 definition {
 
 	property ci.retries.disabled = "true";
@@ -6,7 +6,6 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
-	property testray.component.names = "Upgrades WEM";
 	property testray.main.component.name = "Asset Publisher Widget";
 
 	setUp {

--- a/test.properties
+++ b/test.properties
@@ -4508,6 +4508,7 @@
 
     content.management.playwright.projects=\
         announcements-web,\
+        asset-publisher-web,\
         blogs-web,\
         content-dashboard-web,\
         document-library-web,\
@@ -4561,8 +4562,7 @@
 
     modules.excludes[js-unit][content-management]=\
         apps/asset/asset-display-page-*/**,\
-        apps/asset/asset-list-*/**,\
-        apps/asset/asset-publisher-*/**
+        apps/asset/asset-list-*/**
 
     modules.includes[js-unit][content-management]=${content.management.testing.modules}
 
@@ -4581,7 +4581,6 @@
         **/analytics/**/*Test.java,\
         **/asset/asset-display-page-*/**/*Test.java,\
         **/asset/asset-list-*/**/*Test.java,\
-        **/asset/asset-publisher-*/**/*Test.java,\
         **/calendar/**/*Test.java,\
         **/export-import/**/*Test.java,\
         **/layout/**/*Test.java,\
@@ -4644,6 +4643,7 @@
             (testray.main.component.name ~ "AI-Creator") OR \
             (testray.main.component.name ~ "Adaptive Media") OR \
             (testray.main.component.name ~ "Announcements") OR \
+            (testray.main.component.name ~ "Asset Publisher Widget") OR \
             (testray.main.component.name ~ "Asset Sharing") OR \
             (testray.main.component.name ~ "Auto Tagging") OR \
             (testray.main.component.name ~ "Blogs") OR \
@@ -4665,6 +4665,7 @@
             (testray.main.component.name ~ "Questions") OR \
             (testray.main.component.name ~ "Ratings") OR \
             (testray.main.component.name ~ "Recycle Bin") OR \
+            (testray.main.component.name ~ "Related Assets Widget") OR \
             (testray.main.component.name ~ "Social Bookmarks") OR \
             (testray.main.component.name ~ "Social Networking") OR \
             (testray.main.component.name ~ "Tags") OR \
@@ -6497,7 +6498,6 @@
     modules.includes.public[modules-semantic-versioning][page-management]=${page.management.testing.modules}
 
     page.management.playwright.projects=\
-        asset-publisher-web,\
         fragment-web,\
         iframe-web,\
         layout-admin-web,\
@@ -6511,7 +6511,6 @@
 
     page.management.testing.modules=\
         apps/asset/asset-display-**,\
-        apps/asset/asset-publisher-**,\
         apps/fragment/**,\
         apps/info/info-**,\
         apps/layout/layout-**,\
@@ -6537,7 +6536,6 @@
 
     test.batch.class.names.includes[page-management]=\
         **/asset/asset-display-page-**/**/*Test.java,\
-        **/asset/asset-publisher-**/**/*Test.java,\
         **/fragment/**/*Test.java,\
         **/headless/headless-admin-site/**/*Test.java,\
         **/headless/headless-delivery/**/*SitePage*Test.java,\
@@ -6565,15 +6563,13 @@
 
     test.batch.run.property.query[functional-tomcat90-postgresql155][page-management]=\
         (\
-            (testray.main.component.name == "Asset Publisher Widget") OR \
             (testray.main.component.name == "Content Pages") OR \
             (testray.main.component.name == "Display Page Templates") OR \
             (testray.main.component.name == "Fragment Administration") OR \
             (testray.main.component.name == "Master Pages") OR \
             (testray.main.component.name == "Page Administration") OR \
             (testray.main.component.name == "Pages Tree") OR \
-            (testray.main.component.name == "RSS Publisher Widget") OR \
-            (testray.main.component.name == "Related Assets Widget")\
+            (testray.main.component.name == "RSS Publisher Widget")\
         )
 
     #
@@ -11024,6 +11020,7 @@
         Akismet,\
         Announcements,\
         Asset Framework,\
+        Asset Publisher Widget,\
         Asset Sharing,\
         Auto Tagging,\
         Blogs,\
@@ -11051,6 +11048,7 @@
         Questions,\
         Ratings,\
         Recycle Bin,\
+        Related Assets Widget,\
         Saved Content,\
         Social Bookmarks,\
         Social Networking,\
@@ -11171,7 +11169,6 @@
         solutions
 
     testray.team.page-management.component.names=\
-        Asset Publisher Widget,\
         Content Page Templates,\
         Content Pages,\
         Display Page Templates,\
@@ -11184,7 +11181,6 @@
         Page Administration,\
         Page Editor,\
         Pages Tree,\
-        Related Assets Widget,\
         RSS Publisher Widget,\
         Simulation,\
         Templates,\


### PR DESCRIPTION
Motivation
-----
As part of the changes in components ownership we did some agreement about Asset Publisher in the past.

We decided to move the ownership after the deprecation of Dynamic and Manual style was completed, so since this logic was already merged on master, we are changing the component ownership.

[More Details](https://liferay.atlassian.net/browse/LPD-39304)

Please let me know if you have any question.