### PR TITLE
LPD-43452  migrate some Categories.testcase to integration tests (Vocabulary tests)

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -21,15 +21,22 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
@@ -154,6 +161,20 @@ public class AssetVocabularyServiceTest {
 					externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(vocabulary1, vocabulary2);
+	}
+
+	@Test
+	public void testAddVocabularyWithViewPermission() throws Exception {
+		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(), RandomTestUtil.randomString());
+
+		_testAddVocabularyWithViewPermission(
+			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.GUEST);
+		_testAddVocabularyWithViewPermission(
+			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.OWNER);
+		_testAddVocabularyWithViewPermission(
+			String.valueOf(vocabulary.getPrimaryKey()),
+			RoleConstants.SITE_MEMBER);
 	}
 
 	@Test
@@ -545,6 +566,20 @@ public class AssetVocabularyServiceTest {
 		return results.getLength();
 	}
 
+	private void _testAddVocabularyWithViewPermission(
+			String primKey, String roleName)
+		throws Exception {
+
+		Role role = _roleLocalService.getRole(_group.getCompanyId(), roleName);
+
+		ResourcePermission resourcePermission =
+			_resourcePermissionLocalService.getResourcePermission(
+				_group.getCompanyId(), AssetVocabulary.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId());
+
+		Assert.assertTrue(resourcePermission.hasActionId(ActionKeys.VIEW));
+	}
+
 	@Inject
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
@@ -555,5 +590,11 @@ public class AssetVocabularyServiceTest {
 	private Group _group;
 
 	private Locale _locale;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -108,6 +108,20 @@ public class AssetVocabularyServiceTest {
 	}
 
 	@Test
+	public void testAddVocabulary() throws Exception {
+		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(), RandomTestUtil.randomString());
+
+		_testAddVocabulary(
+			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.GUEST);
+		_testAddVocabulary(
+			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.OWNER);
+		_testAddVocabulary(
+			String.valueOf(vocabulary.getPrimaryKey()),
+			RoleConstants.SITE_MEMBER);
+	}
+
+	@Test
 	public void testAddVocabularyWithExternalReferenceCode() throws Exception {
 		String externalReferenceCode = StringUtil.randomString();
 
@@ -161,20 +175,6 @@ public class AssetVocabularyServiceTest {
 					externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(vocabulary1, vocabulary2);
-	}
-
-	@Test
-	public void testAddVocabularyWithViewPermission() throws Exception {
-		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
-			_group.getGroupId(), RandomTestUtil.randomString());
-
-		_testAddVocabularyWithViewPermission(
-			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.GUEST);
-		_testAddVocabularyWithViewPermission(
-			String.valueOf(vocabulary.getPrimaryKey()), RoleConstants.OWNER);
-		_testAddVocabularyWithViewPermission(
-			String.valueOf(vocabulary.getPrimaryKey()),
-			RoleConstants.SITE_MEMBER);
 	}
 
 	@Test
@@ -566,8 +566,7 @@ public class AssetVocabularyServiceTest {
 		return results.getLength();
 	}
 
-	private void _testAddVocabularyWithViewPermission(
-			String primKey, String roleName)
+	private void _testAddVocabulary(String primKey, String roleName)
 		throws Exception {
 
 		Role role = _roleLocalService.getRole(_group.getCompanyId(), roleName);

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -14,7 +14,6 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -109,29 +108,28 @@ public class AssetVocabularyServiceTest {
 
 		String description = RandomTestUtil.randomString();
 
-		AssetVocabulary vocabulary =
-			AssetVocabularyLocalServiceUtil.addVocabulary(
-				externalReferenceCode, TestPropsValues.getUserId(),
-				_group.getGroupId(), StringPool.BLANK, StringPool.BLANK,
-				HashMapBuilder.put(
-					LocaleUtil.SPAIN, title + "_ES"
-				).put(
-					LocaleUtil.US, title + "_US"
-				).build(),
-				HashMapBuilder.put(
-					LocaleUtil.SPAIN, description + "_ES"
-				).put(
-					LocaleUtil.US, description + "_US"
-				).build(),
-				null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
-				ServiceContextTestUtil.getServiceContext(
-					_group.getGroupId(), TestPropsValues.getUserId()));
+		AssetVocabulary vocabulary = _assetVocabularyLocalService.addVocabulary(
+			externalReferenceCode, TestPropsValues.getUserId(),
+			_group.getGroupId(), StringPool.BLANK, StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, title + "_ES"
+			).put(
+				LocaleUtil.US, title + "_US"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, description + "_ES"
+			).put(
+				LocaleUtil.US, description + "_US"
+			).build(),
+			null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
 		Assert.assertEquals(
 			externalReferenceCode, vocabulary.getExternalReferenceCode());
 
 		vocabulary =
-			AssetVocabularyLocalServiceUtil.
+			_assetVocabularyLocalService.
 				getAssetVocabularyByExternalReferenceCode(
 					externalReferenceCode, _group.getGroupId());
 
@@ -151,7 +149,7 @@ public class AssetVocabularyServiceTest {
 		Assert.assertEquals(externalReferenceCode, vocabulary1.getUuid());
 
 		AssetVocabulary vocabulary2 =
-			AssetVocabularyLocalServiceUtil.
+			_assetVocabularyLocalService.
 				getAssetVocabularyByExternalReferenceCode(
 					externalReferenceCode, _group.getGroupId());
 
@@ -177,7 +175,7 @@ public class AssetVocabularyServiceTest {
 
 		Assert.assertEquals(initialAssetCategoriesCount + 2, searchCount());
 
-		AssetVocabularyLocalServiceUtil.deleteVocabulary(
+		_assetVocabularyLocalService.deleteVocabulary(
 			vocabulary.getVocabularyId());
 
 		Assert.assertEquals(initialAssetCategoriesCount, searchCount());
@@ -189,7 +187,7 @@ public class AssetVocabularyServiceTest {
 			AssetCategoryLocalServiceUtil.fetchAssetCategory(
 				category.getCategoryId()));
 		Assert.assertNull(
-			AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
+			_assetVocabularyLocalService.fetchAssetVocabulary(
 				vocabulary.getVocabularyId()));
 	}
 
@@ -201,7 +199,7 @@ public class AssetVocabularyServiceTest {
 		String title = RandomTestUtil.randomString();
 		String description = RandomTestUtil.randomString();
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), StringPool.BLANK, StringPool.BLANK,
 			HashMapBuilder.put(
@@ -218,7 +216,7 @@ public class AssetVocabularyServiceTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), StringPool.BLANK, StringPool.BLANK,
 			HashMapBuilder.put(
@@ -267,7 +265,7 @@ public class AssetVocabularyServiceTest {
 		serviceContext.setAddGroupPermissions(false);
 		serviceContext.setAddGuestPermissions(false);
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -302,7 +300,7 @@ public class AssetVocabularyServiceTest {
 		serviceContext.setAddGroupPermissions(false);
 		serviceContext.setAddGuestPermissions(false);
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -361,7 +359,7 @@ public class AssetVocabularyServiceTest {
 		serviceContext.setAddGroupPermissions(false);
 		serviceContext.setAddGuestPermissions(false);
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -395,7 +393,7 @@ public class AssetVocabularyServiceTest {
 		serviceContext.setAddGroupPermissions(false);
 		serviceContext.setAddGuestPermissions(false);
 
-		AssetVocabularyLocalServiceUtil.addVocabulary(
+		_assetVocabularyLocalService.addVocabulary(
 			TestPropsValues.getUserId(), _group.getGroupId(),
 			RandomTestUtil.randomString(), serviceContext);
 
@@ -456,7 +454,7 @@ public class AssetVocabularyServiceTest {
 		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.SPAIN);
 
 		AssetVocabulary vocabulary =
-			AssetVocabularyLocalServiceUtil.addDefaultVocabulary(
+			_assetVocabularyLocalService.addDefaultVocabulary(
 				_group.getGroupId());
 
 		Assert.assertEquals(
@@ -485,11 +483,10 @@ public class AssetVocabularyServiceTest {
 			LocaleUtil.US, description + "_US"
 		).build();
 
-		AssetVocabulary vocabulary =
-			AssetVocabularyLocalServiceUtil.addVocabulary(
-				TestPropsValues.getUserId(), _group.getGroupId(),
-				StringPool.BLANK, titleMap, descriptionMap, StringPool.BLANK,
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		AssetVocabulary vocabulary = _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), _group.getGroupId(), StringPool.BLANK,
+			titleMap, descriptionMap, StringPool.BLANK,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(
 			StringUtil.toLowerCase(titleMap.get(LocaleUtil.SPAIN)),
@@ -523,10 +520,9 @@ public class AssetVocabularyServiceTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
 
-		AssetVocabulary vocabulary =
-			AssetVocabularyLocalServiceUtil.addVocabulary(
-				TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
-				title, serviceContext);
+		AssetVocabulary vocabulary = _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			title, serviceContext);
 
 		Assert.assertEquals(title, vocabulary.getTitle(LocaleUtil.US, true));
 		Assert.assertEquals(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
@@ -378,33 +378,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewVocabularyPermissionsCP(viewableBy = null, vocabularyName = null) {
-		Navigator.gotoNavNested(navNested = ${vocabularyName});
-
-		WaitForLiferayEvent.initializeLiferayEventLog();
-
-		Click.waitForMenuToggleJSClick(
-			key_headerName = ${vocabularyName},
-			locator1 = "Portlet#H2_HEADER_VERTICAL_ELLIPSIS");
-
-		MenuItem.click(menuItem = "Permissions");
-
-		SelectFrame(locator1 = "IFrame#MODAL_BODY");
-
-		if (${viewableBy} == "Anyone (Guest Role)") {
-			AssertChecked.assertCheckedNotVisible(locator1 = "AssetPermissions#GUEST_VIEW_CHECKBOX");
-		}
-		else if (${viewableBy} == "Owner") {
-			AssertChecked.assertCheckedNotVisible(locator1 = "AssetPermissions#OWNER_VIEW_CHECKBOX");
-		}
-		else if (${viewableBy} == "Site Members") {
-			AssertChecked.assertCheckedNotVisible(locator1 = "AssetPermissions#SITE_MEMBER_VIEW_CHECKBOX");
-		}
-
-		SelectFrameTop(value1 = "relative=top");
-	}
-
-	@summary = "Default summary"
 	macro viewVocabularyVisibilityEdit(vocabularyName = null) {
 		Navigator.gotoNavNested(navNested = ${vocabularyName});
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/asset/categories/Vocabulary.macro
@@ -97,19 +97,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro addVocabularyWithNullTitle() {
-		Vocabulary.gotoAddVocabulary();
-
-		PortletEntry.inputName(name = " ");
-
-		Button.clickSave();
-
-		AssertTextEquals(
-			locator1 = "Message#REQUIRED_INFO",
-			value1 = "The Name field is required.");
-	}
-
-	@summary = "Default summary"
 	macro addWithAssociatedAssetTypeCP(assetSubtype = null, vocabularyName = null, rowNumber = null, required = null, assetType = null) {
 		Vocabulary.gotoAddVocabulary();
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetPermissions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetPermissions.path
@@ -30,16 +30,6 @@
 	<td>//input[@id='guest_ACTION_VIEW']</td>
 	<td></td>
 </tr>
-<tr>
-	<td>OWNER_VIEW_CHECKBOX</td>
-	<td>//input[@id='owner_ACTION_VIEW']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>SITE_MEMBER_VIEW_CHECKBOX</td>
-	<td>//input[@id='site-member_ACTION_VIEW']</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/Categories.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/Categories.testcase
@@ -257,42 +257,6 @@ definition {
 		}
 	}
 
-	@description = "Add a vocabulary with Guest view permission."
-	@priority = 3
-	test AddVocabularyWithGuestViewPermission {
-		task ("View the new vocabulary with Guest view permission") {
-			Category.openCategoriesAdmin(siteURLKey = "test-site-name");
-
-			Vocabulary.viewVocabularyPermissionsCP(
-				viewableBy = "Anyone (Guest Role)",
-				vocabularyName = "Vocabulary Name");
-		}
-	}
-
-	@description = "Add a vocabulary with Owner view permission."
-	@priority = 3
-	test AddVocabularyWithOwnerViewPermission {
-		task ("View the new vocabulary with Owner view permission") {
-			Category.openCategoriesAdmin(siteURLKey = "test-site-name");
-
-			Vocabulary.viewVocabularyPermissionsCP(
-				viewableBy = "Owner",
-				vocabularyName = "Vocabulary Name");
-		}
-	}
-
-	@description = "Add a vocabulary with Site Member view permission."
-	@priority = 3
-	test AddVocabularyWithSiteMemberViewPermission {
-		task ("View the new vocabulary with Site Member view permission") {
-			Category.openCategoriesAdmin(siteURLKey = "test-site-name");
-
-			Vocabulary.viewVocabularyPermissionsCP(
-				viewableBy = "Site Members",
-				vocabularyName = "Vocabulary Name");
-		}
-	}
-
 	@description = "Cancel a vocabulary creation."
 	@priority = 3
 	test CancelVocabularyCreation {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/Categories.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/Categories.testcase
@@ -360,16 +360,6 @@ definition {
 		}
 	}
 
-	@description = "Cannot add a vocabulary without title."
-	@priority = 3
-	test CannotAddVocabularyWithNullTitle {
-		task ("View cannot add a vocabulary without title") {
-			Category.openCategoriesAdmin(siteURLKey = "test-site-name");
-
-			Vocabulary.addVocabularyWithNullTitle();
-		}
-	}
-
 	@description = "Delete an associated asset type of vocabulary."
 	@priority = 3
 	test DeleteAssociatedAssetTypeOfVocabulary {


### PR DESCRIPTION
LPD-43452 Migrate AddVocabularyWith(Guest/SiteMember/Owner)ViewPermission to Integration test

This PR should be merged only after https://github.com/liferay-content-management/liferay-portal/pull/6150 because deletes some macros 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43452

To make the CI faster, is better to use integration/unit test than Poshi test.

# How am I fixing it?

Creating a test that summarize the behaviour that the POSHI tests were testing

# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-43452 use service instead of Util**
- **LPD-43452 migrate AddVocabularyWithGuestViewPermission, AddVocabularyWithOwnerViewPermission, and AddVocabularyWithSiteMemberViewPermission to integration tests**
- **LPD-43452 no needed, covered on testAddEmptyNameVocabulary**
