### PR TITLE
LPD-42436 Fix Poshi test AppManagement#CanDeactivateAndActivateAssetLibraries

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/controlpanel/apps/appmanager/AppManagement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/controlpanel/apps/appmanager/AppManagement.testcase
@@ -171,24 +171,27 @@ definition {
 		AppManager.openAppManagerAdmin();
 
 		AppManager.viewApp(
-			appName = "Asset Libraries",
-			appStatus = "Active");
+			appName = "Liferay Depot Web",
+			appStatus = "Active",
+			searchTerm = "com.liferay.depot.web");
 
-		AppManager.deactivateApp(appName = "Asset Libraries");
-
-		AssertConsoleTextNotPresent(value1 = "java.lang.NullPointerException");
-
-		AppManager.viewApp(
-			appName = "Asset Libraries",
-			appStatus = "Resolved");
-
-		AppManager.activateApp(appName = "Asset Libraries");
+		AppManager.deactivateApp(appName = "com.liferay.depot.web");
 
 		AssertConsoleTextNotPresent(value1 = "java.lang.NullPointerException");
 
 		AppManager.viewApp(
-			appName = "Asset Libraries",
-			appStatus = "Active");
+			appName = "Liferay Depot Web",
+			appStatus = "Resolved",
+			searchTerm = "com.liferay.depot.web");
+
+		AppManager.activateApp(appName = "com.liferay.depot.web");
+
+		AssertConsoleTextNotPresent(value1 = "java.lang.NullPointerException");
+
+		AppManager.viewApp(
+			appName = "Liferay Depot Web",
+			appStatus = "Active",
+			searchTerm = "com.liferay.depot.web");
 	}
 
 	@description = "This ensures that the Blogs app in the app manager can be deactivated and reactivated."


### PR DESCRIPTION
LPD-42436 Fix Poshi test AppManagement#CanDeactivateAndActivateAssetLibraries

# What is this trying to solve?

Fix the test 

[Link to ticket](https://liferay.atlassian.net/browse/LPD-42436)

# How am I fixing it?

Add the search term with the portlet key and change the app name with the new one
![image](https://github.com/user-attachments/assets/b07dab1f-eec1-4b88-b742-01cf34a19b91)

# How can I test it?

Run poshi test  `ant -f build-test.xml run-selenium-test -Dtest.class=AppManagement#CanDeactivateAndActivateAssetLibraries`