### PR TITLE
LPD-40371 Create a playwright util to manage paginator

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -17,6 +17,7 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
 import {openFieldset} from '../../utils/openFieldset';
+import {nextPage, setItemsPerPage} from '../../utils/pagination';
 import addApprovedStructuredContent from '../../utils/structured-content/addApprovedStructuredContent';
 import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../utils/waitForAlert';
@@ -429,14 +430,12 @@ baseTest(
 
 		await journalPage.goto(site.friendlyUrlPath);
 
-		await page.getByLabel('Items per Page').click();
-
-		await page.getByRole('option', {name: '4 Entries per Page'}).click();
+		await setItemsPerPage(page, 4);
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
 		await page.getByTestId('row').nth(1).getByRole('checkbox').check();
 
-		await page.getByRole('link', {name: 'Page 2'}).click();
+		await nextPage(page);
 
 		await expect(
 			page.getByText('Showing 5 to 8 of 10 entries.')
@@ -445,7 +444,7 @@ baseTest(
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
 		await page.getByTestId('row').nth(1).getByRole('checkbox').check();
 
-		await page.getByRole('link', {name: 'Page 3'}).click();
+		await nextPage(page);
 
 		await expect(
 			page.getByText('Showing 9 to 10 of 10 entries.')

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -12,6 +12,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {messageBoardsPagesTest} from '../../fixtures/messageBoardsTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
 import getRandomString from '../../utils/getRandomString';
+import {gotoPage, setItemsPerPage} from '../../utils/pagination';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -187,6 +188,9 @@ test(
 	'Message Boards Admin: Change delta to a higher value when on last page',
 	{tag: '@LPD-37727'},
 	async ({apiHelpers, messageBoardsPage, page, site}) => {
+		const threadsLinks = page.getByRole('link', {
+			name: /Thread with headline #\d+/,
+		});
 		for (let i = 0; i < 5; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
@@ -197,25 +201,14 @@ test(
 
 		await messageBoardsPage.goto(site.friendlyUrlPath);
 
-		await page.getByLabel('Items per Page').click();
-		await page.getByRole('option', {name: /4\s+Entries per Page/}).click();
+		await setItemsPerPage(page, 4);
+		await expect(threadsLinks).toHaveCount(4);
 
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(4);
+		await gotoPage(page, 2);
+		await expect(threadsLinks).toHaveCount(1);
 
-		await page.getByRole('link', {name: /Page\s+2/}).click();
-
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(1);
-
-		await page.getByLabel('Items per Page').click();
-		await page.getByRole('option', {name: /8\s+Entries per Page/}).click();
-
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(5);
+		await setItemsPerPage(page, 8);
+		await expect(threadsLinks).toHaveCount(5);
 	}
 );
 
@@ -223,6 +216,9 @@ test(
 	'Message Boards Widget: Change delta to a higher value when on last page',
 	{tag: '@LPD-39570'},
 	async ({apiHelpers, messageBoardsWidgetPage, page, site}) => {
+		const threadsLinks = page.getByRole('link', {
+			name: /Thread with headline #\d+/,
+		});
 		for (let i = 0; i < 5; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
@@ -230,27 +226,15 @@ test(
 				siteId: site.id,
 			});
 		}
-
 		await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
 
-		await page.getByLabel('Items per Page').click();
-		await page.getByRole('option', {name: /4\s+Entries per Page/}).click();
+		await setItemsPerPage(page, 4);
+		await expect(threadsLinks).toHaveCount(4);
 
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(4);
+		await gotoPage(page, 2);
+		await expect(threadsLinks).toHaveCount(1);
 
-		await page.getByRole('link', {name: /Page\s+2/}).click();
-
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(1);
-
-		await page.getByLabel('Items per Page').click();
-		await page.getByRole('option', {name: /8\s+Entries per Page/}).click();
-
-		await expect(
-			page.getByRole('link', {name: /Thread with headline #\d+/})
-		).toHaveCount(5);
+		await setItemsPerPage(page, 8);
+		await expect(threadsLinks).toHaveCount(5);
 	}
 );

--- a/modules/test/playwright/utils/pagination.ts
+++ b/modules/test/playwright/utils/pagination.ts
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Page} from '@playwright/test';
-
-import {clickAndExpectToBeVisible} from './clickAndExpectToBeVisible';
+import {FrameLocator, Page, expect} from '@playwright/test';
 
 function getPaginator(page: Page | FrameLocator) {
 	return page.locator('[data-qa-id="paginator"]');
@@ -26,11 +24,22 @@ export async function gotoPage(page, pageNumber: number | string) {
 }
 
 export async function setItemsPerPage(page, limit: number | string) {
-	await clickAndExpectToBeVisible({
-		autoClick: true,
-		target: getPaginator(page).getByRole('option', {
-			name: `${limit} Entries per Page`,
-		}),
-		trigger: getPaginator(page).getByLabel('Items per Page'),
+	const timeout = 300;
+	const option = getPaginator(page).getByRole('option', {
+		name: `${limit} Entries per Page`,
 	});
+
+	await expect(async () => {
+		if (await option.isHidden({timeout})) {
+			await getPaginator(page)
+				.getByLabel('Items per Page')
+				.click({timeout});
+		}
+
+		await expect(option).toBeVisible({timeout});
+	}).toPass({
+		intervals: [timeout * 2, timeout * 3, timeout * 4],
+	});
+
+	await option.click();
 }

--- a/modules/test/playwright/utils/pagination.ts
+++ b/modules/test/playwright/utils/pagination.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Page} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from './clickAndExpectToBeVisible';
+
+function getPaginator(page: Page | FrameLocator) {
+	return page.locator('[data-qa-id="paginator"]');
+}
+
+export async function previousPage(page) {
+	await getPaginator(page).getByTitle('Previous page').click();
+}
+
+export async function nextPage(page) {
+	await getPaginator(page).getByTitle('next page').click();
+}
+
+export async function gotoPage(page, pageNumber: number | string) {
+	await getPaginator(page)
+		.getByRole('link', {name: `Page ${pageNumber}`})
+		.click();
+}
+
+export async function setItemsPerPage(page, limit: number | string) {
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: getPaginator(page).getByRole('option', {
+			name: `${limit} Entries per Page`,
+		}),
+		trigger: getPaginator(page).getByLabel('Items per Page'),
+	});
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40371

Create a playwright util to manage paginator

# How am I fixing it?

>[!WARNING]
> ~~Here b266d270438de2e08ecce7358c454c2437af0bdf I need to fix clickAndExpectToBeVisible.ts to avoid getting stuck instead of re-trying the clic~~

I added some utils to set items per page and navigate using paginator.

# How can you verify that it works?

```sh
npm run playwright -- test -g '@LPD-19384|@LPD-37727|@LPD-39570' --reporter list
```

# tested locally to avoid flakiness
![image](https://github.com/user-attachments/assets/3133cca8-f743-4b2e-a2fb-8b7f21f50bca)
