### PR TITLE
LPD-41695 Google Drive authentication randomly fails on cloud

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -302,7 +302,13 @@ public class DLOpenerGoogleDriveManagerTest {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			_http.URLtoString(options));
 
-		return jsonObject.getString("access_token");
+		String accessToken = jsonObject.getString("access_token");
+
+		Assert.assertFalse(
+			"The JSON response does not include an Access Token: " + jsonObject,
+			accessToken.isEmpty());
+
+		return accessToken;
 	}
 
 	private boolean _isGoogleDriveFile(FileEntry fileEntry) {

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/GoogleAuthorizationCodeFlowStoreUtil.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/GoogleAuthorizationCodeFlowStoreUtil.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class GoogleAuthorizationCodeFlowStoreUtil {
+
+	public static void add(
+		long companyId,
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow) {
+
+		_add(companyId, googleAuthorizationCodeFlow);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(
+					_addMethodKey, companyId, googleAuthorizationCodeFlow));
+		}
+	}
+
+	public static void clear() {
+		_clear();
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(new MethodHandler(_clearMethodKey));
+		}
+	}
+
+	public static GoogleAuthorizationCodeFlow get(long companyId) {
+		return _googleAuthorizationCodeFlows.get(companyId);
+	}
+
+	private static void _add(
+		long companyId,
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow) {
+
+		_googleAuthorizationCodeFlows.put(
+			companyId, googleAuthorizationCodeFlow);
+	}
+
+	private static void _clear() {
+		_googleAuthorizationCodeFlows.clear();
+	}
+
+	private static void _executeOnCluster(MethodHandler methodHandler) {
+		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
+			methodHandler, true);
+
+		clusterRequest.setFireAndForget(true);
+
+		ClusterExecutorUtil.execute(clusterRequest);
+	}
+
+	private static final MethodKey _addMethodKey = new MethodKey(
+		GoogleAuthorizationCodeFlowStoreUtil.class, "_add", long.class,
+		GoogleAuthorizationCodeFlow.class);
+	private static final MethodKey _clearMethodKey = new MethodKey(
+		GoogleAuthorizationCodeFlowStoreUtil.class, "_clear");
+	private static final Map<Long, GoogleAuthorizationCodeFlow>
+		_googleAuthorizationCodeFlows = new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
@@ -141,6 +141,9 @@ public class OAuth2Manager {
 
 		googleAuthorizationCodeFlow.createAndStoreCredential(
 			googleTokenResponse, String.valueOf(userId));
+
+		GoogleAuthorizationCodeFlowStoreUtil.add(
+			companyId, googleAuthorizationCodeFlow);
 	}
 
 	public void revokeCredential(long companyId, long userId)
@@ -155,6 +158,9 @@ public class OAuth2Manager {
 					googleAuthorizationCodeFlow.getCredentialDataStore();
 
 				credentialDataStore.delete(String.valueOf(userId));
+
+				GoogleAuthorizationCodeFlowStoreUtil.add(
+					companyId, googleAuthorizationCodeFlow);
 			}
 		}
 		catch (IOException ioException) {
@@ -177,6 +183,9 @@ public class OAuth2Manager {
 			storedCredential.setAccessToken(accessToken);
 
 			credentialDataStore.set(String.valueOf(userId), storedCredential);
+
+			GoogleAuthorizationCodeFlowStoreUtil.add(
+				companyId, googleAuthorizationCodeFlow);
 		}
 	}
 

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
@@ -34,8 +34,6 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -184,7 +182,7 @@ public class OAuth2Manager {
 
 	@Deactivate
 	protected void deactivate() {
-		_googleAuthorizationCodeFlows.clear();
+		GoogleAuthorizationCodeFlowStoreUtil.clear();
 	}
 
 	private DLGoogleDriveCompanyConfiguration
@@ -208,10 +206,10 @@ public class OAuth2Manager {
 				dlGoogleDriveCompanyConfiguration =
 					_getDLGoogleDriveCompanyConfiguration(companyId);
 
-			if (_googleAuthorizationCodeFlows.containsKey(companyId)) {
-				GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
-					_googleAuthorizationCodeFlows.get(companyId);
+			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+				GoogleAuthorizationCodeFlowStoreUtil.get(companyId);
 
+			if (googleAuthorizationCodeFlow != null) {
 				ClientParametersAuthentication clientParametersAuthentication =
 					(ClientParametersAuthentication)
 						googleAuthorizationCodeFlow.getClientAuthentication();
@@ -247,10 +245,10 @@ public class OAuth2Manager {
 				googleAuthorizationCodeFlowBuilder.setDataStoreFactory(
 					MemoryDataStoreFactory.getDefaultInstance());
 
-			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+			googleAuthorizationCodeFlow =
 				googleAuthorizationCodeFlowBuilder.build();
 
-			_googleAuthorizationCodeFlows.put(
+			GoogleAuthorizationCodeFlowStoreUtil.add(
 				companyId, googleAuthorizationCodeFlow);
 
 			return googleAuthorizationCodeFlow;
@@ -267,8 +265,5 @@ public class OAuth2Manager {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
-
-	private final Map<Long, GoogleAuthorizationCodeFlow>
-		_googleAuthorizationCodeFlows = new ConcurrentHashMap<>();
 
 }

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/GoogleAuthorizationCodeFlowStoreUtilTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/GoogleAuthorizationCodeFlowStoreUtilTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.drive.DriveScopes;
+
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.IOException;
+
+import java.security.GeneralSecurityException;
+
+import java.util.Collections;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class GoogleAuthorizationCodeFlowStoreUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Mockito.when(
+			ClusterExecutorUtil.isEnabled()
+		).thenReturn(
+			false
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_clusterExecutorUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testAdd() throws GeneralSecurityException, IOException {
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow1 =
+			_addGoogleAuthorizationCodeFlow();
+
+		long companyId = RandomTestUtil.randomInt();
+
+		GoogleAuthorizationCodeFlowStoreUtil.add(
+			companyId, googleAuthorizationCodeFlow1);
+
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow2 =
+			GoogleAuthorizationCodeFlowStoreUtil.get(companyId);
+
+		Assert.assertEquals(
+			googleAuthorizationCodeFlow1, googleAuthorizationCodeFlow2);
+	}
+
+	@Test
+	public void testClear() throws GeneralSecurityException, IOException {
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+			_addGoogleAuthorizationCodeFlow();
+
+		long companyId = RandomTestUtil.randomInt();
+
+		GoogleAuthorizationCodeFlowStoreUtil.add(
+			companyId, googleAuthorizationCodeFlow);
+
+		GoogleAuthorizationCodeFlowStoreUtil.clear();
+
+		Assert.assertNull(GoogleAuthorizationCodeFlowStoreUtil.get(companyId));
+	}
+
+	@Test
+	public void testGetWithEmptyGoogleAuthorizationCodeFlowStore() {
+		Assert.assertNull(
+			GoogleAuthorizationCodeFlowStoreUtil.get(
+				RandomTestUtil.randomInt()));
+	}
+
+	private GoogleAuthorizationCodeFlow _addGoogleAuthorizationCodeFlow()
+		throws GeneralSecurityException, IOException {
+
+		return new GoogleAuthorizationCodeFlow(
+			GoogleNetHttpTransport.newTrustedTransport(),
+			JacksonFactory.getDefaultInstance(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			Collections.singleton(DriveScopes.DRIVE_FILE));
+	}
+
+	private static final MockedStatic<ClusterExecutorUtil>
+		_clusterExecutorUtilMockedStatic = Mockito.mockStatic(
+			ClusterExecutorUtil.class);
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41695

The Google Drive authentication fails when Liferay is executed on a cloud environment. This happen because a node stores the credentials for a user, while another node fails retrieving it because it accesses a different instance of the map storing the credentials.

# How am I fixing it?

I'm using the same strategy of `AccessTokenStoreUtil` where the changes to a map storing the credientals are broadcast to all nodes in the cluster.

# How can you verify that it works?

Run the newly created unit test:

:warning: I don't know how to test it in a cloud environment.

`cd modules/apps/document-library-opener/document-library-opener-google-drive-web`
`gw test --tests GoogleAuthorizationCodeFlowStoreUtilTest`

Run the existing integration test:

`cd modules/apps/document-library-opener/document-library-opener-google-drive-test`
`gw tI --tests DLOpenerGoogleDriveManagerTest`
