### PR TITLE
LPD-42478 Unify empty message in Questions

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/components/QuestionList.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/components/QuestionList.es.js
@@ -122,7 +122,7 @@ const QuestionList = ({
 
 	return (
 		<ClayEmptyState
-			aria-label={Liferay.Language.get('the-topic-is-not-found')}
+			aria-label={Liferay.Language.get('this-topic-is-empty')}
 			className="c-mx-auto c-px-0 col-xl-10"
 			description={lang.sub(
 				Liferay.Language.get(
@@ -133,7 +133,7 @@ const QuestionList = ({
 			imgSrc={
 				context.includeContextPath + '/assets/empty_questions_list.png'
 			}
-			title={Liferay.Language.get('the-topic-is-not-found')}
+			title={Liferay.Language.get('this-topic-is-empty')}
 		>
 			<ClayButton
 				displayType="primary"


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-42478)

Empty message for test `QuestionsEntry#CanDeleteThreadThroughMyActivity` was returning `The topic is not found`, but `QuestionsLocalization#CanDeleteQuestionWithComment` was returning `This topic is empty.` 

Poshi macro (which is the same for both tests - ) was changed for the last one, and it doesn't make sense to have different empty messages, so I unified them. 

### How to test it
Both tests `QuestionsEntry#CanDeleteThreadThroughMyActivity` and `QuestionsLocalization#CanDeleteQuestionWithComment` shoul pass