### PR TITLE
[Draft] LPD-43386 Translation progress in Web Content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -22,7 +22,7 @@ export default function useTranslationProgress({
 		titleMapAsXML: initialFields.titleMapAsXML,
 	} as Record<string, Field>);
 	const [translations, setTranslations] = useState(
-		fieldToTranslations(initialFields)
+		fieldToTranslations(fields)
 	);
 	const [translationProgress, setTranslationProgress] =
 		useState<TranslationProgress | null>();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -42,6 +42,11 @@ export default function useTranslationProgress({
 				)
 					.filter(
 						(input) =>
+							!input.dataset.translated ||
+							input.dataset.translated === 'true'
+					)
+					.filter(
+						(input) =>
 							input.value || input.getAttribute('data-translated')
 					)
 					.map(


### PR DESCRIPTION
Hey @NemethNorbert @DiegoHu97, may I ask for your review here, before working on tests? 

You can see the issue details here: https://liferay.atlassian.net/browse/LPD-43386 
Let's imagine we fill: 

- For en_US: title and content field
- For es_ES: only title

So, the thing is that when saved as draft, we are not "cleaning" the content fields, just the [title and description](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js#L327) (this is the reason why it doesn't fail when you fill just the content field, not the title) .Thus, when the WC is saved as draft, the content value for ES is not cleaned and the inputs present looks like: 

**en_US - Title**
`<input class="field form-control" id="_com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXML_en_US" name="_com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXML_en_US" type="hidden" value="english" data-languageid="en_US" dir="ltr" data-field-name="titleMapAsXML">`

**es_ES - Title**
`<input class="field form-control" id="_com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXML_es_ES" name="_com_liferay_journal_web_portlet_JournalPortlet_titleMapAsXML_es_ES" type="hidden" value="español" data-languageid="es_ES" dir="ltr" data-field-name="titleMapAsXML">`

**en_US - Content**
`<input data-field-name="contento3qq1KRo" data-languageid="en_US" data-translated="false" type="hidden" name="_com_liferay_journal_web_portlet_JournalPortlet_ddm$$content$o3qq1KRo$0$$en_US" value="<p>content</p>">`

**es_ES - Content**
`<input data-field-name="contento3qq1KRo" data-languageid="es_ES" data-translated="false" type="hidden" value="<p>content</p>">`

And when calculating the translation progress, this was counting as a "translated" field, thus the label "Translated" was shown. With the current fix, I am first removing the inputs that has the attribute `data-translated=false` (but not the rest, title has not that attribute) 
**Note**: I just realised that for field en_US - Content, data-translated attribute is also set to false... So now, I'm a bit confused...

I kindly ask for your review as I am not yet familiar with all these components ;-) 

The other doubt I have, this happens only when saved as draft. While you are in the page editing the web content, everything works fine... 🤔, with autosave also works fine, and when saved as draft, if you go back to the list and open the WC, also the Translation Progess is correct... there are puzzle pieces that I'm still not able to connect, so I appreciate any feedback here. 