### PR TITLE
LPD-40387 KB adaptions for react v18

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/KBDropdownPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/KBDropdownPropsTransformer.js
@@ -161,8 +161,13 @@ export default function propsTransformer({items, portletNamespace, ...props}) {
 
 						if (action) {
 							event.preventDefault();
+							event.stopPropagation();
 
 							ACTIONS[action](child.data, portletNamespace);
+						}
+
+						if (child.href) {
+							event.stopPropagation();
 						}
 					},
 				})),

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/NavigationPanel.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/NavigationPanel.js
@@ -44,10 +44,6 @@ export default function NavigationPanel({
 	const [searchActive, setSearchActive] = useState(false);
 
 	const handleClickItem = (event, item) => {
-		if (event.defaultPrevented) {
-			return;
-		}
-
 		event.stopPropagation();
 		event.preventDefault();
 


### PR DESCRIPTION
This issue was found because of https://github.com/liferay-content-management/liferay-portal/pull/6034 

# What is the issue
Child dropdown events were bubling to parent, and `event.defaultPrevented` was no longer working with react v18. 

# How do I fix it
With this fix, we stop propagation to parent element when click on a dropdown item, this also works with current react version. 

**Note**: No need to add new test, as this is an improvement and current tests are valid. 