### PR TITLE
LPD-42067 , LPD-41947 | Migration of tags.testcases

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -14,6 +14,7 @@ import {config as analyticsSettingsWebConfig} from './tests/analytics-settings-w
 import {config as analyticsWebConfig} from './tests/analytics-web/config';
 import {config as announcementsWebConfig} from './tests/announcements-web/config';
 import {config as assetPublisherWebConfig} from './tests/asset-publisher-web/config';
+import {config as assetTagsAdminWebConfig} from './tests/asset-tags-admin-web/config';
 import {config as batchPlannerConfig} from './tests/batch-planner/config';
 import {config as blogsWebConfig} from './tests/blogs-web/config';
 import {config as calendarWebConfig} from './tests/calendar-web/config';
@@ -129,6 +130,7 @@ export default defineConfig({
 		depotWebConfig,
 		announcementsWebConfig,
 		assetPublisherWebConfig,
+		assetTagsAdminWebConfig,
 		batchPlannerConfig,
 		blogsWebConfig,
 		calendarWebConfig,

--- a/modules/test/playwright/tests/asset-tags-admin-web/config.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'asset-tags-admin-web',
+	testDir: 'tests/asset-tags-admin-web',
+};

--- a/modules/test/playwright/tests/asset-tags-admin-web/fixtures/tagsAdminPagesTest.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/fixtures/tagsAdminPagesTest.ts
@@ -6,11 +6,16 @@
 import {test} from '@playwright/test';
 
 import {TagsAdminPage} from '../pages/TagsAdminPage';
+import {TagsEditPage} from '../pages/TagsEditPage';
 
 export const tagsPagesTest = test.extend<{
 	tagsAdminPage: TagsAdminPage;
+	tagsEditPage: TagsEditPage;
 }>({
 	tagsAdminPage: async ({page}, use) => {
 		await use(new TagsAdminPage(page));
+	},
+	tagsEditPage: async ({page}, use) => {
+		await use(new TagsEditPage(page));
 	},
 });

--- a/modules/test/playwright/tests/asset-tags-admin-web/fixtures/tagsAdminPagesTest.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/fixtures/tagsAdminPagesTest.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {TagsAdminPage} from '../pages/TagsAdminPage';
+
+export const tagsPagesTest = test.extend<{
+	tagsAdminPage: TagsAdminPage;
+}>({
+	tagsAdminPage: async ({page}, use) => {
+		await use(new TagsAdminPage(page));
+	},
+});

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
@@ -30,14 +30,7 @@ export class TagsAdminPage {
 			await this.selectTag(titles[i]);
 		}
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('menuitem', {name: 'Delete'}),
-			trigger: this.page.getByRole('button', {
-				exact: true,
-				name: 'Actions',
-			}),
-		});
+		this.page.getByRole('button', {name: 'Delete'}).click();
 	}
 
 	async mergeTags(titles: string[]) {
@@ -45,14 +38,7 @@ export class TagsAdminPage {
 			await this.selectTag(titles[i]);
 		}
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('menuitem', {name: 'Merge'}),
-			trigger: this.page.getByRole('button', {
-				exact: true,
-				name: 'Actions',
-			}),
-		});
+		this.page.getByRole('button', {name: 'Merge'}).click();
 	}
 
 	async gotoAdd() {

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
@@ -48,6 +48,10 @@ export class TagsAdminPage {
 		await this.page.getByRole('menuitem', {name: 'Merge'}).click();
 	}
 
+	async gotoAdd() {
+		await this.newButton.click();
+	}
+
 	async gotoEdit(title: string) {
 		await this.page
 			.getByRole('row', {name: 'Select ' + title + ' 0 Show Actions'})

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
@@ -23,4 +23,41 @@ export class TagsAdminPage {
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.tagsAdmin}`
 		);
 	}
+
+	async deleteTags(titles: string[]) {
+		for (const i in titles) {
+			await this.selectTag(titles[i]);
+		}
+
+		await this.page
+			.getByRole('button', {exact: true, name: 'Actions'})
+			.click();
+
+		await this.page.getByRole('menuitem', {name: 'Delete'}).click();
+	}
+
+	async mergeTags(titles: string[]) {
+		for (const i in titles) {
+			await this.selectTag(titles[i]);
+		}
+
+		await this.page
+			.getByRole('button', {exact: true, name: 'Actions'})
+			.click();
+
+		await this.page.getByRole('menuitem', {name: 'Merge'}).click();
+	}
+
+	async gotoEdit(title: string) {
+		await this.page
+			.getByRole('row', {name: 'Select ' + title + ' 0 Show Actions'})
+			.getByLabel('Show Actions')
+			.click();
+
+		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
+	}
+
+	async selectTag(title: string) {
+		await this.page.getByLabel(title).check();
+	}
 }

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 
 export class TagsAdminPage {
@@ -29,11 +30,14 @@ export class TagsAdminPage {
 			await this.selectTag(titles[i]);
 		}
 
-		await this.page
-			.getByRole('button', {exact: true, name: 'Actions'})
-			.click();
-
-		await this.page.getByRole('menuitem', {name: 'Delete'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Delete'}),
+			trigger: this.page.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			}),
+		});
 	}
 
 	async mergeTags(titles: string[]) {
@@ -41,11 +45,14 @@ export class TagsAdminPage {
 			await this.selectTag(titles[i]);
 		}
 
-		await this.page
-			.getByRole('button', {exact: true, name: 'Actions'})
-			.click();
-
-		await this.page.getByRole('menuitem', {name: 'Merge'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Merge'}),
+			trigger: this.page.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			}),
+		});
 	}
 
 	async gotoAdd() {
@@ -53,12 +60,13 @@ export class TagsAdminPage {
 	}
 
 	async gotoEdit(title: string) {
-		await this.page
-			.getByRole('row', {name: 'Select ' + title + ' 0 Show Actions'})
-			.getByLabel('Show Actions')
-			.click();
-
-		await this.page.getByRole('menuitem', {name: 'Edit'}).click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Edit'}),
+			trigger: this.page
+				.getByRole('row', {name: title})
+				.getByLabel('Show Actions'),
+		});
 	}
 
 	async selectTag(title: string) {

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsAdminPage.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+
+export class TagsAdminPage {
+	readonly newButton: Locator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.newButton = page.getByRole('link', {
+			name: 'Add Tag',
+		});
+		this.page = page;
+	}
+
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.tagsAdmin}`
+		);
+	}
+
+    async add(siteUrl?: Site['friendlyUrlPath']) {
+        await this.goto(siteUrl);
+		await this.newButton.click();
+    }
+}

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsEditPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsEditPage.ts
@@ -5,29 +5,26 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {PORTLET_URLS} from '../../../utils/portletUrls';
+import {TagsAdminPage} from './TagsAdminPage';
 
 export class TagsEditPage {
 	readonly nameInput: Locator;
 	readonly saveButton: Locator;
 	readonly page: Page;
+	readonly tagsAdminPage: TagsAdminPage;
 
 	constructor(page: Page) {
 		this.nameInput = page.getByPlaceholder('Name');
 		this.saveButton = page.getByRole('button', {
 			name: 'Save',
 		});
+		this.tagsAdminPage = new TagsAdminPage(page);
 		this.page = page;
 	}
 
-	async goto(siteUrl?: Site['friendlyUrlPath']) {
-		await this.page.goto(
-			`/group${siteUrl || '/guest'}${PORTLET_URLS.tagsAdmin}/new`
-		);
-	}
-
 	async add(title: string, siteUrl?: Site['friendlyUrlPath']) {
-		await this.goto(siteUrl);
+		await this.tagsAdminPage.goto(siteUrl);
+		await this.tagsAdminPage.gotoAdd();
 
 		await this.nameInput.fill(title);
 		await this.saveButton.click();

--- a/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsEditPage.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/pages/TagsEditPage.ts
@@ -7,20 +7,29 @@ import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 
-export class TagsAdminPage {
-	readonly newButton: Locator;
+export class TagsEditPage {
+	readonly nameInput: Locator;
+	readonly saveButton: Locator;
 	readonly page: Page;
 
 	constructor(page: Page) {
-		this.newButton = page.getByRole('link', {
-			name: 'Add Tag',
+		this.nameInput = page.getByPlaceholder('Name');
+		this.saveButton = page.getByRole('button', {
+			name: 'Save',
 		});
 		this.page = page;
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
 		await this.page.goto(
-			`/group${siteUrl || '/guest'}${PORTLET_URLS.tagsAdmin}`
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.tagsAdmin}/new`
 		);
+	}
+
+	async add(title: string, siteUrl?: Site['friendlyUrlPath']) {
+		await this.goto(siteUrl);
+
+		await this.nameInput.fill(title);
+		await this.saveButton.click();
 	}
 }

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {tagsPagesTest} from './fixtures/tagsAdminPagesTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	tagsPagesTest,
+	loginTest()
+);
+
+test('Add and edit tag', async ({site, tagsAdminPage}) => {
+	await tagsAdminPage.goto(site.friendlyUrlPath);
+	await expect(tagsAdminPage.newButton).toBeVisible();
+});

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -65,7 +65,7 @@ test('User can delete multiple tags', async ({
 	await expect(page.getByText('tag2')).not.toBeVisible();
 });
 
-test('The user can Merge tags', async ({
+test('User can Merge tags', async ({
 	page,
 	site,
 	tagsAdminPage,
@@ -78,12 +78,11 @@ test('The user can Merge tags', async ({
 	await tagsAdminPage.mergeTags(['tag1']);
 
 	page.once('dialog', async (dialog) => {
+		await test.step('User cannot merge a single tag', async () => {
+			expect(dialog.message()).toBe('Please choose at least 2 tags.');
 
-		// Expect to not be able to merge a single tag
-
-		expect(dialog.message()).toBe('Please choose at least 2 tags.');
-
-		await dialog.accept();
+			await dialog.accept();
+		});
 	});
 
 	await page.getByRole('button', {name: 'Save'}).click();

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -73,7 +73,7 @@ test('User can Merge tags', async ({
 }) => {
 	await tagsEditPage.add('tag1', site.friendlyUrlPath);
 
-	await expect(tagsAdminPage.newButton).toBeVisible();
+	await tagsAdminPage.newButton.waitFor();
 
 	await tagsAdminPage.mergeTags(['tag1']);
 
@@ -97,7 +97,7 @@ test('User can Merge tags', async ({
 
 	await page.getByRole('button', {name: 'Save'}).click();
 
-	await expect(tagsAdminPage.newButton).toBeVisible();
+	await tagsAdminPage.newButton.waitFor();
 
 	await expect(page.getByText('tag2')).not.toBeVisible();
 });

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {tagsPagesTest} from './fixtures/tagsAdminPagesTest';
 
 const test = mergeTests(
@@ -17,7 +18,8 @@ const test = mergeTests(
 	loginTest()
 );
 
-test('Add and edit tag', async ({site, tagsAdminPage}) => {
-	await tagsAdminPage.goto(site.friendlyUrlPath);
-	await expect(tagsAdminPage.newButton).toBeVisible();
+test('Add and edit tag', async ({page, site, tagsEditPage}) => {
+	await tagsEditPage.add('tag name', site.friendlyUrlPath);
+
+	await waitForAlert(page);
 });

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -18,8 +18,85 @@ const test = mergeTests(
 	loginTest()
 );
 
-test('Add and edit tag', async ({page, site, tagsEditPage}) => {
-	await tagsEditPage.add('tag name', site.friendlyUrlPath);
+test('User can add and edit a tag', async ({
+	page,
+	site,
+	tagsAdminPage,
+	tagsEditPage,
+}) => {
+	await tagsEditPage.add('tag1', site.friendlyUrlPath);
 
 	await waitForAlert(page);
+
+	await tagsAdminPage.gotoEdit('tag1');
+
+	await tagsEditPage.nameInput.fill('tag1_edit');
+
+	await tagsEditPage.saveButton.click();
+
+	await waitForAlert(page);
+
+	await expect(
+		page.getByRole('cell', {exact: true, name: 'tag1_edit'})
+	).toBeVisible();
+});
+
+test('User can delete multiple tags', async ({
+	page,
+	site,
+	tagsAdminPage,
+	tagsEditPage,
+}) => {
+	await tagsEditPage.add('tag1', site.friendlyUrlPath);
+
+	await waitForAlert(page);
+
+	await tagsEditPage.add('tag2', site.friendlyUrlPath);
+
+	await tagsAdminPage.deleteTags(['tag1', 'tag2']);
+
+	await page
+		.getByLabel('Delete Tags')
+		.getByRole('button', {name: 'Delete'})
+		.click();
+
+	await expect(page.getByText('tag1')).not.toBeVisible();
+
+	await expect(page.getByText('tag2')).not.toBeVisible();
+});
+
+test('The user can Merge tags', async ({
+	page,
+	site,
+	tagsAdminPage,
+	tagsEditPage,
+}) => {
+	await tagsEditPage.add('tag1', site.friendlyUrlPath);
+
+	await waitForAlert(page);
+
+	await tagsAdminPage.mergeTags(['tag1']);
+
+	page.once('dialog', async (dialog) => {
+
+		// Expect to not be able to merge a single tag
+
+		expect(dialog.message()).toBe('Please choose at least 2 tags.');
+
+		await dialog.accept();
+	});
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await tagsEditPage.add('tag2', site.friendlyUrlPath);
+
+	await tagsAdminPage.mergeTags(['tag1', 'tag2']);
+
+	page.once('dialog', async (dialog) => {
+		await dialog.accept();
+	});
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await expect(page.getByText('tag2')).not.toBeVisible();
 });

--- a/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
+++ b/modules/test/playwright/tests/asset-tags-admin-web/tags.spec.ts
@@ -73,7 +73,7 @@ test('User can Merge tags', async ({
 }) => {
 	await tagsEditPage.add('tag1', site.friendlyUrlPath);
 
-	await waitForAlert(page);
+	await expect(tagsAdminPage.newButton).toBeVisible();
 
 	await tagsAdminPage.mergeTags(['tag1']);
 
@@ -96,6 +96,8 @@ test('User can Merge tags', async ({
 	});
 
 	await page.getByRole('button', {name: 'Save'}).click();
+
+	await expect(tagsAdminPage.newButton).toBeVisible();
 
 	await expect(page.getByText('tag2')).not.toBeVisible();
 });

--- a/modules/test/playwright/tests/asset-tags-admin-web/test.properties
+++ b/modules/test/playwright/tests/asset-tags-admin-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Tags

--- a/test.properties
+++ b/test.properties
@@ -4560,6 +4560,7 @@
     content.management.playwright.projects=\
         announcements-web,\
         asset-publisher-web,\
+        asset-tags-admin-web,\
         blogs-web,\
         content-dashboard-web,\
         document-library-web,\


### PR DESCRIPTION
# What is this trying to solve?
[LPD-42067](https://liferay.atlassian.net/browse/LPD-42067)
[LPD-41947](https://liferay.atlassian.net/browse/LPD-41947)

Migration of poshi testcases from [Tags.testcase](https://github.com/liferay-content-management/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/tags/Tags.testcase)

# Motivation

Reduce the number of functional tests to the minimum, while maintaining maximum test coverage. There are other testcases that will end up as backend unit tests, while some will be discarded. The removal of Tags.testcase will be included in the final pull of the migration.

# How can you verify that it works?

Run the tests