### PR TITLE
[NOT FORWARD] LPD-38760 Alloy Editor in blogs cannot display image added via item selector URL

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,7 +25,7 @@
 			max-width: 100%;
 		}
 
-		img[data-cke-saved-src^='data:image'] {
+		img[data-cke-saved-src^='data:image']:not([data-fileentryid]) {
 			display: none;
 		}
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,7 +25,10 @@
 			max-width: 100%;
 		}
 
-		img[data-cke-saved-src]:has(+ .uploading-image-container) {
+		.uploading-image-container + img[data-cke-saved-src^='data:image'],
+		img[data-cke-saved-src^='data:image']:has(
+				+ .uploading-image-container
+			) {
 			display: none;
 		}
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,10 +25,7 @@
 			max-width: 100%;
 		}
 
-		.uploading-image-container + img[data-cke-saved-src^='data:image'],
-		img[data-cke-saved-src^='data:image']:has(
-				+ .uploading-image-container
-			) {
+		img[data-cke-saved-src^='data:image'] {
 			display: none;
 		}
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,8 +25,8 @@
 			max-width: 100%;
 		}
 
-		img[data-cke-saved-src]:not([data-fileentryid]) {
-			visibility: hidden;
+		img[data-cke-saved-src]:has(+ .uploading-image-container) {
+			display: none;
 		}
 
 		.cover-image-container {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -394,7 +394,8 @@
 
 						if (image) {
 							const ckeditorImage = document.querySelector(
-								`img[data-cke-saved-src]:has(+ .${CSS_UPLOADING_IMAGE_CONTAINER})`
+								`.${CSS_UPLOADING_IMAGE_CONTAINER} + img[data-cke-saved-src^="data:image"],
+								img[data-cke-saved-src^="data:image"]:has(+ .${CSS_UPLOADING_IMAGE_CONTAINER})`
 							);
 
 							if (ckeditorImage) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -363,7 +363,7 @@
 				const TPL_PROGRESS_BAR = '<div class="progressbar"></div>';
 
 				const ckeditorImage = document.querySelector(
-					'[data-cke-saved-src^="data:image"]'
+					'img[data-cke-saved-src^="data:image"]:not([data-fileentryid])'
 				);
 
 				const _onUploadError = () => {
@@ -404,7 +404,6 @@
 						}
 
 						if (image) {
-
 							image.removeAttribute(ATTR_DATA_RANDOM_ID);
 							image.classList.remove(CSS_UPLOADING_IMAGE);
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -356,10 +356,9 @@
 			AUI().use('aui-progressbar', 'uploader', (A) => {
 				const ATTR_DATA_RANDOM_ID = 'data-random-id';
 				const CSS_UPLOADING_IMAGE = 'uploading-image';
-				const CSS_UPLOADING_IMAGE_CONTAINER =
-					'uploading-image-container';
 
-				const TPL_IMAGE_CONTAINER = `<div class="${CSS_UPLOADING_IMAGE_CONTAINER}"></div>`;
+				const TPL_IMAGE_CONTAINER =
+					'<div class="uploading-image-container"></div>';
 
 				const TPL_PROGRESS_BAR = '<div class="progressbar"></div>';
 
@@ -394,8 +393,7 @@
 
 						if (image) {
 							const ckeditorImage = document.querySelector(
-								`.${CSS_UPLOADING_IMAGE_CONTAINER} + img[data-cke-saved-src^="data:image"],
-								img[data-cke-saved-src^="data:image"]:has(+ .${CSS_UPLOADING_IMAGE_CONTAINER})`
+								'[data-cke-saved-src^="data:image"]'
 							);
 
 							if (ckeditorImage) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -362,8 +362,16 @@
 
 				const TPL_PROGRESS_BAR = '<div class="progressbar"></div>';
 
+				const ckeditorImage = document.querySelector(
+					'[data-cke-saved-src^="data:image"]'
+				);
+
 				const _onUploadError = () => {
 					const image = this._tempImage;
+
+					if (ckeditorImage) {
+						ckeditorImage.remove();
+					}
 
 					if (image) {
 						image.parentElement.remove();
@@ -391,14 +399,11 @@
 					if (data.success) {
 						const image = this._tempImage;
 
-						if (image) {
-							const ckeditorImage = document.querySelector(
-								'[data-cke-saved-src^="data:image"]'
-							);
+						if (ckeditorImage) {
+							ckeditorImage.remove();
+						}
 
-							if (ckeditorImage) {
-								ckeditorImage.remove();
-							}
+						if (image) {
 
 							image.removeAttribute(ATTR_DATA_RANDOM_ID);
 							image.classList.remove(CSS_UPLOADING_IMAGE);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -356,9 +356,10 @@
 			AUI().use('aui-progressbar', 'uploader', (A) => {
 				const ATTR_DATA_RANDOM_ID = 'data-random-id';
 				const CSS_UPLOADING_IMAGE = 'uploading-image';
+				const CSS_UPLOADING_IMAGE_CONTAINER =
+					'uploading-image-container';
 
-				const TPL_IMAGE_CONTAINER =
-					'<div class="uploading-image-container"></div>';
+				const TPL_IMAGE_CONTAINER = `<div class="${CSS_UPLOADING_IMAGE_CONTAINER}"></div>`;
 
 				const TPL_PROGRESS_BAR = '<div class="progressbar"></div>';
 
@@ -392,6 +393,14 @@
 						const image = this._tempImage;
 
 						if (image) {
+							const ckeditorImage = document.querySelector(
+								`img[data-cke-saved-src]:has(+ .${CSS_UPLOADING_IMAGE_CONTAINER})`
+							);
+
+							if (ckeditorImage) {
+								ckeditorImage.remove();
+							}
+
 							image.removeAttribute(ATTR_DATA_RANDOM_ID);
 							image.classList.remove(CSS_UPLOADING_IMAGE);
 
@@ -419,14 +428,6 @@
 								fileEntryId: data.file.fileEntryId,
 								uploadImageReturnType: '',
 							});
-
-							const ckeditorImage = document.querySelector(
-								'[data-cke-saved-src]'
-							);
-
-							if (ckeditorImage) {
-								ckeditorImage.remove();
-							}
 
 							const fragment =
 								CKEDITOR.htmlParser.fragment.fromHtml(


### PR DESCRIPTION
>[!NOTE]
> This PR is going to be **manually forwarded to FI** after a review.
>
> I have several commits and I left in this first review because the git history adds contexts about my tries; But will be flattened at one commit before forwarding to FI

## What is this trying to solve?

### https://liferay.atlassian.net/browse/LPD-38760

Currently, when an image is added via a URL in the blog editor, it does not display correctly in edit mode. Additionally, if a new image is added after inserting one via URL, the previous image is either deleted or hidden, negatively impacting content editing and increasing page weight by keeping redundant elements in the DOM.

## How am I fixing it?

To address this issue, I followed a similar approach to the fix that initially caused this behavior ([LPS-195447](https://liferay.atlassian.net/browse/LPS-195447)), adjusting selectors to target only elements with inline data in the `src` attribute. This will allow hidden images to be removed in case of an error, avoiding their accumulation in the DOM.

>[!WARNING] 
>Despite this improvement, the issue will persist if inline data is used instead of URLs, such as base64 data directly in the `src` attribute.


## How can you verify that it works?

Run the POSHI test `ItemSelector#CanAddBlogsImageViaURL`

## Before the PR
![image](https://github.com/user-attachments/assets/c84c7439-77e3-436b-a5e3-79ec8021de56)

## After the PR
![image](https://github.com/user-attachments/assets/004ed941-f649-4846-8584-e45e19e2e5f9)

## Alternative Solutions:

A more robust solution would be to prevent the editor (CKEditor) from automatically adding the image element when the `addImages` plugin is activated, as this automatic setup seems to be contributing to the problem. However, I am not an expert in CKEditor, and my knowledge is limited, so I am unsure how to prevent this automatic paste function effectively.

### Issues with the Alternative Solution:

**Compatibility**: This plugin is initiated but didnt work in other modules, such as:
   - `BaseAlloyEditorConfigContributor.java`
   - `CKEditorConfigContributor.java`
   - `LayoutTranslateEditorConfigContributor.java`
   - DDM Configurations

Currently, the issue only affects Blogs, but disabling CKEditor’s automatic paste function could cause problems in other modules, like Knowledge Base, Web Content, Message Boards, and Wiki, where automatic paste functionality is crucial and does not go through `_onPaste()`.

---

>[!IMPORTANT]
> Is the expected behavior that the plugin doesn't work by default to handle pasted images?

>[!NOTE]
> **CSS Files**: I try to move the blog CSS to the editor CSS so that it’s closer to the plugin code and deploys at once. However, this could potentially cause issues in other modules, where CKEditor images are used without the plugin.