### PR TITLE
LPD-33318 Apply ERC to Announcements widget config

### DIFF
--- a/modules/apps/announcements/announcements-test/build.gradle
+++ b/modules/apps/announcements/announcements-test/build.gradle
@@ -1,4 +1,8 @@
 dependencies {
+	testIntegrationImplementation project(":apps:announcements:announcements-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/test/UpgradePortletPreferencesTest.java
@@ -9,9 +9,12 @@ import com.liferay.announcements.constants.AnnouncementsPortletKeys;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -19,6 +22,10 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -29,6 +36,7 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -92,6 +100,54 @@ public class UpgradePortletPreferencesTest {
 	}
 
 	@Test
+	public void testUpgradeExternalReferenceCodeWithSpecialCharacters()
+		throws Exception {
+
+		String specialCharacters = "One\\+-!():^[]\"{}~*?|&,; /Two";
+
+		_testUpgrade(
+			_addModels(
+				1,
+				() -> {
+					Group group = GroupTestUtil.addGroup();
+
+					group.setExternalReferenceCode(specialCharacters);
+
+					return _groupLocalService.updateGroup(group);
+				}),
+			_addModels(
+				1,
+				() -> {
+					Organization organization =
+						OrganizationTestUtil.addOrganization();
+
+					organization.setExternalReferenceCode(specialCharacters);
+
+					return _organizationLocalService.updateOrganization(
+						organization);
+				}),
+			_addModels(
+				1,
+				() -> {
+					Role role = RoleTestUtil.addRole(
+						RoleConstants.TYPE_REGULAR);
+
+					role.setExternalReferenceCode(specialCharacters);
+
+					return _roleLocalService.updateRole(role);
+				}),
+			_addModels(
+				1,
+				() -> {
+					UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+					userGroup.setExternalReferenceCode(specialCharacters);
+
+					return _userGroupLocalService.updateUserGroup(userGroup);
+				}));
+	}
+
+	@Test
 	public void testUpgradeInvalidSelectedScopeId() throws Exception {
 		String randomSelectedScopeId = String.valueOf(
 			RandomTestUtil.randomLong());
@@ -152,14 +208,14 @@ public class UpgradePortletPreferencesTest {
 			RandomTestUtil.randomLong());
 
 		_testUpgrade(
-			ListUtil.toString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			_toJSONArrayString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			selectedScopeGroupIds + ',' + randomSelectedScopeId,
-			ListUtil.toString(
+			_toJSONArrayString(
 				organizations, _ORGANIZATION_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			selectedScopeOrganizationIds + ',' + randomSelectedScopeId,
-			ListUtil.toString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			_toJSONArrayString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			selectedScopeRoleIds + ',' + randomSelectedScopeId,
-			ListUtil.toString(
+			_toJSONArrayString(
 				userGroups, _USERGROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			selectedScopeUserGroupIds + ',' + randomSelectedScopeId);
 	}
@@ -264,15 +320,15 @@ public class UpgradePortletPreferencesTest {
 		throws Exception {
 
 		_testUpgrade(
-			ListUtil.toString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			_toJSONArrayString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			ListUtil.toString(groups, Group.GROUP_ID_ACCESSOR),
-			ListUtil.toString(
+			_toJSONArrayString(
 				organizations, _ORGANIZATION_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			ListUtil.toString(
 				organizations, Organization.ORGANIZATION_ID_ACCESSOR),
-			ListUtil.toString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			_toJSONArrayString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			ListUtil.toString(roles, Role.ROLE_ID_ACCESSOR),
-			ListUtil.toString(
+			_toJSONArrayString(
 				userGroups, _USERGROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
 			ListUtil.toString(userGroups, UserGroup.USER_GROUP_ID_ACCESSOR));
 	}
@@ -334,6 +390,16 @@ public class UpgradePortletPreferencesTest {
 			).build());
 	}
 
+	private <T> String _toJSONArrayString(
+		List<T> list, Accessor<T, String> accessor) {
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+			TransformUtil.transform(
+				ListUtil.toList(list, accessor), HtmlUtil::escape));
+
+		return jsonArray.toString();
+	}
+
 	private static final String _CLASS_NAME =
 		"com.liferay.announcements.web.internal.upgrade.v2_1_0." +
 			"UpgradePortletPreferences";
@@ -360,16 +426,28 @@ public class UpgradePortletPreferencesTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
+	@Inject
+	private GroupLocalService _groupLocalService;
+
 	private Layout _layout;
 
 	@Inject
 	private MultiVMPool _multiVMPool;
 
+	@Inject
+	private OrganizationLocalService _organizationLocalService;
+
 	private String _portletId;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.announcements.web.internal.upgrade.registry.AnnouncementsWebUpgradeStepRegistrator))"
 	)
 	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/announcements/announcements-test/src/testIntegration/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/test/UpgradePortletPreferencesTest.java
@@ -1,0 +1,375 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal.upgrade.v2_1_0.test;
+
+import com.liferay.announcements.constants.AnnouncementsPortletKeys;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Accessor;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletPreferencesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, AnnouncementsPortletKeys.ANNOUNCEMENTS);
+	}
+
+	@Test
+	public void testUpgradeEmptySelectedScopeIds() throws Exception {
+		Map<String, String> map = HashMapBuilder.put(
+			"selectedScopeGroupIds", StringPool.BLANK
+		).put(
+			"selectedScopeOrganizationIds", StringPool.BLANK
+		).put(
+			"selectedScopeRoleIds", StringPool.BLANK
+		).put(
+			"selectedScopeUserGroupIds", StringPool.BLANK
+		).build();
+
+		_testUpgrade(map, map);
+	}
+
+	@Test
+	public void testUpgradeInvalidSelectedScopeId() throws Exception {
+		String randomSelectedScopeId = String.valueOf(
+			RandomTestUtil.randomLong());
+
+		Map<String, String> map = HashMapBuilder.put(
+			"selectedScopeGroupIds", randomSelectedScopeId
+		).put(
+			"selectedScopeOrganizationIds", randomSelectedScopeId
+		).put(
+			"selectedScopeRoleIds", randomSelectedScopeId
+		).put(
+			"selectedScopeUserGroupIds", randomSelectedScopeId
+		).build();
+
+		_testUpgrade(map, map);
+	}
+
+	@Test
+	public void testUpgradeInvalidSelectedScopeIds() throws Exception {
+		String randomSelectedScopeIds =
+			String.valueOf(RandomTestUtil.randomLong()) + ',' +
+				String.valueOf(RandomTestUtil.randomLong()) + ',' +
+					String.valueOf(RandomTestUtil.randomLong());
+
+		Map<String, String> map = HashMapBuilder.put(
+			"selectedScopeGroupIds", randomSelectedScopeIds
+		).put(
+			"selectedScopeOrganizationIds", randomSelectedScopeIds
+		).put(
+			"selectedScopeRoleIds", randomSelectedScopeIds
+		).put(
+			"selectedScopeUserGroupIds", randomSelectedScopeIds
+		).build();
+
+		_testUpgrade(map, map);
+	}
+
+	@Test
+	public void testUpgradeSomeInvalidSelectedScopeIds() throws Exception {
+		List<Group> groups = _addModels(2, GroupTestUtil::addGroup);
+		List<Organization> organizations = _addModels(
+			2, OrganizationTestUtil::addOrganization);
+		List<Role> roles = _addModels(
+			2, () -> RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR));
+		List<UserGroup> userGroups = _addModels(
+			2, UserGroupTestUtil::addUserGroup);
+
+		String selectedScopeGroupIds = ListUtil.toString(
+			groups, Group.GROUP_ID_ACCESSOR);
+		String selectedScopeOrganizationIds = ListUtil.toString(
+			organizations, Organization.ORGANIZATION_ID_ACCESSOR);
+		String selectedScopeRoleIds = ListUtil.toString(
+			roles, Role.ROLE_ID_ACCESSOR);
+		String selectedScopeUserGroupIds = ListUtil.toString(
+			userGroups, UserGroup.USER_GROUP_ID_ACCESSOR);
+
+		String randomSelectedScopeId = String.valueOf(
+			RandomTestUtil.randomLong());
+
+		_testUpgrade(
+			ListUtil.toString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			selectedScopeGroupIds + ',' + randomSelectedScopeId,
+			ListUtil.toString(
+				organizations, _ORGANIZATION_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			selectedScopeOrganizationIds + ',' + randomSelectedScopeId,
+			ListUtil.toString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			selectedScopeRoleIds + ',' + randomSelectedScopeId,
+			ListUtil.toString(
+				userGroups, _USERGROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			selectedScopeUserGroupIds + ',' + randomSelectedScopeId);
+	}
+
+	@Test
+	public void testUpgradeValidSelectedScopeId() throws Exception {
+		_testUpgrade(
+			_addModels(1, GroupTestUtil::addGroup),
+			_addModels(1, OrganizationTestUtil::addOrganization),
+			_addModels(
+				1, () -> RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR)),
+			_addModels(1, UserGroupTestUtil::addUserGroup));
+	}
+
+	@Test
+	public void testUpgradeValidSelectedScopeIds() throws Exception {
+		_testUpgrade(
+			_addModels(3, GroupTestUtil::addGroup),
+			_addModels(3, OrganizationTestUtil::addOrganization),
+			_addModels(
+				3, () -> RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR)),
+			_addModels(3, UserGroupTestUtil::addUserGroup));
+	}
+
+	@Test
+	public void testUpgradeWithoutSelectedScopeIds() throws Exception {
+		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
+	}
+
+	private static <T extends ExternalReferenceCodeModel> Accessor<T, String>
+		_getExternalReferenceCodeAccessor(Class<T> typeClass) {
+
+		return new Accessor<T, String>() {
+
+			@Override
+			public String get(T t) {
+				return t.getExternalReferenceCode();
+			}
+
+			@Override
+			public Class<String> getAttributeClass() {
+				return String.class;
+			}
+
+			@Override
+			public Class<T> getTypeClass() {
+				return typeClass;
+			}
+
+		};
+	}
+
+	private <T> List<T> _addModels(
+			int count, UnsafeSupplier<T, Exception> unsafeSupplier)
+		throws Exception {
+
+		List<T> models = new ArrayList<>();
+
+		for (int i = 0; i < count; i++) {
+			models.add(unsafeSupplier.get());
+		}
+
+		return models;
+	}
+
+	private void _assertPortletPreferences(Map<String, String> expectedMap)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		Map<String, String[]> map = portletPreferences.getMap();
+
+		Assert.assertEquals(
+			MapUtil.toString(map), expectedMap.size(), map.size());
+
+		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
+			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
+
+			Assert.assertArrayEquals(
+				new String[] {entry.getValue()}, map.get(entry.getKey()));
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _testUpgrade(
+			List<Group> groups, List<Organization> organizations,
+			List<Role> roles, List<UserGroup> userGroups)
+		throws Exception {
+
+		_testUpgrade(
+			ListUtil.toString(groups, _GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			ListUtil.toString(groups, Group.GROUP_ID_ACCESSOR),
+			ListUtil.toString(
+				organizations, _ORGANIZATION_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			ListUtil.toString(
+				organizations, Organization.ORGANIZATION_ID_ACCESSOR),
+			ListUtil.toString(roles, _ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			ListUtil.toString(roles, Role.ROLE_ID_ACCESSOR),
+			ListUtil.toString(
+				userGroups, _USERGROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR),
+			ListUtil.toString(userGroups, UserGroup.USER_GROUP_ID_ACCESSOR));
+	}
+
+	private void _testUpgrade(
+			Map<String, String> expectedMap, Map<String, String> map)
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreferences(_layout, _portletId, map);
+
+		_assertPortletPreferences(map);
+
+		_runUpgrade();
+
+		_assertPortletPreferences(expectedMap);
+	}
+
+	private void _testUpgrade(
+			String selectedScopeGroupExternalReferenceCodes,
+			String selectedScopeGroupIds,
+			String selectedScopeOrganizationExternalReferenceCodes,
+			String selectedScopeOrganizationIds,
+			String selectedScopeRoleExternalReferenceCodes,
+			String selectedScopeRoleIds,
+			String selectedScopeUserGroupExternalReferenceCodes,
+			String selectedScopeUserGroupIds)
+		throws Exception {
+
+		_testUpgrade(
+			HashMapBuilder.put(
+				"selectedScopeGroupExternalReferenceCodes",
+				selectedScopeGroupExternalReferenceCodes
+			).put(
+				"selectedScopeGroupIds", selectedScopeGroupIds
+			).put(
+				"selectedScopeOrganizationExternalReferenceCodes",
+				selectedScopeOrganizationExternalReferenceCodes
+			).put(
+				"selectedScopeOrganizationIds", selectedScopeOrganizationIds
+			).put(
+				"selectedScopeRoleExternalReferenceCodes",
+				selectedScopeRoleExternalReferenceCodes
+			).put(
+				"selectedScopeRoleIds", selectedScopeRoleIds
+			).put(
+				"selectedScopeUserGroupExternalReferenceCodes",
+				selectedScopeUserGroupExternalReferenceCodes
+			).put(
+				"selectedScopeUserGroupIds", selectedScopeUserGroupIds
+			).build(),
+			HashMapBuilder.put(
+				"selectedScopeGroupIds", selectedScopeGroupIds
+			).put(
+				"selectedScopeOrganizationIds", selectedScopeOrganizationIds
+			).put(
+				"selectedScopeRoleIds", selectedScopeRoleIds
+			).put(
+				"selectedScopeUserGroupIds", selectedScopeUserGroupIds
+			).build());
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.announcements.web.internal.upgrade.v2_1_0." +
+			"UpgradePortletPreferences";
+
+	private static final Accessor<Group, String>
+		_GROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR =
+			_getExternalReferenceCodeAccessor(Group.class);
+
+	private static final Accessor<Organization, String>
+		_ORGANIZATION_EXTERNAL_REFERENCE_CODE_ACCESSOR =
+			_getExternalReferenceCodeAccessor(Organization.class);
+
+	private static final Accessor<Role, String>
+		_ROLE_EXTERNAL_REFERENCE_CODE_ACCESSOR =
+			_getExternalReferenceCodeAccessor(Role.class);
+
+	private static final Accessor<UserGroup, String>
+		_USERGROUP_EXTERNAL_REFERENCE_CODE_ACCESSOR =
+			_getExternalReferenceCodeAccessor(UserGroup.class);
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private String _portletId;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.announcements.web.internal.upgrade.registry.AnnouncementsWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -101,18 +101,16 @@ public class AnnouncementsDisplayContext {
 		_announcementScopes = new LinkedHashMap<>();
 
 		if (isCustomizeAnnouncementsDisplayed()) {
-			long[] selectedScopeGroupIdsArray =
-				ListUtil.toLongArray(
-					_getSelectedScopeGroups(), Group.GROUP_ID_ACCESSOR);
-			long[] selectedScopeOrganizationIdsArray =
-				ListUtil.toLongArray(
-					_getSelectedScopeOrganizations(), Organization.ORGANIZATION_ID_ACCESSOR);
-			long[] selectedScopeRoleIdsArray =
-				ListUtil.toLongArray(
-					_getSelectedScopeRoles(), Role.ROLE_ID_ACCESSOR);
-			long[] selectedScopeUserGroupIdsArray =
-				ListUtil.toLongArray(
-					_getSelectedScopeUserGroups(), UserGroup.USER_GROUP_ID_ACCESSOR);
+			long[] selectedScopeGroupIdsArray = ListUtil.toLongArray(
+				_getSelectedScopeGroups(), Group.GROUP_ID_ACCESSOR);
+			long[] selectedScopeOrganizationIdsArray = ListUtil.toLongArray(
+				_getSelectedScopeOrganizations(),
+				Organization.ORGANIZATION_ID_ACCESSOR);
+			long[] selectedScopeRoleIdsArray = ListUtil.toLongArray(
+				_getSelectedScopeRoles(), Role.ROLE_ID_ACCESSOR);
+			long[] selectedScopeUserGroupIdsArray = ListUtil.toLongArray(
+				_getSelectedScopeUserGroups(),
+				UserGroup.USER_GROUP_ID_ACCESSOR);
 
 			if (selectedScopeGroupIdsArray.length != 0) {
 				_announcementScopes.put(
@@ -205,7 +203,6 @@ public class AnnouncementsDisplayContext {
 		List<Group> selectedGroups = new ArrayList<>();
 
 		for (Group group : _getSelectedScopeGroups()) {
-
 			if (GroupPermissionUtil.contains(
 					_announcementsRequestHelper.getPermissionChecker(), group,
 					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
@@ -230,7 +227,6 @@ public class AnnouncementsDisplayContext {
 		List<Organization> selectedOrganizations = new ArrayList<>();
 
 		for (Organization organization : _getSelectedScopeOrganizations()) {
-
 			if (OrganizationPermissionUtil.contains(
 					_announcementsRequestHelper.getPermissionChecker(),
 					organization, ActionKeys.MANAGE_ANNOUNCEMENTS)) {
@@ -264,7 +260,6 @@ public class AnnouncementsDisplayContext {
 		List<Role> selectedRoles = new ArrayList<>();
 
 		for (Role role : _getSelectedScopeRoles()) {
-
 			if (AnnouncementsUtil.hasManageAnnouncementsPermission(
 					role, _announcementsRequestHelper.getPermissionChecker())) {
 
@@ -329,7 +324,8 @@ public class AnnouncementsDisplayContext {
 		for (UserGroup userGroup : _getSelectedScopeUserGroups()) {
 			if (UserGroupPermissionUtil.contains(
 					_announcementsRequestHelper.getPermissionChecker(),
-					userGroup.getUserGroupId(), ActionKeys.MANAGE_ANNOUNCEMENTS)) {
+					userGroup.getUserGroupId(),
+					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
 
 				selectedUserGroups.add(userGroup);
 			}
@@ -397,13 +393,16 @@ public class AnnouncementsDisplayContext {
 	}
 
 	public boolean isScopeRoleSelected(Role role) {
-		String selectedScopeRoleExternalReferenceCodes = _getSelectedScopeRoleExternalReferenceCodes();
+		String selectedScopeRoleExternalReferenceCodes =
+			_getSelectedScopeRoleExternalReferenceCodes();
 
-		return selectedScopeRoleExternalReferenceCodes.contains(role.getExternalReferenceCode());
+		return selectedScopeRoleExternalReferenceCodes.contains(
+			role.getExternalReferenceCode());
 	}
 
 	public boolean isScopeUserGroupSelected(UserGroup userGroup) {
-		String selectedScopeUserGroupExternalReferenceCodes = _getSelectedScopeUserGroupExternalReferenceCodes();
+		String selectedScopeUserGroupExternalReferenceCodes =
+			_getSelectedScopeUserGroupExternalReferenceCodes();
 
 		return selectedScopeUserGroupExternalReferenceCodes.contains(
 			userGroup.getExternalReferenceCode());
@@ -473,20 +472,6 @@ public class AnnouncementsDisplayContext {
 		return _portletURL;
 	}
 
-	private List<Group> _getSelectedScopeGroups() throws PortalException {
-		List<Group> groups = new ArrayList<>();
-
-		for (String externalReferenceCode :
-			StringUtil.split(_getSelectedScopeGroupExternalReferenceCodes())) {
-			groups.add(
-				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
-					externalReferenceCode,
-					_announcementsRequestHelper.getCompanyId()));
-		}
-
-		return groups;
-	}
-
 	private String _getSelectedScopeGroupExternalReferenceCodes() {
 		Layout layout = _announcementsRequestHelper.getLayout();
 
@@ -499,33 +484,63 @@ public class AnnouncementsDisplayContext {
 			group.getExternalReferenceCode());
 	}
 
-	private List<Organization> _getSelectedScopeOrganizations()
-		throws PortalException {
-		List<Organization> organizations = new ArrayList<>();
+	private List<Group> _getSelectedScopeGroups() throws PortalException {
+		List<Group> groups = new ArrayList<>();
 
 		for (String externalReferenceCode :
-			StringUtil.split(_getSelectedScopeOrganizationExternalReferenceCodes())) {
-			organizations.add(
-				OrganizationLocalServiceUtil.getOrganizationByExternalReferenceCode(
+				StringUtil.split(
+					_getSelectedScopeGroupExternalReferenceCodes())) {
+
+			groups.add(
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
 					externalReferenceCode,
 					_announcementsRequestHelper.getCompanyId()));
 		}
 
-		return organizations;
+		return groups;
 	}
 
 	private String _getSelectedScopeOrganizationExternalReferenceCodes() {
 		return PrefsParamUtil.getString(
 			_announcementsRequestHelper.getPortletPreferences(),
 			_announcementsRequestHelper.getRequest(),
-			"selectedScopeOrganizationExternalReferenceCodes", StringPool.BLANK);
+			"selectedScopeOrganizationExternalReferenceCodes",
+			StringPool.BLANK);
+	}
+
+	private List<Organization> _getSelectedScopeOrganizations()
+		throws PortalException {
+
+		List<Organization> organizations = new ArrayList<>();
+
+		for (String externalReferenceCode :
+				StringUtil.split(
+					_getSelectedScopeOrganizationExternalReferenceCodes())) {
+
+			organizations.add(
+				OrganizationLocalServiceUtil.
+					getOrganizationByExternalReferenceCode(
+						externalReferenceCode,
+						_announcementsRequestHelper.getCompanyId()));
+		}
+
+		return organizations;
+	}
+
+	private String _getSelectedScopeRoleExternalReferenceCodes() {
+		return PrefsParamUtil.getString(
+			_announcementsRequestHelper.getPortletPreferences(),
+			_announcementsRequestHelper.getRequest(),
+			"selectedScopeRoleExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private List<Role> _getSelectedScopeRoles() throws PortalException {
 		List<Role> roles = new ArrayList<>();
 
 		for (String externalReferenceCode :
-			StringUtil.split(_getSelectedScopeRoleExternalReferenceCodes())) {
+				StringUtil.split(
+					_getSelectedScopeRoleExternalReferenceCodes())) {
+
 			roles.add(
 				RoleLocalServiceUtil.getRoleByExternalReferenceCode(
 					externalReferenceCode,
@@ -535,19 +550,22 @@ public class AnnouncementsDisplayContext {
 		return roles;
 	}
 
-	private String _getSelectedScopeRoleExternalReferenceCodes() {
+	private String _getSelectedScopeUserGroupExternalReferenceCodes() {
 		return PrefsParamUtil.getString(
 			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(), "selectedScopeRoleExternalReferenceCodes",
-			StringPool.BLANK);
+			_announcementsRequestHelper.getRequest(),
+			"selectedScopeUserGroupExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private List<UserGroup> _getSelectedScopeUserGroups()
 		throws PortalException {
+
 		List<UserGroup> userGroups = new ArrayList<>();
 
 		for (String externalReferenceCode :
-			StringUtil.split(_getSelectedScopeUserGroupExternalReferenceCodes())) {
+				StringUtil.split(
+					_getSelectedScopeUserGroupExternalReferenceCodes())) {
+
 			userGroups.add(
 				UserGroupLocalServiceUtil.getUserGroupByExternalReferenceCode(
 					externalReferenceCode,
@@ -555,13 +573,6 @@ public class AnnouncementsDisplayContext {
 		}
 
 		return userGroups;
-	}
-
-	private String _getSelectedScopeUserGroupExternalReferenceCodes() {
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(),
-			"selectedScopeUserGroupExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private static final UUID _UUID = UUID.fromString(

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsParamUtil;
@@ -100,14 +101,18 @@ public class AnnouncementsDisplayContext {
 		_announcementScopes = new LinkedHashMap<>();
 
 		if (isCustomizeAnnouncementsDisplayed()) {
-			long[] selectedScopeGroupIdsArray = GetterUtil.getLongValues(
-				StringUtil.split(_getSelectedScopeGroupIds()));
-			long[] selectedScopeOrganizationIdsArray = GetterUtil.getLongValues(
-				StringUtil.split(_getSelectedScopeOrganizationIds()));
-			long[] selectedScopeRoleIdsArray = GetterUtil.getLongValues(
-				StringUtil.split(_getSelectedScopeRoleIds()));
-			long[] selectedScopeUserGroupIdsArray = GetterUtil.getLongValues(
-				StringUtil.split(_getSelectedScopeUserGroupIds()));
+			long[] selectedScopeGroupIdsArray =
+				ListUtil.toLongArray(
+					_getSelectedScopeGroups(), Group.GROUP_ID_ACCESSOR);
+			long[] selectedScopeOrganizationIdsArray =
+				ListUtil.toLongArray(
+					_getSelectedScopeOrganizations(), Organization.ORGANIZATION_ID_ACCESSOR);
+			long[] selectedScopeRoleIdsArray =
+				ListUtil.toLongArray(
+					_getSelectedScopeRoles(), Role.ROLE_ID_ACCESSOR);
+			long[] selectedScopeUserGroupIdsArray =
+				ListUtil.toLongArray(
+					_getSelectedScopeUserGroups(), UserGroup.USER_GROUP_ID_ACCESSOR);
 
 			if (selectedScopeGroupIdsArray.length != 0) {
 				_announcementScopes.put(
@@ -199,17 +204,13 @@ public class AnnouncementsDisplayContext {
 
 		List<Group> selectedGroups = new ArrayList<>();
 
-		String[] selectedScopeGroupIds = StringUtil.split(
-			_getSelectedScopeGroupIds());
-
-		for (String selectedScopeGroupId : selectedScopeGroupIds) {
-			long groupId = Long.valueOf(selectedScopeGroupId);
+		for (Group group : _getSelectedScopeGroups()) {
 
 			if (GroupPermissionUtil.contains(
-					_announcementsRequestHelper.getPermissionChecker(), groupId,
+					_announcementsRequestHelper.getPermissionChecker(), group,
 					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
 
-				selectedGroups.add(GroupLocalServiceUtil.getGroup(groupId));
+				selectedGroups.add(group);
 			}
 		}
 
@@ -228,21 +229,13 @@ public class AnnouncementsDisplayContext {
 
 		List<Organization> selectedOrganizations = new ArrayList<>();
 
-		String[] selectedScopeOrganizationIds = StringUtil.split(
-			_getSelectedScopeOrganizationIds());
-
-		for (String selectedScopeOrganizationId :
-				selectedScopeOrganizationIds) {
-
-			long organizationId = Long.valueOf(selectedScopeOrganizationId);
+		for (Organization organization : _getSelectedScopeOrganizations()) {
 
 			if (OrganizationPermissionUtil.contains(
 					_announcementsRequestHelper.getPermissionChecker(),
-					organizationId, ActionKeys.MANAGE_ANNOUNCEMENTS)) {
+					organization, ActionKeys.MANAGE_ANNOUNCEMENTS)) {
 
-				selectedOrganizations.add(
-					OrganizationLocalServiceUtil.getOrganization(
-						organizationId));
+				selectedOrganizations.add(organization);
 			}
 		}
 
@@ -270,12 +263,7 @@ public class AnnouncementsDisplayContext {
 
 		List<Role> selectedRoles = new ArrayList<>();
 
-		String[] selectedScopeRoleIds = StringUtil.split(
-			_getSelectedScopeRoleIds());
-
-		for (String selectedScopeRoleId : selectedScopeRoleIds) {
-			Role role = RoleLocalServiceUtil.getRole(
-				Long.valueOf(selectedScopeRoleId));
+		for (Role role : _getSelectedScopeRoles()) {
 
 			if (AnnouncementsUtil.hasManageAnnouncementsPermission(
 					role, _announcementsRequestHelper.getPermissionChecker())) {
@@ -338,18 +326,12 @@ public class AnnouncementsDisplayContext {
 
 		List<UserGroup> selectedUserGroups = new ArrayList<>();
 
-		String[] selectedScopeUserGroupIds = StringUtil.split(
-			_getSelectedScopeUserGroupIds());
-
-		for (String selectedScopeUserGroupId : selectedScopeUserGroupIds) {
-			long userGroupId = Long.valueOf(selectedScopeUserGroupId);
-
+		for (UserGroup userGroup : _getSelectedScopeUserGroups()) {
 			if (UserGroupPermissionUtil.contains(
 					_announcementsRequestHelper.getPermissionChecker(),
-					userGroupId, ActionKeys.MANAGE_ANNOUNCEMENTS)) {
+					userGroup.getUserGroupId(), ActionKeys.MANAGE_ANNOUNCEMENTS)) {
 
-				selectedUserGroups.add(
-					UserGroupLocalServiceUtil.getUserGroup(userGroupId));
+				selectedUserGroups.add(userGroup);
 			}
 		}
 
@@ -399,31 +381,32 @@ public class AnnouncementsDisplayContext {
 	}
 
 	public boolean isScopeGroupSelected(Group scopeGroup) {
-		String selectedScopeGroupIds = _getSelectedScopeGroupIds();
+		String selectedScopeGroupExternalReferenceCodes =
+			_getSelectedScopeGroupExternalReferenceCodes();
 
-		return selectedScopeGroupIds.contains(
-			String.valueOf(scopeGroup.getGroupId()));
+		return selectedScopeGroupExternalReferenceCodes.contains(
+			scopeGroup.getExternalReferenceCode());
 	}
 
 	public boolean isScopeOrganizationSelected(Organization organization) {
-		String selectedScopeOrganizationIds =
-			_getSelectedScopeOrganizationIds();
+		String selectedScopeOrganizationExternalReferenceCodes =
+			_getSelectedScopeOrganizationExternalReferenceCodes();
 
-		return selectedScopeOrganizationIds.contains(
-			String.valueOf(organization.getOrganizationId()));
+		return selectedScopeOrganizationExternalReferenceCodes.contains(
+			organization.getExternalReferenceCode());
 	}
 
 	public boolean isScopeRoleSelected(Role role) {
-		String selectedScopeRoleIds = _getSelectedScopeRoleIds();
+		String selectedScopeRoleExternalReferenceCodes = _getSelectedScopeRoleExternalReferenceCodes();
 
-		return selectedScopeRoleIds.contains(String.valueOf(role.getRoleId()));
+		return selectedScopeRoleExternalReferenceCodes.contains(role.getExternalReferenceCode());
 	}
 
 	public boolean isScopeUserGroupSelected(UserGroup userGroup) {
-		String selectedScopeUserGroupIds = _getSelectedScopeUserGroupIds();
+		String selectedScopeUserGroupExternalReferenceCodes = _getSelectedScopeUserGroupExternalReferenceCodes();
 
-		return selectedScopeUserGroupIds.contains(
-			String.valueOf(userGroup.getUserGroupId()));
+		return selectedScopeUserGroupExternalReferenceCodes.contains(
+			userGroup.getExternalReferenceCode());
 	}
 
 	public boolean isShowReadEntries() {
@@ -490,34 +473,95 @@ public class AnnouncementsDisplayContext {
 		return _portletURL;
 	}
 
-	private String _getSelectedScopeGroupIds() {
-		Layout layout = _announcementsRequestHelper.getLayout();
+	private List<Group> _getSelectedScopeGroups() throws PortalException {
+		List<Group> groups = new ArrayList<>();
 
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(), "selectedScopeGroupIds",
-			String.valueOf(layout.getGroupId()));
+		for (String externalReferenceCode :
+			StringUtil.split(_getSelectedScopeGroupExternalReferenceCodes())) {
+			groups.add(
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					externalReferenceCode,
+					_announcementsRequestHelper.getCompanyId()));
+		}
+
+		return groups;
 	}
 
-	private String _getSelectedScopeOrganizationIds() {
+	private String _getSelectedScopeGroupExternalReferenceCodes() {
+		Layout layout = _announcementsRequestHelper.getLayout();
+
+		Group group = layout.getGroup();
+
 		return PrefsParamUtil.getString(
 			_announcementsRequestHelper.getPortletPreferences(),
 			_announcementsRequestHelper.getRequest(),
-			"selectedScopeOrganizationIds", StringPool.BLANK);
+			"selectedScopeGroupExternalReferenceCodes",
+			group.getExternalReferenceCode());
 	}
 
-	private String _getSelectedScopeRoleIds() {
+	private List<Organization> _getSelectedScopeOrganizations()
+		throws PortalException {
+		List<Organization> organizations = new ArrayList<>();
+
+		for (String externalReferenceCode :
+			StringUtil.split(_getSelectedScopeOrganizationExternalReferenceCodes())) {
+			organizations.add(
+				OrganizationLocalServiceUtil.getOrganizationByExternalReferenceCode(
+					externalReferenceCode,
+					_announcementsRequestHelper.getCompanyId()));
+		}
+
+		return organizations;
+	}
+
+	private String _getSelectedScopeOrganizationExternalReferenceCodes() {
 		return PrefsParamUtil.getString(
 			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(), "selectedScopeRoleIds",
+			_announcementsRequestHelper.getRequest(),
+			"selectedScopeOrganizationExternalReferenceCodes", StringPool.BLANK);
+	}
+
+	private List<Role> _getSelectedScopeRoles() throws PortalException {
+		List<Role> roles = new ArrayList<>();
+
+		for (String externalReferenceCode :
+			StringUtil.split(_getSelectedScopeRoleExternalReferenceCodes())) {
+			roles.add(
+				RoleLocalServiceUtil.getRoleByExternalReferenceCode(
+					externalReferenceCode,
+					_announcementsRequestHelper.getCompanyId()));
+		}
+
+		return roles;
+	}
+
+	private String _getSelectedScopeRoleExternalReferenceCodes() {
+		return PrefsParamUtil.getString(
+			_announcementsRequestHelper.getPortletPreferences(),
+			_announcementsRequestHelper.getRequest(), "selectedScopeRoleExternalReferenceCodes",
 			StringPool.BLANK);
 	}
 
-	private String _getSelectedScopeUserGroupIds() {
+	private List<UserGroup> _getSelectedScopeUserGroups()
+		throws PortalException {
+		List<UserGroup> userGroups = new ArrayList<>();
+
+		for (String externalReferenceCode :
+			StringUtil.split(_getSelectedScopeUserGroupExternalReferenceCodes())) {
+			userGroups.add(
+				UserGroupLocalServiceUtil.getUserGroupByExternalReferenceCode(
+					externalReferenceCode,
+					_announcementsRequestHelper.getCompanyId()));
+		}
+
+		return userGroups;
+	}
+
+	private String _getSelectedScopeUserGroupExternalReferenceCodes() {
 		return PrefsParamUtil.getString(
 			_announcementsRequestHelper.getPortletPreferences(),
 			_announcementsRequestHelper.getRequest(),
-			"selectedScopeUserGroupIds", StringPool.BLANK);
+			"selectedScopeUserGroupExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private static final UUID _UUID = UUID.fromString(

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -11,9 +11,14 @@ import com.liferay.announcements.kernel.model.AnnouncementsFlagConstants;
 import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalServiceUtil;
 import com.liferay.announcements.web.internal.display.context.helper.AnnouncementsRequestHelper;
 import com.liferay.announcements.web.internal.util.AnnouncementsUtil;
+import com.liferay.petra.function.UnsafeBiFunction;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.UnsafeTriFunction;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -23,6 +28,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -52,6 +58,7 @@ import java.text.DateFormat;
 import java.text.Format;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -191,51 +198,16 @@ public class AnnouncementsDisplayContext {
 	}
 
 	public List<Group> getGroups() throws PortalException {
-		if (!isCustomizeAnnouncementsDisplayed() ||
-			StringUtil.equals(
-				_announcementsRequestHelper.getPortletId(),
-				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
-
-			return AnnouncementsUtil.getGroups(
-				_announcementsRequestHelper.getThemeDisplay());
-		}
-
-		List<Group> selectedGroups = new ArrayList<>();
-
-		for (Group group : _getSelectedScopeGroups()) {
-			if (GroupPermissionUtil.contains(
-					_announcementsRequestHelper.getPermissionChecker(), group,
-					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
-
-				selectedGroups.add(group);
-			}
-		}
-
-		return selectedGroups;
+		return _getEntries(
+			AnnouncementsUtil::getGroups, this::_getSelectedScopeGroups,
+			GroupPermissionUtil::contains);
 	}
 
 	public List<Organization> getOrganizations() throws PortalException {
-		if (!isCustomizeAnnouncementsDisplayed() ||
-			StringUtil.equals(
-				_announcementsRequestHelper.getPortletId(),
-				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
-
-			return AnnouncementsUtil.getOrganizations(
-				_announcementsRequestHelper.getThemeDisplay());
-		}
-
-		List<Organization> selectedOrganizations = new ArrayList<>();
-
-		for (Organization organization : _getSelectedScopeOrganizations()) {
-			if (OrganizationPermissionUtil.contains(
-					_announcementsRequestHelper.getPermissionChecker(),
-					organization, ActionKeys.MANAGE_ANNOUNCEMENTS)) {
-
-				selectedOrganizations.add(organization);
-			}
-		}
-
-		return selectedOrganizations;
+		return _getEntries(
+			AnnouncementsUtil::getOrganizations,
+			this::_getSelectedScopeOrganizations,
+			OrganizationPermissionUtil::contains);
 	}
 
 	public int getPageDelta() {
@@ -248,26 +220,11 @@ public class AnnouncementsDisplayContext {
 	}
 
 	public List<Role> getRoles() throws PortalException {
-		if (!isCustomizeAnnouncementsDisplayed() ||
-			StringUtil.equals(
-				_announcementsRequestHelper.getPortletId(),
-				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
-
-			return AnnouncementsUtil.getRoles(
-				_announcementsRequestHelper.getThemeDisplay());
-		}
-
-		List<Role> selectedRoles = new ArrayList<>();
-
-		for (Role role : _getSelectedScopeRoles()) {
-			if (AnnouncementsUtil.hasManageAnnouncementsPermission(
-					role, _announcementsRequestHelper.getPermissionChecker())) {
-
-				selectedRoles.add(role);
-			}
-		}
-
-		return selectedRoles;
+		return _getEntries(
+			AnnouncementsUtil::getRoles, this::_getSelectedScopeRoles,
+			(permissionChecker, role, actionKey) ->
+				AnnouncementsUtil.hasManageAnnouncementsPermission(
+					role, permissionChecker));
 	}
 
 	public SearchContainer<AnnouncementsEntry> getSearchContainer()
@@ -310,28 +267,11 @@ public class AnnouncementsDisplayContext {
 	}
 
 	public List<UserGroup> getUserGroups() throws PortalException {
-		if (!isCustomizeAnnouncementsDisplayed() ||
-			StringUtil.equals(
-				_announcementsRequestHelper.getPortletId(),
-				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
-
-			return AnnouncementsUtil.getUserGroups(
-				_announcementsRequestHelper.getThemeDisplay());
-		}
-
-		List<UserGroup> selectedUserGroups = new ArrayList<>();
-
-		for (UserGroup userGroup : _getSelectedScopeUserGroups()) {
-			if (UserGroupPermissionUtil.contains(
-					_announcementsRequestHelper.getPermissionChecker(),
-					userGroup.getUserGroupId(),
-					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
-
-				selectedUserGroups.add(userGroup);
-			}
-		}
-
-		return selectedUserGroups;
+		return _getEntries(
+			AnnouncementsUtil::getUserGroups, this::_getSelectedScopeUserGroups,
+			(permissionChecker, userGroup, actionKey) ->
+				UserGroupPermissionUtil.contains(
+					permissionChecker, userGroup.getUserGroupId(), actionKey));
 	}
 
 	public UUID getUuid() {
@@ -376,32 +316,36 @@ public class AnnouncementsDisplayContext {
 			"customizeAnnouncementsDisplayed", !scopeGroup.isUser());
 	}
 
-	public boolean isScopeGroupSelected(Group scopeGroup) {
-		String selectedScopeGroupExternalReferenceCodes =
+	public boolean isScopeGroupSelected(Group scopeGroup) throws JSONException {
+		List<String> selectedScopeGroupExternalReferenceCodes =
 			_getSelectedScopeGroupExternalReferenceCodes();
 
 		return selectedScopeGroupExternalReferenceCodes.contains(
 			scopeGroup.getExternalReferenceCode());
 	}
 
-	public boolean isScopeOrganizationSelected(Organization organization) {
-		String selectedScopeOrganizationExternalReferenceCodes =
+	public boolean isScopeOrganizationSelected(Organization organization)
+		throws JSONException {
+
+		List<String> selectedScopeOrganizationExternalReferenceCodes =
 			_getSelectedScopeOrganizationExternalReferenceCodes();
 
 		return selectedScopeOrganizationExternalReferenceCodes.contains(
 			organization.getExternalReferenceCode());
 	}
 
-	public boolean isScopeRoleSelected(Role role) {
-		String selectedScopeRoleExternalReferenceCodes =
+	public boolean isScopeRoleSelected(Role role) throws JSONException {
+		List<String> selectedScopeRoleExternalReferenceCodes =
 			_getSelectedScopeRoleExternalReferenceCodes();
 
 		return selectedScopeRoleExternalReferenceCodes.contains(
 			role.getExternalReferenceCode());
 	}
 
-	public boolean isScopeUserGroupSelected(UserGroup userGroup) {
-		String selectedScopeUserGroupExternalReferenceCodes =
+	public boolean isScopeUserGroupSelected(UserGroup userGroup)
+		throws JSONException {
+
+		List<String> selectedScopeUserGroupExternalReferenceCodes =
 			_getSelectedScopeUserGroupExternalReferenceCodes();
 
 		return selectedScopeUserGroupExternalReferenceCodes.contains(
@@ -445,6 +389,38 @@ public class AnnouncementsDisplayContext {
 		return false;
 	}
 
+	private <T> List<T> _getEntries(
+			UnsafeFunction<ThemeDisplay, List<T>, PortalException>
+				unsafeFunction,
+			UnsafeSupplier<List<T>, PortalException> unsafeSupplier,
+			UnsafeTriFunction
+				<PermissionChecker, T, String, Boolean, PortalException>
+					unsafeTriFunction)
+		throws PortalException {
+
+		if (!isCustomizeAnnouncementsDisplayed() ||
+			StringUtil.equals(
+				_announcementsRequestHelper.getPortletId(),
+				AnnouncementsPortletKeys.ANNOUNCEMENTS_ADMIN)) {
+
+			return unsafeFunction.apply(
+				_announcementsRequestHelper.getThemeDisplay());
+		}
+
+		List<T> selectedEntries = new ArrayList<>();
+
+		for (T entry : unsafeSupplier.get()) {
+			if (unsafeTriFunction.apply(
+					_announcementsRequestHelper.getPermissionChecker(), entry,
+					ActionKeys.MANAGE_ANNOUNCEMENTS)) {
+
+				selectedEntries.add(entry);
+			}
+		}
+
+		return selectedEntries;
+	}
+
 	private int _getFlag() {
 		if (_flag != null) {
 			return _flag;
@@ -472,38 +448,56 @@ public class AnnouncementsDisplayContext {
 		return _portletURL;
 	}
 
-	private String _getSelectedScopeGroupExternalReferenceCodes() {
-		Layout layout = _announcementsRequestHelper.getLayout();
+	private <T, E extends Exception> List<T> _getSelectedScopeEntries(
+			List<String> externalReferenceCodes,
+			UnsafeBiFunction<String, Long, T, E> unsafeBiFunction)
+		throws E {
 
-		Group group = layout.getGroup();
+		List<T> entries = new ArrayList<>();
 
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(),
-			"selectedScopeGroupExternalReferenceCodes",
-			group.getExternalReferenceCode());
-	}
-
-	private List<Group> _getSelectedScopeGroups() throws PortalException {
-		List<Group> groups = new ArrayList<>();
-
-		for (String externalReferenceCode :
-				StringUtil.split(
-					_getSelectedScopeGroupExternalReferenceCodes())) {
-
-			groups.add(
-				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+		for (String externalReferenceCode : externalReferenceCodes) {
+			entries.add(
+				unsafeBiFunction.apply(
 					externalReferenceCode,
 					_announcementsRequestHelper.getCompanyId()));
 		}
 
-		return groups;
+		return entries;
 	}
 
-	private String _getSelectedScopeOrganizationExternalReferenceCodes() {
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(),
+	private List<String> _getSelectedScopeExternalReferenceCodes(
+			String param, String defaultValue)
+		throws JSONException {
+
+		return AnnouncementsUtil.toStringList(
+			PrefsParamUtil.getString(
+				_announcementsRequestHelper.getPortletPreferences(),
+				_announcementsRequestHelper.getRequest(), param, defaultValue));
+	}
+
+	private List<String> _getSelectedScopeGroupExternalReferenceCodes()
+		throws JSONException {
+
+		Layout layout = _announcementsRequestHelper.getLayout();
+
+		Group group = layout.getGroup();
+
+		return _getSelectedScopeExternalReferenceCodes(
+			"selectedScopeGroupExternalReferenceCodes",
+			AnnouncementsUtil.toJSONArrayString(
+				Collections.singletonList(group.getExternalReferenceCode())));
+	}
+
+	private List<Group> _getSelectedScopeGroups() throws PortalException {
+		return _getSelectedScopeEntries(
+			_getSelectedScopeGroupExternalReferenceCodes(),
+			GroupLocalServiceUtil::getGroupByExternalReferenceCode);
+	}
+
+	private List<String> _getSelectedScopeOrganizationExternalReferenceCodes()
+		throws JSONException {
+
+		return _getSelectedScopeExternalReferenceCodes(
 			"selectedScopeOrganizationExternalReferenceCodes",
 			StringPool.BLANK);
 	}
@@ -511,68 +505,38 @@ public class AnnouncementsDisplayContext {
 	private List<Organization> _getSelectedScopeOrganizations()
 		throws PortalException {
 
-		List<Organization> organizations = new ArrayList<>();
-
-		for (String externalReferenceCode :
-				StringUtil.split(
-					_getSelectedScopeOrganizationExternalReferenceCodes())) {
-
-			organizations.add(
-				OrganizationLocalServiceUtil.
-					getOrganizationByExternalReferenceCode(
-						externalReferenceCode,
-						_announcementsRequestHelper.getCompanyId()));
-		}
-
-		return organizations;
+		return _getSelectedScopeEntries(
+			_getSelectedScopeOrganizationExternalReferenceCodes(),
+			OrganizationLocalServiceUtil::
+				getOrganizationByExternalReferenceCode);
 	}
 
-	private String _getSelectedScopeRoleExternalReferenceCodes() {
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(),
+	private List<String> _getSelectedScopeRoleExternalReferenceCodes()
+		throws JSONException {
+
+		return _getSelectedScopeExternalReferenceCodes(
 			"selectedScopeRoleExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private List<Role> _getSelectedScopeRoles() throws PortalException {
-		List<Role> roles = new ArrayList<>();
-
-		for (String externalReferenceCode :
-				StringUtil.split(
-					_getSelectedScopeRoleExternalReferenceCodes())) {
-
-			roles.add(
-				RoleLocalServiceUtil.getRoleByExternalReferenceCode(
-					externalReferenceCode,
-					_announcementsRequestHelper.getCompanyId()));
-		}
-
-		return roles;
+		return _getSelectedScopeEntries(
+			_getSelectedScopeRoleExternalReferenceCodes(),
+			RoleLocalServiceUtil::getRoleByExternalReferenceCode);
 	}
 
-	private String _getSelectedScopeUserGroupExternalReferenceCodes() {
-		return PrefsParamUtil.getString(
-			_announcementsRequestHelper.getPortletPreferences(),
-			_announcementsRequestHelper.getRequest(),
+	private List<String> _getSelectedScopeUserGroupExternalReferenceCodes()
+		throws JSONException {
+
+		return _getSelectedScopeExternalReferenceCodes(
 			"selectedScopeUserGroupExternalReferenceCodes", StringPool.BLANK);
 	}
 
 	private List<UserGroup> _getSelectedScopeUserGroups()
 		throws PortalException {
 
-		List<UserGroup> userGroups = new ArrayList<>();
-
-		for (String externalReferenceCode :
-				StringUtil.split(
-					_getSelectedScopeUserGroupExternalReferenceCodes())) {
-
-			userGroups.add(
-				UserGroupLocalServiceUtil.getUserGroupByExternalReferenceCode(
-					externalReferenceCode,
-					_announcementsRequestHelper.getCompanyId()));
-		}
-
-		return userGroups;
+		return _getSelectedScopeEntries(
+			_getSelectedScopeUserGroupExternalReferenceCodes(),
+			UserGroupLocalServiceUtil::getUserGroupByExternalReferenceCode);
 	}
 
 	private static final UUID _UUID = UUID.fromString(

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/registry/AnnouncementsWebUpgradeStepRegistrator.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/registry/AnnouncementsWebUpgradeStepRegistrator.java
@@ -6,10 +6,15 @@
 package com.liferay.announcements.web.internal.upgrade.registry;
 
 import com.liferay.announcements.web.internal.upgrade.v1_0_2.PermissionUpgradeProcess;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -41,6 +46,25 @@ public class AnnouncementsWebUpgradeStepRegistrator
 			"1.0.4", "2.0.0",
 			new com.liferay.announcements.web.internal.upgrade.v2_0_0.
 				PortletPreferencesUpgradeProcess());
+
+		registry.register(
+			"2.0.0", "2.1.0",
+			new com.liferay.announcements.web.internal.upgrade.v2_1_0.
+				UpgradePortletPreferences(
+					_groupLocalService, _organizationLocalService,
+					_roleLocalService, _userGroupLocalService));
 	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private OrganizationLocalService _organizationLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
 
 }

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/UpgradePortletPreferences.java
@@ -7,6 +7,8 @@ package com.liferay.announcements.web.internal.upgrade.v2_1_0;
 
 import com.liferay.announcements.constants.AnnouncementsPortletKeys;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -14,8 +16,9 @@ import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
-import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.function.Function;
 
@@ -77,11 +80,11 @@ public class UpgradePortletPreferences
 		String selectedScopeIds = portletPreferences.getValue(
 			"selectedScope" + scope + "Ids", null);
 
-		if (selectedScopeIds == null) {
+		if (Validator.isBlank(selectedScopeIds)) {
 			return;
 		}
 
-		String selectedScopeExternalReferenceCodes = ListUtil.toString(
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
 			TransformUtil.transformToList(
 				StringUtil.split(selectedScopeIds, 0L),
 				id -> {
@@ -95,14 +98,13 @@ public class UpgradePortletPreferences
 						return null;
 					}
 
-					return model.getExternalReferenceCode();
-				}),
-			(String)null);
+					return HtmlUtil.escape(model.getExternalReferenceCode());
+				}));
 
-		if (!selectedScopeExternalReferenceCodes.isEmpty()) {
+		if (jsonArray.length() > 0) {
 			portletPreferences.setValue(
 				"selectedScope" + scope + "ExternalReferenceCodes",
-				selectedScopeExternalReferenceCodes);
+				jsonArray.toString());
 		}
 	}
 

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/upgrade/v2_1_0/UpgradePortletPreferences.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal.upgrade.v2_1_0;
+
+import com.liferay.announcements.constants.AnnouncementsPortletKeys;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.function.Function;
+
+import javax.portlet.PortletPreferences;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class UpgradePortletPreferences
+	extends BasePortletPreferencesUpgradeProcess {
+
+	public UpgradePortletPreferences(
+		GroupLocalService groupLocalService,
+		OrganizationLocalService organizationLocalService,
+		RoleLocalService roleLocalService,
+		UserGroupLocalService userGroupLocalService) {
+
+		_groupLocalService = groupLocalService;
+		_organizationLocalService = organizationLocalService;
+		_roleLocalService = roleLocalService;
+		_userGroupLocalService = userGroupLocalService;
+	}
+
+	@Override
+	protected String[] getPortletIds() {
+		return new String[] {AnnouncementsPortletKeys.ANNOUNCEMENTS + "%"};
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		_upgradeSelectedScopeIds(
+			portletPreferences, "Group", _groupLocalService::fetchGroup);
+		_upgradeSelectedScopeIds(
+			portletPreferences, "Organization",
+			_organizationLocalService::fetchOrganization);
+		_upgradeSelectedScopeIds(
+			portletPreferences, "Role", _roleLocalService::fetchRole);
+		_upgradeSelectedScopeIds(
+			portletPreferences, "UserGroup",
+			_userGroupLocalService::fetchUserGroup);
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+
+	private <T extends ExternalReferenceCodeModel> void
+			_upgradeSelectedScopeIds(
+				PortletPreferences portletPreferences, String scope,
+				Function<Long, T> fetchFunction)
+		throws Exception {
+
+		String selectedScopeIds = portletPreferences.getValue(
+			"selectedScope" + scope + "Ids", null);
+
+		if (selectedScopeIds == null) {
+			return;
+		}
+
+		String selectedScopeExternalReferenceCodes = ListUtil.toString(
+			TransformUtil.transformToList(
+				StringUtil.split(selectedScopeIds, 0L),
+				id -> {
+					if (id == 0) {
+						return null;
+					}
+
+					T model = fetchFunction.apply(id);
+
+					if (model == null) {
+						return null;
+					}
+
+					return model.getExternalReferenceCode();
+				}),
+			(String)null);
+
+		if (!selectedScopeExternalReferenceCodes.isEmpty()) {
+			portletPreferences.setValue(
+				"selectedScope" + scope + "ExternalReferenceCodes",
+				selectedScopeExternalReferenceCodes);
+		}
+	}
+
+	private final GroupLocalService _groupLocalService;
+	private final OrganizationLocalService _organizationLocalService;
+	private final RoleLocalService _roleLocalService;
+	private final UserGroupLocalService _userGroupLocalService;
+
+}

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/util/AnnouncementsUtil.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/util/AnnouncementsUtil.java
@@ -5,7 +5,12 @@
 
 package com.liferay.announcements.web.internal.util;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
@@ -31,6 +36,7 @@ import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -261,6 +267,22 @@ public class AnnouncementsUtil {
 		}
 
 		return false;
+	}
+
+	public static String toJSONArrayString(List<String> stringList) {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+			TransformUtil.transform(stringList, HtmlUtil::escape));
+
+		return jsonArray.toString();
+	}
+
+	public static List<String> toStringList(String jsonArrayString)
+		throws JSONException {
+
+		return TransformUtil.transform(
+			JSONUtil.toStringList(
+				JSONFactoryUtil.createJSONArray(jsonArrayString)),
+			HtmlUtil::unescape);
 	}
 
 	private static final boolean _PERMISSIONS_CHECK_GUEST_ENABLED =

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -348,17 +348,24 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 		}
 
 		function <portlet:namespace />saveConfigurations() {
-			var currentScopeGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeGroupExternalReferenceCodes'
-			);
-			var selectedScopeGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeGroupExternalReferenceCodes'
-			);
+			var currentScopeGroupExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />currentScopeGroupExternalReferenceCodes'
+				);
+			var selectedScopeGroupExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />selectedScopeGroupExternalReferenceCodes'
+				);
 
-			if (currentScopeGroupExternalReferenceCodes && selectedScopeGroupExternalReferenceCodes) {
+			if (
+				currentScopeGroupExternalReferenceCodes &&
+				selectedScopeGroupExternalReferenceCodes
+			) {
 				selectedScopeGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeGroupExternalReferenceCodes)
+					Liferay.Util.getSelectedOptionValues(
+						currentScopeGroupExternalReferenceCodes
+					)
 				);
 			}
 
@@ -371,7 +378,10 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 					'#<portlet:namespace />selectedScopeOrganizationExternalReferenceCodes'
 				);
 
-			if (currentScopeOrganizationExternalReferenceCodes && selectedScopeOrganizationExternalReferenceCodes) {
+			if (
+				currentScopeOrganizationExternalReferenceCodes &&
+				selectedScopeOrganizationExternalReferenceCodes
+			) {
 				selectedScopeOrganizationExternalReferenceCodes.setAttribute(
 					'value',
 					Liferay.Util.getSelectedOptionValues(
@@ -380,31 +390,45 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 				);
 			}
 
-			var currentScopeRoleExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeRoleExternalReferenceCodes'
-			);
-			var selectedScopeRoleExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeRoleExternalReferenceCodes'
-			);
+			var currentScopeRoleExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />currentScopeRoleExternalReferenceCodes'
+				);
+			var selectedScopeRoleExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />selectedScopeRoleExternalReferenceCodes'
+				);
 
-			if (currentScopeRoleExternalReferenceCodes && selectedScopeRoleExternalReferenceCodes) {
+			if (
+				currentScopeRoleExternalReferenceCodes &&
+				selectedScopeRoleExternalReferenceCodes
+			) {
 				selectedScopeRoleExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeRoleExternalReferenceCodes)
+					Liferay.Util.getSelectedOptionValues(
+						currentScopeRoleExternalReferenceCodes
+					)
 				);
 			}
 
-			var currentScopeUserGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeUserGroupExternalReferenceCodes'
-			);
-			var selectedScopeUserGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeUserGroupExternalReferenceCodes'
-			);
+			var currentScopeUserGroupExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />currentScopeUserGroupExternalReferenceCodes'
+				);
+			var selectedScopeUserGroupExternalReferenceCodes =
+				<portlet:namespace />form.querySelector(
+					'#<portlet:namespace />selectedScopeUserGroupExternalReferenceCodes'
+				);
 
-			if (currentScopeUserGroupExternalReferenceCodes && selectedScopeUserGroupExternalReferenceCodes) {
+			if (
+				currentScopeUserGroupExternalReferenceCodes &&
+				selectedScopeUserGroupExternalReferenceCodes
+			) {
 				selectedScopeUserGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeUserGroupExternalReferenceCodes)
+					Liferay.Util.getSelectedOptionValues(
+						currentScopeUserGroupExternalReferenceCodes
+					)
 				);
 			}
 

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -99,7 +99,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 								String descriptiveName = curGroup.isOrganization() ? String.format("%s (%s)", curGroup.getDescriptiveName(locale), LanguageUtil.get(request, OrganizationConstants.TYPE_ORGANIZATION)) : curGroup.getDescriptiveName(locale);
 
-								KeyValuePair keyValuePair = new KeyValuePair(curGroup.getExternalReferenceCode(), descriptiveName);
+								KeyValuePair keyValuePair = new KeyValuePair(HtmlUtil.escape(curGroup.getExternalReferenceCode()), descriptiveName);
 
 								if (announcementsDisplayContext.isScopeGroupSelected(curGroup)) {
 									leftList.add(keyValuePair);
@@ -134,14 +134,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (Organization organization : organizations) {
 								if (announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
-									leftList.add(new KeyValuePair(organization.getExternalReferenceCode(), organization.getName()));
+									leftList.add(new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName()));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Organization organization : organizations) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(organization.getExternalReferenceCode(), organization.getName());
+								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(organization.getExternalReferenceCode()), organization.getName());
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -173,14 +173,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (UserGroup userGroup : userGroups) {
 								if (announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
-									leftList.add(new KeyValuePair(userGroup.getExternalReferenceCode(), userGroup.getName()));
+									leftList.add(new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName()));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (UserGroup userGroup : userGroups) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(userGroup.getExternalReferenceCode(), userGroup.getName());
+								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(userGroup.getExternalReferenceCode()), userGroup.getName());
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -212,14 +212,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (Role role : roles) {
 								if (announcementsDisplayContext.isScopeRoleSelected(role)) {
-									leftList.add(new KeyValuePair(role.getExternalReferenceCode(), role.getTitle(locale)));
+									leftList.add(new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale)));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Role role : roles) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(role.getExternalReferenceCode(), role.getTitle(locale));
+								KeyValuePair tempKeyValuePair = new KeyValuePair(HtmlUtil.escape(role.getExternalReferenceCode()), role.getTitle(locale));
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -363,9 +363,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			) {
 				selectedScopeGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(
-						currentScopeGroupExternalReferenceCodes
-					)
+					getSelectedOptionValues(currentScopeGroupExternalReferenceCodes)
 				);
 			}
 
@@ -384,7 +382,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			) {
 				selectedScopeOrganizationExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(
+					getSelectedOptionValues(
 						currentScopeOrganizationExternalReferenceCodes
 					)
 				);
@@ -405,9 +403,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			) {
 				selectedScopeRoleExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(
-						currentScopeRoleExternalReferenceCodes
-					)
+					getSelectedOptionValues(currentScopeRoleExternalReferenceCodes)
 				);
 			}
 
@@ -426,13 +422,21 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			) {
 				selectedScopeUserGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(
+					getSelectedOptionValues(
 						currentScopeUserGroupExternalReferenceCodes
 					)
 				);
 			}
 
 			submitForm(<portlet:namespace />form);
+		}
+
+		function getSelectedOptionValues(select) {
+			return JSON.stringify(
+				Array.from(select.getElementsByTagName('option')).map(
+					(item) => item.value
+				)
+			);
 		}
 	}
 </aui:script>

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -99,7 +99,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 								String descriptiveName = curGroup.isOrganization() ? String.format("%s (%s)", curGroup.getDescriptiveName(locale), LanguageUtil.get(request, OrganizationConstants.TYPE_ORGANIZATION)) : curGroup.getDescriptiveName(locale);
 
-								KeyValuePair keyValuePair = new KeyValuePair(String.valueOf(curGroup.getGroupId()), descriptiveName);
+								KeyValuePair keyValuePair = new KeyValuePair(curGroup.getExternalReferenceCode(), descriptiveName);
 
 								if (announcementsDisplayContext.isScopeGroupSelected(curGroup)) {
 									leftList.add(keyValuePair);
@@ -110,15 +110,15 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							}
 							%>
 
-							<aui:input name="preferences--selectedScopeGroupIds--" type="hidden" />
+							<aui:input name="preferences--selectedScopeGroupExternalReferenceCodes--" type="hidden" />
 
-							<div id="<portlet:namespace />scopeGroupIdsBoxes">
+							<div id="<portlet:namespace />ScopeGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeGroupIds"
+									leftBoxName="currentScopeGroupExternalReferenceCodes"
 									leftList="<%= leftList %>"
 									leftReorder="<%= Boolean.TRUE.toString() %>"
 									leftTitle="current"
-									rightBoxName="availableScopeGroupIds"
+									rightBoxName="availableScopeGroupExternalReferenceCodes"
 									rightList="<%= rightList %>"
 									rightTitle="available"
 								/>
@@ -134,14 +134,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (Organization organization : organizations) {
 								if (announcementsDisplayContext.isScopeOrganizationSelected(organization)) {
-									leftList.add(new KeyValuePair(String.valueOf(organization.getOrganizationId()), organization.getName()));
+									leftList.add(new KeyValuePair(organization.getExternalReferenceCode(), organization.getName()));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Organization organization : organizations) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(String.valueOf(organization.getOrganizationId()), organization.getName());
+								KeyValuePair tempKeyValuePair = new KeyValuePair(organization.getExternalReferenceCode(), organization.getName());
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -149,15 +149,15 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							}
 							%>
 
-							<aui:input name="preferences--selectedScopeOrganizationIds--" type="hidden" />
+							<aui:input name="preferences--selectedScopeOrganizationExternalReferenceCodes--" type="hidden" />
 
-							<div id="<portlet:namespace />scopeOrganizationIdsBoxes">
+							<div id="<portlet:namespace />ScopeOrganizationExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeOrganizationIds"
+									leftBoxName="currentScopeOrganizationExternalReferenceCodes"
 									leftList="<%= leftList %>"
 									leftReorder="<%= Boolean.TRUE.toString() %>"
 									leftTitle="current"
-									rightBoxName="availableScopeOrganizationIds"
+									rightBoxName="availableScopeOrganizationExternalReferenceCodes"
 									rightList="<%= rightList %>"
 									rightTitle="available"
 								/>
@@ -173,14 +173,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (UserGroup userGroup : userGroups) {
 								if (announcementsDisplayContext.isScopeUserGroupSelected(userGroup)) {
-									leftList.add(new KeyValuePair(String.valueOf(userGroup.getUserGroupId()), userGroup.getName()));
+									leftList.add(new KeyValuePair(userGroup.getExternalReferenceCode(), userGroup.getName()));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (UserGroup userGroup : userGroups) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(String.valueOf(userGroup.getUserGroupId()), userGroup.getName());
+								KeyValuePair tempKeyValuePair = new KeyValuePair(userGroup.getExternalReferenceCode(), userGroup.getName());
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -188,15 +188,15 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							}
 							%>
 
-							<aui:input name="preferences--selectedScopeUserGroupIds--" type="hidden" />
+							<aui:input name="preferences--selectedScopeUserGroupExternalReferenceCodes--" type="hidden" />
 
-							<div id="<portlet:namespace />scopeUserGroupIdsBoxes">
+							<div id="<portlet:namespace />ScopeUserGroupExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeUserGroupIds"
+									leftBoxName="currentScopeUserGroupExternalReferenceCodes"
 									leftList="<%= leftList %>"
 									leftReorder="<%= Boolean.TRUE.toString() %>"
 									leftTitle="current"
-									rightBoxName="availableScopeUserGroupIds"
+									rightBoxName="availableScopeUserGroupExternalReferenceCodes"
 									rightList="<%= rightList %>"
 									rightTitle="available"
 								/>
@@ -212,14 +212,14 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 
 							for (Role role : roles) {
 								if (announcementsDisplayContext.isScopeRoleSelected(role)) {
-									leftList.add(new KeyValuePair(String.valueOf(role.getRoleId()), role.getTitle(locale)));
+									leftList.add(new KeyValuePair(role.getExternalReferenceCode(), role.getTitle(locale)));
 								}
 							}
 
 							List<KeyValuePair> rightList = new ArrayList<KeyValuePair>();
 
 							for (Role role : roles) {
-								KeyValuePair tempKeyValuePair = new KeyValuePair(String.valueOf(role.getRoleId()), role.getTitle(locale));
+								KeyValuePair tempKeyValuePair = new KeyValuePair(role.getExternalReferenceCode(), role.getTitle(locale));
 
 								if (!leftList.contains(tempKeyValuePair)) {
 									rightList.add(tempKeyValuePair);
@@ -227,15 +227,15 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 							}
 							%>
 
-							<aui:input name="preferences--selectedScopeRoleIds--" type="hidden" />
+							<aui:input name="preferences--selectedScopeRoleExternalReferenceCodes--" type="hidden" />
 
-							<div id="<portlet:namespace />scopeRoleIdsBoxes">
+							<div id="<portlet:namespace />ScopeRoleExternalReferenceCodesBoxes">
 								<liferay-ui:input-move-boxes
-									leftBoxName="currentScopeRoleIds"
+									leftBoxName="currentScopeRoleExternalReferenceCodes"
 									leftList="<%= leftList %>"
 									leftReorder="<%= Boolean.TRUE.toString() %>"
 									leftTitle="current"
-									rightBoxName="availableScopeRoleIds"
+									rightBoxName="availableScopeRoleExternalReferenceCodes"
 									rightList="<%= rightList %>"
 									rightTitle="available"
 								/>
@@ -348,63 +348,63 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 		}
 
 		function <portlet:namespace />saveConfigurations() {
-			var currentScopeGroupIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeGroupIds'
+			var currentScopeGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />currentScopeGroupExternalReferenceCodes'
 			);
-			var selectedScopeGroupIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeGroupIds'
+			var selectedScopeGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />selectedScopeGroupExternalReferenceCodes'
 			);
 
-			if (currentScopeGroupIds && selectedScopeGroupIds) {
-				selectedScopeGroupIds.setAttribute(
+			if (currentScopeGroupExternalReferenceCodes && selectedScopeGroupExternalReferenceCodes) {
+				selectedScopeGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeGroupIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeGroupExternalReferenceCodes)
 				);
 			}
 
-			var currentScopeOrganizationIds =
+			var currentScopeOrganizationExternalReferenceCodes =
 				<portlet:namespace />form.querySelector(
-					'#<portlet:namespace />currentScopeOrganizationIds'
+					'#<portlet:namespace />currentScopeOrganizationExternalReferenceCodes'
 				);
-			var selectedScopeOrganizationIds =
+			var selectedScopeOrganizationExternalReferenceCodes =
 				<portlet:namespace />form.querySelector(
-					'#<portlet:namespace />selectedScopeOrganizationIds'
+					'#<portlet:namespace />selectedScopeOrganizationExternalReferenceCodes'
 				);
 
-			if (currentScopeOrganizationIds && selectedScopeOrganizationIds) {
-				selectedScopeOrganizationIds.setAttribute(
+			if (currentScopeOrganizationExternalReferenceCodes && selectedScopeOrganizationExternalReferenceCodes) {
+				selectedScopeOrganizationExternalReferenceCodes.setAttribute(
 					'value',
 					Liferay.Util.getSelectedOptionValues(
-						currentScopeOrganizationIds
+						currentScopeOrganizationExternalReferenceCodes
 					)
 				);
 			}
 
-			var currentScopeRoleIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeRoleIds'
+			var currentScopeRoleExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />currentScopeRoleExternalReferenceCodes'
 			);
-			var selectedScopeRoleIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeRoleIds'
+			var selectedScopeRoleExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />selectedScopeRoleExternalReferenceCodes'
 			);
 
-			if (currentScopeRoleIds && selectedScopeRoleIds) {
-				selectedScopeRoleIds.setAttribute(
+			if (currentScopeRoleExternalReferenceCodes && selectedScopeRoleExternalReferenceCodes) {
+				selectedScopeRoleExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeRoleIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeRoleExternalReferenceCodes)
 				);
 			}
 
-			var currentScopeUserGroupIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />currentScopeUserGroupIds'
+			var currentScopeUserGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />currentScopeUserGroupExternalReferenceCodes'
 			);
-			var selectedScopeUserGroupIds = <portlet:namespace />form.querySelector(
-				'#<portlet:namespace />selectedScopeUserGroupIds'
+			var selectedScopeUserGroupExternalReferenceCodes = <portlet:namespace />form.querySelector(
+				'#<portlet:namespace />selectedScopeUserGroupExternalReferenceCodes'
 			);
 
-			if (currentScopeUserGroupIds && selectedScopeUserGroupIds) {
-				selectedScopeUserGroupIds.setAttribute(
+			if (currentScopeUserGroupExternalReferenceCodes && selectedScopeUserGroupExternalReferenceCodes) {
+				selectedScopeUserGroupExternalReferenceCodes.setAttribute(
 					'value',
-					Liferay.Util.getSelectedOptionValues(currentScopeUserGroupIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeUserGroupExternalReferenceCodes)
 				);
 			}
 

--- a/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
@@ -454,6 +454,15 @@ export class HeadlessAdminUserApiHelper {
 		return userGroup;
 	}
 
+	async assignUsersToUserGroup(userGroupId: number, userIds: number[]) {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/user-groups/${userGroupId}/user-group-users`,
+			{
+				data: {userIds},
+			}
+		);
+	}
+
 	async getAccountRoles(accountId: number) {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/accounts/${accountId}/account-roles`

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -10,7 +10,7 @@ import {loginTest} from '../../fixtures/loginTest';
 
 export const test = mergeTests(announcementsPagesTest, loginTest());
 
-test('LPD-18804: Do not have a blank option for distribution scope', async ({
+test('Do not have a blank option for distribution scope', {	tag: '@LPD-18804' }, async ({
 	announcementsPage,
 	page,
 }) => {
@@ -29,7 +29,7 @@ test('LPD-18804: Do not have a blank option for distribution scope', async ({
 	).toBe('General');
 });
 
-test('LPD-27067 Content field is required', async ({
+test('Content field is required', { tag: '@LPD-27067' }, async ({
 	announcementsPage,
 	page,
 }) => {

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -6,6 +6,7 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
@@ -17,6 +18,9 @@ import {announcementsPagesTest} from './fixtures/announcementsPagesTest';
 export const test = mergeTests(
 	announcementsPagesTest,
 	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
 	isolatedSiteTest,
 	loginTest(),
 	pageEditorPagesTest
@@ -67,114 +71,128 @@ test(
 		pageEditorPage,
 		site,
 	}) => {
+		const [organization, role, site1, userGroup] =
+			await test.step('Create new organization, role, site, and user group', async () => {
+				const user =
+					await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+						'test@liferay.com'
+					);
 
-		// Create new organization, role, site, and user group.
+				const organization =
+					await apiHelpers.headlessAdminUser.postOrganization();
 
-		const user =
-			await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
-				'test@liferay.com'
+				await apiHelpers.headlessAdminUser.assignUserToOrganizationByEmailAddress(
+					organization.id,
+					user.emailAddress
+				);
+
+				const role = await apiHelpers.headlessAdminUser.postRole({
+					name: 'Role' + getRandomString(),
+				});
+
+				const site1 = await apiHelpers.headlessSite.createSite({
+					name: 'Site' + getRandomString(),
+				});
+
+				const userGroup =
+					await apiHelpers.headlessAdminUser.postUserGroup();
+
+				await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+					userGroup.id,
+					[user.id]
+				);
+
+				return [organization, role, site1, userGroup];
+			});
+
+		const [layout, widgetId] =
+			await test.step('Create a page with the Announcements widget', async () => {
+				const widgetId = getRandomString();
+
+				const widgetDefinition = getWidgetDefinition({
+					id: widgetId,
+					widgetName:
+						'com_liferay_announcements_web_portlet_AnnouncementsPortlet',
+				});
+
+				const layout = await apiHelpers.headlessDelivery.createSitePage(
+					{
+						pageDefinition: getPageDefinition([widgetDefinition]),
+						siteId: site.id,
+						title: getRandomString(),
+					}
+				);
+
+				return [layout, widgetId];
+			});
+
+		await test.step('Configure the distribution scope of the Announcements widget', async () => {
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+			await expect(
+				announcementsWidgetConfigurationPage.distributionScopeOrganizationsTab
+			).toBeVisible();
+			await expect(
+				announcementsWidgetConfigurationPage.distributionScopeRolesTab
+			).toBeVisible();
+			await expect(
+				announcementsWidgetConfigurationPage.distributionScopeSitesTab
+			).toBeVisible();
+			await expect(
+				announcementsWidgetConfigurationPage.distributionScopeUserGroupsTab
+			).toBeVisible();
+
+			await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+				'Organizations',
+				organization.name
+			);
+			await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+				'Roles',
+				role.name
+			);
+			await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+				'Sites',
+				site1.name
+			);
+			await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+				'User Groups',
+				userGroup.name
 			);
 
-		const organization =
-			await apiHelpers.headlessAdminUser.postOrganization();
+			await announcementsWidgetConfigurationPage.saveAndClose();
 
-		await apiHelpers.headlessAdminUser.assignUserToOrganizationByEmailAddress(
-			organization.id,
-			user.emailAddress
-		);
-
-		const role = await apiHelpers.headlessAdminUser.postRole({
-			name: 'Role' + getRandomString(),
+			await pageEditorPage.publishPage();
 		});
 
-		const site1 = await apiHelpers.headlessSite.createSite({
-			name: 'Site' + getRandomString(),
+		await test.step('Check that the configured distribution scopes can be selected when adding a new announcement', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+			);
+
+			await announcementsWidgetPage.addAnnouncementButton.click();
+
+			await expect(
+				announcementsWidgetPage.getDistributionScopeSelectOptions(
+					'Organizations'
+				)
+			).toContainText([organization.name]);
+			await expect(
+				announcementsWidgetPage.getDistributionScopeSelectOptions(
+					'Roles'
+				)
+			).toContainText([role.name]);
+			await expect(
+				announcementsWidgetPage.getDistributionScopeSelectOptions(
+					'Sites'
+				)
+			).toContainText([site1.name]);
+			await expect(
+				announcementsWidgetPage.getDistributionScopeSelectOptions(
+					'User Groups'
+				)
+			).toContainText([userGroup.name]);
 		});
-
-		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
-
-		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
-			userGroup.id,
-			[user.id]
-		);
-
-		// Create a page with the Announcements widget.
-
-		const widgetId = getRandomString();
-
-		const widgetDefinition = getWidgetDefinition({
-			id: widgetId,
-			widgetName:
-				'com_liferay_announcements_web_portlet_AnnouncementsPortlet',
-		});
-
-		const layout = await apiHelpers.headlessDelivery.createSitePage({
-			pageDefinition: getPageDefinition([widgetDefinition]),
-			siteId: site.id,
-			title: getRandomString(),
-		});
-
-		// Configure the distribution scope of the Announcements widget.
-
-		await pageEditorPage.goto(layout, site.friendlyUrlPath);
-
-		await pageEditorPage.goToWidgetConfiguration(widgetId);
-
-		await expect(
-			announcementsWidgetConfigurationPage.distributionScopeOrganizationsTab
-		).toBeVisible();
-		await expect(
-			announcementsWidgetConfigurationPage.distributionScopeRolesTab
-		).toBeVisible();
-		await expect(
-			announcementsWidgetConfigurationPage.distributionScopeSitesTab
-		).toBeVisible();
-		await expect(
-			announcementsWidgetConfigurationPage.distributionScopeUserGroupsTab
-		).toBeVisible();
-
-		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
-			'Organizations',
-			organization.name
-		);
-		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
-			'Roles',
-			role.name
-		);
-		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
-			'Sites',
-			site1.name
-		);
-		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
-			'User Groups',
-			userGroup.name
-		);
-
-		await announcementsWidgetConfigurationPage.saveAndClose();
-
-		await pageEditorPage.publishPage();
-
-		// Check that the configured distribution scopes can be selected when adding a new announcement.
-
-		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
-
-		await announcementsWidgetPage.addAnnouncementButton.click();
-
-		await expect(
-			announcementsWidgetPage.getDistributionScopeSelectOptions(
-				'Organizations'
-			)
-		).toContainText([organization.name]);
-		await expect(
-			announcementsWidgetPage.getDistributionScopeSelectOptions('Roles')
-		).toContainText([role.name]);
-		await expect(
-			announcementsWidgetPage.getDistributionScopeSelectOptions('Sites')
-		).toContainText([site1.name]);
-		await expect(
-			announcementsWidgetPage.getDistributionScopeSelectOptions(
-				'User Groups'
-			)
-		).toContainText([userGroup.name]);
 	}
 );

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -5,39 +5,41 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {announcementsPagesTest} from './fixtures/announcementsPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {announcementsPagesTest} from './fixtures/announcementsPagesTest';
 
 export const test = mergeTests(announcementsPagesTest, loginTest());
 
-test('Do not have a blank option for distribution scope', {	tag: '@LPD-18804' }, async ({
-	announcementsPage,
-	page,
-}) => {
-	await announcementsPage.goToCreateNewAnnouncement();
+test(
+	'Do not have a blank option for distribution scope',
+	{tag: '@LPD-18804'},
+	async ({announcementsPage, page}) => {
+		await announcementsPage.goToCreateNewAnnouncement();
 
-	await page.getByRole('button', {name: 'Configuration'}).click();
-	await page.getByLabel('Distribution Scope').selectOption({index: 0});
+		await page.getByRole('button', {name: 'Configuration'}).click();
+		await page.getByLabel('Distribution Scope').selectOption({index: 0});
 
-	expect(
-		await page
-			.getByLabel('Distribution Scope')
-			.evaluate(
-				(select: HTMLSelectElement) =>
-					select.options[select.selectedIndex].label
-			)
-	).toBe('General');
-});
+		expect(
+			await page
+				.getByLabel('Distribution Scope')
+				.evaluate(
+					(select: HTMLSelectElement) =>
+						select.options[select.selectedIndex].label
+				)
+		).toBe('General');
+	}
+);
 
-test('Content field is required', { tag: '@LPD-27067' }, async ({
-	announcementsPage,
-	page,
-}) => {
-	await announcementsPage.goToCreateNewAnnouncement();
+test(
+	'Content field is required',
+	{tag: '@LPD-27067'},
+	async ({announcementsPage, page}) => {
+		await announcementsPage.goToCreateNewAnnouncement();
 
-	const requiredField = page.locator(
-		'#_com_liferay_announcements_web_portlet_AnnouncementsAdminPortlet_contentEditorContainer svg.lexicon-icon-asterisk'
-	);
+		const requiredField = page.locator(
+			'#_com_liferay_announcements_web_portlet_AnnouncementsAdminPortlet_contentEditorContainer svg.lexicon-icon-asterisk'
+		);
 
-	await expect(requiredField).toBeVisible();
-});
+		await expect(requiredField).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -5,10 +5,22 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../utils/getRandomString';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {announcementsPagesTest} from './fixtures/announcementsPagesTest';
 
-export const test = mergeTests(announcementsPagesTest, loginTest());
+export const test = mergeTests(
+	announcementsPagesTest,
+	apiHelpersTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
 
 test(
 	'Do not have a blank option for distribution scope',
@@ -41,5 +53,128 @@ test(
 		);
 
 		await expect(requiredField).toBeVisible();
+	}
+);
+
+test(
+	'The distribution scopes of the Announcements widget can be configured',
+	{tag: '@LPD-33318'},
+	async ({
+		announcementsWidgetConfigurationPage,
+		announcementsWidgetPage,
+		apiHelpers,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create new organization, role, site, and user group.
+
+		const user =
+			await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+				'test@liferay.com'
+			);
+
+		const organization =
+			await apiHelpers.headlessAdminUser.postOrganization();
+
+		await apiHelpers.headlessAdminUser.assignUserToOrganizationByEmailAddress(
+			organization.id,
+			user.emailAddress
+		);
+
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: 'Role' + getRandomString(),
+		});
+
+		const site1 = await apiHelpers.headlessSite.createSite({
+			name: 'Site' + getRandomString(),
+		});
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		await apiHelpers.headlessAdminUser.assignUsersToUserGroup(
+			userGroup.id,
+			[user.id]
+		);
+
+		// Create a page with the Announcements widget.
+
+		const widgetId = getRandomString();
+
+		const widgetDefinition = getWidgetDefinition({
+			id: widgetId,
+			widgetName:
+				'com_liferay_announcements_web_portlet_AnnouncementsPortlet',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Configure the distribution scope of the Announcements widget.
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		await expect(
+			announcementsWidgetConfigurationPage.distributionScopeOrganizationsTab
+		).toBeVisible();
+		await expect(
+			announcementsWidgetConfigurationPage.distributionScopeRolesTab
+		).toBeVisible();
+		await expect(
+			announcementsWidgetConfigurationPage.distributionScopeSitesTab
+		).toBeVisible();
+		await expect(
+			announcementsWidgetConfigurationPage.distributionScopeUserGroupsTab
+		).toBeVisible();
+
+		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+			'Organizations',
+			organization.name
+		);
+		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+			'Roles',
+			role.name
+		);
+		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+			'Sites',
+			site1.name
+		);
+		await announcementsWidgetConfigurationPage.distributionScopeMoveToCurrent(
+			'User Groups',
+			userGroup.name
+		);
+
+		await announcementsWidgetConfigurationPage.saveAndClose();
+
+		await pageEditorPage.publishPage();
+
+		// Check that the configured distribution scopes can be selected when adding a new announcement.
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await announcementsWidgetPage.addAnnouncementButton.click();
+
+		await expect(
+			announcementsWidgetPage.getDistributionScopeSelectOptions(
+				'Organizations'
+			)
+		).toContainText([organization.name]);
+		await expect(
+			announcementsWidgetPage.getDistributionScopeSelectOptions('Roles')
+		).toContainText([role.name]);
+		await expect(
+			announcementsWidgetPage.getDistributionScopeSelectOptions('Sites')
+		).toContainText([site1.name]);
+		await expect(
+			announcementsWidgetPage.getDistributionScopeSelectOptions(
+				'User Groups'
+			)
+		).toContainText([userGroup.name]);
 	}
 );

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -5,7 +5,7 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {announcementsPagesTest} from '../../fixtures/announcementsPagesTest';
+import {announcementsPagesTest} from './fixtures/announcementsPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
 
 export const test = mergeTests(announcementsPagesTest, loginTest());

--- a/modules/test/playwright/tests/announcements-web/fixtures/announcementsPagesTest.ts
+++ b/modules/test/playwright/tests/announcements-web/fixtures/announcementsPagesTest.ts
@@ -6,12 +6,22 @@
 import {test} from '@playwright/test';
 
 import {AnnouncementsPage} from '../pages/AnnouncementsPage';
+import {AnnouncementsWidgetConfigurationPage} from '../pages/AnnouncementsWidgetConfigurationPage';
+import {AnnouncementsWidgetPage} from '../pages/AnnouncementsWidgetPage';
 
 const announcementsPagesTest = test.extend<{
 	announcementsPage: AnnouncementsPage;
+	announcementsWidgetConfigurationPage: AnnouncementsWidgetConfigurationPage;
+	announcementsWidgetPage: AnnouncementsWidgetPage;
 }>({
 	announcementsPage: async ({page}, use) => {
 		await use(new AnnouncementsPage(page));
+	},
+	announcementsWidgetConfigurationPage: async ({page}, use) => {
+		await use(new AnnouncementsWidgetConfigurationPage(page));
+	},
+	announcementsWidgetPage: async ({page}, use) => {
+		await use(new AnnouncementsWidgetPage(page));
 	},
 });
 

--- a/modules/test/playwright/tests/announcements-web/fixtures/announcementsPagesTest.ts
+++ b/modules/test/playwright/tests/announcements-web/fixtures/announcementsPagesTest.ts
@@ -5,7 +5,7 @@
 
 import {test} from '@playwright/test';
 
-import {AnnouncementsPage} from '../pages/announcements-web/AnnouncementsPage';
+import {AnnouncementsPage} from '../pages/AnnouncementsPage';
 
 const announcementsPagesTest = test.extend<{
 	announcementsPage: AnnouncementsPage;

--- a/modules/test/playwright/tests/announcements-web/pages/AnnouncementsPage.ts
+++ b/modules/test/playwright/tests/announcements-web/pages/AnnouncementsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
+import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
 
 export class AnnouncementsPage {
 	readonly page: Page;

--- a/modules/test/playwright/tests/announcements-web/pages/AnnouncementsPage.ts
+++ b/modules/test/playwright/tests/announcements-web/pages/AnnouncementsPage.ts
@@ -5,23 +5,23 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
 
 export class AnnouncementsPage {
 	readonly page: Page;
 
-	readonly applicationsMenuPage: ApplicationsMenuPage;
 	readonly newButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
-		this.applicationsMenuPage = new ApplicationsMenuPage(page);
 		this.newButton = page.getByRole('link', {name: 'Add Announcement'});
 	}
 
-	async goto() {
-		await this.applicationsMenuPage.goToAnnouncements();
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.announcements}`
+		);
 	}
 
 	async goToCreateNewAnnouncement() {

--- a/modules/test/playwright/tests/announcements-web/pages/AnnouncementsWidgetConfigurationPage.ts
+++ b/modules/test/playwright/tests/announcements-web/pages/AnnouncementsWidgetConfigurationPage.ts
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {waitForAlert} from '../../../utils/waitForAlert';
+
+type DistributionScope = 'Organizations' | 'Roles' | 'Sites' | 'User Groups';
+
+export class AnnouncementsWidgetConfigurationPage {
+	readonly page: Page;
+
+	readonly configurationIframe: FrameLocator;
+
+	readonly distributionScopeOrganizationsTab: Locator;
+	readonly distributionScopeRolesTab: Locator;
+	readonly distributionScopeSitesTab: Locator;
+	readonly distributionScopeUserGroupsTab: Locator;
+	readonly cancelButton: Locator;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.configurationIframe = this.page.frameLocator(
+			'iframe[title*="Announcements"]'
+		);
+
+		this.distributionScopeOrganizationsTab =
+			this.configurationIframe.getByRole('tab', {name: 'Organizations'});
+		this.distributionScopeRolesTab = this.configurationIframe.getByRole(
+			'tab',
+			{name: 'Roles'}
+		);
+		this.distributionScopeSitesTab = this.configurationIframe.getByRole(
+			'tab',
+			{name: 'Sites'}
+		);
+		this.distributionScopeUserGroupsTab =
+			this.configurationIframe.getByRole('tab', {name: 'User Groups'});
+
+		this.cancelButton = this.configurationIframe.getByRole('button', {
+			name: 'Cancel',
+		});
+		this.saveButton = this.configurationIframe.getByRole('button', {
+			name: 'Save',
+		});
+	}
+
+	async distributionScopeMoveToCurrent(
+		distributionScope: DistributionScope,
+		option: string
+	) {
+		await this.configurationIframe
+			.getByRole('tab', {name: distributionScope})
+			.click();
+
+		const distributionScopeCode =
+			this.getDistributionScopeCode(distributionScope);
+
+		const availableScopeList = this.configurationIframe.locator(
+			`[id="_com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet_availableScope${distributionScopeCode}ExternalReferenceCodes"]`
+		);
+
+		await availableScopeList.waitFor();
+
+		await availableScopeList.selectOption({label: option});
+
+		await this.configurationIframe
+			.getByRole('button', {
+				name: 'Move selected items from Available to Current.',
+			})
+			.click();
+	}
+
+	async saveAndClose() {
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.configurationIframe,
+			'Success:You have successfully updated the setup.'
+		);
+
+		await this.cancelButton.click();
+	}
+
+	private getDistributionScopeCode(distributionScope: DistributionScope) {
+		switch (distributionScope) {
+			case 'Organizations':
+				return 'Organization';
+			case 'Roles':
+				return 'Role';
+			case 'Sites':
+				return 'Group';
+			default:
+				return 'UserGroup';
+		}
+	}
+}

--- a/modules/test/playwright/tests/announcements-web/pages/AnnouncementsWidgetPage.ts
+++ b/modules/test/playwright/tests/announcements-web/pages/AnnouncementsWidgetPage.ts
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+type DistributionScope = 'Organizations' | 'Roles' | 'Sites' | 'User Groups';
+
+export class AnnouncementsWidgetPage {
+	readonly page: Page;
+
+	readonly addAnnouncementButton: Locator;
+	readonly distributionScopeSelect: Locator;
+	readonly distributionScopeSelectOptions: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.addAnnouncementButton = this.page.getByRole('button', {
+			name: 'Add Announcement',
+		});
+		this.distributionScopeSelect =
+			this.page.getByLabel('Distribution Scope');
+		this.distributionScopeSelectOptions = this.page.locator(
+			'#_com_liferay_announcements_web_portlet_AnnouncementsPortlet_distributionScope > option'
+		);
+	}
+
+	getDistributionScopeSelectOptions(distributionScope: DistributionScope) {
+		return this.page.locator(
+			`#_com_liferay_announcements_web_portlet_AnnouncementsPortlet_distributionScope > optgroup[label='${distributionScope}'] > option`
+		);
+	}
+}

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 export const PORTLET_URLS = {
+	announcements:
+		'/~/control_panel/manage?p_p_id=com_liferay_announcements_web_portlet_AnnouncementsAdminPortlet',
 	blogs: '/~/control_panel/manage?p_p_id=com_liferay_blogs_web_portlet_BlogsAdminPortlet',
 	collections:
 		'/~/control_panel/manage?p_p_id=com_liferay_asset_list_web_portlet_AssetListPortlet',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33318

Move current Announcements portlet preferences using IDs to use ERCs.

# How am I fixing it?

Replacing portlet preferences in widget JSP and DisplayContext and add an upgrade process.

# How can you verify that it works?

Functional tests
`cd modules/test/playwright`
`npm run playwright -- test -g 'The distribution scopes of the Announcements widget can be configured'`

Integration tests
`cd modules/apps/announcements/announcements-test`
`gw tI --tests UpgradePortletPreferencesTest`
