### PR TITLE
LPD-43566 migrate some Categories.testcase to integration tests (Vocabulary trim test)

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.Role;
@@ -119,6 +120,31 @@ public class AssetVocabularyServiceTest {
 		_testAddVocabulary(
 			String.valueOf(vocabulary.getPrimaryKey()),
 			RoleConstants.SITE_MEMBER);
+	}
+
+	@Test
+	public void testAddVocabularyLongTitlesAreTrimmed() throws Exception {
+		int nameMaxLength = ModelHintsUtil.getMaxLength(
+			AssetVocabulary.class.getName(), "name");
+
+		String title = RandomTestUtil.randomString(nameMaxLength);
+
+		AssetVocabulary vocabulary = _assetVocabularyLocalService.addVocabulary(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			StringPool.BLANK, StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, title + RandomTestUtil.randomString(10)
+			).put(
+				LocaleUtil.US, title + RandomTestUtil.randomString(10)
+			).build(),
+			null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(title.trim()), vocabulary.getName());
+
+		_testAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
 	}
 
 	@Test
@@ -550,6 +576,36 @@ public class AssetVocabularyServiceTest {
 			StringUtil.toLowerCase(title), vocabulary.getName());
 	}
 
+	@Test
+	public void testUpdateVocabularyLongTitlesAreTrimmed() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
+			_group.getGroupId(), name);
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(name.trim()), vocabulary.getName());
+
+		int nameMaxLength = ModelHintsUtil.getMaxLength(
+			AssetVocabulary.class.getName(), "name");
+
+		String title = RandomTestUtil.randomString(nameMaxLength);
+
+		vocabulary = _assetVocabularyLocalService.updateVocabulary(
+			vocabulary.getVocabularyId(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, title + RandomTestUtil.randomString(10)
+			).put(
+				LocaleUtil.US, title + RandomTestUtil.randomString(10)
+			).build(),
+			null, vocabulary.getSettings(), vocabulary.getVisibilityType());
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(name.trim()), vocabulary.getName());
+
+		_testAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -577,6 +633,16 @@ public class AssetVocabularyServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId());
 
 		Assert.assertTrue(resourcePermission.hasActionId(ActionKeys.VIEW));
+	}
+
+	private void _testAssetCategoryLongTitlesAreTrimmed(
+		AssetVocabulary assetVocabulary, String title) {
+
+		Map<Locale, String> titleMap = assetVocabulary.getTitleMap();
+
+		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+			Assert.assertEquals(title, entry.getValue());
+		}
 	}
 
 	@Inject

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -144,7 +144,7 @@ public class AssetVocabularyServiceTest {
 		Assert.assertEquals(
 			StringUtil.toLowerCase(title.trim()), vocabulary.getName());
 
-		_testAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
+		_assertAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
 	}
 
 	@Test
@@ -603,7 +603,7 @@ public class AssetVocabularyServiceTest {
 		Assert.assertEquals(
 			StringUtil.toLowerCase(name.trim()), vocabulary.getName());
 
-		_testAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
+		_assertAssetCategoryLongTitlesAreTrimmed(vocabulary, title);
 	}
 
 	@Rule
@@ -622,6 +622,16 @@ public class AssetVocabularyServiceTest {
 		return results.getLength();
 	}
 
+	private void _assertAssetCategoryLongTitlesAreTrimmed(
+		AssetVocabulary assetVocabulary, String title) {
+
+		Map<Locale, String> titleMap = assetVocabulary.getTitleMap();
+
+		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+			Assert.assertEquals(title, entry.getValue());
+		}
+	}
+
 	private void _testAddVocabulary(String primKey, String roleName)
 		throws Exception {
 
@@ -633,16 +643,6 @@ public class AssetVocabularyServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL, primKey, role.getRoleId());
 
 		Assert.assertTrue(resourcePermission.hasActionId(ActionKeys.VIEW));
-	}
-
-	private void _testAssetCategoryLongTitlesAreTrimmed(
-		AssetVocabulary assetVocabulary, String title) {
-
-		Map<Locale, String> titleMap = assetVocabulary.getTitleMap();
-
-		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
-			Assert.assertEquals(title, entry.getValue());
-		}
 	}
 
 	@Inject

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -12,9 +12,9 @@ import com.liferay.asset.kernel.exception.VocabularyNameException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -205,7 +205,7 @@ public class AssetVocabularyServiceTest {
 			ResourceActionLocalServiceUtil.getResourceActionsCount(
 				AssetVocabulary.class.getName()));
 		Assert.assertNull(
-			AssetCategoryLocalServiceUtil.fetchAssetCategory(
+			_assetCategoryLocalService.fetchAssetCategory(
 				category.getCategoryId()));
 		Assert.assertNull(
 			_assetVocabularyLocalService.fetchAssetVocabulary(
@@ -299,7 +299,7 @@ public class AssetVocabularyServiceTest {
 				user, permissionChecker)) {
 
 			List<AssetVocabulary> vocabularies =
-				AssetVocabularyServiceUtil.getGroupVocabularies(
+				_assetVocabularyService.getGroupVocabularies(
 					_group.getGroupId(), false, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null);
 
@@ -334,7 +334,7 @@ public class AssetVocabularyServiceTest {
 				user, permissionChecker)) {
 
 			List<AssetVocabulary> vocabularies =
-				AssetVocabularyServiceUtil.getGroupVocabularies(
+				_assetVocabularyService.getGroupVocabularies(
 					_group.getGroupId(), true, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS, null);
 
@@ -350,7 +350,7 @@ public class AssetVocabularyServiceTest {
 		throws Exception {
 
 		List<AssetVocabulary> vocabularies =
-			AssetVocabularyServiceUtil.getGroupVocabularies(
+			_assetVocabularyService.getGroupVocabularies(
 				_group.getGroupId(), false, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, null);
 
@@ -362,7 +362,7 @@ public class AssetVocabularyServiceTest {
 		throws Exception {
 
 		List<AssetVocabulary> vocabularies =
-			AssetVocabularyServiceUtil.getGroupVocabularies(
+			_assetVocabularyService.getGroupVocabularies(
 				_group.getGroupId(), true, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				null);
 
@@ -393,7 +393,7 @@ public class AssetVocabularyServiceTest {
 				user, permissionChecker)) {
 
 			List<AssetVocabulary> vocabularies =
-				AssetVocabularyServiceUtil.getGroupVocabularies(
+				_assetVocabularyService.getGroupVocabularies(
 					_group.getGroupId(), false);
 
 			Assert.assertTrue(ListUtil.isEmpty(vocabularies));
@@ -427,7 +427,7 @@ public class AssetVocabularyServiceTest {
 				user, permissionChecker)) {
 
 			List<AssetVocabulary> vocabularies =
-				AssetVocabularyServiceUtil.getGroupVocabularies(
+				_assetVocabularyService.getGroupVocabularies(
 					_group.getGroupId(), true);
 
 			Assert.assertTrue(ListUtil.isEmpty(vocabularies));
@@ -440,7 +440,7 @@ public class AssetVocabularyServiceTest {
 	@Test
 	public void testGetGroupVocabulariesWithNoVocabularies() throws Exception {
 		List<AssetVocabulary> vocabularies =
-			AssetVocabularyServiceUtil.getGroupVocabularies(
+			_assetVocabularyService.getGroupVocabularies(
 				_group.getGroupId(), false);
 
 		Assert.assertTrue(ListUtil.isEmpty(vocabularies));
@@ -451,7 +451,7 @@ public class AssetVocabularyServiceTest {
 		throws Exception {
 
 		List<AssetVocabulary> vocabularies =
-			AssetVocabularyServiceUtil.getGroupVocabularies(
+			_assetVocabularyService.getGroupVocabularies(
 				_group.getGroupId(), true);
 
 		Assert.assertEquals(vocabularies.toString(), 1, vocabularies.size());
@@ -580,7 +580,13 @@ public class AssetVocabularyServiceTest {
 	}
 
 	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject
+	private AssetVocabularyService _assetVocabularyService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -165,9 +166,11 @@ public class AssetVocabularyLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
+		Map<Locale, String> trimmedTitleMap = _getTrimmedTitleMap(titleMap);
+
 		if (Validator.isNull(name)) {
 			name = _generateVocabularyName(
-				groupId, titleMap.get(LocaleUtil.getSiteDefault()));
+				groupId, trimmedTitleMap.get(LocaleUtil.getSiteDefault()));
 		}
 
 		name = _getVocabularyName(name);
@@ -193,7 +196,7 @@ public class AssetVocabularyLocalServiceImpl
 			vocabulary.setTitle(title);
 		}
 		else {
-			vocabulary.setTitleMap(titleMap);
+			vocabulary.setTitleMap(trimmedTitleMap);
 		}
 
 		vocabulary.setDescriptionMap(descriptionMap);
@@ -473,7 +476,7 @@ public class AssetVocabularyLocalServiceImpl
 		AssetVocabulary vocabulary =
 			assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
 
-		vocabulary.setTitleMap(titleMap);
+		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
 		vocabulary.setDescriptionMap(descriptionMap);
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
@@ -492,7 +495,7 @@ public class AssetVocabularyLocalServiceImpl
 		AssetVocabulary vocabulary =
 			assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
 
-		vocabulary.setTitleMap(titleMap);
+		vocabulary.setTitleMap(_getTrimmedTitleMap(titleMap));
 
 		if (Validator.isNotNull(title)) {
 			vocabulary.setTitle(title);
@@ -590,6 +593,21 @@ public class AssetVocabularyLocalServiceImpl
 
 			curVocabularyName = curVocabularyName + CharPool.DASH + count++;
 		}
+	}
+
+	private Map<Locale, String> _getTrimmedTitleMap(
+		Map<Locale, String> titleMap) {
+
+		Map<Locale, String> trimmedTitleMap = new HashMap<>();
+
+		for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+			trimmedTitleMap.put(
+				entry.getKey(),
+				ModelHintsUtil.trimString(
+					AssetVocabulary.class.getName(), "name", entry.getValue()));
+		}
+
+		return trimmedTitleMap;
 	}
 
 	private String _getVocabularyName(String vocabularyName) {


### PR DESCRIPTION
LPD-43566 Migrate Vocabulary character limit to integration tests

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43566

We want to test that the user can not try to add a vocabulary with more than the limit of the name field.


# How am I fixing it?

Like on the frontend part, we trim the titles (all the titles) to the maxlength of the column

# How can you verify that it works?

Run the included automated tests.


# Commits



- **LPD-43566 use services instead of Utils**
- **LPD-43566 trim all the titles on the vocabulary to match with the name column**
- **LPD-43566 add test to check the vocabulary trimmed**
