### PR TITLE
LPD-39503

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
@@ -23,6 +23,7 @@ export default function historyReducer(state, action) {
 			};
 		case EVENT_TYPES.HISTORY.BLUR:
 			if (state.history.edited) {
+				Liferay.fire('journal:unlock');
 				Liferay.fire('journal:storeState', {
 					fieldName:
 						Liferay.Language.get('edit') + ' ' + action.payload,
@@ -46,6 +47,8 @@ export default function historyReducer(state, action) {
 				},
 			};
 		case EVENT_TYPES.HISTORY.MARK:
+			Liferay.fire('journal:lock');
+
 			return {
 				history: {
 					...state.history,

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
@@ -92,11 +92,13 @@ export default function fieldChange({
 
 		if (Liferay.FeatureFlags['LPD-11228']) {
 			if (
-				fieldInstance.type === 'color' ||
-				fieldInstance.type === 'image' ||
-				fieldInstance.type === 'numeric' ||
-				fieldInstance.type === 'rich_text' ||
-				fieldInstance.type === 'text'
+				(fieldInstance.type === 'color' ||
+					fieldInstance.type === 'image' ||
+					fieldInstance.type === 'numeric' ||
+					fieldInstance.type === 'rich_text' ||
+					fieldInstance.type === 'text') &&
+				document.activeElement.name !== 'journal_undo_redo' &&
+				document.body !== document.activeElement
 			) {
 				dispatch({type: EVENT_TYPES.HISTORY.MARK});
 			}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -90,7 +90,8 @@ export default function UndoRedo({
 		}
 	);
 
-	const handleUndo = (newStep) => {
+	const handleUndo = (num) => {
+		const newStep = num || step - 1
 		const nextStep = history[newStep];
 
 		const selectedLanguageIdInput = document.getElementById(
@@ -160,7 +161,8 @@ export default function UndoRedo({
 		Liferay.fire('inputLocalized:updateTranslationStatus');
 	};
 
-	const handleRedo = (newStep) => {
+	const handleRedo = (num) => {
+		const newStep = num || step + 1;
 		const nextStep = history[newStep];
 
 		const selectedLanguageIdInput = document.getElementById(
@@ -450,7 +452,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:undo');
-					handleUndo(step - 1);
+					handleUndo();
 				}}
 				size="sm"
 				symbol="undo"
@@ -464,7 +466,7 @@ export default function UndoRedo({
 				displayType="secondary"
 				onClick={() => {
 					Liferay.fire('journal:redo');
-					handleRedo(step + 1);
+					handleRedo();
 				}}
 				size="sm"
 				symbol="redo"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/UndoRedo.js
@@ -28,6 +28,7 @@ export default function UndoRedo({
 	portletNamespace,
 }) {
 	const [active, setActive] = useState(false);
+	const [lock, setLock] = useState(false);
 
 	const [
 
@@ -90,8 +91,8 @@ export default function UndoRedo({
 		}
 	);
 
-	const handleUndo = (num) => {
-		const newStep = num || step - 1
+	const handleUndo = (newStep = step - 1) => {
+		setLock(true);
 		const nextStep = history[newStep];
 
 		const selectedLanguageIdInput = document.getElementById(
@@ -159,10 +160,11 @@ export default function UndoRedo({
 
 		updateMetadataFields(nextStep, newStep);
 		Liferay.fire('inputLocalized:updateTranslationStatus');
+		setLock(false);
 	};
 
-	const handleRedo = (num) => {
-		const newStep = num || step + 1;
+	const handleRedo = (newStep = step + 1) => {
+		setLock(true);
 		const nextStep = history[newStep];
 
 		const selectedLanguageIdInput = document.getElementById(
@@ -221,10 +223,12 @@ export default function UndoRedo({
 
 		updateMetadataFields(nextStep, newStep);
 		Liferay.fire('inputLocalized:updateTranslationStatus');
+		setLock(false);
 	};
 
 	const handleStoreState = useCallback(
 		({fieldName}) => {
+			setLock(true);
 			const defaultLanguageIdInput = document.getElementById(
 				`${portletNamespace}defaultLanguageId`
 			);
@@ -263,6 +267,7 @@ export default function UndoRedo({
 				selectedLanguageId: selectedLanguageIdInput.value,
 				step: step + 1,
 			});
+			setLock(false);
 		},
 		[
 			descriptionInputComponent,
@@ -290,7 +295,13 @@ export default function UndoRedo({
 			step.selectedLanguageId
 		);
 
-		descriptionInputComponent.updateInput(step.descriptionInputValue);
+		setTimeout(
+			() =>
+				descriptionInputComponent.updateInput(
+					step.descriptionInputValue
+				),
+			200
+		);
 
 		friendlyURLInputComponent.updateInput(step.friendlyURLInputValue);
 
@@ -443,13 +454,27 @@ export default function UndoRedo({
 		};
 	}, [handleUpdateFriendlyURL]);
 
+	useEffect(() => {
+		const handleLock = () => setLock(true);
+		const handleUnlock = () => setLock(false);
+
+		Liferay.on('journal:lock', handleLock);
+		Liferay.on('journal:unlock', handleUnlock);
+
+		return () => {
+			Liferay.detach('journal:lock', handleLock);
+			Liferay.detach('journal:unlock', handleUnlock);
+		};
+	}, []);
+
 	return (
 		<div className="d-flex">
 			<ClayButtonWithIcon
 				aria-label={Liferay.Language.get('undo')}
 				className="btn-monospaced"
-				disabled={step <= 0}
+				disabled={step <= 0 || lock}
 				displayType="secondary"
+				name="journal_undo_redo"
 				onClick={() => {
 					Liferay.fire('journal:undo');
 					handleUndo();
@@ -462,8 +487,11 @@ export default function UndoRedo({
 			<ClayButtonWithIcon
 				aria-label={Liferay.Language.get('redo')}
 				className="btn-monospaced"
-				disabled={!history.length || step === history.length - 1}
+				disabled={
+					!history.length || step === history.length - 1 || lock
+				}
 				displayType="secondary"
+				name="journal_undo_redo"
 				onClick={() => {
 					Liferay.fire('journal:redo');
 					handleRedo();

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -41,6 +41,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 
 					function <%= namespace + randomNamespace %>onBlurMethod() {
 						if (edited && Liferay.FeatureFlags['LPD-11228']) {
+							Liferay.fire('journal:unlock')
 							edited = false;
 
 							var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
@@ -53,7 +54,10 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 					}
 
 					function <%= namespace + randomNamespace %>onChangeEditor() {
-						if (Liferay.FeatureFlags['LPD-11228']) edited = true;
+						if (Liferay.FeatureFlags['LPD-11228'] && document.activeElement.name !== 'journal_undo_redo' && document.body !== document.activeElement) {
+							Liferay.fire('journal:lock')
+							edited = true;
+						}
 
 						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
 


### PR DESCRIPTION
This is a draft to discuss the solution

# What is this trying to solve?

[LPD-39592](https://liferay.atlassian.net/browse/LPD-39503)

Because the implementation of UndoRedo relies on custom events, and we are using the onBlur event of the input fields to create new history steps, there is an edge case issue, where the user clicks on undo right after editing an input field. In this case we handle undo before we create the new history step from the blur event of the field.

# How am I fixing it?

I made sure the Undo / Redo button is disabled while we are editing an input field.

# How can you verify that it works?

Follow the reproduction steps from the ticket

# Why doesn't this include any test?

The already existing tests are sufficient, this changes the behaviour of the undo redo button by disabling it while the user is editing an input field. Because it is changing the UX, Ruth Alves approved this change

/cc @ambrinchaudhary 
