### PR TITLE
LPD-41767 Creating new folder in Documents and Media portlet shows two success messages

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -14,7 +14,7 @@ DLAdminManagementToolbarDisplayContext dlAdminManagementToolbarDisplayContext = 
 DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisplayContext, request, renderRequest, renderResponse);
 %>
 
-<liferay-ui:success key='<%= portletDisplay.getId() + "requestProcessed" %>' message="your-request-completed-successfully" />
+<liferay-ui:success key='<%= DLPortletKeys.DOCUMENT_LIBRARY_ADMIN + "requestProcessed" %>' message="your-request-completed-successfully" />
 
 <c:choose>
 	<c:when test="<%= dlViewDisplayContext.isFileEntryTypesNavigation() %>">


### PR DESCRIPTION
Creating new folder in Documents and Media portlet shows two success messages

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-41767)

Two success messages are shown when the DM widget is in a page, be it widget or content page

# How am I fixing it?

Changing the success message so that it only shows in admin view, this is because for pages, getSessionMessagesScriptBodyContent is in charge of displaying the message. The issue is that rendering the success tag does not remove the key from the session, so it will be picked up again.

This happens because the same view is used in a page and in admin view

# How can you verify that it works?

Follow the steps in the ticket. One message is shown when the widget is in a page, and one message is shown in admin view

There are several poshi tests that already cover this messages