### PR TITLE
LPD-42429 Web Content Folders don't display their descriptions in table view

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -473,6 +473,14 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							</div>
 						</liferay-ui:search-container-column-text>
 
+						<c:if test="<%= !journalDisplayContext.hasHighlightedDDMStructure() %>">
+							<liferay-ui:search-container-column-text
+								cssClass="table-cell-expand table-cell-minw-200 text-truncate"
+								name="description"
+								value="<%= StringUtil.shorten(HtmlUtil.stripHtml(curFolder.getDescription()), 200) %>"
+							/>
+						</c:if>
+
 						<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
 							<liferay-ui:search-container-column-text
 								cssClass="table-cell-expand-smallest table-cell-minw-200"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -317,11 +317,11 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							value="<%= curArticle.getDisplayDate() %>"
 						/>
 
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
-								name="create-date"
-								value="<%= curArticle.getCreateDate() %>"
-							/>
+						<liferay-ui:search-container-column-date
+							cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
+							name="create-date"
+							value="<%= curArticle.getCreateDate() %>"
+						/>
 
 						<liferay-ui:search-container-column-text>
 							<clay:dropdown-actions

--- a/modules/test/playwright/tests/journal-web/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalPage.spec.ts
@@ -23,6 +23,55 @@ export const test = mergeTests(
 	loginTest()
 );
 
+test(
+	'Table view displays folders and articles correctly',
+	{
+		tag: '@LPD-42429',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'First Web content'},
+		});
+
+		await apiHelpers.jsonWebServicesJournal.addFolder({
+			groupId: site.id,
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await journalPage.changeView('table');
+
+		await expect(page.getByRole('cell', {name: 'Title'})).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'Description'})
+		).toBeVisible();
+
+		await expect(page.getByRole('cell', {name: 'Author'})).toBeVisible();
+
+		await expect(page.getByRole('cell', {name: 'Status'})).toBeVisible();
+
+		await expect(page.getByRole('cell', {name: 'Type'})).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'Modified Date'})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'Display Date'})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'Create Date'})
+		).toBeVisible();
+	}
+);
+
 test('LPP-50468 After clicking on Clear (filter by structrure) you can see all the web contents', async ({
 	apiHelpers,
 	journalEditArticlePage,


### PR DESCRIPTION
# What is this trying to solve?
[LPD-42429](https://liferay.atlassian.net/browse/LPD-42429)

Folders and Articles don't have the same number of columns which makes it confusing to display them in the same table.

# How am I fixing it?
By adding Folder descriptions to match how Articles have their descriptions.

# How can you verify that it works?
Run the included automated tests.

Cheers,
Balázs
