### PR TITLE
LPD-43168 Return null if the url is null

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web-test/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-web-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-api")
 	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/layout/display/page/test/KBArticleLayoutDisplayPageProviderTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-web-test/src/testIntegration/java/com/liferay/knowledge/base/web/internal/layout/display/page/test/KBArticleLayoutDisplayPageProviderTest.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.web.internal.layout.display.page.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roberto Díaz
+ */
+@RunWith(Arquillian.class)
+public class KBArticleLayoutDisplayPageProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProviderWithEmptyURLTitle() {
+		Assert.assertNull(
+			_layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				_group.getGroupId(), StringPool.BLANK));
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.knowledge.base.web.internal.layout.display.page.KBArticleLayoutDisplayPageProvider"
+	)
+	private LayoutDisplayPageProvider<FileEntry> _layoutDisplayPageProvider;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
@@ -110,6 +110,10 @@ public class KBArticleLayoutDisplayPageProvider
 		try {
 			List<String> parts = StringUtil.split(urlTitle, CharPool.SLASH);
 
+			if (parts.size() <= 1) {
+				return null;
+			}
+
 			KBArticle kbArticle =
 				_kbArticleLocalService.fetchKBArticleByUrlTitle(
 					groupId, _getKBFolderId(groupId, parts),


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43168

# How am I fixing it?

I check if the article coulb re retrived or not and return null in this case

# How can you verify that it works?

Run the included automated tests.

# Commits:

- **LPD-43168 Return null if the url is null**
- **LPD-43168 Add tests**
