### PR TITLE
LPD-42564 Clear the input date before entering a new scheduled date

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1207,6 +1207,16 @@ definition {
 	macro editDisplayDate(displayDate = null) {
 		Panel.expandPanel(panel = "Schedule");
 
+		DoubleClick(locator1 = "TextInput#DISPLAY_DATE");
+
+		Type.sendKeys(
+			locator1 = "TextInput#DISPLAY_DATE",
+			value1 = "keys=CONTROL,a");
+
+		KeyPress(
+			locator1 = "TextInput#DISPLAY_DATE",
+			value1 = "\BACK_SPACE");
+
 		Type.clickAtType(
 			locator1 = "TextInput#DISPLAY_DATE",
 			value1 = ${displayDate});


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-42563)

Fix test WebContent#PreviewScheduledWebContentInWCD

### How did I fix it
The schedule date was not being set correctly, I need to clear the input date before entering a new one. 

