### PR TITLE
LPD-42706

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/view_entry.jsp
@@ -40,7 +40,7 @@ if (portletTitleBasedNavigation) {
 			<ul class="middle navbar-nav">
 				<li class="nav-item">
 					<span class="text-secondary">
-						<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(entry.getUserName()), LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - entry.getModifiedDate().getTime(), true)} %>" key="x-modified-x-ago" translateArguments="<%= false %>" />
+						<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - entry.getModifiedDate().getTime(), true) %>" key="modified-x-ago" translateArguments="<%= false %>" />
 					</span>
 				</li>
 			</ul>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -70,7 +70,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 						</c:choose>
 
 						<span class="text-default">
-							<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
+							<liferay-ui:message arguments="<%= repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry) %>" key="modified-x-ago" />
 						</span>
 					</liferay-ui:search-container-column-text>
 
@@ -117,7 +117,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 						cssClass="table-cell-expand-smaller table-cell-minw-150"
 						name="modified-date"
 					>
-						<liferay-ui:message arguments="<%= new String[] {repositoryEntry.getUserName(), repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry)} %>" key="x-modified-x-ago" />
+						<liferay-ui:message arguments="<%= repositoryBrowserTagDisplayContext.getRepositoryEntryModifiedDateDescription(repositoryEntry) %>" key="modified-x-ago" />
 					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
@@ -17,8 +17,6 @@ Folder folder = (Folder)row.getObject();
 folder = folder.toEscapedModel();
 
 Date modifiedDate = folder.getModifiedDate();
-
-String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
 %>
 
 <h2 class="h5">
@@ -40,14 +38,7 @@ String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System
 </h2>
 
 <span>
-	<c:choose>
-		<c:when test="<%= Validator.isNull(folder.getUserName()) %>">
-			<liferay-ui:message arguments="<%= modifiedDateDescription %>" key="modified-x-ago" />
-		</c:when>
-		<c:otherwise>
-			<liferay-ui:message arguments="<%= new String[] {folder.getUserName(), modifiedDateDescription} %>" key="x-modified-x-ago" />
-		</c:otherwise>
-	</c:choose>
+	<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true) %>" key="modified-x-ago" />
 </span>
 <span>
 	<%= DLUtil.getAbsolutePath(liferayPortletRequest, dlAdminDisplayContext.getRootFolderId(), folder.getParentFolderId()).replace(StringPool.RAQUO_CHAR, StringPool.GREATER_THAN) %>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_descriptive.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_descriptive.jsp
@@ -65,11 +65,9 @@ KBArticleViewDisplayContext kbArticleViewDisplayContext = new KBArticleViewDispl
 
 						<%
 						Date modifiedDate = kbFolder.getModifiedDate();
-
-						String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
 						%>
 
-						<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbFolder.getUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+						<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true) %>" key="modified-x-ago" />
 					</span>
 				</liferay-ui:search-container-column-text>
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_templates.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_templates.jsp
@@ -58,7 +58,7 @@ ViewKBTemplatesDisplayContext viewKBTemplatesDisplayContext = (ViewKBTemplatesDi
 								</h2>
 
 								<span class="text-default">
-									<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(kbTemplate.getUserName()), viewKBTemplatesDisplayContext.getKBTemplateModifiedDateDescription(kbTemplate)} %>" key="x-modified-x-ago" />
+									<liferay-ui:message arguments="<%= viewKBTemplatesDisplayContext.getKBTemplateModifiedDateDescription(kbTemplate) %>" key="modified-x-ago" />
 								</span>
 							</liferay-ui:search-container-column-text>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBDisplayContext.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/display/context/MBDisplayContext.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.web.internal.display.context;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.portal.kernel.language.LanguageUtil;
+
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Jürgen KAppler
+ */
+public class MBDisplayContext {
+
+	public MBDisplayContext(HttpServletRequest httpServletRequest) {
+		_httpServletRequest = httpServletRequest;
+	}
+
+	public String getModifiedLabel(MBMessage message) {
+		String messageUserName = "anonymous";
+
+		if (!message.isAnonymous()) {
+			messageUserName = message.getStatusByUserName();
+		}
+
+		Date modifiedDate = message.getModifiedDate();
+
+		String modifiedDateDescription = LanguageUtil.getTimeDescription(
+			_httpServletRequest,
+			System.currentTimeMillis() - modifiedDate.getTime(), true);
+
+		return LanguageUtil.format(
+			_httpServletRequest, "x-modified-x-ago",
+			new String[] {messageUserName, modifiedDateDescription});
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+
+}

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -97,6 +97,7 @@ page import="com.liferay.message.boards.web.internal.dao.search.MBResultRowSplit
 page import="com.liferay.message.boards.web.internal.display.MBCategoryDisplay" %><%@
 page import="com.liferay.message.boards.web.internal.display.context.MBBannedUsersManagementToolbarDisplayContext" %><%@
 page import="com.liferay.message.boards.web.internal.display.context.MBConfigurationDisplayContext" %><%@
+page import="com.liferay.message.boards.web.internal.display.context.MBDisplayContext" %><%@
 page import="com.liferay.message.boards.web.internal.display.context.MBEditMessageDisplayContext" %><%@
 page import="com.liferay.message.boards.web.internal.display.context.MBEntriesManagementToolbarDisplayContext" %><%@
 page import="com.liferay.message.boards.web.internal.display.context.MBNavigationDisplayContext" %><%@
@@ -231,6 +232,8 @@ Format dateFormat = FastDateFormatFactoryUtil.getDate(locale, timeZone);
 Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 
 NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
+
+MBDisplayContext mbDisplayContext = new MBDisplayContext(request);
 %>
 
 <%@ include file="/message_boards/init-ext.jsp" %>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_entries.jspf
@@ -94,21 +94,8 @@
 
 			<c:choose>
 				<c:when test="<%= (message != null) && (thread.getMessageCount() == 1) %>">
-
-					<%
-					String messageUserName = "anonymous";
-
-					if (!message.isAnonymous()) {
-						messageUserName = message.getUserName();
-					}
-
-					Date modifiedDate = message.getModifiedDate();
-
-					String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-					%>
-
 					<p class="list-group-subtext">
-						<liferay-ui:message arguments="<%= new String[] {messageUserName, modifiedDateDescription} %>" key="x-modified-x-ago" />
+						<%= HtmlUtil.escape(mbDisplayContext.getModifiedLabel(message)) %>
 					</p>
 				</c:when>
 				<c:otherwise>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -45,17 +45,7 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 			>
 
 				<%
-				String messageUserName = "anonymous";
-
-				if (!message.isAnonymous()) {
-					messageUserName = message.getUserName();
-				}
-
-				Date modifiedDate = message.getModifiedDate();
-
-				String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-
-				String userDisplayText = LanguageUtil.format(request, "x-modified-x-ago", new Object[] {messageUserName, modifiedDateDescription});
+				String userDisplayText = mbDisplayContext.getModifiedLabel(message);
 				%>
 
 				<span class="message-user-display text-default" title="<%= HtmlUtil.escapeAttribute(userDisplayText) %>">

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jspf
@@ -172,21 +172,8 @@ MBCategoryDisplay categoryDisplay = new MBCategoryDisplay(scopeGroupId, category
 
 							<c:choose>
 								<c:when test="<%= (message != null) && (thread.getMessageCount() == 1) %>">
-
-									<%
-									String messageUserName = "anonymous";
-
-									if (!message.isAnonymous()) {
-										messageUserName = message.getUserName();
-									}
-
-									Date modifiedDate = message.getModifiedDate();
-
-									String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-									%>
-
 									<div>
-										<liferay-ui:message arguments="<%= new String[] {messageUserName, modifiedDateDescription} %>" key="x-modified-x-ago" />
+										<%= HtmlUtil.escape(mbDisplayContext.getModifiedLabel(message)) %>
 									</div>
 								</c:when>
 								<c:otherwise>

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/display/context/MBDisplayContextTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/display/context/MBDisplayContextTest.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.message.boards.web.internal.display.context;
+
+import com.liferay.message.boards.model.MBMessage;
+import com.liferay.portal.kernel.bean.BeanProperties;
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class MBDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		BeanPropertiesUtil beanPropertiesUtil = new BeanPropertiesUtil();
+
+		beanPropertiesUtil.setBeanProperties(_beanProperties);
+
+		_setUpLanguageUtil();
+	}
+
+	@Test
+	public void testGetModifiedLabel() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		MBDisplayContext mbDisplayContext = new MBDisplayContext(
+			httpServletRequest);
+
+		MBMessage mbMessage = Mockito.mock(MBMessage.class);
+
+		String userName = RandomTestUtil.randomString();
+		String statusByUserName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			mbMessage.getModifiedDate()
+		).thenReturn(
+			new Date()
+		);
+
+		Mockito.when(
+			mbMessage.getUserName()
+		).thenReturn(
+			userName
+		);
+
+		Mockito.when(
+			mbMessage.getStatusByUserName()
+		).thenReturn(
+			statusByUserName
+		);
+
+		_testGetModifiedLabel(
+			false, statusByUserName, mbMessage, mbDisplayContext);
+		_testGetModifiedLabel(true, "anonymous", mbMessage, mbDisplayContext);
+	}
+
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Mockito.when(
+			_language.format(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString(),
+				(String[])Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				String[] values = invocation.getArgument(2);
+
+				return values[0];
+			}
+		);
+
+		Mockito.when(
+			_language.getTimeDescription(
+				Mockito.any(HttpServletRequest.class), Mockito.anyLong(),
+				Mockito.anyBoolean())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		languageUtil.setLanguage(_language);
+	}
+
+	private void _testGetModifiedLabel(
+		boolean anonymous, String expectedModifiedLabel, MBMessage mbMessage,
+		MBDisplayContext mbDisplayContext) {
+
+		Mockito.when(
+			mbMessage.isAnonymous()
+		).thenReturn(
+			anonymous
+		);
+
+		Assert.assertEquals(
+			expectedModifiedLabel,
+			mbDisplayContext.getModifiedLabel(mbMessage));
+	}
+
+	private final BeanProperties _beanProperties = Mockito.mock(
+		BeanProperties.class);
+	private final Language _language = Mockito.mock(Language.class);
+
+}


### PR DESCRIPTION
Incorrect user shown in some views

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-42706)

In some views we show the user that created the entry instead of the one that modified it, this creates a confusion with the clients

# How am I fixing it?

Where we have the status, use the user that modified the entry, in other cases, just show the time when it was modified


