### PR TITLE
LPD-42737 Cannot see related assets, tags and categories of an expired versioned Document

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLAssetHelperImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/helper/DLAssetHelperImpl.java
@@ -31,7 +31,8 @@ public class DLAssetHelperImpl implements DLAssetHelper {
 
 		String version = fileVersion.getVersion();
 
-		if (fileVersion.isApproved() || Validator.isNull(version) ||
+		if (fileVersion.isApproved() || fileVersion.isExpired() ||
+			Validator.isNull(version) ||
 			version.equals(DLFileEntryConstants.VERSION_DEFAULT) ||
 			fileEntry.isInTrash()) {
 

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -44,6 +44,7 @@ import {JSONWebServicesCompanyApiHelper} from './json-web-services/JSONWebServic
 import {JSONWebServicesDDMApiHelper} from './json-web-services/JSONWebServicesDDMApiHelper';
 import {JSONWebServicesDepotApiHelper} from './json-web-services/JSONWebServicesDepotApiHelper';
 import {JSONWebServicesDepotGroupRelApiHelper} from './json-web-services/JSONWebServicesDepotGroupRelApiHelper';
+import {JSONWebServicesDocumentLibraryApiHelper} from './json-web-services/JSONWebServicesDocumentLibraryApiHelper';
 import {JSONWebServicesFragmentCollectionApiHelper} from './json-web-services/JSONWebServicesFragmentCollectionApiHelper';
 import {JSONWebServicesFragmentEntryApiHelper} from './json-web-services/JSONWebServicesFragmentEntryApiHelper';
 import {JSONWebServicesGroupApiHelper} from './json-web-services/JSONWebServicesGroupApiHelper';
@@ -122,6 +123,7 @@ export class ApiHelpers {
 	readonly jsonWebServicesDDM: JSONWebServicesDDMApiHelper;
 	readonly jsonWebServicesDepot: JSONWebServicesDepotApiHelper;
 	readonly jsonWebServicesDepotGroupRel: JSONWebServicesDepotGroupRelApiHelper;
+	readonly jsonWebServicesDocumentLibrary: JSONWebServicesDocumentLibraryApiHelper;
 	readonly jsonWebServicesFragmentEntry: JSONWebServicesFragmentEntryApiHelper;
 	readonly jsonWebServicesFragmentCollection: JSONWebServicesFragmentCollectionApiHelper;
 	readonly jsonWebServicesGroup: JSONWebServicesGroupApiHelper;
@@ -195,6 +197,8 @@ export class ApiHelpers {
 		this.jsonWebServicesDepot = new JSONWebServicesDepotApiHelper(this);
 		this.jsonWebServicesDepotGroupRel =
 			new JSONWebServicesDepotGroupRelApiHelper(this);
+		this.jsonWebServicesDocumentLibrary =
+			new JSONWebServicesDocumentLibraryApiHelper(this);
 		this.jsonWebServicesFragmentEntry =
 			new JSONWebServicesFragmentEntryApiHelper(this);
 		this.jsonWebServicesFragmentCollection =
@@ -311,6 +315,23 @@ export class ApiHelpers {
 		const response = await this.page.request.patch(url, {
 			data,
 			headers: await getHeader(this.page),
+		});
+
+		const text = await response.text();
+
+		if (!text) {
+			return response;
+		}
+
+		return response.json();
+	}
+
+	async patchMultipart<T>(url: string, options: PostOptions<T> = {}) {
+		const response = await this.page.request.patch(url, {
+			data: options.data,
+			failOnStatusCode: options.failOnStatusCode || false,
+			headers: options.headers || (await getHeader(this.page)),
+			multipart: options.multipart,
 		});
 
 		const text = await response.text();

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -68,7 +68,7 @@ interface HeadlessClientConfig {
 	HEADERS: Record<string, string>;
 }
 
-interface PostOptions<T> {
+interface RequestOptions<T> {
 	data?: T;
 	failOnStatusCode?: boolean;
 	headers?: {[key: string]: string};
@@ -239,7 +239,7 @@ export class ApiHelpers {
 
 	async postResponse<T>(
 		url: string,
-		{data, failOnStatusCode, headers, multipart}: PostOptions<T> = {}
+		{data, failOnStatusCode, headers, multipart}: RequestOptions<T> = {}
 	) {
 		return await this.page.request.post(url, {
 			data,
@@ -249,7 +249,7 @@ export class ApiHelpers {
 		});
 	}
 
-	async post<T>(url: string, options: PostOptions<T> = {}) {
+	async post<T>(url: string, options: RequestOptions<T> = {}) {
 		const response = await this.postResponse(url, options);
 
 		if (response.status() === 204) {
@@ -270,7 +270,7 @@ export class ApiHelpers {
 		});
 	}
 
-	async put<T>(url: string, options: PostOptions<T> = {}) {
+	async put<T>(url: string, options: RequestOptions<T> = {}) {
 		const response = await this.putResponse(url, options);
 
 		if (response.status() === 204) {
@@ -282,7 +282,7 @@ export class ApiHelpers {
 
 	async putResponse<T>(
 		url: string,
-		{data, failOnStatusCode, headers, multipart}: PostOptions<T> = {}
+		{data, failOnStatusCode, headers, multipart}: RequestOptions<T> = {}
 	) {
 		return await this.page.request.put(url, {
 			data,
@@ -326,7 +326,7 @@ export class ApiHelpers {
 		return response.json();
 	}
 
-	async patchMultipart<T>(url: string, options: PostOptions<T> = {}) {
+	async patchRequestOptions<T>(url: string, options: RequestOptions<T> = {}) {
 		const response = await this.page.request.patch(url, {
 			data: options.data,
 			failOnStatusCode: options.failOnStatusCode || false,

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -306,7 +306,7 @@ export class HeadlessDeliveryApiHelper {
 		documentId: number;
 		file?: fs.ReadStream;
 	}) {
-		return this.apiHelpers.patchMultipart(
+		return this.apiHelpers.patchRequestOptions(
 			`${this.apiHelpers.baseUrl}${this.basePath}/documents/${documentId}`,
 			{
 				failOnStatusCode: true,

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -22,6 +22,7 @@ type TDocument = {
 	externalReferenceCode?: string;
 	fileName?: string;
 	id?: number;
+	keywords?: string[];
 	taxonomyCategoryIds?: number[];
 	title?: string;
 	viewableBy?: string;
@@ -179,6 +180,7 @@ export class HeadlessDeliveryApiHelper {
 		contentStructureId,
 		datePublished,
 		description = '',
+		relatedContents,
 		siteId,
 		tags,
 		title,
@@ -188,6 +190,7 @@ export class HeadlessDeliveryApiHelper {
 		contentStructureId: number;
 		datePublished: string;
 		description?: string;
+		relatedContents?: {contentType: string; id: number; title: string}[];
 		siteId: string;
 		tags?: string[];
 		title: string;
@@ -201,6 +204,7 @@ export class HeadlessDeliveryApiHelper {
 					datePublished,
 					description,
 					keywords: tags,
+					relatedContents,
 					taxonomyCategoryIds: categoryIds,
 					title,
 					viewableBy,
@@ -280,6 +284,30 @@ export class HeadlessDeliveryApiHelper {
 
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/documents`,
+			{
+				failOnStatusCode: true,
+				headers: {
+					...(await this.apiHelpers.getCSRFTokenHeader()),
+				},
+				multipart: {
+					document: JSON.stringify(document),
+					file,
+				},
+			}
+		);
+	}
+
+	async patchDocument({
+		document,
+		documentId,
+		file,
+	}: {
+		document?: TDocument;
+		documentId: number;
+		file?: fs.ReadStream;
+	}) {
+		return this.apiHelpers.patchMultipart(
+			`${this.apiHelpers.baseUrl}${this.basePath}/documents/${documentId}`,
 			{
 				failOnStatusCode: true,
 				headers: {

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesDocumentLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesDocumentLibraryApiHelper.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {liferayConfig} from '../../liferay.config';
+import {ApiHelpers} from '../ApiHelpers';
+
+export enum DLFILE_STATUS {
+	APPROVED = '0',
+	DENIED = '4',
+	DRAFT = '2',
+	EXPIRED = '3',
+	IN_TRASH = '8',
+	INACTIVE = '5',
+	INCOMPLETE = '6',
+	PENDING = '1',
+	SCHEDULED = '7',
+}
+
+type TDLFileEntry = {
+	fileEntryId?: string;
+};
+
+type TDLFileVersion = {
+	fileVersionId?: string;
+};
+
+export class JSONWebServicesDocumentLibraryApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly baseFileEntryPath: string;
+	readonly baseFileVersionPath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.baseFileEntryPath = '/api/jsonws/dlfileentry';
+		this.baseFileVersionPath = '/api/jsonws/dlfileversion';
+	}
+
+	async getLastestFileVersion(fileEntryId: string): Promise<TDLFileVersion> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('fileEntryId', fileEntryId);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.baseFileVersionPath}/get-latest-file-version`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+
+	async updateStatus(
+		userId: string,
+		fileVersionId: string,
+		status: DLFILE_STATUS
+	): Promise<TDLFileEntry> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('userId', userId);
+		urlSearchParams.append('fileVersionId', fileVersionId);
+		urlSearchParams.append('status', status);
+		urlSearchParams.append('workflowContext', '{}');
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.baseFileEntryPath}/update-status`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+}

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -15,6 +15,9 @@ export type TVocabularyCategory = {
 
 export class DocumentLibraryPage {
 	readonly exportImportOptionsMenuItem: Locator;
+	readonly infoPanel: Locator;
+	readonly infoPanelButton: Locator;
+	readonly infoPanelTab: Locator;
 	readonly optionsMenu: Locator;
 	readonly orderMenu: Locator;
 	readonly page: Page;
@@ -26,6 +29,15 @@ export class DocumentLibraryPage {
 		this.exportImportOptionsMenuItem = page.getByRole('menuitem', {
 			name: 'Export / Import',
 		});
+		this.infoPanel = page.locator(
+			'[id="_com_liferay_document_library_web_portlet_DLAdminPortlet_ContextualSidebar"]'
+		);
+		this.infoPanelButton = page.locator(
+			'[id="_com_liferay_document_library_web_portlet_DLAdminPortlet_OpenContextualSidebar"]'
+		);
+		this.infoPanelTab = page.locator(
+			'[id^=_com_liferay_document_library_web_portlet_DLAdminPortlet_tabs_]'
+		);
 		this.optionsMenu = page
 			.getByTestId('headerOptions')
 			.getByLabel('Options');
@@ -56,6 +68,64 @@ export class DocumentLibraryPage {
 		await privateFileIcon.waitFor();
 
 		await expect(privateFileIcon).toBeVisible();
+	}
+
+	async openInfoPanel(entryTitle: string, tabName: 'Details' | 'Versions') {
+		const infoPanelHeading = this.infoPanel.getByRole('heading', {
+			name: entryTitle,
+		});
+
+		if (await infoPanelHeading.isHidden()) {
+			this.infoPanelButton.click();
+		}
+
+		await infoPanelHeading.waitFor();
+
+		const infoPanelTab = this.page.getByRole('tab', {name: tabName});
+
+		if (
+			await infoPanelTab.evaluate(
+				(element) => !element.classList.contains('active')
+			)
+		) {
+			await infoPanelTab.click();
+		}
+	}
+
+	async assertInfoPanelCategories(categoryNames: string[]) {
+		await expect(
+			this.page.getByRole('tab', {name: 'Details'})
+		).toBeVisible();
+		await expect(this.infoPanelTab.getByText('Categories')).toBeVisible();
+
+		for (const categoryName of categoryNames) {
+			await expect(this.infoPanelTab.getByText(categoryName)).toBeVisible;
+		}
+	}
+
+	async assertInfoPanelRelatedAssets(relatedAssetNames: string[]) {
+		await expect(
+			this.page.getByRole('tab', {name: 'Details'})
+		).toBeVisible();
+		await expect(
+			this.infoPanelTab.getByText('Related Assets')
+		).toBeVisible();
+
+		for (const relatedAssetName of relatedAssetNames) {
+			await expect(this.infoPanelTab.getByText(relatedAssetName))
+				.toBeVisible;
+		}
+	}
+
+	async assertInfoPanelTags(tags: string[]) {
+		await expect(
+			this.page.getByRole('tab', {name: 'Details'})
+		).toBeVisible();
+		await expect(this.infoPanelTab.getByText('Tags')).toBeVisible();
+
+		for (const tag of tags) {
+			await expect(this.infoPanelTab.getByText(tag)).toBeVisible;
+		}
 	}
 
 	async changeTab(tabName: string) {
@@ -113,6 +183,17 @@ export class DocumentLibraryPage {
 			.locator('.management-bar')
 			.getByRole('button', {name: 'Download'})
 			.click();
+	}
+
+	async goToViewFileEntry(entryTitle: string) {
+		await this.page
+			.getByRole('link', {exact: true, name: entryTitle})
+			.click();
+
+		await this.page
+			.getByLabel('Control Menu')
+			.getByRole('heading', {name: entryTitle})
+			.waitFor();
 	}
 
 	async goToEditFileEntry(entryTitle: string) {

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -13,9 +13,11 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {createCategories} from '../../helpers/CreateCategories';
+import {DLFILE_STATUS} from '../../helpers/json-web-services/JSONWebServicesDocumentLibraryApiHelper';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
+import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../utils/waitForAlert';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
@@ -390,5 +392,121 @@ test(
 
 			await expect(await page.getByText(document.title)).toBeVisible();
 		}
+	}
+);
+
+test(
+	'Categories, related assets and tags of an expired versioned document should be visible',
+	{
+		tag: '@LPD-42737',
+	},
+
+	async ({apiHelpers, documentLibraryPage, site}) => {
+		const documentTitle = 'Title' + getRandomString();
+
+		const documentId =
+			await test.step('Create a new document', async () => {
+				const document = await apiHelpers.headlessDelivery.postDocument(
+					site.id,
+					createReadStream(
+						path.join(__dirname, '/dependencies/image1.jpeg')
+					),
+					{
+						description: getRandomString(),
+						fileName: getRandomString(),
+						title: documentTitle,
+					}
+				);
+
+				expect(document).toHaveProperty('title', documentTitle);
+
+				return document.id;
+			});
+
+		const [categoryName, keyword, structuredContentTitle] =
+			await test.step('Update the document with a new version: add category, related asset and tag', async () => {
+				const categories = await createCategories({
+					apiHelpers,
+					categoryNames: [{name: 'Category' + getRandomString()}],
+					site,
+					vocabularyName: getRandomString(),
+				});
+
+				const keyword = 'Keyword' + getRandomString();
+
+				const contentStructureId =
+					await getBasicWebContentStructureId(apiHelpers);
+				const structuredContentTitle =
+					'StructuredContent' + getRandomString();
+
+				await apiHelpers.headlessDelivery.postStructuredContent({
+					contentStructureId,
+					datePublished: null,
+					description: getRandomString(),
+					relatedContents: [
+						{
+							contentType: 'Document',
+							id: documentId,
+							title: documentTitle,
+						},
+					],
+					siteId: site.id,
+					title: structuredContentTitle,
+					viewableBy: 'Anyone',
+				});
+
+				const updatedDocument =
+					await apiHelpers.headlessDelivery.patchDocument({
+						document: {
+							keywords: [keyword],
+							taxonomyCategoryIds: [categories[0].id],
+						},
+						documentId,
+					});
+
+				expect(updatedDocument.keywords).toContain(keyword);
+				expect(
+					updatedDocument.relatedContents.map((r) => r.title)
+				).toContain(structuredContentTitle);
+				expect(
+					updatedDocument.taxonomyCategoryBriefs.map(
+						(t) => t.taxonomyCategoryName
+					)
+				).toContain(categories[0].name);
+
+				return [categories[0].name, keyword, structuredContentTitle];
+			});
+
+		const user =
+			await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+				'test@liferay.com'
+			);
+
+		await test.step('Expire the document', async () => {
+			const fileVersion =
+				await apiHelpers.jsonWebServicesDocumentLibrary.getLastestFileVersion(
+					documentId
+				);
+
+			const fileEntry =
+				await apiHelpers.jsonWebServicesDocumentLibrary.updateStatus(
+					user.id,
+					fileVersion.fileVersionId,
+					DLFILE_STATUS.EXPIRED
+				);
+
+			expect(fileEntry.fileEntryId).toBe(String(documentId));
+		});
+
+		await test.step('Check that category, related asset and tag are visible in document view page', async () => {
+			await documentLibraryPage.goto(site.friendlyUrlPath);
+			await documentLibraryPage.goToViewFileEntry(documentTitle);
+			await documentLibraryPage.openInfoPanel(documentTitle, 'Details');
+			await documentLibraryPage.assertInfoPanelCategories([categoryName]);
+			await documentLibraryPage.assertInfoPanelRelatedAssets([
+				structuredContentTitle,
+			]);
+			await documentLibraryPage.assertInfoPanelTags([keyword]);
+		});
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-42737

When a document is versioned and is expired, its tags, categories and related assets cannot be seen in the Info panel of the view page or in the Edit page.

# How am I fixing it?

Adding the Expired status in the condition for returning the `fileEntryId` instead of the `fileVersionId`, because the `fileVersionId` is only found in the Assets when the document is in Draft status.

# How can you verify that it works?

I'm checking only in Info panel of view page, not in the Edit page because they both share the same fixed logic.

`cd  modules/test/playwright`
`npm run playwright -- test -g 'Categories, related assets and tags of an expired versioned document should be visible'`
