### PR TITLE
LPD-41695 Google Drive authentication randomly fails on cloud (3rd try)

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -302,7 +302,15 @@ public class DLOpenerGoogleDriveManagerTest {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			_http.URLtoString(options));
 
-		return jsonObject.getString("access_token");
+		String accessToken = jsonObject.getString("access_token");
+
+		if (accessToken.isEmpty()) {
+			throw new Exception(
+				"The JSON response does not include an Access Token: " +
+					jsonObject);
+		}
+
+		return accessToken;
 	}
 
 	private boolean _isGoogleDriveFile(FileEntry fileEntry) {

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/OAuth2Manager.java
@@ -15,7 +15,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.store.DataStore;
-import com.google.api.client.util.store.MemoryDataStoreFactory;
 import com.google.api.services.drive.DriveScopes;
 
 import com.liferay.document.library.google.drive.configuration.DLGoogleDriveCompanyConfiguration;
@@ -185,6 +184,7 @@ public class OAuth2Manager {
 	@Deactivate
 	protected void deactivate() {
 		_googleAuthorizationCodeFlows.clear();
+		StoredCredentialStoreUtil.clear();
 	}
 
 	private DLGoogleDriveCompanyConfiguration
@@ -245,7 +245,7 @@ public class OAuth2Manager {
 
 			googleAuthorizationCodeFlowBuilder =
 				googleAuthorizationCodeFlowBuilder.setDataStoreFactory(
-					MemoryDataStoreFactory.getDefaultInstance());
+					new StoredCredentialDataStoreFactory(companyId));
 
 			GoogleAuthorizationCodeFlow googleAuthorizationCodeFlow =
 				googleAuthorizationCodeFlowBuilder.build();

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStore.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStore.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.api.client.util.store.DataStore;
+import com.google.api.client.util.store.DataStoreFactory;
+
+import java.io.IOException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialDataStore implements DataStore<StoredCredential> {
+
+	public StoredCredentialDataStore(
+		long companyId, DataStoreFactory dataStoreFactory, String id) {
+
+		_companyId = companyId;
+		_dataStoreFactory = dataStoreFactory;
+		_id = id;
+	}
+
+	@Override
+	public DataStore<StoredCredential> clear() throws IOException {
+		StoredCredentialStoreUtil.clear(_companyId);
+
+		return this;
+	}
+
+	@Override
+	public boolean containsKey(String key) throws IOException {
+		if (key == null) {
+			return false;
+		}
+
+		return StoredCredentialStoreUtil.containsKey(_companyId, key);
+	}
+
+	@Override
+	public boolean containsValue(StoredCredential value) throws IOException {
+		if (value == null) {
+			return false;
+		}
+
+		return StoredCredentialStoreUtil.containsValue(_companyId, value);
+	}
+
+	@Override
+	public DataStore<StoredCredential> delete(String key) throws IOException {
+		if (key != null) {
+			StoredCredentialStoreUtil.delete(_companyId, key);
+		}
+
+		return this;
+	}
+
+	@Override
+	public StoredCredential get(String key) throws IOException {
+		return StoredCredentialStoreUtil.get(_companyId, key);
+	}
+
+	@Override
+	public DataStoreFactory getDataStoreFactory() {
+		return _dataStoreFactory;
+	}
+
+	@Override
+	public String getId() {
+		return _id;
+	}
+
+	@Override
+	public boolean isEmpty() throws IOException {
+		return StoredCredentialStoreUtil.isEmpty(_companyId);
+	}
+
+	@Override
+	public Set<String> keySet() throws IOException {
+		return Collections.unmodifiableSet(
+			StoredCredentialStoreUtil.keySet(_companyId));
+	}
+
+	@Override
+	public DataStore<StoredCredential> set(String key, StoredCredential value)
+		throws IOException {
+
+		StoredCredentialStoreUtil.add(_companyId, key, value);
+
+		return this;
+	}
+
+	@Override
+	public int size() throws IOException {
+		return StoredCredentialStoreUtil.size(_companyId);
+	}
+
+	@Override
+	public Collection<StoredCredential> values() throws IOException {
+		return Collections.unmodifiableCollection(
+			StoredCredentialStoreUtil.values(_companyId));
+	}
+
+	private final long _companyId;
+	private final DataStoreFactory _dataStoreFactory;
+	private final String _id;
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStoreFactory.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStoreFactory.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.util.store.DataStore;
+import com.google.api.client.util.store.DataStoreFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialDataStoreFactory implements DataStoreFactory {
+
+	public StoredCredentialDataStoreFactory(long companyId) {
+		_companyId = companyId;
+	}
+
+	@Override
+	public <V extends Serializable> DataStore<V> getDataStore(String id)
+		throws IOException {
+
+		return (DataStore<V>)new StoredCredentialDataStore(
+			_companyId, this, id);
+	}
+
+	private final long _companyId;
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtil.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtil.java
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialStoreUtil {
+
+	public static void add(
+		long companyId, String userId, StoredCredential storedCredential) {
+
+		_add(companyId, userId, storedCredential);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(
+					_addMethodKey, companyId, userId, storedCredential));
+		}
+	}
+
+	public static void clear() {
+		_clear();
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(new MethodHandler(_clearMethodKey));
+		}
+	}
+
+	public static void clear(long companyId) {
+		_clear(companyId);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(_clearCompanyMethodKey, companyId));
+		}
+	}
+
+	public static boolean containsKey(long companyId, String userId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.containsKey(userId);
+	}
+
+	public static boolean containsValue(
+		long companyId, StoredCredential storedCredential) {
+
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.containsValue(storedCredential);
+	}
+
+	public static void delete(long companyId, String userId) {
+		_delete(companyId, userId);
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			_executeOnCluster(
+				new MethodHandler(_deleteMethodKey, companyId, userId));
+		}
+	}
+
+	public static StoredCredential get(long companyId, String userId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.get(userId);
+	}
+
+	public static boolean isEmpty(long companyId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.isEmpty();
+	}
+
+	public static Set<String> keySet(long companyId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.keySet();
+	}
+
+	public static int size(long companyId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.size();
+	}
+
+	public static Collection<StoredCredential> values(long companyId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.getOrDefault(companyId, new HashMap<>());
+
+		return storedCredentials.values();
+	}
+
+	private static void _add(
+		long companyId, String userId, StoredCredential storedCredential) {
+
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.computeIfAbsent(
+				companyId, key -> new ConcurrentHashMap<>());
+
+		storedCredentials.put(userId, storedCredential);
+	}
+
+	private static void _clear() {
+		_storedCredentials.clear();
+	}
+
+	private static void _clear(long companyId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.computeIfAbsent(
+				companyId, key -> new ConcurrentHashMap<>());
+
+		storedCredentials.clear();
+	}
+
+	private static void _delete(long companyId, String userId) {
+		Map<String, StoredCredential> storedCredentials =
+			_storedCredentials.computeIfAbsent(
+				companyId, key -> new ConcurrentHashMap<>());
+
+		storedCredentials.remove(userId);
+	}
+
+	private static void _executeOnCluster(MethodHandler methodHandler) {
+		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
+			methodHandler, true);
+
+		clusterRequest.setFireAndForget(true);
+
+		ClusterExecutorUtil.execute(clusterRequest);
+	}
+
+	private static final MethodKey _addMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_add", long.class, String.class,
+		StoredCredential.class);
+	private static final MethodKey _clearCompanyMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_clear", long.class);
+	private static final MethodKey _clearMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_clear");
+	private static final MethodKey _deleteMethodKey = new MethodKey(
+		StoredCredentialStoreUtil.class, "_delete", long.class, String.class);
+	private static final Map<Long, Map<String, StoredCredential>>
+		_storedCredentials = new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStoreTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialDataStoreTest.java
@@ -1,0 +1,302 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialDataStoreTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Mockito.when(
+			ClusterExecutorUtil.isEnabled()
+		).thenReturn(
+			false
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_clusterExecutorUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			_storedCredentialDataStores[i] = new StoredCredentialDataStore(
+				RandomTestUtil.randomLong(), null,
+				RandomTestUtil.randomString());
+		}
+
+		for (int i = 0; i < _USER_COUNT; i++) {
+			_userIds[i] = String.valueOf(RandomTestUtil.randomLong());
+		}
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				_storedCredentials[i][j] = _addStoredCredential();
+			}
+		}
+	}
+
+	@After
+	public void tearDown() {
+		Map<Long, Map<Long, StoredCredential>> storedCredentials =
+			ReflectionTestUtil.getFieldValue(
+				StoredCredentialStoreUtil.class, "_storedCredentials");
+
+		storedCredentials.clear();
+	}
+
+	@Test
+	public void testClear() throws Exception {
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_storedCredentialDataStores[0].clear();
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> {
+				if (Objects.equals(
+						dataStore.getId(),
+						_storedCredentialDataStores[0].getId())) {
+
+					Assert.assertNull(dataStore.get(userId));
+				}
+				else {
+					Assert.assertEquals(
+						storedCredential, dataStore.get(userId));
+				}
+			});
+	}
+
+	@Test
+	public void testContainsKey() throws Exception {
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> Assert.assertFalse(
+				dataStore.containsKey(userId)));
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> Assert.assertTrue(
+				dataStore.containsKey(userId)));
+	}
+
+	@Test
+	public void testContainsValue() throws Exception {
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> Assert.assertFalse(
+				dataStore.containsValue(storedCredential)));
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> Assert.assertTrue(
+				dataStore.containsValue(storedCredential)));
+	}
+
+	@Test
+	public void testDelete() throws Exception {
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_storedCredentialDataStores[0].delete(_userIds[0]);
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> {
+				if (Objects.equals(
+						dataStore.getId(),
+						_storedCredentialDataStores[0].getId()) &&
+					Objects.equals(userId, _userIds[0])) {
+
+					Assert.assertNull(dataStore.get(userId));
+				}
+				else {
+					Assert.assertEquals(
+						storedCredential, dataStore.get(userId));
+				}
+			});
+	}
+
+	@Test
+	public void testGetNonexistentStoredCredential() throws Exception {
+		_forEachDataStore(
+			dataStore -> Assert.assertNull(
+				dataStore.get(String.valueOf(RandomTestUtil.randomLong()))));
+	}
+
+	@Test
+	public void testIsEmpty() throws Exception {
+		_forEachDataStore(dataStore -> Assert.assertTrue(dataStore.isEmpty()));
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachDataStore(dataStore -> Assert.assertFalse(dataStore.isEmpty()));
+	}
+
+	@Test
+	public void testKeySet() throws Exception {
+		_forEachDataStore(
+			dataStore -> {
+				Set<String> keySet = dataStore.keySet();
+
+				Assert.assertTrue(keySet.isEmpty());
+			});
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachDataStore(
+			dataStore -> Assert.assertEquals(
+				_getCompanyKeySet(dataStore.getId()), dataStore.keySet()));
+	}
+
+	@Test
+	public void testSet() throws Exception {
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> Assert.assertEquals(
+				storedCredential, dataStore.get(userId)));
+	}
+
+	@Test
+	public void testSize() throws Exception {
+		_forEachDataStore(
+			dataStore -> Assert.assertEquals(0, dataStore.size()));
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachDataStore(
+			dataStore -> Assert.assertEquals(_USER_COUNT, dataStore.size()));
+	}
+
+	@Test
+	public void testValues() throws Exception {
+		_forEachDataStore(
+			dataStore -> {
+				Collection<StoredCredential> values = dataStore.values();
+
+				Assert.assertTrue(values.isEmpty());
+			});
+
+		_forEachUser(StoredCredentialDataStore::set);
+
+		_forEachDataStore(
+			dataStore -> Assert.assertEquals(
+				_getCompanyValues(dataStore.getId()),
+				new HashSet<StoredCredential>(dataStore.values())));
+	}
+
+	private StoredCredential _addStoredCredential() {
+		StoredCredential storedCredential = new StoredCredential();
+
+		storedCredential.setAccessToken(RandomTestUtil.randomString());
+		storedCredential.setExpirationTimeMilliseconds(
+			RandomTestUtil.randomLong());
+		storedCredential.setRefreshToken(RandomTestUtil.randomString());
+
+		return storedCredential;
+	}
+
+	private void _forEachDataStore(
+			UnsafeConsumer<StoredCredentialDataStore, Exception> unsafeConsumer)
+		throws Exception {
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			unsafeConsumer.accept(_storedCredentialDataStores[i]);
+		}
+	}
+
+	private void _forEachUser(
+			UnsafeTriConsumer
+				<StoredCredentialDataStore, String, StoredCredential, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				unsafeTriConsumer.accept(
+					_storedCredentialDataStores[i], _userIds[j],
+					_storedCredentials[i][j]);
+			}
+		}
+	}
+
+	private Set<String> _getCompanyKeySet(String id) throws Exception {
+		Set<String> keySet = new HashSet<>();
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> {
+				if (Objects.equals(dataStore.getId(), id)) {
+					keySet.add(userId);
+				}
+			});
+
+		return keySet;
+	}
+
+	private Set<StoredCredential> _getCompanyValues(String id)
+		throws Exception {
+
+		Set<StoredCredential> values = new HashSet<>();
+
+		_forEachUser(
+			(dataStore, userId, storedCredential) -> {
+				if (Objects.equals(dataStore.getId(), id)) {
+					values.add(storedCredential);
+				}
+			});
+
+		return values;
+	}
+
+	private static final int _COMPANY_COUNT = 3;
+
+	private static final int _USER_COUNT = 3;
+
+	private static final MockedStatic<ClusterExecutorUtil>
+		_clusterExecutorUtilMockedStatic = Mockito.mockStatic(
+			ClusterExecutorUtil.class);
+
+	private final StoredCredentialDataStore[] _storedCredentialDataStores =
+		new StoredCredentialDataStore[_COMPANY_COUNT];
+	private final StoredCredential[][] _storedCredentials =
+		new StoredCredential[_COMPANY_COUNT][_USER_COUNT];
+	private final String[] _userIds = new String[_USER_COUNT];
+
+}

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtilTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/test/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialStoreUtilTest.java
@@ -1,0 +1,340 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.opener.google.drive.web.internal.oauth;
+
+import com.google.api.client.auth.oauth2.StoredCredential;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
+import com.liferay.portal.kernel.io.Deserializer;
+import com.liferay.portal.kernel.io.Serializer;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class StoredCredentialStoreUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Mockito.when(
+			ClusterExecutorUtil.isEnabled()
+		).thenReturn(
+			false
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_clusterExecutorUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			_companyIds[i] = RandomTestUtil.randomLong();
+		}
+
+		for (int i = 0; i < _USER_COUNT; i++) {
+			_userIds[i] = String.valueOf(RandomTestUtil.randomLong());
+		}
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				_storedCredentials[i][j] = _addStoredCredential();
+			}
+		}
+	}
+
+	@After
+	public void tearDown() {
+		Map<Long, Map<Long, StoredCredential>> storedCredentials =
+			ReflectionTestUtil.getFieldValue(
+				StoredCredentialStoreUtil.class, "_storedCredentials");
+
+		storedCredentials.clear();
+	}
+
+	@Test
+	public void testAdd() throws Exception {
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertEquals(
+				storedCredential,
+				StoredCredentialStoreUtil.get(companyId, userId)));
+	}
+
+	@Test
+	public void testClear() throws Exception {
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		StoredCredentialStoreUtil.clear();
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertNull(
+				StoredCredentialStoreUtil.get(companyId, userId)));
+	}
+
+	@Test
+	public void testClearCompany() throws Exception {
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		StoredCredentialStoreUtil.clear(_companyIds[0]);
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> {
+				if (companyId == _companyIds[0]) {
+					Assert.assertNull(
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+				else {
+					Assert.assertEquals(
+						storedCredential,
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+			});
+	}
+
+	@Test
+	public void testContainsKey() throws Exception {
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertFalse(
+				StoredCredentialStoreUtil.containsKey(companyId, userId)));
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertTrue(
+				StoredCredentialStoreUtil.containsKey(companyId, userId)));
+	}
+
+	@Test
+	public void testContainsValue() throws Exception {
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertFalse(
+				StoredCredentialStoreUtil.containsValue(
+					companyId, storedCredential)));
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> Assert.assertTrue(
+				StoredCredentialStoreUtil.containsValue(
+					companyId, storedCredential)));
+	}
+
+	@Test
+	public void testDelete() throws Exception {
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		StoredCredentialStoreUtil.delete(_companyIds[0], _userIds[0]);
+
+		_forEachUser(
+			(companyId, userId, storedCredential) -> {
+				if ((companyId == _companyIds[0]) &&
+					Objects.equals(userId, _userIds[0])) {
+
+					Assert.assertNull(
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+				else {
+					Assert.assertEquals(
+						storedCredential,
+						StoredCredentialStoreUtil.get(companyId, userId));
+				}
+			});
+	}
+
+	@Test
+	public void testGetNonexistentStoredCredential() {
+		Assert.assertNull(
+			StoredCredentialStoreUtil.get(
+				RandomTestUtil.randomLong(),
+				String.valueOf(RandomTestUtil.randomLong())));
+	}
+
+	@Test
+	public void testIsEmpty() throws Exception {
+		_forEachCompany(
+			companyId -> Assert.assertTrue(
+				StoredCredentialStoreUtil.isEmpty(companyId)));
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachCompany(
+			companyId -> Assert.assertFalse(
+				StoredCredentialStoreUtil.isEmpty(companyId)));
+	}
+
+	@Test
+	public void testKeySet() throws Exception {
+		_forEachCompany(
+			companyId -> {
+				Set<String> keySet = StoredCredentialStoreUtil.keySet(
+					companyId);
+
+				Assert.assertTrue(keySet.isEmpty());
+			});
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachCompany(
+			companyId -> Assert.assertEquals(
+				_getCompanyKeySet(companyId),
+				StoredCredentialStoreUtil.keySet(companyId)));
+	}
+
+	@Test
+	public void testSize() throws Exception {
+		_forEachCompany(
+			companyId -> Assert.assertEquals(
+				0, StoredCredentialStoreUtil.size(companyId)));
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachCompany(
+			companyId -> Assert.assertEquals(
+				_USER_COUNT, StoredCredentialStoreUtil.size(companyId)));
+	}
+
+	@Test
+	public void testStoredCredentialIsSerializable()
+		throws ClassNotFoundException {
+
+		StoredCredential storedCredential = _addStoredCredential();
+
+		Serializer serializer = new Serializer();
+
+		serializer.writeObject(storedCredential);
+
+		Deserializer deserializer = new Deserializer(serializer.toByteBuffer());
+
+		StoredCredential deserializedStoredCredential =
+			deserializer.readObject();
+
+		Assert.assertEquals(storedCredential, deserializedStoredCredential);
+	}
+
+	@Test
+	public void testValues() throws Exception {
+		_forEachCompany(
+			companyId -> {
+				Collection<StoredCredential> values =
+					StoredCredentialStoreUtil.values(companyId);
+
+				Assert.assertTrue(values.isEmpty());
+			});
+
+		_forEachUser(StoredCredentialStoreUtil::add);
+
+		_forEachCompany(
+			companyId -> Assert.assertEquals(
+				_getCompanyValues(companyId),
+				new HashSet<StoredCredential>(
+					StoredCredentialStoreUtil.values(companyId))));
+	}
+
+	private StoredCredential _addStoredCredential() {
+		StoredCredential storedCredential = new StoredCredential();
+
+		storedCredential.setAccessToken(RandomTestUtil.randomString());
+		storedCredential.setExpirationTimeMilliseconds(
+			RandomTestUtil.randomLong());
+		storedCredential.setRefreshToken(RandomTestUtil.randomString());
+
+		return storedCredential;
+	}
+
+	private void _forEachCompany(UnsafeConsumer<Long, Exception> unsafeConsumer)
+		throws Exception {
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			unsafeConsumer.accept(_companyIds[i]);
+		}
+	}
+
+	private void _forEachUser(
+			UnsafeTriConsumer<Long, String, StoredCredential, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		for (int i = 0; i < _COMPANY_COUNT; i++) {
+			for (int j = 0; j < _USER_COUNT; j++) {
+				unsafeTriConsumer.accept(
+					_companyIds[i], _userIds[j], _storedCredentials[i][j]);
+			}
+		}
+	}
+
+	private Set<String> _getCompanyKeySet(long companyId1) throws Exception {
+		Set<String> keySet = new HashSet<>();
+
+		_forEachUser(
+			(companyId2, userId, storedCredential) -> {
+				if (companyId1 == companyId2) {
+					keySet.add(userId);
+				}
+			});
+
+		return keySet;
+	}
+
+	private Set<StoredCredential> _getCompanyValues(long companyId1)
+		throws Exception {
+
+		Set<StoredCredential> values = new HashSet<>();
+
+		_forEachUser(
+			(companyId2, userId, storedCredential) -> {
+				if (companyId1 == companyId2) {
+					values.add(storedCredential);
+				}
+			});
+
+		return values;
+	}
+
+	private static final int _COMPANY_COUNT = 3;
+
+	private static final int _USER_COUNT = 3;
+
+	private static final MockedStatic<ClusterExecutorUtil>
+		_clusterExecutorUtilMockedStatic = Mockito.mockStatic(
+			ClusterExecutorUtil.class);
+
+	private final long[] _companyIds = new long[_COMPANY_COUNT];
+	private final StoredCredential[][] _storedCredentials =
+		new StoredCredential[_COMPANY_COUNT][_USER_COUNT];
+	private final String[] _userIds = new String[_USER_COUNT];
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41695

Third PR after #6087 and #6099

The Google Drive authentication fails when Liferay is executed on a cloud environment. This happen because a node stores the credentials for a user, while another node fails retrieving it because it accesses a different instance of the map storing the credentials.

# How am I fixing it?

I'm using the same strategy of `AccessTokenStoreUtil` where the changes to a map storing the credientals are broadcast to all nodes in the cluster.

In the second PR, I'm not storing in the Util class `GoogleAuthorizationCodeFlow` instances because is not serializable. Instead, I'm storing the `StoredCredential` class, which is serializable.

In the third PR, I've created an implementation for the Google `DataStore` interface to be used by the `GoogleAuthorizationCodeFlow`. This implementation internally holds the `StoredCredential`s. It will act as a proxy to the `StoredCredentialStoreUtil` class.

# How can you verify that it works?

:warning: I don't know how to test it in a cloud environment.

Run the newly created unit tests:

`cd modules/apps/document-library-opener/document-library-opener-google-drive-web`
`gw test --tests StoredCredentialStoreUtilTest`
`gw test --tests StoredCredentialDataStoreTest`

Run the existing integration tests:

`cd modules/apps/document-library-opener/document-library-opener-google-drive-test`
`gw tI --tests DLOpenerGoogleDriveManagerTest`
`gw tI --tests EditInGoogleDocsMVCActionCommandTest`