### PR TITLE
LPD-43468 Trim all titles to have the max size of name column

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -139,7 +138,7 @@ public class AssetCategoryLocalServiceTest {
 			_group.getGroupId());
 
 		String externalReferenceCode = StringUtil.randomString();
-		Locale locale = PortalUtil.getSiteDefaultLocale(_group.getGroupId());
+		Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
 
 		AssetCategoryLocalServiceUtil.addCategory(
 			externalReferenceCode, TestPropsValues.getUserId(),
@@ -233,7 +232,7 @@ public class AssetCategoryLocalServiceTest {
 			_group.getGroupId());
 
 		String externalReferenceCode = StringUtil.randomString();
-		Locale locale = PortalUtil.getSiteDefaultLocale(_group.getGroupId());
+		Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
 
 		AssetCategory assetCategory = AssetCategoryLocalServiceUtil.addCategory(
 			externalReferenceCode, TestPropsValues.getUserId(),

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -430,6 +430,54 @@ public class AssetCategoryLocalServiceTest {
 	}
 
 	@Test
+	public void testCategoryWithLongTitlesAreTrimmed() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		int nameMaxLength = ModelHintsUtil.getMaxLength(
+			AssetCategory.class.getName(), "name");
+
+		String assetCategoryTitle = RandomTestUtil.randomString(nameMaxLength);
+
+		Map<Locale, String> titleMap = HashMapBuilder.put(
+			LocaleUtil.SPAIN,
+			assetCategoryTitle + RandomTestUtil.randomString(10)
+		).put(
+			LocaleUtil.US, assetCategoryTitle + RandomTestUtil.randomString(10)
+		).build();
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			titleMap.get(_portal.getSiteDefaultLocale(_group.getGroupId())),
+			assetVocabulary.getVocabularyId(), serviceContext);
+
+		_testAssetCategoryLongTitlesAreTrimmed(
+			assetCategory, assetCategoryTitle);
+
+		assetCategory = _assetCategoryLocalService.updateCategory(
+			assetCategory.getUserId(), assetCategory.getCategoryId(),
+			assetCategory.getParentCategoryId(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN,
+				assetCategoryTitle + RandomTestUtil.randomString(10)
+			).put(
+				LocaleUtil.US,
+				assetCategoryTitle + RandomTestUtil.randomString(10)
+			).build(),
+			assetCategory.getDescriptionMap(), assetCategory.getVocabularyId(),
+			null, serviceContext);
+
+		_testAssetCategoryLongTitlesAreTrimmed(
+			assetCategory, assetCategoryTitle);
+	}
+
+	@Test
 	public void testDeleteCategory() throws Exception {
 		Map<Locale, String> titleMap = HashMapBuilder.put(
 			LocaleUtil.US, RandomTestUtil.randomString()
@@ -895,6 +943,18 @@ public class AssetCategoryLocalServiceTest {
 		return JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, serviceContext);
+	}
+
+	private void _testAssetCategoryLongTitlesAreTrimmed(
+		AssetCategory assetCategory, String title) {
+
+		Assert.assertEquals(title, assetCategory.getName());
+
+		Map<Locale, String> titleMap = assetCategory.getTitleMap();
+
+		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+			Assert.assertEquals(title, entry.getValue());
+		}
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -56,6 +56,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -105,16 +106,15 @@ public class AssetCategoryLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		Locale defaultLocale = PortalUtil.getSiteDefaultLocale(groupId);
-
-		String name = titleMap.get(defaultLocale);
-
-		name = ModelHintsUtil.trimString(
-			AssetCategory.class.getName(), "name", name);
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
 
 		if (categoryProperties == null) {
 			categoryProperties = new String[0];
 		}
+
+		Locale defaultLocale = PortalUtil.getSiteDefaultLocale(groupId);
+
+		String name = trimmedTitleMap.get(defaultLocale);
 
 		validate(0, parentCategoryId, name, vocabularyId);
 
@@ -150,7 +150,7 @@ public class AssetCategoryLocalServiceImpl
 		}
 
 		category.setName(name);
-		category.setTitleMap(titleMap);
+		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
 		category.setVocabularyId(vocabularyId);
 
@@ -625,13 +625,12 @@ public class AssetCategoryLocalServiceImpl
 		AssetCategory category = assetCategoryPersistence.findByPrimaryKey(
 			categoryId);
 
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
 		Locale defaultLocale = PortalUtil.getSiteDefaultLocale(
 			category.getGroupId());
 
-		String name = titleMap.get(defaultLocale);
-
-		name = ModelHintsUtil.trimString(
-			AssetCategory.class.getName(), "name", name);
+		String name = trimmedTitleMap.get(defaultLocale);
 
 		if (categoryProperties == null) {
 			categoryProperties = new String[0];
@@ -670,7 +669,7 @@ public class AssetCategoryLocalServiceImpl
 		}
 
 		category.setName(name);
-		category.setTitleMap(titleMap);
+		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
 
 		return assetCategoryPersistence.update(category);
@@ -771,6 +770,21 @@ public class AssetCategoryLocalServiceImpl
 					"There is another category named ", name,
 					" as a child of category ", parentCategoryId));
 		}
+	}
+
+	private Map<Locale, String> _getTrimmedTitleMap(
+		Map<Locale, String> titleMap) {
+
+		Map<Locale, String> trimmedTitleMap = new HashMap<>();
+
+		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+			trimmedTitleMap.put(
+				entry.getKey(),
+				ModelHintsUtil.trimString(
+					AssetCategory.class.getName(), "name", entry.getValue()));
+		}
+
+		return trimmedTitleMap;
 	}
 
 	private void _rebuildTreePath(


### PR DESCRIPTION
LPD-43468 When creating/editing a Category if you ignore the Front validator, you can add title on non-default languages on more than 255 characters

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43468

When you are creating or editing a Category a validation of the title is shown, but you can skip this validation if you change the language. So this can allow users to add a title for a language that is bigger that 255 characters, that is the max value of the name column and in the case of the default language, is trimmed to that value on backend

# How am I fixing it?

Trim all the titles, are the default or not. 

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-43468 use service instead util**
- **LPD-43468 add test to check that all the titles are trimmed**
- **LPD-43468 trim all the titles, not only the default locale**
