### PR TITLE
LPD-43121 Using ancestors when we are using fetchDDMTemplateByExternalReferenceCode

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 33.0.1
+Bundle-Version: 33.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalService.java
@@ -398,6 +398,11 @@ public interface DDMTemplateLocalService
 	public DDMTemplate fetchDDMTemplateByExternalReferenceCode(
 		String externalReferenceCode, long groupId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DDMTemplate fetchDDMTemplateByExternalReferenceCode(
+		String externalReferenceCode, long groupId,
+		boolean includeAncestorTemplates);
+
 	/**
 	 * Returns the ddm template matching the UUID and group.
 	 *

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalServiceUtil.java
@@ -445,6 +445,14 @@ public class DDMTemplateLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static DDMTemplate fetchDDMTemplateByExternalReferenceCode(
+		String externalReferenceCode, long groupId,
+		boolean includeAncestorTemplates) {
+
+		return getService().fetchDDMTemplateByExternalReferenceCode(
+			externalReferenceCode, groupId, includeAncestorTemplates);
+	}
+
 	/**
 	 * Returns the ddm template matching the UUID and group.
 	 *

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMTemplateLocalServiceWrapper.java
@@ -482,6 +482,15 @@ public class DDMTemplateLocalServiceWrapper
 			externalReferenceCode, groupId);
 	}
 
+	@Override
+	public DDMTemplate fetchDDMTemplateByExternalReferenceCode(
+		String externalReferenceCode, long groupId,
+		boolean includeAncestorTemplates) {
+
+		return _ddmTemplateLocalService.fetchDDMTemplateByExternalReferenceCode(
+			externalReferenceCode, groupId, includeAncestorTemplates);
+	}
+
 	/**
 	 * Returns the ddm template matching the UUID and group.
 	 *

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -509,6 +509,36 @@ public class DDMTemplateLocalServiceImpl
 		}
 	}
 
+	@Override
+	public DDMTemplate fetchDDMTemplateByExternalReferenceCode(
+		String externalReferenceCode, long groupId,
+		boolean includeAncestorTemplates) {
+
+		DDMTemplate template = ddmTemplatePersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
+
+		if (template != null) {
+			return template;
+		}
+
+		if (!includeAncestorTemplates) {
+			return null;
+		}
+
+		for (long ancestorSiteGroupId :
+				_getAncestorSiteAndDepotGroupIds(groupId)) {
+
+			template = ddmTemplatePersistence.fetchByERC_G(
+				externalReferenceCode, ancestorSiteGroupId);
+
+			if (template != null) {
+				return template;
+			}
+		}
+
+		return null;
+	}
+
 	/**
 	 * Returns the template with the primary key.
 	 *

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMTemplateLocalServiceTest.java
@@ -19,6 +19,8 @@ import com.liferay.dynamic.data.mapping.util.comparator.TemplateIdComparator;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -213,6 +215,35 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 
 		Assert.assertNull(
 			_ddmTemplateLocalService.fetchTemplate(template.getTemplateId()));
+	}
+
+	@Test
+	public void testFetchDDMTemplateByExternalReferenceCodeIncludingAncestorTemplates()
+		throws Exception {
+
+		Company company = _companyLocalService.getCompany(group.getCompanyId());
+
+		DDMTemplate template = _ddmTemplateLocalService.addTemplate(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			company.getGroupId(), _classNameId, 0, _resourceClassNameId,
+			Collections.singletonMap(
+				LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()),
+			null, DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY,
+			DDMTemplateConstants.TEMPLATE_MODE_CREATE,
+			TemplateConstants.LANG_TYPE_VM,
+			getTestTemplateScript(TemplateConstants.LANG_TYPE_VM),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertNull(
+			_ddmTemplateLocalService.fetchDDMTemplateByExternalReferenceCode(
+				template.getExternalReferenceCode(), group.getGroupId(),
+				false));
+
+		Assert.assertNotNull(
+			_ddmTemplateLocalService.fetchDDMTemplateByExternalReferenceCode(
+				template.getExternalReferenceCode(), group.getGroupId(), true));
+
+		_ddmTemplateLocalService.deleteTemplate(template);
 	}
 
 	@Test
@@ -608,6 +639,9 @@ public class DDMTemplateLocalServiceTest extends BaseDDMServiceTestCase {
 
 	private static long _classNameId;
 	private static long _resourceClassNameId;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private DDMTemplateLocalService _ddmTemplateLocalService;

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -405,7 +405,7 @@ public class JournalContentDisplayContext {
 					_ddmTemplateLocalService.
 						fetchDDMTemplateByExternalReferenceCode(
 							ddmTemplateExternalReferenceCode,
-							_themeDisplay.getScopeGroupId());
+							_themeDisplay.getScopeGroupId(), true);
 
 				if (ddmTemplate != null) {
 					ddmTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -306,7 +306,7 @@ public class JournalContentExportImportPortletPreferencesProcessor
 					_ddmTemplateLocalService.
 						fetchDDMTemplateByExternalReferenceCode(
 							preferenceDDMTemplateExternalReferenceCode,
-							article.getGroupId());
+							article.getGroupId(), true);
 
 				if (ddmTemplate != null) {
 					preferenceDDMTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/JournalContentPortlet.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/JournalContentPortlet.java
@@ -217,7 +217,7 @@ public class JournalContentPortlet extends MVCPortlet {
 						_ddmTemplateLocalService.
 							fetchDDMTemplateByExternalReferenceCode(
 								ddmTemplateExternalReferenceCode,
-								article.getGroupId());
+								article.getGroupId(), true);
 
 					if (ddmTemplate != null) {
 						ddmTemplateKey = ddmTemplate.getTemplateKey();

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/action/JournalContentConfigurationAction.java
@@ -337,7 +337,7 @@ public class JournalContentConfigurationAction
 				_ddmTemplateLocalService.
 					fetchDDMTemplateByExternalReferenceCode(
 						ddmTemplateExternalReferenceCode,
-						_getArticleGroupId(portletRequest));
+						_getArticleGroupId(portletRequest), true);
 		}
 		else {
 			String ddmTemplateKey = getParameter(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43121

Here in this PR there are commits from three PRs, 

1. LPD-42376 : this is already in brian, you can see it [here](https://github.com/brianchandotcom/liferay-portal/pull/156546).
2. LPD-43040 : this is in bpm repository pending to review it, see [here](https://liferay.atlassian.net/browse/LPD-43040)
3. LPD-43121 : finally, there is a commit related to the changes of this PR

# How am I fixing it?

Fetch template including ancestors since we can have the template in an AssetLibrary, in the site or in the global site

# How can you verify that it works?

There is already a test to cover this, added in the las pr:  https://github.com/liferay-content-management/liferay-portal/pull/6077/commits/8504492706478a916dbe3714d1aa4225f3792749
