### PR TITLE
Lpd 41695 google drive authentication randomly fails on cloud 2

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -302,7 +302,15 @@ public class DLOpenerGoogleDriveManagerTest {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			_http.URLtoString(options));
 
-		return jsonObject.getString("access_token");
+		String accessToken = jsonObject.getString("access_token");
+
+		if (accessToken.isEmpty()) {
+			throw new Exception(
+				"The JSON response does not include an Access Token: " +
+					jsonObject);
+		}
+
+		return accessToken;
 	}
 
 	private boolean _isGoogleDriveFile(FileEntry fileEntry) {

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
@@ -7,18 +7,20 @@ package com.liferay.document.library.opener.google.drive.web.internal.oauth;
 
 import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.CredentialRefreshListener;
 import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.api.client.auth.oauth2.TokenErrorResponse;
+import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.util.store.DataStore;
-import com.google.api.client.util.store.MemoryDataStoreFactory;
 import com.google.api.services.drive.DriveScopes;
 
 import com.liferay.document.library.google.drive.configuration.DLGoogleDriveCompanyConfiguration;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -54,11 +56,6 @@ public class OAuth2Manager {
 		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
 			_getGoogleAuthorizationCodeFlow(companyId);
 
-		if (googleAuthorizationCodeFlow == null) {
-			throw new PortalException(
-				"No Google authorization code flow found");
-		}
-
 		GoogleAuthorizationCodeRequestUrl googleAuthorizationCodeRequestUrl =
 			googleAuthorizationCodeFlow.newAuthorizationUrl();
 
@@ -78,20 +75,14 @@ public class OAuth2Manager {
 	public Credential getCredential(long companyId, long userId)
 		throws PortalException {
 
-		try {
-			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
-				_getGoogleAuthorizationCodeFlow(companyId);
+		StoredCredential storedCredential = StoredCredentialStoreUtil.get(
+			companyId, userId);
 
-			if (googleAuthorizationCodeFlow == null) {
-				return null;
-			}
+		if (storedCredential == null) {
+			return null;
+		}
 
-			return googleAuthorizationCodeFlow.loadCredential(
-				String.valueOf(userId));
-		}
-		catch (IOException ioException) {
-			throw new PortalException(ioException);
-		}
+		return _getCredential(companyId, userId, storedCredential);
 	}
 
 	public boolean isConfigured(long companyId) {
@@ -126,11 +117,6 @@ public class OAuth2Manager {
 		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
 			_getGoogleAuthorizationCodeFlow(companyId);
 
-		if (googleAuthorizationCodeFlow == null) {
-			throw new PortalException(
-				"No Google Authorization Code Flow found");
-		}
-
 		GoogleAuthorizationCodeTokenRequest
 			googleAuthorizationCodeTokenRequest =
 				googleAuthorizationCodeFlow.newTokenRequest(code);
@@ -141,50 +127,106 @@ public class OAuth2Manager {
 		GoogleTokenResponse googleTokenResponse =
 			googleAuthorizationCodeTokenRequest.execute();
 
-		googleAuthorizationCodeFlow.createAndStoreCredential(
-			googleTokenResponse, String.valueOf(userId));
+		Credential credential = _getCredential(
+			companyId, userId, googleTokenResponse);
+
+		StoredCredentialStoreUtil.add(
+			companyId, userId, new StoredCredential(credential));
 	}
 
-	public void revokeCredential(long companyId, long userId)
-		throws PortalException {
-
-		try {
-			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
-				_getGoogleAuthorizationCodeFlow(companyId);
-
-			if (googleAuthorizationCodeFlow != null) {
-				DataStore<StoredCredential> credentialDataStore =
-					googleAuthorizationCodeFlow.getCredentialDataStore();
-
-				credentialDataStore.delete(String.valueOf(userId));
-			}
-		}
-		catch (IOException ioException) {
-			throw new PortalException(ioException);
-		}
+	public void revokeCredential(long companyId, long userId) {
+		StoredCredentialStoreUtil.delete(companyId, userId);
 	}
 
-	public void setAccessToken(long companyId, long userId, String accessToken)
-		throws IOException, PortalException {
+	public void setAccessToken(
+		long companyId, long userId, String accessToken) {
 
-		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
-			_getGoogleAuthorizationCodeFlow(companyId);
+		StoredCredential storedCredential = new StoredCredential();
 
-		if (googleAuthorizationCodeFlow != null) {
-			DataStore<StoredCredential> credentialDataStore =
-				googleAuthorizationCodeFlow.getCredentialDataStore();
+		storedCredential.setAccessToken(accessToken);
 
-			StoredCredential storedCredential = new StoredCredential();
-
-			storedCredential.setAccessToken(accessToken);
-
-			credentialDataStore.set(String.valueOf(userId), storedCredential);
-		}
+		StoredCredentialStoreUtil.add(companyId, userId, storedCredential);
 	}
 
 	@Deactivate
 	protected void deactivate() {
 		_googleAuthorizationCodeFlows.clear();
+		StoredCredentialStoreUtil.clear();
+	}
+
+	private Credential _getCredential(long companyId, long userId)
+		throws PortalException {
+
+		GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
+			_getGoogleAuthorizationCodeFlow(companyId);
+
+		CredentialRefreshListener credentialRefreshListener =
+			new CredentialRefreshListener() {
+
+				@Override
+				public void onTokenErrorResponse(
+						Credential credential,
+						TokenErrorResponse tokenErrorResponse)
+					throws IOException {
+
+					StoredCredentialStoreUtil.add(
+						companyId, userId, new StoredCredential(credential));
+				}
+
+				@Override
+				public void onTokenResponse(
+						Credential credential, TokenResponse tokenResponse)
+					throws IOException {
+
+					StoredCredentialStoreUtil.add(
+						companyId, userId, new StoredCredential(credential));
+				}
+
+			};
+
+		return new Credential.Builder(
+			googleAuthorizationCodeFlow.getMethod()
+		).addRefreshListener(
+			credentialRefreshListener
+		).setClientAuthentication(
+			googleAuthorizationCodeFlow.getClientAuthentication()
+		).setClock(
+			googleAuthorizationCodeFlow.getClock()
+		).setJsonFactory(
+			googleAuthorizationCodeFlow.getJsonFactory()
+		).setRequestInitializer(
+			googleAuthorizationCodeFlow.getRequestInitializer()
+		).setTokenServerEncodedUrl(
+			googleAuthorizationCodeFlow.getTokenServerEncodedUrl()
+		).setTransport(
+			googleAuthorizationCodeFlow.getTransport()
+		).build();
+	}
+
+	private Credential _getCredential(
+			long companyId, long userId,
+			GoogleTokenResponse googleTokenResponse)
+		throws PortalException {
+
+		Credential credential = _getCredential(companyId, userId);
+
+		credential.setFromTokenResponse(googleTokenResponse);
+
+		return credential;
+	}
+
+	private Credential _getCredential(
+			long companyId, long userId, StoredCredential storedCredential)
+		throws PortalException {
+
+		Credential credential = _getCredential(companyId, userId);
+
+		credential.setAccessToken(storedCredential.getAccessToken());
+		credential.setExpirationTimeMilliseconds(
+			storedCredential.getExpirationTimeMilliseconds());
+		credential.setRefreshToken(storedCredential.getRefreshToken());
+
+		return credential;
 	}
 
 	private DLGoogleDriveCompanyConfiguration
@@ -200,7 +242,11 @@ public class OAuth2Manager {
 		throws PortalException {
 
 		if (!isConfigured(companyId)) {
-			return null;
+			throw new PortalException(
+				StringBundler.concat(
+					"The company ", companyId,
+					" is not configured to create a Google authorization code ",
+					"flow"));
 		}
 
 		try {
@@ -225,11 +271,6 @@ public class OAuth2Manager {
 
 					return googleAuthorizationCodeFlow;
 				}
-
-				DataStore<StoredCredential> credentialDataStore =
-					googleAuthorizationCodeFlow.getCredentialDataStore();
-
-				credentialDataStore.clear();
 			}
 
 			GoogleAuthorizationCodeFlow.Builder
@@ -243,12 +284,14 @@ public class OAuth2Manager {
 							dlGoogleDriveCompanyConfiguration.clientSecret()),
 						Collections.singleton(DriveScopes.DRIVE_FILE));
 
-			googleAuthorizationCodeFlowBuilder =
-				googleAuthorizationCodeFlowBuilder.setDataStoreFactory(
-					MemoryDataStoreFactory.getDefaultInstance());
-
 			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
 				googleAuthorizationCodeFlowBuilder.build();
+
+			if (googleAuthorizationCodeFlow == null) {
+				throw new PortalException(
+					"A Google authorization code flow could not be created " +
+						"for company " + companyId);
+			}
 
 			_googleAuthorizationCodeFlows.put(
 				companyId, googleAuthorizationCodeFlow);

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtil.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtil.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialStoreUtil {
+
+	public static void add(
+		long companyId, long userId, StoredCredential storedCredential) {
+
+		_add(companyId, userId, storedCredential);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(
+					_addMethodKey, companyId, userId, storedCredential));
+		}
+	}
+
+	public static void clear() {
+		_clear();
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(new MethodHandler(_clearMethodKey));
+		}
+	}
+
+	public static void delete(long companyId, long userId) {
+		_delete(companyId, userId);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(_deleteMethodKey, companyId, userId));
+		}
+	}
+
+	public static StoredCredential get(long companyId, long userId) {
+		Map<Long, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.get(userId);
+	}
+
+	private static void _add(
+		long companyId, long userId, StoredCredential storedCredential) {
+
+		Map<Long, StoredCredential> accessTokens =
+			_storedCredentials.computeIfAbsent(
+				companyId, key -> new ConcurrentHashMap<>());
+
+		accessTokens.put(userId, storedCredential);
+	}
+
+	private static void _clear() {
+		_storedCredentials.clear();
+	}
+
+	private static void _delete(long companyId, long userId) {
+		Map<Long, StoredCredential> storedCredentials =
+			_storedCredentials.computeIfAbsent(
+				companyId, key -> new ConcurrentHashMap<>());
+
+		storedCredentials.remove(userId);
+	}
+
+	private static void _executeOnCluster(MethodHandler methodHandler) {
+		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
+			methodHandler, true);
+
+		clusterRequest.setFireAndForget(true);
+
+		ClusterExecutorUtil.execute(clusterRequest);
+	}
+
+	private static final MethodKey _addMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_add", long.class, long.class,
+		StoredCredential.class);
+	private static final MethodKey _clearMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_clear");
+	private static final MethodKey _deleteMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_delete", long.class, long.class);
+	private static final Map<Long, Map<Long, StoredCredential>>
+		_storedCredentials = new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtilTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtilTest.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.io.Deserializer;
+import com.liferay.portal.kernel.io.Serializer;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialStoreUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Mockito.when(
+			ClusterExecutorUtil.isEnabled()
+		).thenReturn(
+			false
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_clusterExecutorUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			_companyIds[i] = RandomTestUtil.randomLong();
+		}
+
+		for (int i = 0; i < _USER_COUNT; i++) {
+			_userIds[i] = RandomTestUtil.randomLong();
+		}
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				_storedCredentials[i][j] = _addStoredCredential();
+			}
+		}
+	}
+
+	@After
+	public void tearDown() {
+		Map<Long, Map<Long, StoredCredential>> storedCredentials =
+			ReflectionTestUtil.getFieldValue(
+				StoredCredentialStoreUtil.class, "_storedCredentials");
+
+		storedCredentials.clear();
+	}
+
+	@Test
+	public void testAdd() throws Throwable {
+		_process(StoredCredentialStoreUtil::add);
+
+		_process(
+			(companyId, userId, storedCredential) -> Assert.assertEquals(
+				storedCredential,
+				StoredCredentialStoreUtil.get(companyId, userId)));
+	}
+
+	@Test
+	public void testClear() throws Throwable {
+		_process(StoredCredentialStoreUtil::add);
+
+		StoredCredentialStoreUtil.clear();
+
+		_process(
+			(companyId, userId, storedCredential) -> Assert.assertNull(
+				StoredCredentialStoreUtil.get(companyId, userId)));
+	}
+
+	@Test
+	public void testDelete() throws Throwable {
+		_process(StoredCredentialStoreUtil::add);
+
+		StoredCredentialStoreUtil.delete(_companyIds[0], _userIds[0]);
+
+		_process(
+			(companyId, userId, storedCredential) -> {
+				if ((companyId == _companyIds[0]) && (userId == _userIds[0])) {
+					Assert.assertNull(
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+				else {
+					Assert.assertEquals(
+						storedCredential,
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+			});
+	}
+
+	@Test
+	public void testGetNonexistentStoredCredential() {
+		Assert.assertNull(
+			StoredCredentialStoreUtil.get(
+				RandomTestUtil.randomLong(), RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testStoredCredentialIsSerializable()
+		throws ClassNotFoundException {
+
+		StoredCredential storedCredential = _addStoredCredential();
+
+		Serializer serializer = new Serializer();
+
+		serializer.writeObject(storedCredential);
+
+		Deserializer deserializer = new Deserializer(serializer.toByteBuffer());
+
+		StoredCredential deserializedStoredCredential =
+			deserializer.readObject();
+
+		Assert.assertEquals(storedCredential, deserializedStoredCredential);
+	}
+
+	private StoredCredential _addStoredCredential() {
+		StoredCredential storedCredential = new StoredCredential();
+
+		storedCredential.setAccessToken(RandomTestUtil.randomString());
+		storedCredential.setExpirationTimeMilliseconds(
+			RandomTestUtil.randomLong());
+		storedCredential.setRefreshToken(RandomTestUtil.randomString());
+
+		return storedCredential;
+	}
+
+	private void _process(
+			UnsafeTriConsumer<Long, Long, StoredCredential, Exception>
+				unsafeTriConsumer)
+		throws Throwable {
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				unsafeTriConsumer.accept(
+					_companyIds[i], _userIds[j], _storedCredentials[i][j]);
+			}
+		}
+	}
+
+	private static final int _COMPANY_COUNT = 3;
+
+	private static final int _USER_COUNT = 3;
+
+	private static final MockedStatic<ClusterExecutorUtil>
+		_clusterExecutorUtilMockedStatic = Mockito.mockStatic(
+			ClusterExecutorUtil.class);
+
+	private final long[] _companyIds = new long[_COMPANY_COUNT];
+	private final StoredCredential[][] _storedCredentials =
+		new StoredCredential[_COMPANY_COUNT][_USER_COUNT];
+	private final long[] _userIds = new long[_USER_COUNT];
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41695

Second PR after #6087 

The Google Drive authentication fails when Liferay is executed on a cloud environment. This happen because a node stores the credentials for a user, while another node fails retrieving it because it accesses a different instance of the map storing the credentials.

# How am I fixing it?

I'm using the same strategy of `AccessTokenStoreUtil` where the changes to a map storing the credientals are broadcast to all nodes in the cluster.

In this second PR, I'm not storing in the Util class `GoogleAuthorizationCodeFlow` instances because is not serializable. Instead, I'm storing the `StoredCredential` class, which is serializable.

In the class `OAuth2Manager` I'm still using the map of `GoogleAuthorizationCodeFlow` to hold the authorization flow parameters, and if a thread starts in another node it is safe because it will create another instance if it doesn' exist.
However I'm not using anymore the `GoogleAuthorizationCodeFlow` to store the credentials. The credentials are now stored in the new class `StoredCredentialStoreUtil`.

# How can you verify that it works?

:warning: I don't know how to test it in a cloud environment.

Run the newly created unit test:

`cd modules/apps/document-library-opener/document-library-opener-google-drive-web`
`gw test --tests StoredCredentialStoreUtilTest`

Run the existing integration test:

`cd modules/apps/document-library-opener/document-library-opener-google-drive-test`
`gw tI --tests DLOpenerGoogleDriveManagerTest`
`gw tI --tests EditInGoogleDocsMVCActionCommandTest`
