### PR TITLE
LPD-36686 add external reference code support for assetTag entity

### DIFF
--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -159,8 +159,9 @@ public class AssetTagStagedModelDataHandler
 
 			try {
 				importedAssetTag = _assetTagLocalService.addTag(
-					null, userId, portletDataContext.getScopeGroupId(),
-					assetTag.getName(), serviceContext);
+					assetTag.getExternalReferenceCode(), userId,
+					portletDataContext.getScopeGroupId(), assetTag.getName(),
+					serviceContext);
 			}
 			catch (DuplicateTagException duplicateTagException) {
 				if (_log.isDebugEnabled()) {
@@ -168,7 +169,8 @@ public class AssetTagStagedModelDataHandler
 				}
 
 				importedAssetTag = _assetTagLocalService.addTag(
-					null, userId, portletDataContext.getScopeGroupId(),
+					assetTag.getExternalReferenceCode(), userId,
+					portletDataContext.getScopeGroupId(),
 					assetTag.getName() + " (Duplicate)", serviceContext);
 			}
 		}

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagStagedModelDataHandlerTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagStagedModelDataHandlerTest.java
@@ -68,6 +68,9 @@ public class AssetTagStagedModelDataHandlerTest
 		AssetTag tag = (AssetTag)stagedModel;
 		AssetTag importedTag = (AssetTag)importedStagedModel;
 
+		Assert.assertEquals(
+			tag.getExternalReferenceCode(),
+			importedTag.getExternalReferenceCode());
 		Assert.assertEquals(tag.getName(), importedTag.getName());
 	}
 

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagStagedModelDataHandlerTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagStagedModelDataHandlerTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.List;
@@ -42,7 +43,9 @@ public class AssetTagStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		return AssetTestUtil.addTag(group.getGroupId());
+		return AssetTestUtil.addTag(
+			RandomTestUtil.randomString(), group.getGroupId(),
+			RandomTestUtil.randomString());
 	}
 
 	@Override

--- a/modules/apps/asset/asset-test-util/bnd.bnd
+++ b/modules/apps/asset/asset-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Test Utilities
 Bundle-SymbolicName: com.liferay.asset.test.util
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.asset.test.util,\
 	com.liferay.asset.test.util.asset.renderer.factory

--- a/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
+++ b/modules/apps/asset/asset-test-util/src/main/java/com/liferay/asset/test/util/AssetTestUtil.java
@@ -103,10 +103,17 @@ public class AssetTestUtil {
 	public static AssetTag addTag(long groupId, String assetTagName)
 		throws PortalException {
 
+		return addTag(null, groupId, assetTagName);
+	}
+
+	public static AssetTag addTag(
+			String externalReferenceCode, long groupId, String assetTagName)
+		throws PortalException {
+
 		long userId = TestPropsValues.getUserId();
 
 		return AssetTagLocalServiceUtil.addTag(
-			null, userId, groupId, assetTagName,
+			externalReferenceCode, userId, groupId, assetTagName,
 			ServiceContextTestUtil.getServiceContext(groupId, userId));
 	}
 

--- a/modules/apps/asset/asset-test-util/src/main/resources/com/liferay/asset/test/util/packageinfo
+++ b/modules/apps/asset/asset-test-util/src/main/resources/com/liferay/asset/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
LPD-36686 Technical Task | Add ExternalReferenceCode to Tags

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-36686

As a systems administrator I want to be able to use an External Reference Code of a tag during the import/export process so that my data is migrated accurately without any duplication or mismatches

After https://github.com/liferay-content-management/liferay-portal/pull/6060 We realized that on the staging imp/exp an error can happens if ERC is different than UUID

# How am I fixing it?

passing the erc on the method instead of null

# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-36686 the tag imported should have the same externalReferenceCode that the original one**
- **LPD-36686 add test**
- **LPD-36686 if the ERC is null will be the same as the uuid so to make the test robust we should check a random value for the ERC**
- **LPD-36686 baseline**
