### PR TITLE
LPD-40981 Performance Issue with First Comment on a Web Content

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2183,7 +2183,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
 
-		if (httpServletRequest == null) {
+		if (message.isDiscussion() || (httpServletRequest == null)) {
 			if (Validator.isNull(serviceContext.getLayoutFullURL())) {
 				return StringPool.BLANK;
 			}

--- a/modules/apps/message-boards/message-boards-service/src/test/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImplTest.java
+++ b/modules/apps/message-boards/message-boards-service/src/test/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImplTest.java
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.service.impl;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.message.boards.model.impl.MBMessageImpl;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Mikel Lorza
+ */
+public class MBMessageLocalServiceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetMessageURL() throws PortalException {
+		MBMessage mbMessage = new MBMessageImpl();
+
+		mbMessage.setMessageId(RandomTestUtil.randomLong());
+		mbMessage.setCategoryId(RandomTestUtil.randomLong());
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setLayoutFullURL("http://localhost");
+
+		Assert.assertEquals(
+			"http://localhost/-/message_boards/view_message/" +
+				mbMessage.getMessageId(),
+			ReflectionTestUtil.invoke(
+				new MBMessageLocalServiceImpl(), "_getMessageURL",
+				new Class<?>[] {MBMessage.class, ServiceContext.class},
+				new Object[] {mbMessage, serviceContext}));
+	}
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40981

There is a performance issue when we are adding the first comment on a web content. The issue comes when by default, we find if there is a message board portlet to show the mb message. Above process takes long time (only the first time) to process it if we have a lot of pages,  since, we have to iterate each page and get it from the database , in order to find if we have an instance of mb message portlet, see [this line](https://github.com/liferay/liferay-portal/blob/9888af7bdecba9e1e343ee7e3c3544c6376ce73b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java#L2138) and [this line ](https://github.com/liferay/liferay-portal/blob/9888af7bdecba9e1e343ee7e3c3544c6376ce73b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java#L2141), where finally we are iterating layouts [here](https://github.com/liferay/liferay-portal/blob/59723a7e6a697b4c56fb706bf998f348f7c20502/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L7040). This search is only affected the first time, since the next time we have the layouts chached. Above issue is an issue from page-management team, but from our side we can improve our code when we are adding a comment to a content or a file. This improvement comes from not searching a mb message portlet instance, since we don't need it to show a comment of a content in an asset publisher. This is something that we can provide to the customer in a quick way.

# How am I fixing it?

We do not need to find a MBPortlet to show a comment in scenarios when we are adding a comment to a content in an asset publisher, since we are not showing this type of message on the portlet. For that reason, when we are in this uses case we are adding a mb discussion instead of mb message. So, we will use message.isDiscussion() sentence in order to know if we are adding a comment.

# How can you verify that it works?

Run included test.