### PR TITLE
LPD-41162 Get all connected sites and depots to an AssetEntry.

### DIFF
--- a/modules/apps/asset/asset-info-impl/build.gradle
+++ b/modules/apps/asset/asset-info-impl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-info-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:info:info-taglib")
 	compileOnly project(":apps:template:template-api")

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
@@ -15,7 +15,7 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
@@ -261,7 +261,7 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 
 		try {
 			groupsIds =
-				SiteConnectedGroupGroupProviderUtil.
+				_siteConnectedGroupGroupProvider.
 					getCurrentAndAncestorSiteAndDepotGroupIds(scopeGroupId);
 		}
 		catch (PortalException portalException) {
@@ -321,6 +321,9 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 	@Reference
 	private InfoItemFieldReaderFieldSetProvider
 		_infoItemFieldReaderFieldSetProvider;
+
+	@Reference
+	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;
 
 	private final InfoField<TagsInfoFieldType> _tagsInfoField =
 		InfoField.builder(

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
@@ -15,6 +15,8 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
@@ -26,7 +28,9 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.type.KeyLocalizedLabelPair;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -257,11 +261,25 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 	private List<AssetVocabulary> _getNoninternalAssetVocabularies(
 		String itemClassName, long itemClassTypeId, long scopeGroupId) {
 
+		long[] groupsIds;
+
+		try {
+			List<DepotEntry> depotEntries =
+				_depotEntryLocalService.getGroupConnectedDepotEntries(
+					scopeGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			groupsIds = ArrayUtil.append(
+				_portal.getCurrentAndAncestorSiteGroupIds(scopeGroupId),
+				ListUtil.toLongArray(depotEntries, DepotEntry::getGroupId));
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+
 		if (itemClassTypeId > 0) {
 			List<AssetVocabulary> groupsAssetVocabularies =
 				_assetVocabularyLocalService.getGroupsVocabularies(
-					_portal.getCurrentAndAncestorSiteGroupIds(scopeGroupId),
-					itemClassName, itemClassTypeId);
+					groupsIds, itemClassName, itemClassTypeId);
 
 			return ListUtil.filter(
 				groupsAssetVocabularies,
@@ -272,8 +290,7 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 
 		List<AssetVocabulary> groupsAssetVocabularies =
 			_assetVocabularyLocalService.getGroupsVocabularies(
-				_portal.getCurrentAndAncestorSiteGroupIds(scopeGroupId),
-				itemClassName);
+				groupsIds, itemClassName);
 
 		return ListUtil.filter(
 			groupsAssetVocabularies,
@@ -308,6 +325,9 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		).multivalued(
 			true
 		).build();
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private InfoItemFieldReaderFieldSetProvider

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
@@ -15,8 +15,7 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.info.exception.NoSuchInfoItemException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
@@ -28,12 +27,9 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.type.KeyLocalizedLabelPair;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SortedArrayList;
 
 import java.util.ArrayList;
@@ -264,13 +260,9 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		long[] groupsIds;
 
 		try {
-			List<DepotEntry> depotEntries =
-				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					scopeGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			groupsIds = ArrayUtil.append(
-				_portal.getCurrentAndAncestorSiteGroupIds(scopeGroupId),
-				ListUtil.toLongArray(depotEntries, DepotEntry::getGroupId));
+			groupsIds =
+				SiteConnectedGroupGroupProviderUtil.
+					getCurrentAndAncestorSiteAndDepotGroupIds(scopeGroupId);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -327,14 +319,8 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		).build();
 
 	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
 	private InfoItemFieldReaderFieldSetProvider
 		_infoItemFieldReaderFieldSetProvider;
-
-	@Reference
-	private Portal _portal;
 
 	private final InfoField<TagsInfoFieldType> _tagsInfoField =
 		InfoField.builder(

--- a/modules/apps/asset/asset-test/build.gradle
+++ b/modules/apps/asset/asset-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:bookmarks:bookmarks-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
@@ -19,6 +19,8 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.info.field.InfoField;
@@ -70,6 +72,15 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
 		_group = GroupTestUtil.addGroup();
 	}
 
@@ -120,6 +131,37 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 
 		AssetEntry assetEntry = AssetTestUtil.addAssetEntry(
 			_group.getGroupId());
+
+		InfoFieldSet infoFieldSet =
+			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(assetEntry);
+
+		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+			assetVocabulary.getName());
+
+		Assert.assertEquals(
+			assetVocabulary.getName(), infoFieldSetEntry.getName());
+	}
+
+	@Test
+	public void testGetInfoFieldSetAssetLibraryVocabulary() throws Exception {
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _depotEntry.getGroupId(),
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.US, RandomTestUtil.randomString()
+				).build(),
+				null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				ServiceContextTestUtil.getServiceContext(
+					_depotEntry.getGroupId()));
+
+		AssetCategory assetCategory = _addAssetCategory(assetVocabulary);
+
+		AssetEntry assetEntry = AssetTestUtil.addAssetEntry(
+			_group.getGroupId());
+
+		_assetEntryAssetCategoryRelLocalService.addAssetEntryAssetCategoryRel(
+			assetEntry.getEntryId(), assetCategory.getCategoryId());
 
 		InfoFieldSet infoFieldSet =
 			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(assetEntry);
@@ -389,6 +431,12 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41162

Asset Library Vocabularies should be visible when mapping fields to an element.

# How am I fixing it?

Add the groupIds for available Asset Libraries to the assetVocabularyLocalSerice.getGroupsVocabularies call

# How can you verify that it works?

Run the test AssetEntryInfoItemFieldSetProviderTest.testGetInfoFieldSetAssetLibraryVocabulary