### PR TITLE
LPD-42536 & LPD-42574 Fix test and merge tests

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -325,39 +325,7 @@ autoSaveTest(
 );
 
 autoSaveTest(
-	'Undo/Redo buttons work with metadata fields',
-	{
-		tag: '@LPD-26863',
-	},
-	async ({journalEditArticlePage, page, site}) => {
-		const title = getRandomString();
-
-		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
-
-		await expect(async () => {
-			await journalEditArticlePage.fillTitle(title);
-
-			await expect(journalEditArticlePage.undoButton).toBeEnabled();
-		}).toPass();
-
-		await journalEditArticlePage.undoButton.click();
-
-		await expect(journalEditArticlePage.undoButton).toBeDisabled();
-
-		await expect(journalEditArticlePage.titleInput).toHaveValue('');
-
-		await waitForAlert(page, 'Info:Please complete all', {type: 'info'});
-
-		await journalEditArticlePage.redoButton.click();
-
-		await expect(journalEditArticlePage.redoButton).toBeDisabled();
-
-		await expect(journalEditArticlePage.titleInput).toHaveValue(title);
-	}
-);
-
-autoSaveTest(
-	'Undo/Redo buttons work with content field',
+	'Undo/Redo buttons works',
 	{
 		tag: '@LPD-26863',
 	},
@@ -390,19 +358,23 @@ autoSaveTest(
 			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
 
-		await expect(
-			journalEditArticlePage.changesSavedIndicator
-		).toBeVisible();
-
 		await fillAndClickOutside(page, localizableField, title);
-
-		await expect(
-			journalEditArticlePage.changesSavedIndicator
-		).toBeVisible();
 
 		await journalEditArticlePage.undoButton.click();
 
 		await expect(localizableField).toHaveValue('');
+
+		await journalEditArticlePage.undoButton.click();
+
+		await expect(journalEditArticlePage.undoButton).toBeDisabled();
+
+		await expect(journalEditArticlePage.titleInput).toHaveValue('');
+
+		await waitForAlert(page, 'Info:Please complete all', {type: 'info'});
+
+		await journalEditArticlePage.redoButton.click();
+
+		await expect(journalEditArticlePage.titleInput).toHaveValue(title);
 
 		await journalEditArticlePage.redoButton.click();
 

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -340,10 +340,6 @@ autoSaveTest(
 			await expect(journalEditArticlePage.undoButton).toBeEnabled();
 		}).toPass();
 
-		await expect(
-			journalEditArticlePage.changesSavedIndicator
-		).toBeVisible();
-
 		await journalEditArticlePage.undoButton.click();
 
 		await expect(journalEditArticlePage.undoButton).toBeDisabled();

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -329,7 +329,7 @@ autoSaveTest(
 	{
 		tag: '@LPD-26863',
 	},
-	async ({journalEditArticlePage, site}) => {
+	async ({journalEditArticlePage, page, site}) => {
 		const title = getRandomString();
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
@@ -349,6 +349,8 @@ autoSaveTest(
 		await expect(journalEditArticlePage.undoButton).toBeDisabled();
 
 		await expect(journalEditArticlePage.titleInput).toHaveValue('');
+
+		await waitForAlert(page, 'Info:Please complete all', {type: 'info'});
 
 		await journalEditArticlePage.redoButton.click();
 


### PR DESCRIPTION
LPD-42536 & LPD-42574 Fix test and merge tests

# What is this trying to solve?
- Fix failing test
- Merge undo/redo for metadata and content tests, by this way we can save many steps and decrese test execution time

[Link to ticket fix test](https://liferay.atlassian.net/browse/LPD-42536)
[Link to ticket merge tests](https://liferay.atlassian.net/browse/LPD-42574)

# How am I fixing it?
- Adding `await waitForAlert(page, 'Info:Please complete all', {type: 'info'});` check to wait for the title to be updated

# How can I test it?
- Run the PW test, before if we executed the tests sepparately it took half a minute for each test, now it takes a bit more than 30 seconds to execute both test cases
![image](https://github.com/user-attachments/assets/f70d0226-dfec-4941-8ad5-d12f7b43a02e)
