### PR TITLE
LPD-42529 Structured-contents API call returns the default language for article selector field

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -368,7 +368,8 @@ public class ContentFieldUtil {
 										() ->
 											journalArticle.
 												getResourcePrimKey());
-									setTitle(journalArticle::getTitle);
+									setTitle(
+										() -> journalArticle.getTitle(locale));
 								}
 							});
 					}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -428,6 +428,7 @@ public class StructuredContentResourceTest
 			false);
 		_testGetStructuredContentWithAllTypesOfContentFieldsAndAcceptAllLanguagesHeader(
 			true);
+		_testGetStructuredContentWithArticleFieldWithDifferentLocale();
 		_testGetStructuredContentWithDataDefinitionEmptyDefaultValue();
 		_testGetStructuredContentWithDateExpired();
 		_testGetStructuredContentWithDateExpiredNeverExpire();
@@ -1090,8 +1091,19 @@ public class StructuredContentResourceTest
 					).build())),
 			StorageType.DEFAULT.getValue(), DDMStructureConstants.TYPE_DEFAULT);
 
+		Map<Locale, String> titleMap = HashMapBuilder.put(
+			LocaleUtil.getDefault(), "test"
+		).put(
+			LocaleUtil.FRANCE, "test fr"
+		).build();
+
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			testGroup.getGroupId(), _journalFolder.getFolderId());
+			testGroup.getGroupId(), _journalFolder.getFolderId(),
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, titleMap, null,
+			titleMap, LocaleUtil.getSiteDefault(), false, true,
+			ServiceContextTestUtil.getServiceContext(
+				testCompany.getCompanyId(), testGroup.getGroupId(),
+				TestPropsValues.getUserId()));
 
 		StructuredContent structuredContent = super.randomStructuredContent();
 
@@ -1802,6 +1814,50 @@ public class StructuredContentResourceTest
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	private void _testGetStructuredContentWithArticleFieldWithDifferentLocale()
+		throws Exception {
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGroup.getGroupId(),
+				_randomCompleteStructuredContent(
+					_dlFileEntry.getFileEntryId(), false));
+
+		StructuredContentResource.Builder builder =
+			StructuredContentResource.builder();
+
+		StructuredContentResource frenchStructuredContentResource =
+			builder.authentication(
+				"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+			).locale(
+				LocaleUtil.FRANCE
+			).build();
+
+		StructuredContent getStructuredContent =
+			frenchStructuredContentResource.getStructuredContent(
+				postStructuredContent.getId());
+
+		ContentField articleSelector = null;
+		String fieldName = "WebContent";
+
+		for (ContentField contentField :
+				getStructuredContent.getContentFields()) {
+
+			if (fieldName.equals(contentField.getName())) {
+				articleSelector = contentField;
+
+				break;
+			}
+		}
+
+		ContentFieldValue articleValue = articleSelector.getContentFieldValue();
+
+		StructuredContentLink structuredContent =
+			articleValue.getStructuredContentLink();
+
+		Assert.assertEquals("test fr", structuredContent.getTitle());
 	}
 
 	private void _testGetStructuredContentWithDataDefinitionEmptyDefaultValue()


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-42529 

### How am I fixing it?
The issue is that the article field is handled as a regular field (localizeable or not depending on the settings) but the content of an article field has its own localization. If the API requests the localized version of a content we should return the article field article in the correct locale.

### How can you verify that it works?

To test run:
`gw testIntegration --tests=StructuredContentResourceTest.testGetStructuredContent`
