### PR TITLE
LPD-42946 Fix Poshi test ItemSelector#CannotViewWCDraftViaFilterResults

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ItemSelector.macro
@@ -1105,9 +1105,13 @@ definition {
 		LexiconEntry.changeDisplayStyle(displayStyle = "list");
 
 		if (isSet(draft)) {
-			AssertElementPresent(
+			AssertElementNotPresent(
 				key_rowEntry = ${webContentTitle},
 				locator1 = "ContentRow#ENTRY_CONTENT_ENTRY_NAME");
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#EMPTY_INFO",
+				value1 = "No web content was found.");
 		}
 		else {
 			for (var webContentTitle : list ${webContentTitle}) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/assetpublisher/AssetPublisherUseCase.testcase
@@ -433,7 +433,27 @@ definition {
 			var rssFeedURL = selenium.getAttribute("//div[contains(@class,'subscribe-action')]//a[contains(@href,'asset-publisher') and contains(.,'RSS')]@href");
 		}
 
+		task ("Add a widget page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Test Page Name");
+		}
+
+		task ("Add a RSS Publisher widget to page") {
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Test Page Name",
+				widgetName = "RSS Publisher");
+		}
+
 		task ("Add a RSS Feed based on AP RSS Url") {
+			task ("Add a RSS Publisher to page") {
+				JSONLayout.addWidgetToPublicLayout(
+					groupName = "Test Site Name",
+					layoutName = "Asset Publisher Page",
+					widgetName = "RSS Publisher");
+			}
+
 			Navigator.gotoSitePage(
 				pageName = "Test Page Name",
 				siteName = "Test Site Name");


### PR DESCRIPTION
LPD-42946 Fix Poshi test ItemSelector#CannotViewWCDraftViaFilterResults
# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-42946)

# How am I fixing it?

We souldn't use AssetElementPresent as we don't expect that the item selector finds the web content in draf 

# How can I test it?

Run the test