### PR TITLE
LPD-40834 The default values of a Web Content appear in a search

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -14,6 +14,8 @@ import com.liferay.journal.service.JournalArticleResourceLocalService;
 import com.liferay.journal.util.comparator.ArticleVersionComparator;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -84,6 +86,28 @@ public class JournalArticleModelIndexerWriterContributor
 							journalArticle)));
 		}
 		else {
+			batchIndexingActionable.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property resourcePrimKeyProperty =
+						PropertyFactoryUtil.forName("resourcePrimKey");
+
+					DynamicQuery journalArticleDynamicQuery =
+						_journalArticleLocalService.dynamicQuery();
+
+					journalArticleDynamicQuery.setProjection(
+						ProjectionFactoryUtil.property("resourcePrimKey"));
+
+					Property property = PropertyFactoryUtil.forName(
+						"classNameId");
+
+					journalArticleDynamicQuery.add(
+						property.eq(
+							PortalUtil.getClassNameId(DDMStructure.class)));
+
+					dynamicQuery.add(
+						resourcePrimKeyProperty.notIn(
+							journalArticleDynamicQuery));
+				});
 			batchIndexingActionable.setInterval(
 				_batchIndexingHelper.getBulkSize(
 					JournalArticleResource.class.getName()));

--- a/modules/apps/journal/journal-test-util/bnd.bnd
+++ b/modules/apps/journal/journal-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Test Utilities
 Bundle-SymbolicName: com.liferay.journal.test.util
-Bundle-Version: 13.2.1
+Bundle-Version: 13.3.0
 Export-Package:\
 	com.liferay.journal.test.util,\
 	com.liferay.journal.test.util.search

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.rss.util.RSSUtil;
 
@@ -889,6 +890,49 @@ public class JournalTestUtil {
 			ddmFormValuesToFieldsConverter,
 			PortalUtil.getSiteDefaultLocale(groupId), fieldValue, groupId,
 			journalConverter);
+	}
+
+	public static Tuple addStructureWithPredefinedValues(
+			long userId, long groupId, String title)
+		throws Exception {
+
+		DDMForm ddmForm = DDMStructureTestUtil.getSampleDDMForm(
+			_locales, LocaleUtil.US);
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			groupId, JournalArticle.class.getName(), ddmForm, LocaleUtil.US);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			groupId, ddmStructure.getStructureId(),
+			PortalUtil.getClassNameId(JournalArticle.class),
+			TemplateConstants.LANG_TYPE_FTL, getSampleTemplateFTL(),
+			LocaleUtil.US);
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent(
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Valor Predefinido"
+			).put(
+				LocaleUtil.US, "Predefined Value"
+			).build(),
+			LocaleUtil.US.toString());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId, userId);
+
+		JournalArticle journalArticle =
+			JournalArticleLocalServiceUtil.addArticleDefaultValues(
+				serviceContext.getUserId(), serviceContext.getScopeGroupId(),
+				PortalUtil.getClassNameId(DDMStructure.class),
+				ddmStructure.getStructureId(),
+				HashMapBuilder.put(
+					LocaleUtil.US, title
+				).build(),
+				null, content, ddmStructure.getStructureId(),
+				ddmTemplate.getTemplateKey(), null, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
+				serviceContext);
+
+		return new Tuple(ddmStructure, journalArticle);
 	}
 
 	public static void expireArticle(long groupId, JournalArticle article)

--- a/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
+++ b/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerReindexTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleIndexerReindexTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleIndexerReindexTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_indexer = IndexerRegistryUtil.getIndexer(JournalArticle.class);
+
+		UserTestUtil.setUser(TestPropsValues.getUser());
+	}
+
+	@Test
+	public void testReindexing() throws Exception {
+		SearchContext searchContext = _getSearchContext("Architectural");
+
+		_assertSearchCount(0, searchContext);
+
+		JournalTestUtil.addArticle(
+			_group.getGroupId(), "Liferay Architectural Approach",
+			RandomTestUtil.randomString());
+
+		_assertSearchCount(1, searchContext);
+
+		_reindex(true);
+
+		_assertSearchCount(1, searchContext);
+
+		_reindex(false);
+
+		_assertSearchCount(1, searchContext);
+	}
+
+	@Test
+	public void testReindexingWithPredefinedValues() throws Exception {
+		SearchContext searchContext = _getSearchContext("Architectural");
+
+		_assertSearchCount(0, searchContext);
+
+		JournalTestUtil.addStructureWithPredefinedValues(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			"Liferay Architectural Approach");
+
+		_assertSearchCount(0, searchContext);
+
+		_reindex(true);
+
+		_assertSearchCount(0, searchContext);
+
+		_reindex(false);
+
+		_assertSearchCount(0, searchContext);
+	}
+
+	private void _assertSearchCount(
+			int expectedCount, SearchContext searchContext)
+		throws Exception {
+
+		Hits hits = _indexer.search(searchContext);
+
+		Assert.assertEquals(hits.toString(), expectedCount, hits.getLength());
+	}
+
+	private SearchContext _getSearchContext(String keywords) throws Exception {
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			_group.getGroupId());
+
+		searchContext.setAttribute("status", WorkflowConstants.STATUS_APPROVED);
+		searchContext.setKeywords(keywords);
+
+		return searchContext;
+	}
+
+	private void _reindex(boolean indexAllArticleVersionsEnabled)
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						JournalServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"indexAllArticleVersionsEnabled",
+							indexAllArticleVersionsEnabled
+						).build())) {
+
+			_indexer.reindex(
+				new String[] {String.valueOf(TestPropsValues.getCompanyId())});
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Indexer<JournalArticle> _indexer;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40834

 A reindex makes visible to the user the JournalArticle holding the Default Values of a WC Structure, when the configuration setting `isIndexAllArticleVersions` is `false`.

# How am I fixing it?

Adding a criteria to the dynamic query searching for Journal Articles.

# How can you verify that it works?

`cd modules/apps/journal/journal-test`
`gw tI --tests JournalArticleIndexerReindexTest`