### PR TITLE
LPD-42720 Poshi migration > playwright | categories > properties

### DIFF
--- a/modules/test/playwright/tests/asset-categories-admin-web/categories.spec.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/categories.spec.ts
@@ -40,7 +40,7 @@ test('User can add, edit, delete properties in category.', async ({
 
 	await assetCategoriesAdminPage.goto(site.friendlyUrlPath);
 
-	await test.step('add', async () => {
+	await test.step('Add', async () => {
 		await assetCategoriesEditPage.goto(categoryName);
 		await assetCategoriesEditPage.addProperties(properties);
 
@@ -55,7 +55,7 @@ test('User can add, edit, delete properties in category.', async ({
 		await expect(page.getByLabel('value')).toHaveCount(3);
 	});
 
-	await test.step('edit', async () => {
+	await test.step('Edit', async () => {
 		const editedValue = 'value 2 - EDITED Category Property';
 		await page.getByLabel('value').nth(1).fill(editedValue);
 		await assetCategoriesEditPage.save();
@@ -64,8 +64,23 @@ test('User can add, edit, delete properties in category.', async ({
 		await expect(page.getByLabel('value').nth(1)).toHaveValue(editedValue);
 	});
 
-	await test.step('delete', async () => {
+	await test.step('Can not duplicate property key', async () => {
+		await assetCategoriesEditPage.addProperties(
+			{
+				[Object.keys(properties)[0]]: 'duplicated key',
+			},
+			{save: false}
+		);
+		await assetCategoriesEditPage.saveButton.click();
+
+		await expect(
+			page.getByText('Error:Please enter a unique property key.')
+		).toBeVisible();
+	});
+
+	await test.step('Delete', async () => {
 		await page.getByRole('button', {name: 'Remove'}).nth(1).click();
+		await page.getByRole('button', {name: 'Remove'}).last().click();
 		await assetCategoriesEditPage.save();
 
 		await assetCategoriesEditPage.goToPropertiesTab(categoryName);

--- a/modules/test/playwright/tests/asset-categories-admin-web/pages/AssetCategoriesEditPage.ts
+++ b/modules/test/playwright/tests/asset-categories-admin-web/pages/AssetCategoriesEditPage.ts
@@ -37,7 +37,10 @@ export class AssetCategoriesEditPage {
 		await this.propertiesTab.click();
 	}
 
-	async addProperties(properties: {[key: string]: string}) {
+	async addProperties(
+		properties: {[key: string]: string},
+		{save = true} = {}
+	) {
 		await this.propertiesTab.click();
 
 		const keyInputs = this.page.getByLabel('key');
@@ -60,8 +63,9 @@ export class AssetCategoriesEditPage {
 			await valueInput.fill(value);
 		}
 
-		await this.saveButton.click();
-		await waitForAlert(this.page);
+		if (save) {
+			await this.save();
+		}
 	}
 
 	async save() {


### PR DESCRIPTION
>[!NOTE]
> Follow up #6131 after analyzing test cases with @DiegoHu97 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-42720

Migrate some functional categories properties tests 
 - Can not add duplicated category properties key

# How am I fixing it?

Adding one extra step to the current test

# How can you verify that it works?

1. Go to `/modules/test/playwright`
1. Run `npm install` (setup)
1. Run npm run `npm run playwright test -- ./tests/asset-categories-admin-web/categories.spec.ts` to run the test

# Test launched 10 times test locally to avoid flaky results
![image](https://github.com/user-attachments/assets/12d451f9-b657-47af-bea9-c9c4d702e7a8)
