### PR TITLE
LPD-43352 Manage orphan document references in upgrade

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -127,6 +127,10 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 				_fileEntryFriendlyURLResolver.resolveFriendlyURL(
 					group.getGroupId(), friendlyURL);
 
+			if (fileEntry == null) {
+				return null;
+			}
+
 			return (DLFileEntry)fileEntry.getModel();
 		}
 
@@ -184,6 +188,14 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 		if (matcher.find()) {
 			try {
 				DLFileEntry dlFileEntry = _getDLFileEntry(companyId, matcher);
+
+				if (dlFileEntry == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn("Missing file entry for URL " + src);
+					}
+
+					return 0;
+				}
 
 				return dlFileEntry.getFileEntryId();
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -13,10 +13,12 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
@@ -74,6 +76,8 @@ public class DDMFieldAttributeUpgradeProcessTest {
 		_assertContains(
 			journalArticle.getContent(),
 			"data-fileentryid=\"" + _dlFileEntry.getFileEntryId() + "\"");
+		_assertContains(
+			journalArticle.getContent(), "/documents/d/orphan/document");
 	}
 
 	private void _addDLFileEntry() throws Exception {
@@ -91,19 +95,35 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	}
 
 	private void _addJournalArticle() throws Exception {
-		String previewURL = DLURLHelperUtil.getPreviewURL(
-			new LiferayFileEntry(_dlFileEntry),
-			new LiferayFileVersion(_dlFileEntry.getFileVersion()), null, null);
+		boolean portletImportInProcess =
+			ExportImportThreadLocal.isPortletImportInProcess();
 
-		_journalArticle = JournalTestUtil.addArticleWithXMLContent(
-			DDMStructureTestUtil.getSampleStructuredContent(
-				"content",
-				Collections.singletonList(
-					HashMapBuilder.put(
-						LocaleUtil.US, "<img src=\"" + previewURL + "\"/>"
-					).build()),
-				LanguageUtil.getLanguageId(LocaleUtil.US)),
-			"BASIC-WEB-CONTENT", "BASIC-WEB-CONTENT");
+		try {
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			_journalArticle = JournalTestUtil.addArticleWithXMLContent(
+				DDMStructureTestUtil.getSampleStructuredContent(
+					"content",
+					Collections.singletonList(
+						HashMapBuilder.put(
+							LocaleUtil.US,
+							StringBundler.concat(
+								"<img src=\"",
+								DLURLHelperUtil.getPreviewURL(
+									new LiferayFileEntry(_dlFileEntry),
+									new LiferayFileVersion(
+										_dlFileEntry.getFileVersion()),
+									null, null),
+								"\"/><img src=\"/documents/d/orphan/document\"",
+								"/>")
+						).build()),
+					LanguageUtil.getLanguageId(LocaleUtil.US)),
+				"BASIC-WEB-CONTENT", "BASIC-WEB-CONTENT");
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(
+				portletImportInProcess);
+		}
 	}
 
 	private void _assertContains(String content, String fragment) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43352

Upgrading content with orphan references will fail.

# How am I fixing it?

By ignoring orphan references.

# How can you verify that it works?

Run the integration test:
```
$ gw testIntegration --tests '*.v5_6_1.test.DDMFieldAttributeUpgradeProcessTest'
```