### PR TITLE
LPD-36686 add external reference code support for assetTag entity

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/service/impl/AssetAutoTaggerEntryLocalServiceImpl.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/service/impl/AssetAutoTaggerEntryLocalServiceImpl.java
@@ -64,8 +64,8 @@ public class AssetAutoTaggerEntryLocalServiceImpl
 
 		if (assetTag == null) {
 			assetTag = _assetTagLocalService.addTag(
-				assetEntry.getUserId(), assetEntry.getGroupId(), assetTagName,
-				new ServiceContext());
+				null, assetEntry.getUserId(), assetEntry.getGroupId(),
+				assetTagName, new ServiceContext());
 		}
 
 		_assetTagLocalService.addAssetEntryAssetTag(

--- a/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/test/AssetAutoTaggerEntryLocalServiceTest.java
+++ b/modules/apps/asset/asset-auto-tagger-test/src/testIntegration/java/com/liferay/asset/auto/tagger/service/test/AssetAutoTaggerEntryLocalServiceTest.java
@@ -55,11 +55,11 @@ public class AssetAutoTaggerEntryLocalServiceTest {
 		throws PortalException {
 
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "Tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "Tag",
 			_serviceContext);
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag",
 			_serviceContext);
 
 		AssetAutoTaggerEntry assetAutoTaggerEntry =

--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/portlet/AssetTagsAdminPortlet.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/portlet/AssetTagsAdminPortlet.java
@@ -94,13 +94,13 @@ public class AssetTagsAdminPortlet extends MVCPortlet {
 			// Add tag
 
 			_assetTagService.addTag(
-				serviceContext.getScopeGroupId(), name, serviceContext);
+				null, serviceContext.getScopeGroupId(), name, serviceContext);
 		}
 		else {
 
 			// Update tag
 
-			_assetTagService.updateTag(tagId, name, serviceContext);
+			_assetTagService.updateTag(null, tagId, name, serviceContext);
 		}
 	}
 

--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -175,8 +175,9 @@ public class AssetTagStagedModelDataHandler
 		else {
 			try {
 				importedAssetTag = _assetTagLocalService.updateTag(
-					null, userId, existingAssetTag.getTagId(),
-					assetTag.getName(), serviceContext);
+					existingAssetTag.getExternalReferenceCode(), userId,
+					existingAssetTag.getTagId(), assetTag.getName(),
+					serviceContext);
 			}
 			catch (DuplicateTagException duplicateTagException) {
 				if (_log.isDebugEnabled()) {
@@ -184,7 +185,8 @@ public class AssetTagStagedModelDataHandler
 				}
 
 				importedAssetTag = _assetTagLocalService.updateTag(
-					null, userId, existingAssetTag.getTagId(),
+					existingAssetTag.getExternalReferenceCode(), userId,
+					existingAssetTag.getTagId(),
 					assetTag.getName() + " (Duplicate)", serviceContext);
 			}
 		}

--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -159,7 +159,7 @@ public class AssetTagStagedModelDataHandler
 
 			try {
 				importedAssetTag = _assetTagLocalService.addTag(
-					userId, portletDataContext.getScopeGroupId(),
+					null, userId, portletDataContext.getScopeGroupId(),
 					assetTag.getName(), serviceContext);
 			}
 			catch (DuplicateTagException duplicateTagException) {
@@ -168,15 +168,15 @@ public class AssetTagStagedModelDataHandler
 				}
 
 				importedAssetTag = _assetTagLocalService.addTag(
-					userId, portletDataContext.getScopeGroupId(),
+					null, userId, portletDataContext.getScopeGroupId(),
 					assetTag.getName() + " (Duplicate)", serviceContext);
 			}
 		}
 		else {
 			try {
 				importedAssetTag = _assetTagLocalService.updateTag(
-					userId, existingAssetTag.getTagId(), assetTag.getName(),
-					serviceContext);
+					null, userId, existingAssetTag.getTagId(),
+					assetTag.getName(), serviceContext);
 			}
 			catch (DuplicateTagException duplicateTagException) {
 				if (_log.isDebugEnabled()) {
@@ -184,7 +184,7 @@ public class AssetTagStagedModelDataHandler
 				}
 
 				importedAssetTag = _assetTagLocalService.updateTag(
-					userId, existingAssetTag.getTagId(),
+					null, userId, existingAssetTag.getTagId(),
 					assetTag.getName() + " (Duplicate)", serviceContext);
 			}
 		}

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagFixture.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagFixture.java
@@ -39,7 +39,7 @@ public class AssetTagFixture {
 				_group.getGroupId(), userId);
 
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			userId, _group.getGroupId(), RandomTestUtil.randomString(),
+			null, userId, _group.getGroupId(), RandomTestUtil.randomString(),
 			serviceContext);
 
 		_assetTags.add(assetTag);

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagIndexerIndexedFieldsTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagIndexerIndexedFieldsTest.java
@@ -204,6 +204,8 @@ public class AssetTagIndexerIndexedFieldsTest {
 			"assetCount_Number_sortable",
 			String.valueOf(assetTag.getAssetCount())
 		).put(
+			"externalReferenceCode", assetTag.getExternalReferenceCode()
+		).put(
 			"groupExternalReferenceCode", _group.getExternalReferenceCode()
 		).put(
 			"name_String_sortable", StringUtil.toLowerCase(assetTag.getName())

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagsSearchTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/search/test/AssetTagsSearchTest.java
@@ -60,11 +60,11 @@ public class AssetTagsSearchTest {
 	@Test
 	public void testExactMatchSearch() throws Exception {
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag",
 			_serviceContext);
 
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
 			_serviceContext);
 
 		BaseModelSearchResult<AssetTag> searchResult =
@@ -77,11 +77,11 @@ public class AssetTagsSearchTest {
 	@Test
 	public void testNoMatchSearch() throws Exception {
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
 			_serviceContext);
 
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag2",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag2",
 			_serviceContext);
 
 		BaseModelSearchResult<AssetTag> searchResult =
@@ -97,8 +97,8 @@ public class AssetTagsSearchTest {
 
 		for (String assetTag : searchAssetTags) {
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), _group.getGroupId(), assetTag,
-				_serviceContext);
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				assetTag, _serviceContext);
 		}
 
 		BaseModelSearchResult<AssetTag> searchResult =

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
@@ -108,7 +108,7 @@ public class AssetTagLocalServiceTest {
 	@Test
 	public void testAddTag() throws PortalException {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag",
 			_serviceContext);
 
 		Assert.assertEquals("tag", assetTag.getName());
@@ -117,8 +117,8 @@ public class AssetTagLocalServiceTest {
 	@Test(expected = AssetTagNameException.class)
 	public void testAddTagWithEmptyName() throws Exception {
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), StringPool.BLANK,
-			_serviceContext);
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			StringPool.BLANK, _serviceContext);
 	}
 
 	@Test(expected = AssetTagException.class)
@@ -127,14 +127,14 @@ public class AssetTagLocalServiceTest {
 			AssetHelper.INVALID_CHARACTERS);
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			stringWithInvalidCharacters, _serviceContext);
 	}
 
 	@Test
 	public void testAddTagWithMultipleWords() throws PortalException {
 		AssetTag tag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag name",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag name",
 			_serviceContext);
 
 		Assert.assertEquals("tag name", tag.getName());
@@ -143,15 +143,15 @@ public class AssetTagLocalServiceTest {
 	@Test(expected = AssetTagNameException.class)
 	public void testAddTagWithNullName() throws Exception {
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), null,
+			null, TestPropsValues.getUserId(), _group.getGroupId(), null,
 			_serviceContext);
 	}
 
 	@Test(expected = AssetTagNameException.class)
 	public void testAddTagWithOnlySpacesInName() throws Exception {
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), StringPool.SPACE,
-			_serviceContext);
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			StringPool.SPACE, _serviceContext);
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class AssetTagLocalServiceTest {
 		throws PortalException {
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "-_^()!$",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "-_^()!$",
 			_serviceContext);
 	}
 
@@ -168,7 +168,7 @@ public class AssetTagLocalServiceTest {
 		int originalTagsCount = _assetTagLocalService.getAssetTagsCount();
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag",
 			_serviceContext);
 
 		Assert.assertEquals(
@@ -178,7 +178,7 @@ public class AssetTagLocalServiceTest {
 	@Test
 	public void testAddUTF8FormattedTags() throws PortalException {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "標籤名稱",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "標籤名稱",
 			_serviceContext);
 
 		Assert.assertEquals("標籤名稱", assetTag.getName());
@@ -207,7 +207,7 @@ public class AssetTagLocalServiceTest {
 	@Test
 	public void testDeleteTag() throws Exception {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "Tag",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "Tag",
 			_serviceContext);
 
 		_serviceContext.setAssetTagNames(new String[] {assetTag.getName()});
@@ -276,7 +276,7 @@ public class AssetTagLocalServiceTest {
 				new String[] {"tAg1", "TAG1"});
 
 			_assetTagLocalService.addTag(
-				TestPropsValues.getUserId(), group.getGroupId(), "tAg1",
+				null, TestPropsValues.getUserId(), group.getGroupId(), "tAg1",
 				_serviceContext);
 
 			for (AssetTag assetTag : assetTags) {
@@ -302,13 +302,13 @@ public class AssetTagLocalServiceTest {
 
 		try {
 			AssetTag expectedAssetTag1 = _assetTagLocalService.addTag(
-				TestPropsValues.getUserId(), _group.getGroupId(), "tAg1",
+				null, TestPropsValues.getUserId(), _group.getGroupId(), "tAg1",
 				_serviceContext);
 			AssetTag expectedAssetTag2 = _assetTagLocalService.addTag(
-				TestPropsValues.getUserId(), group.getGroupId(), "tAg1",
+				null, TestPropsValues.getUserId(), group.getGroupId(), "tAg1",
 				_serviceContext);
 			AssetTag expectedAssetTag3 = _assetTagLocalService.addTag(
-				TestPropsValues.getUserId(), _group.getGroupId(), "TAG1",
+				null, TestPropsValues.getUserId(), _group.getGroupId(), "TAG1",
 				_serviceContext);
 
 			Assert.assertTrue(
@@ -408,7 +408,7 @@ public class AssetTagLocalServiceTest {
 		throws PortalException {
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(100), _serviceContext);
 	}
 
@@ -461,13 +461,13 @@ public class AssetTagLocalServiceTest {
 	@Test
 	public void testUpdateTagWithCaseSensitive() throws PortalException {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
 			_serviceContext);
 
 		String tagName = "updated TAG1";
 
 		AssetTag actualAssetTag = _assetTagLocalService.updateTag(
-			TestPropsValues.getUserId(), assetTag.getTagId(), tagName,
+			null, TestPropsValues.getUserId(), assetTag.getTagId(), tagName,
 			_serviceContext);
 
 		Assert.assertEquals(tagName, actualAssetTag.getName());
@@ -492,8 +492,8 @@ public class AssetTagLocalServiceTest {
 		for (String tagName : tagNames) {
 			assetTags.add(
 				_assetTagLocalService.addTag(
-					TestPropsValues.getUserId(), _group.getGroupId(), tagName,
-					_serviceContext));
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
+					tagName, _serviceContext));
 		}
 
 		return assetTags;
@@ -533,7 +533,7 @@ public class AssetTagLocalServiceTest {
 
 		for (String tagName : tagNames) {
 			AssetTag assetTag = _assetTagLocalService.addTag(
-				TestPropsValues.getUserId(), _group.getGroupId(), tagName,
+				null, TestPropsValues.getUserId(), _group.getGroupId(), tagName,
 				_serviceContext);
 
 			Assert.assertEquals(tagName, assetTag.getName());

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagLocalServiceTest.java
@@ -467,8 +467,8 @@ public class AssetTagLocalServiceTest {
 		String tagName = "updated TAG1";
 
 		AssetTag actualAssetTag = _assetTagLocalService.updateTag(
-			null, TestPropsValues.getUserId(), assetTag.getTagId(), tagName,
-			_serviceContext);
+			assetTag.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			assetTag.getTagId(), tagName, _serviceContext);
 
 		Assert.assertEquals(tagName, actualAssetTag.getName());
 	}

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagServiceTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/service/test/AssetTagServiceTest.java
@@ -49,10 +49,10 @@ public class AssetTagServiceTest {
 			_group.getGroupId());
 
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 		AssetTagLocalServiceUtil.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		Assert.assertEquals(

--- a/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
+++ b/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
@@ -106,7 +106,7 @@ public class AssetTestUtil {
 		long userId = TestPropsValues.getUserId();
 
 		return AssetTagLocalServiceUtil.addTag(
-			userId, groupId, assetTagName,
+			null, userId, groupId, assetTagName,
 			ServiceContextTestUtil.getServiceContext(groupId, userId));
 	}
 

--- a/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/BaseAssetSearchTestCase.java
+++ b/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/BaseAssetSearchTestCase.java
@@ -132,22 +132,23 @@ public abstract class BaseAssetSearchTestCase {
 			serviceContext = ServiceContextTestUtil.getServiceContext(groupId);
 
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), groupId, "liferay",
+				null, TestPropsValues.getUserId(), groupId, "liferay",
 				serviceContext);
 
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), groupId, "architecture",
+				null, TestPropsValues.getUserId(), groupId, "architecture",
 				serviceContext);
 
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), groupId, "modularity",
+				null, TestPropsValues.getUserId(), groupId, "modularity",
 				serviceContext);
 
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), groupId, "osgi", serviceContext);
+				null, TestPropsValues.getUserId(), groupId, "osgi",
+				serviceContext);
 
 			AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), groupId, "services",
+				null, TestPropsValues.getUserId(), groupId, "services",
 				serviceContext);
 		}
 

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/kernel/service/persistence/test/AssetTagFinderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/kernel/service/persistence/test/AssetTagFinderTest.java
@@ -91,7 +91,7 @@ public class AssetTagFinderTest {
 	@Test
 	public void testCountByG_C_N_WithCaseSensitiveTags() throws Exception {
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
 			_serviceContext);
 
 		_testCountByG_C_N("Tag1", _portal.getClassNameId(MBMessage.class));
@@ -120,7 +120,7 @@ public class AssetTagFinderTest {
 	@Test
 	public void testFindByG_C_N_WithCaseSensitiveTags() throws Exception {
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
+			null, TestPropsValues.getUserId(), _group.getGroupId(), "tag1",
 			_serviceContext);
 
 		_serviceContext.setAssetTagNames(new String[] {"tag1"});

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetTagsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/AssetTagsImporter.java
@@ -46,7 +46,7 @@ public class AssetTagsImporter {
 
 			if (assetTag == null) {
 				assetTag = _assetTagLocalService.addTag(
-					userId, scopeGroupId, tagName, serviceContext);
+					null, userId, scopeGroupId, tagName, serviceContext);
 			}
 
 			assetTags.add(assetTag);

--- a/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/test/BlogsEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/test/BlogsEntryContentDashboardItemTest.java
@@ -186,7 +186,7 @@ public class BlogsEntryContentDashboardItemTest {
 	@Test
 	public void testGetAssetTags() throws Exception {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), _serviceContext);
 
 		_serviceContext.setAssetTagNames(new String[] {assetTag.getName()});

--- a/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/test/JournalArticleContentDashboardItemTest.java
@@ -217,7 +217,7 @@ public class JournalArticleContentDashboardItemTest {
 	@Test
 	public void testGetAssetTags() throws Exception {
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), _serviceContext);
 
 		_serviceContext.setAssetTagNames(new String[] {assetTag.getName()});

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryDLAppServiceWhenCopyingWithAssetCategoriesAndAssetTagsTest.java
@@ -386,7 +386,7 @@ public class
 		long userId = TestPropsValues.getUserId();
 
 		_assetTagLocalService.addTag(
-			userId, groupId, assetTagName,
+			null, userId, groupId, assetTagName,
 			ServiceContextTestUtil.getServiceContext(groupId, userId));
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -192,7 +192,7 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 
 		return _toKeyword(
 			_assetTagService.addTag(
-				siteId, keyword.getName(), new ServiceContext()));
+				null, siteId, keyword.getName(), new ServiceContext()));
 	}
 
 	@Override
@@ -200,7 +200,8 @@ public class KeywordResourceImpl extends BaseKeywordResourceImpl {
 		throws Exception {
 
 		return _toKeyword(
-			_assetTagService.updateTag(keywordId, keyword.getName(), null));
+			_assetTagService.updateTag(
+				null, keywordId, keyword.getName(), null));
 	}
 
 	@Override

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
@@ -170,7 +170,7 @@ public class JournalArticleAssetEntryTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		AssetTag assetTag1 = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag1.getName()});
@@ -187,7 +187,7 @@ public class JournalArticleAssetEntryTest {
 			false, true, serviceContext);
 
 		AssetTag assetTag2 = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag2.getName()});
@@ -216,7 +216,7 @@ public class JournalArticleAssetEntryTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag.getName()});
@@ -230,7 +230,7 @@ public class JournalArticleAssetEntryTest {
 		String updatedAssetTagName = RandomTestUtil.randomString();
 
 		_assetTagLocalService.updateTag(
-			TestPropsValues.getUserId(), assetTag.getTagId(),
+			null, TestPropsValues.getUserId(), assetTag.getTagId(),
 			updatedAssetTagName, serviceContext);
 
 		_assertSearch(updatedAssetTagName, journalArticle);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
@@ -230,8 +230,8 @@ public class JournalArticleAssetEntryTest {
 		String updatedAssetTagName = RandomTestUtil.randomString();
 
 		_assetTagLocalService.updateTag(
-			null, TestPropsValues.getUserId(), assetTag.getTagId(),
-			updatedAssetTagName, serviceContext);
+			assetTag.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			assetTag.getTagId(), updatedAssetTagName, serviceContext);
 
 		_assertSearch(updatedAssetTagName, journalArticle);
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -895,7 +895,7 @@ public class JournalArticleLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		AssetTag assetTag1 = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag1.getName()});
@@ -912,7 +912,7 @@ public class JournalArticleLocalServiceTest {
 			false, true, serviceContext);
 
 		AssetTag assetTag2 = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag2.getName()});
@@ -1053,7 +1053,7 @@ public class JournalArticleLocalServiceTest {
 				_group.getGroupId(), TestPropsValues.getUserId());
 
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		serviceContext.setAssetTagNames(new String[] {assetTag.getName()});

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -506,8 +506,8 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		throws Exception {
 
 		return _assetTagLocalService.addTag(
-			user.getUserId(), testGroup.getGroupId(), StringUtil.randomString(),
-			serviceContext);
+			null, user.getUserId(), testGroup.getGroupId(),
+			StringUtil.randomString(), serviceContext);
 	}
 
 	private JournalArticle _addJournalArticle(

--- a/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/test/util/MembershipPolicyTestUtil.java
+++ b/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/test/util/MembershipPolicyTestUtil.java
@@ -242,7 +242,7 @@ public class MembershipPolicyTestUtil {
 
 		if (includeCategorization) {
 			AssetTag tag = AssetTagLocalServiceUtil.addTag(
-				TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 				RandomTestUtil.randomString(), new ServiceContext());
 
 			serviceContext.setAssetTagNames(new String[] {tag.getName()});

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/AssetTagExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/AssetTagExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.BaseExternalReferenceCodeUpgradeProcessTestCase;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class AssetTagExternalReferenceCodeUpgradeProcessTest
+	extends BaseExternalReferenceCodeUpgradeProcessTestCase {
+
+	@Override
+	protected ExternalReferenceCodeModel[] addExternalReferenceCodeModels(
+			String tableName)
+		throws PortalException {
+
+		AssetTag assetTag = _assetTagLocalService.addTag(
+			TestPropsValues.getUserId(), group.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		return new ExternalReferenceCodeModel[] {assetTag};
+	}
+
+	@Override
+	protected ExternalReferenceCodeModel fetchExternalReferenceCodeModel(
+		ExternalReferenceCodeModel externalReferenceCodeModel,
+		String tableName) {
+
+		AssetTag assetTag = (AssetTag)externalReferenceCodeModel;
+
+		return _assetTagLocalService.fetchAssetTag(assetTag.getTagId());
+	}
+
+	@Override
+	protected String[] getTableNames() {
+		return new String[] {"AssetTag"};
+	}
+
+	@Override
+	protected UpgradeProcess getUpgradeProcess() {
+		return new BaseExternalReferenceCodeUpgradeProcess() {
+
+			@Override
+			protected String[][] getTableAndPrimaryKeyColumnNames() {
+				return new String[][] {{"AssetTag", "tagId"}};
+			}
+
+		};
+	}
+
+	@Override
+	protected UpgradeStepRegistrator getUpgradeStepRegistrator() {
+		return null;
+	}
+
+	@Override
+	protected Version getVersion() {
+		return null;
+	}
+
+	@Inject
+	private AssetTagLocalService _assetTagLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/AssetTagExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/AssetTagExternalReferenceCodeUpgradeProcessTest.java
@@ -35,7 +35,7 @@ public class AssetTagExternalReferenceCodeUpgradeProcessTest
 		throws PortalException {
 
 		AssetTag assetTag = _assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -318,7 +318,7 @@ public class GroupServiceTest {
 			group.getGroupId());
 
 		_assetTagLocalService.addTag(
-			TestPropsValues.getUserId(), group.getGroupId(),
+			null, TestPropsValues.getUserId(), group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
 		Assert.assertEquals(

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/internal/blueprint/test/SXPBlueprintSearchResultTest.java
@@ -876,7 +876,8 @@ public class SXPBlueprintSearchResultTest {
 	@Test
 	public void testBoostTaggedContents() throws Exception {
 		_assetTag = AssetTagLocalServiceUtil.addTag(
-			_user.getUserId(), _group.getGroupId(), "Boost", _serviceContext);
+			null, _user.getUserId(), _group.getGroupId(), "Boost",
+			_serviceContext);
 
 		_journalArticleBuilder.setTitle(
 			"Article"
@@ -910,7 +911,8 @@ public class SXPBlueprintSearchResultTest {
 	@Test
 	public void testBoostTagsMatch() throws Exception {
 		_assetTag = AssetTagLocalServiceUtil.addTag(
-			_user.getUserId(), _group.getGroupId(), "cola", _serviceContext);
+			null, _user.getUserId(), _group.getGroupId(), "cola",
+			_serviceContext);
 
 		_journalArticleBuilder.setTitle(
 			"coca cola"

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portlet.asset.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.exception.DuplicateAssetTagExternalReferenceCodeException;
 import com.liferay.asset.kernel.exception.NoSuchTagException;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
@@ -120,6 +121,8 @@ public class AssetTagPersistenceTest {
 
 		newAssetTag.setUuid(RandomTestUtil.randomString());
 
+		newAssetTag.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		newAssetTag.setGroupId(RandomTestUtil.nextLong());
 
 		newAssetTag.setCompanyId(RandomTestUtil.nextLong());
@@ -150,6 +153,9 @@ public class AssetTagPersistenceTest {
 			newAssetTag.getCtCollectionId());
 		Assert.assertEquals(existingAssetTag.getUuid(), newAssetTag.getUuid());
 		Assert.assertEquals(
+			existingAssetTag.getExternalReferenceCode(),
+			newAssetTag.getExternalReferenceCode());
+		Assert.assertEquals(
 			existingAssetTag.getTagId(), newAssetTag.getTagId());
 		Assert.assertEquals(
 			existingAssetTag.getGroupId(), newAssetTag.getGroupId());
@@ -171,6 +177,26 @@ public class AssetTagPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingAssetTag.getLastPublishDate()),
 			Time.getShortTimestamp(newAssetTag.getLastPublishDate()));
+	}
+
+	@Test(expected = DuplicateAssetTagExternalReferenceCodeException.class)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		AssetTag assetTag = addAssetTag();
+
+		AssetTag newAssetTag = addAssetTag();
+
+		newAssetTag.setGroupId(assetTag.getGroupId());
+
+		newAssetTag = _persistence.update(newAssetTag);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newAssetTag);
+
+		newAssetTag.setExternalReferenceCode(
+			assetTag.getExternalReferenceCode());
+
+		_persistence.update(newAssetTag);
 	}
 
 	@Test
@@ -246,6 +272,15 @@ public class AssetTagPersistenceTest {
 	}
 
 	@Test
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
+
+		_persistence.countByERC_G("null", 0L);
+
+		_persistence.countByERC_G((String)null, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		AssetTag newAssetTag = addAssetTag();
 
@@ -271,9 +306,10 @@ public class AssetTagPersistenceTest {
 	protected OrderByComparator<AssetTag> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"AssetTag", "mvccVersion", true, "ctCollectionId", true, "uuid",
-			true, "tagId", true, "groupId", true, "companyId", true, "userId",
-			true, "userName", true, "createDate", true, "modifiedDate", true,
-			"name", true, "assetCount", true, "lastPublishDate", true);
+			true, "externalReferenceCode", true, "tagId", true, "groupId", true,
+			"companyId", true, "userId", true, "userName", true, "createDate",
+			true, "modifiedDate", true, "name", true, "assetCount", true,
+			"lastPublishDate", true);
 	}
 
 	@Test
@@ -537,6 +573,17 @@ public class AssetTagPersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				assetTag, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "groupId"));
+
+		Assert.assertEquals(
+			assetTag.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				assetTag, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(assetTag.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				assetTag, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected AssetTag addAssetTag() throws Exception {
@@ -549,6 +596,8 @@ public class AssetTagPersistenceTest {
 		assetTag.setCtCollectionId(RandomTestUtil.nextLong());
 
 		assetTag.setUuid(RandomTestUtil.randomString());
+
+		assetTag.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		assetTag.setGroupId(RandomTestUtil.nextLong());
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 108.0.1
+Bundle-Version: 108.1.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1315,6 +1315,7 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -152,6 +152,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="tagId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -52,10 +52,6 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		if (Validator.isBlank(externalReferenceCode)) {
-			externalReferenceCode = null;
-		}
-
 		User user = _userPersistence.findByPrimaryKey(userId);
 
 		long repositoryId = counterLocalService.increment();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -504,6 +504,17 @@ public class PortalUpgradeProcessRegistryImpl
 				}
 
 			});
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 12, 0),
+			new BaseExternalReferenceCodeUpgradeProcess() {
+
+				@Override
+				protected String[][] getTableAndPrimaryKeyColumnNames() {
+					return new String[][] {{"AssetTag", "tagId"}};
+				}
+
+			});
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagCacheModel.java
@@ -67,7 +67,7 @@ public class AssetTagCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(27);
+		StringBundler sb = new StringBundler(29);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -75,6 +75,8 @@ public class AssetTagCacheModel
 		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", tagId=");
 		sb.append(tagId);
 		sb.append(", groupId=");
@@ -112,6 +114,13 @@ public class AssetTagCacheModel
 		}
 		else {
 			assetTagImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			assetTagImpl.setExternalReferenceCode("");
+		}
+		else {
+			assetTagImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		assetTagImpl.setTagId(tagId);
@@ -167,6 +176,7 @@ public class AssetTagCacheModel
 
 		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		tagId = objectInput.readLong();
 
@@ -195,6 +205,13 @@ public class AssetTagCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(tagId);
@@ -229,6 +246,7 @@ public class AssetTagCacheModel
 	public long mvccVersion;
 	public long ctCollectionId;
 	public String uuid;
+	public String externalReferenceCode;
 	public long tagId;
 	public long groupId;
 	public long companyId;

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagModelImpl.java
@@ -65,12 +65,12 @@ public class AssetTagModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
-		{"uuid_", Types.VARCHAR}, {"tagId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
-		{"name", Types.VARCHAR}, {"assetCount", Types.INTEGER},
-		{"lastPublishDate", Types.TIMESTAMP}
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"tagId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"name", Types.VARCHAR},
+		{"assetCount", Types.INTEGER}, {"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -80,6 +80,7 @@ public class AssetTagModelImpl
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("tagId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -93,7 +94,7 @@ public class AssetTagModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetTag (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,tagId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name VARCHAR(75) null,assetCount INTEGER,lastPublishDate DATE null,primary key (tagId, ctCollectionId))";
+		"create table AssetTag (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,tagId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name VARCHAR(75) null,assetCount INTEGER,lastPublishDate DATE null,primary key (tagId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table AssetTag";
 
@@ -135,19 +136,25 @@ public class AssetTagModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 2L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 4L;
+	public static final long GROUPID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
+	public static final long NAME_COLUMN_BITMASK = 8L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 16L;
 
 	public static final String MAPPING_TABLE_ASSETENTRIES_ASSETTAGS_NAME =
 		"AssetEntries_AssetTags";
@@ -270,6 +277,8 @@ public class AssetTagModelImpl
 			attributeGetterFunctions.put(
 				"ctCollectionId", AssetTag::getCtCollectionId);
 			attributeGetterFunctions.put("uuid", AssetTag::getUuid);
+			attributeGetterFunctions.put(
+				"externalReferenceCode", AssetTag::getExternalReferenceCode);
 			attributeGetterFunctions.put("tagId", AssetTag::getTagId);
 			attributeGetterFunctions.put("groupId", AssetTag::getGroupId);
 			attributeGetterFunctions.put("companyId", AssetTag::getCompanyId);
@@ -306,6 +315,10 @@ public class AssetTagModelImpl
 				(BiConsumer<AssetTag, Long>)AssetTag::setCtCollectionId);
 			attributeSetterBiConsumers.put(
 				"uuid", (BiConsumer<AssetTag, String>)AssetTag::setUuid);
+			attributeSetterBiConsumers.put(
+				"externalReferenceCode",
+				(BiConsumer<AssetTag, String>)
+					AssetTag::setExternalReferenceCode);
 			attributeSetterBiConsumers.put(
 				"tagId", (BiConsumer<AssetTag, Long>)AssetTag::setTagId);
 			attributeSetterBiConsumers.put(
@@ -396,6 +409,35 @@ public class AssetTagModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -673,6 +715,7 @@ public class AssetTagModelImpl
 		assetTagImpl.setMvccVersion(getMvccVersion());
 		assetTagImpl.setCtCollectionId(getCtCollectionId());
 		assetTagImpl.setUuid(getUuid());
+		assetTagImpl.setExternalReferenceCode(getExternalReferenceCode());
 		assetTagImpl.setTagId(getTagId());
 		assetTagImpl.setGroupId(getGroupId());
 		assetTagImpl.setCompanyId(getCompanyId());
@@ -698,6 +741,8 @@ public class AssetTagModelImpl
 		assetTagImpl.setCtCollectionId(
 			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		assetTagImpl.setUuid(this.<String>getColumnOriginalValue("uuid_"));
+		assetTagImpl.setExternalReferenceCode(
+			this.<String>getColumnOriginalValue("externalReferenceCode"));
 		assetTagImpl.setTagId(this.<Long>getColumnOriginalValue("tagId"));
 		assetTagImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
 		assetTagImpl.setCompanyId(
@@ -799,6 +844,16 @@ public class AssetTagModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			assetTagCacheModel.uuid = null;
+		}
+
+		assetTagCacheModel.externalReferenceCode = getExternalReferenceCode();
+
+		String externalReferenceCode = assetTagCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			assetTagCacheModel.externalReferenceCode = null;
 		}
 
 		assetTagCacheModel.tagId = getTagId();
@@ -918,6 +973,7 @@ public class AssetTagModelImpl
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _tagId;
 	private long _groupId;
 	private long _companyId;
@@ -963,6 +1019,8 @@ public class AssetTagModelImpl
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
 		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("tagId", _tagId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1002,25 +1060,27 @@ public class AssetTagModelImpl
 
 		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("tagId", 8L);
+		columnBitmasks.put("externalReferenceCode", 8L);
 
-		columnBitmasks.put("groupId", 16L);
+		columnBitmasks.put("tagId", 16L);
 
-		columnBitmasks.put("companyId", 32L);
+		columnBitmasks.put("groupId", 32L);
 
-		columnBitmasks.put("userId", 64L);
+		columnBitmasks.put("companyId", 64L);
 
-		columnBitmasks.put("userName", 128L);
+		columnBitmasks.put("userId", 128L);
 
-		columnBitmasks.put("createDate", 256L);
+		columnBitmasks.put("userName", 256L);
 
-		columnBitmasks.put("modifiedDate", 512L);
+		columnBitmasks.put("createDate", 512L);
 
-		columnBitmasks.put("name", 1024L);
+		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("assetCount", 2048L);
+		columnBitmasks.put("name", 2048L);
 
-		columnBitmasks.put("lastPublishDate", 4096L);
+		columnBitmasks.put("assetCount", 4096L);
+
+		columnBitmasks.put("lastPublishDate", 8192L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -177,7 +177,7 @@
 			<finder-column name="expirationDate" />
 		</finder>
 	</entity>
-	<entity local-service="true" name="AssetTag" remote-service="true" uuid="true">
+	<entity external-reference-code="group" local-service="true" name="AssetTag" remote-service="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagLocalServiceBaseImpl.java
@@ -251,6 +251,21 @@ public abstract class AssetTagLocalServiceBaseImpl
 		return assetTagPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
+	@Override
+	public AssetTag fetchAssetTagByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return assetTagPersistence.fetchByERC_G(externalReferenceCode, groupId);
+	}
+
+	@Override
+	public AssetTag getAssetTagByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return assetTagPersistence.findByERC_G(externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the asset tag with the primary key.
 	 *

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetTagServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetTagServiceHttp.java
@@ -42,7 +42,8 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class AssetTagServiceHttp {
 
 	public static com.liferay.asset.kernel.model.AssetTag addTag(
-			HttpPrincipal httpPrincipal, long groupId, String name,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -51,7 +52,8 @@ public class AssetTagServiceHttp {
 				AssetTagServiceUtil.class, "addTag", _addTagParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, name, serviceContext);
+				methodKey, externalReferenceCode, groupId, name,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -902,7 +904,8 @@ public class AssetTagServiceHttp {
 	}
 
 	public static com.liferay.asset.kernel.model.AssetTag updateTag(
-			HttpPrincipal httpPrincipal, long tagId, String name,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long tagId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -912,7 +915,7 @@ public class AssetTagServiceHttp {
 				_updateTagParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, tagId, name, serviceContext);
+				methodKey, externalReferenceCode, tagId, name, serviceContext);
 
 			Object returnObj = null;
 
@@ -945,7 +948,7 @@ public class AssetTagServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(AssetTagServiceHttp.class);
 
 	private static final Class<?>[] _addTagParameterTypes0 = new Class[] {
-		long.class, String.class,
+		String.class, long.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _deleteTagParameterTypes1 = new Class[] {
@@ -1017,7 +1020,7 @@ public class AssetTagServiceHttp {
 	private static final Class<?>[] _unsubscribeTagParameterTypes24 =
 		new Class[] {long.class, long.class};
 	private static final Class<?>[] _updateTagParameterTypes25 = new Class[] {
-		long.class, String.class,
+		String.class, long.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -710,7 +710,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public AssetTag updateTag(
-			long userId, long tagId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long tagId, String name,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Tag
@@ -741,6 +742,11 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 
 		validate(name);
 
+		if (Validator.isBlank(externalReferenceCode)) {
+			externalReferenceCode = null;
+		}
+
+		tag.setExternalReferenceCode(externalReferenceCode);
 		tag.setName(name);
 
 		tag = assetTagPersistence.update(tag);

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -94,10 +94,6 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 
 		// Tag
 
-		if (Validator.isBlank(externalReferenceCode)) {
-			externalReferenceCode = null;
-		}
-
 		User user = _userLocalService.getUser(userId);
 
 		long tagId = counterLocalService.increment();
@@ -741,10 +737,6 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		}
 
 		validate(name);
-
-		if (Validator.isBlank(externalReferenceCode)) {
-			externalReferenceCode = null;
-		}
 
 		tag.setExternalReferenceCode(externalReferenceCode);
 		tag.setName(name);

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -77,21 +77,26 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	/**
 	 * Adds an asset tag.
 	 *
-	 * @param  userId the primary key of the user adding the asset tag
-	 * @param  groupId the primary key of the group in which the asset tag is to
-	 *         be added
-	 * @param  name the asset tag's name
-	 * @param  serviceContext the service context to be applied
+	 * @param externalReferenceCode
+	 * @param userId                the primary key of the user adding the asset tag
+	 * @param groupId               the primary key of the group in which the asset tag is to
+	 *                              be added
+	 * @param name                  the asset tag's name
+	 * @param serviceContext        the service context to be applied
 	 * @return the asset tag that was added
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public AssetTag addTag(
-			long userId, long groupId, String name,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String name, ServiceContext serviceContext)
 		throws PortalException {
 
 		// Tag
+
+		if (Validator.isBlank(externalReferenceCode)) {
+			externalReferenceCode = null;
+		}
 
 		User user = _userLocalService.getUser(userId);
 
@@ -100,6 +105,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		AssetTag tag = assetTagPersistence.create(tagId);
 
 		tag.setUuid(serviceContext.getUuid());
+		tag.setExternalReferenceCode(externalReferenceCode);
 		tag.setGroupId(groupId);
 		tag.setCompanyId(user.getCompanyId());
 		tag.setUserId(user.getUserId());
@@ -152,7 +158,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 				serviceContext.setAddGuestPermissions(true);
 				serviceContext.setScopeGroupId(group.getGroupId());
 
-				tag = addTag(userId, group.getGroupId(), name, serviceContext);
+				tag = addTag(
+					null, userId, group.getGroupId(), name, serviceContext);
 			}
 
 			if (tag != null) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
@@ -271,7 +271,8 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 
 	@Override
 	public AssetTag updateTag(
-			long tagId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long tagId, String name,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		AssetTag tag = assetTagLocalService.getTag(tagId);
@@ -280,7 +281,7 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 			getPermissionChecker(), tag.getGroupId(), ActionKeys.MANAGE_TAG);
 
 		return assetTagLocalService.updateTag(
-			getUserId(), tagId, name, serviceContext);
+			externalReferenceCode, getUserId(), tagId, name, serviceContext);
 	}
 
 	protected AssetTag sanitize(AssetTag tag) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagServiceImpl.java
@@ -44,14 +44,15 @@ public class AssetTagServiceImpl extends AssetTagServiceBaseImpl {
 
 	@Override
 	public AssetTag addTag(
-			long groupId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long groupId, String name,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		AssetTagsPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.MANAGE_TAG);
 
 		return assetTagLocalService.addTag(
-			getUserId(), groupId, name, serviceContext);
+			externalReferenceCode, getUserId(), groupId, name, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portlet.asset.service.persistence.impl;
 
+import com.liferay.asset.kernel.exception.DuplicateAssetTagExternalReferenceCodeException;
 import com.liferay.asset.kernel.exception.NoSuchTagException;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetTagTable;
@@ -25,9 +26,14 @@ import com.liferay.portal.kernel.dao.orm.Query;
 import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelperUtil;
@@ -35,6 +41,7 @@ import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.service.persistence.impl.TableMapper;
 import com.liferay.portal.kernel.service.persistence.impl.TableMapperFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -3914,6 +3921,211 @@ public class AssetTagPersistenceImpl
 	private static final String _FINDER_COLUMN_G_LIKEN_NAME_3 =
 		"(assetTag.name IS NULL OR assetTag.name LIKE '')";
 
+	private FinderPath _finderPathFetchByERC_G;
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchTagException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag
+	 * @throws NoSuchTagException if a matching asset tag could not be found
+	 */
+	@Override
+	public AssetTag findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchTagException {
+
+		AssetTag assetTag = fetchByERC_G(externalReferenceCode, groupId);
+
+		if (assetTag == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchTagException(sb.toString());
+		}
+
+		return assetTag;
+	}
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	@Override
+	public AssetTag fetchByERC_G(String externalReferenceCode, long groupId) {
+		return fetchByERC_G(externalReferenceCode, groupId, true);
+	}
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	@Override
+	public AssetTag fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				CTPersistenceHelperUtil.setCTCollectionIdWithSafeCloseable(
+					AssetTag.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			Object[] finderArgs = null;
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {externalReferenceCode, groupId};
+			}
+
+			Object result = null;
+
+			if (useFinderCache) {
+				result = FinderCacheUtil.getResult(
+					_finderPathFetchByERC_G, finderArgs, this);
+			}
+
+			if (result instanceof AssetTag) {
+				AssetTag assetTag = (AssetTag)result;
+
+				if (!Objects.equals(
+						externalReferenceCode,
+						assetTag.getExternalReferenceCode()) ||
+					(groupId != assetTag.getGroupId())) {
+
+					result = null;
+				}
+			}
+
+			if (result == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_SELECT_ASSETTAG_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					List<AssetTag> list = query.list();
+
+					if (list.isEmpty()) {
+						if (useFinderCache) {
+							FinderCacheUtil.putResult(
+								_finderPathFetchByERC_G, finderArgs, list);
+						}
+					}
+					else {
+						AssetTag assetTag = list.get(0);
+
+						result = assetTag;
+
+						cacheResult(assetTag);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			if (result instanceof List<?>) {
+				return null;
+			}
+			else {
+				return (AssetTag)result;
+			}
+		}
+	}
+
+	/**
+	 * Removes the asset tag where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the asset tag that was removed
+	 */
+	@Override
+	public AssetTag removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchTagException {
+
+		AssetTag assetTag = findByERC_G(externalReferenceCode, groupId);
+
+		return remove(assetTag);
+	}
+
+	/**
+	 * Returns the number of asset tags where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching asset tags
+	 */
+	@Override
+	public int countByERC_G(String externalReferenceCode, long groupId) {
+		AssetTag assetTag = fetchByERC_G(externalReferenceCode, groupId);
+
+		if (assetTag == null) {
+			return 0;
+		}
+
+		return 1;
+	}
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"assetTag.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(assetTag.externalReferenceCode IS NULL OR assetTag.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"assetTag.groupId = ?";
+
 	public AssetTagPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -3946,6 +4158,13 @@ public class AssetTagPersistenceImpl
 			FinderCacheUtil.putResult(
 				_finderPathFetchByUUID_G,
 				new Object[] {assetTag.getUuid(), assetTag.getGroupId()},
+				assetTag);
+
+			FinderCacheUtil.putResult(
+				_finderPathFetchByERC_G,
+				new Object[] {
+					assetTag.getExternalReferenceCode(), assetTag.getGroupId()
+				},
 				assetTag);
 		}
 	}
@@ -4035,6 +4254,14 @@ public class AssetTagPersistenceImpl
 
 			FinderCacheUtil.putResult(
 				_finderPathFetchByUUID_G, args, assetTagModelImpl);
+
+			args = new Object[] {
+				assetTagModelImpl.getExternalReferenceCode(),
+				assetTagModelImpl.getGroupId()
+			};
+
+			FinderCacheUtil.putResult(
+				_finderPathFetchByERC_G, args, assetTagModelImpl);
 		}
 	}
 
@@ -4172,6 +4399,66 @@ public class AssetTagPersistenceImpl
 			String uuid = PortalUUIDUtil.generate();
 
 			assetTag.setUuid(uuid);
+		}
+
+		if (Validator.isNull(assetTag.getExternalReferenceCode())) {
+			assetTag.setExternalReferenceCode(assetTag.getUuid());
+		}
+		else {
+			if (!Objects.equals(
+					assetTagModelImpl.getColumnOriginalValue(
+						"externalReferenceCode"),
+					assetTag.getExternalReferenceCode())) {
+
+				long userId = GetterUtil.getLong(
+					PrincipalThreadLocal.getName());
+
+				if (userId > 0) {
+					long companyId = assetTag.getCompanyId();
+
+					long groupId = assetTag.getGroupId();
+
+					long classPK = 0;
+
+					if (!isNew) {
+						classPK = assetTag.getPrimaryKey();
+					}
+
+					try {
+						assetTag.setExternalReferenceCode(
+							SanitizerUtil.sanitize(
+								companyId, groupId, userId,
+								AssetTag.class.getName(), classPK,
+								ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+								assetTag.getExternalReferenceCode(), null));
+					}
+					catch (SanitizerException sanitizerException) {
+						throw new SystemException(sanitizerException);
+					}
+				}
+			}
+
+			AssetTag ercAssetTag = fetchByERC_G(
+				assetTag.getExternalReferenceCode(), assetTag.getGroupId());
+
+			if (isNew) {
+				if (ercAssetTag != null) {
+					throw new DuplicateAssetTagExternalReferenceCodeException(
+						"Duplicate asset tag with external reference code " +
+							assetTag.getExternalReferenceCode() +
+								" and group " + assetTag.getGroupId());
+				}
+			}
+			else {
+				if ((ercAssetTag != null) &&
+					(assetTag.getTagId() != ercAssetTag.getTagId())) {
+
+					throw new DuplicateAssetTagExternalReferenceCodeException(
+						"Duplicate asset tag with external reference code " +
+							assetTag.getExternalReferenceCode() +
+								" and group " + assetTag.getGroupId());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -5036,6 +5323,7 @@ public class AssetTagPersistenceImpl
 		ctControlColumnNames.add("mvccVersion");
 		ctControlColumnNames.add("ctCollectionId");
 		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctStrictColumnNames.add("userId");
@@ -5060,6 +5348,9 @@ public class AssetTagPersistenceImpl
 		_mappingTableNames.add("AssetEntries_AssetTags");
 
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
+
+		_uniqueIndexColumnNames.add(
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -5185,6 +5476,11 @@ public class AssetTagPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_LikeN",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"groupId", "name"}, false);
+
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
 
 		AssetTagUtil.setPersistence(this);
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateAssetTagExternalReferenceCodeException.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/DuplicateAssetTagExternalReferenceCodeException.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.kernel.exception;
+
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateAssetTagExternalReferenceCodeException
+	extends DuplicateExternalReferenceCodeException {
+
+	public DuplicateAssetTagExternalReferenceCodeException() {
+	}
+
+	public DuplicateAssetTagExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateAssetTagExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateAssetTagExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagModel.java
@@ -7,6 +7,7 @@ package com.liferay.asset.kernel.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -29,8 +30,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface AssetTagModel
-	extends BaseModel<AssetTag>, CTModel<AssetTag>, MVCCModel, ShardedModel,
-			StagedGroupedModel {
+	extends BaseModel<AssetTag>, CTModel<AssetTag>, ExternalReferenceCodeModel,
+			MVCCModel, ShardedModel, StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -102,6 +103,23 @@ public interface AssetTagModel
 	 */
 	@Override
 	public void setUuid(String uuid);
+
+	/**
+	 * Returns the external reference code of this asset tag.
+	 *
+	 * @return the external reference code of this asset tag
+	 */
+	@AutoEscape
+	@Override
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this asset tag.
+	 *
+	 * @param externalReferenceCode the external reference code of this asset tag
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**
 	 * Returns the tag ID of this asset tag.

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagTable.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagTable.java
@@ -29,6 +29,10 @@ public class AssetTagTable extends BaseTable<AssetTagTable> {
 		"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<AssetTagTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<AssetTagTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<AssetTagTable, Long> tagId = createColumn(
 		"tagId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<AssetTagTable, Long> groupId = createColumn(

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetTagWrapper.java
@@ -39,6 +39,7 @@ public class AssetTagWrapper
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("tagId", getTagId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -71,6 +72,13 @@ public class AssetTagWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long tagId = (Long)attributes.get("tagId");
@@ -177,6 +185,16 @@ public class AssetTagWrapper
 	@Override
 	public long getCtCollectionId() {
 		return model.getCtCollectionId();
+	}
+
+	/**
+	 * Returns the external reference code of this asset tag.
+	 *
+	 * @return the external reference code of this asset tag
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -332,6 +350,16 @@ public class AssetTagWrapper
 	@Override
 	public void setCtCollectionId(long ctCollectionId) {
 		model.setCtCollectionId(ctCollectionId);
+	}
+
+	/**
+	 * Sets the external reference code of this asset tag.
+	 *
+	 * @param externalReferenceCode the external reference code of this asset tag
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.4.0
+version 11.5.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
@@ -312,6 +312,10 @@ public interface AssetTagLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AssetTag fetchAssetTag(long tagId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AssetTag fetchAssetTagByExternalReferenceCode(
+		String externalReferenceCode, long groupId);
+
 	/**
 	 * Returns the asset tag matching the UUID and group.
 	 *
@@ -369,6 +373,11 @@ public interface AssetTagLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AssetTag getAssetTag(long tagId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AssetTag getAssetTagByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException;
 
 	/**
 	 * Returns the asset tag matching the UUID and group.

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
@@ -97,17 +97,18 @@ public interface AssetTagLocalService
 	/**
 	 * Adds an asset tag.
 	 *
-	 * @param userId the primary key of the user adding the asset tag
-	 * @param groupId the primary key of the group in which the asset tag is to
+	 * @param externalReferenceCode
+	 * @param userId                the primary key of the user adding the asset tag
+	 * @param groupId               the primary key of the group in which the asset tag is to
 	 be added
-	 * @param name the asset tag's name
-	 * @param serviceContext the service context to be applied
+	 * @param name                  the asset tag's name
+	 * @param serviceContext        the service context to be applied
 	 * @return the asset tag that was added
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	public AssetTag addTag(
-			long userId, long groupId, String name,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String name, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -741,7 +742,8 @@ public interface AssetTagLocalService
 
 	@Indexable(type = IndexableType.REINDEX)
 	public AssetTag updateTag(
-			long userId, long tagId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long tagId, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	@Override

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceUtil.java
@@ -342,6 +342,13 @@ public class AssetTagLocalServiceUtil {
 		return getService().fetchAssetTag(tagId);
 	}
 
+	public static AssetTag fetchAssetTagByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return getService().fetchAssetTagByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the asset tag matching the UUID and group.
 	 *
@@ -414,6 +421,14 @@ public class AssetTagLocalServiceUtil {
 	 */
 	public static AssetTag getAssetTag(long tagId) throws PortalException {
 		return getService().getAssetTag(tagId);
+	}
+
+	public static AssetTag getAssetTagByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getAssetTagByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceUtil.java
@@ -72,19 +72,22 @@ public class AssetTagLocalServiceUtil {
 	/**
 	 * Adds an asset tag.
 	 *
-	 * @param userId the primary key of the user adding the asset tag
-	 * @param groupId the primary key of the group in which the asset tag is to
+	 * @param externalReferenceCode
+	 * @param userId                the primary key of the user adding the asset tag
+	 * @param groupId               the primary key of the group in which the asset tag is to
 	 be added
-	 * @param name the asset tag's name
-	 * @param serviceContext the service context to be applied
+	 * @param name                  the asset tag's name
+	 * @param serviceContext        the service context to be applied
 	 * @return the asset tag that was added
 	 */
 	public static AssetTag addTag(
-			long userId, long groupId, String name,
+			String externalReferenceCode, long userId, long groupId,
+			String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
-		return getService().addTag(userId, groupId, name, serviceContext);
+		return getService().addTag(
+			externalReferenceCode, userId, groupId, name, serviceContext);
 	}
 
 	/**
@@ -869,11 +872,12 @@ public class AssetTagLocalServiceUtil {
 	}
 
 	public static AssetTag updateTag(
-			long userId, long tagId, String name,
+			String externalReferenceCode, long userId, long tagId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
-		return getService().updateTag(userId, tagId, name, serviceContext);
+		return getService().updateTag(
+			externalReferenceCode, userId, tagId, name, serviceContext);
 	}
 
 	public static AssetTagLocalService getService() {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceWrapper.java
@@ -383,6 +383,14 @@ public class AssetTagLocalServiceWrapper
 		return _assetTagLocalService.fetchAssetTag(tagId);
 	}
 
+	@Override
+	public AssetTag fetchAssetTagByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return _assetTagLocalService.fetchAssetTagByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the asset tag matching the UUID and group.
 	 *
@@ -467,6 +475,15 @@ public class AssetTagLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetTagLocalService.getAssetTag(tagId);
+	}
+
+	@Override
+	public AssetTag getAssetTagByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetTagLocalService.getAssetTagByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalServiceWrapper.java
@@ -71,21 +71,23 @@ public class AssetTagLocalServiceWrapper
 	/**
 	 * Adds an asset tag.
 	 *
-	 * @param userId the primary key of the user adding the asset tag
-	 * @param groupId the primary key of the group in which the asset tag is to
+	 * @param externalReferenceCode
+	 * @param userId                the primary key of the user adding the asset tag
+	 * @param groupId               the primary key of the group in which the asset tag is to
 	 be added
-	 * @param name the asset tag's name
-	 * @param serviceContext the service context to be applied
+	 * @param name                  the asset tag's name
+	 * @param serviceContext        the service context to be applied
 	 * @return the asset tag that was added
 	 */
 	@Override
 	public AssetTag addTag(
-			long userId, long groupId, String name,
+			String externalReferenceCode, long userId, long groupId,
+			String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetTagLocalService.addTag(
-			userId, groupId, name, serviceContext);
+			externalReferenceCode, userId, groupId, name, serviceContext);
 	}
 
 	/**
@@ -974,12 +976,12 @@ public class AssetTagLocalServiceWrapper
 
 	@Override
 	public AssetTag updateTag(
-			long userId, long tagId, String name,
+			String externalReferenceCode, long userId, long tagId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetTagLocalService.updateTag(
-			userId, tagId, name, serviceContext);
+			externalReferenceCode, userId, tagId, name, serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagService.java
@@ -49,7 +49,8 @@ public interface AssetTagService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portlet.asset.service.impl.AssetTagServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the asset tag remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link AssetTagServiceUtil} if injection and service tracking are not available.
 	 */
 	public AssetTag addTag(
-			long groupId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long groupId, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void deleteTag(long tagId) throws PortalException;
@@ -141,7 +142,8 @@ public interface AssetTagService extends BaseService {
 	public void unsubscribeTag(long userId, long tagId) throws PortalException;
 
 	public AssetTag updateTag(
-			long tagId, String name, ServiceContext serviceContext)
+			String externalReferenceCode, long tagId, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagServiceUtil.java
@@ -31,11 +31,12 @@ public class AssetTagServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portlet.asset.service.impl.AssetTagServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static AssetTag addTag(
-			long groupId, String name,
+			String externalReferenceCode, long groupId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
-		return getService().addTag(groupId, name, serviceContext);
+		return getService().addTag(
+			externalReferenceCode, groupId, name, serviceContext);
 	}
 
 	public static void deleteTag(long tagId) throws PortalException {
@@ -183,11 +184,12 @@ public class AssetTagServiceUtil {
 	}
 
 	public static AssetTag updateTag(
-			long tagId, String name,
+			String externalReferenceCode, long tagId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
-		return getService().updateTag(tagId, name, serviceContext);
+		return getService().updateTag(
+			externalReferenceCode, tagId, name, serviceContext);
 	}
 
 	public static AssetTagService getService() {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagServiceWrapper.java
@@ -28,11 +28,12 @@ public class AssetTagServiceWrapper
 
 	@Override
 	public AssetTag addTag(
-			long groupId, String name,
+			String externalReferenceCode, long groupId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _assetTagService.addTag(groupId, name, serviceContext);
+		return _assetTagService.addTag(
+			externalReferenceCode, groupId, name, serviceContext);
 	}
 
 	@Override
@@ -216,11 +217,12 @@ public class AssetTagServiceWrapper
 
 	@Override
 	public AssetTag updateTag(
-			long tagId, String name,
+			String externalReferenceCode, long tagId, String name,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _assetTagService.updateTag(tagId, name, serviceContext);
+		return _assetTagService.updateTag(
+			externalReferenceCode, tagId, name, serviceContext);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 13.0.0
+version 14.0.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagPersistence.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagPersistence.java
@@ -1043,6 +1043,56 @@ public interface AssetTagPersistence
 	public int countByG_LikeN(long[] groupIds, String name);
 
 	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchTagException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag
+	 * @throws NoSuchTagException if a matching asset tag could not be found
+	 */
+	public AssetTag findByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchTagException;
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	public AssetTag fetchByERC_G(String externalReferenceCode, long groupId);
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	public AssetTag fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
+
+	/**
+	 * Removes the asset tag where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the asset tag that was removed
+	 */
+	public AssetTag removeByERC_G(String externalReferenceCode, long groupId)
+		throws NoSuchTagException;
+
+	/**
+	 * Returns the number of asset tags where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching asset tags
+	 */
+	public int countByERC_G(String externalReferenceCode, long groupId);
+
+	/**
 	 * Caches the asset tag in the entity cache if it is enabled.
 	 *
 	 * @param assetTag the asset tag

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagUtil.java
@@ -1287,6 +1287,74 @@ public class AssetTagUtil {
 	}
 
 	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchTagException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag
+	 * @throws NoSuchTagException if a matching asset tag could not be found
+	 */
+	public static AssetTag findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.asset.kernel.exception.NoSuchTagException {
+
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	public static AssetTag fetchByERC_G(
+		String externalReferenceCode, long groupId) {
+
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the asset tag where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching asset tag, or <code>null</code> if a matching asset tag could not be found
+	 */
+	public static AssetTag fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
+	}
+
+	/**
+	 * Removes the asset tag where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the asset tag that was removed
+	 */
+	public static AssetTag removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.asset.kernel.exception.NoSuchTagException {
+
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the number of asset tags where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching asset tags
+	 */
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
 	 * Caches the asset tag in the entity cache if it is enabled.
 	 *
 	 * @param assetTag the asset tag

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/asset/JSONAssettagAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/asset/JSONAssettagAPI.macro
@@ -10,6 +10,7 @@ definition {
 		var curl = '''
 			${portalURL}/api/jsonws/assettag/add-tag \
 				-u ${userLoginInfo} \
+				-d externalReferenceCode='' \
 				-d groupId=${groupId} \
 				-d name=${tagName}
 		''';

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -43,9 +43,11 @@ create index IX_FEC4A201 on AssetEntry (layoutUuid[$COLUMN_LENGTH:75$]);
 create index IX_2E4E3885 on AssetEntry (publishDate);
 create index IX_9029E15A on AssetEntry (visible);
 
+create unique index IX_FBB2C925 on AssetTag (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_D63322F9 on AssetTag (groupId, name[$COLUMN_LENGTH:75$]);
+create unique index IX_B421E018 on AssetTag (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_C43137AF on AssetTag (name[$COLUMN_LENGTH:75$]);
-create unique index IX_A43FBC4 on AssetTag (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
+create index IX_562A3FC4 on AssetTag (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_B22D908C on AssetVocabulary (companyId);
 create unique index IX_E06DEF51 on AssetVocabulary (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -145,6 +145,7 @@ create table AssetTag (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	tagId LONG not null,
 	groupId LONG,
 	companyId LONG,


### PR DESCRIPTION
LPD-36686 Technical Task | Add ExternalReferenceCode to Tags

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36686

As a systems administrator I want to be able to use an External Reference Code of a tag during the import/export process so that my data is migrated accurately without any duplication or mismatches

# How am I fixing it?

The first step is to add the support on the service for the external reference code field on the AssetTag entity. Then, modify the addTag and updateTag methods to ensure that the erc can be added by the user if it is wanted.

# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-36686 add external reference code field to AssetTag entity**
- **LPD-36686 buildService**
- **LPD-36686 upgrade process for the assetTag entity for external reference code**
- **LPD-36686 add test to check the new upgrade for the external reference code for AssetTag entity**
- **LPD-36686 modify addTag method to take into account the externalReferenceCode**
- **LPD-36686 modify updateTag method to take into account the externalReferenceCode**
- **LPD-36686 buildService**
- **LPD-36686 add externalReferenceCode parameter on addTag and updateTag calls as null**
- **LPD-36686 update the tag with the correct values**
- **LPD-36686 baseline**
- **LPD-36686 modify poshi macro to take into account the externalReferenceCode on the call of the tag creation**
- **LPD-36686 fix indexing test**
- **LPD-36686 not needed**
