### PR TITLE
LPD-43309 Translate tooltip in fieldset taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -30,10 +30,10 @@ else if (collapsible) {
 
 					<c:if test="<%= Validator.isNotNull(helpMessage) %>">
 						<clay:icon
-							aria-label="<%= helpMessage %>"
+							aria-label="<%= LanguageUtil.get(request, helpMessage) %>"
 							cssClass="lfr-portal-tooltip"
 							symbol="question-circle-full"
-							title="<%= helpMessage %>"
+							title="<%= LanguageUtil.get(request, helpMessage) %>"
 						/>
 					</c:if>
 

--- a/modules/test/playwright/tests/journal-web/journalFolder.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalFolder.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
+);
+
+test(
+	'Tooltip should be translated correctly',
+	{
+		tag: '@LPD-43309',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		await test.step('Create a web content folder and access to edit it', async () => {
+			const webContentFolder =
+				await apiHelpers.jsonWebServicesJournal.addFolder({
+					groupId: site.id,
+				});
+
+			await journalPage.goto(site.friendlyUrlPath);
+
+			await journalPage.changeView('cards');
+
+			await page
+				.locator(`.card-body:has-text('${webContentFolder.name}')`)
+				.getByLabel('More actions')
+				.click();
+
+			await page.getByRole('menuitem', {name: 'Edit'}).click();
+		});
+
+		await test.step('Check tooltip is translated', async () => {
+			const svgElement = page.locator(
+				'svg[aria-label="Folders can be restricted to only allow certain structures."]'
+			);
+
+			await expect(svgElement).toBeHidden();
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-56950
https://liferay.atlassian.net/browse/LPD-43309

Hello, can you take a look at this as it is related to journal-web?

Added translations to the aria-label and title so the tooltip would function correctly.

The playwright test checks to see if the tooltip is hidden and translated correctly.
Please let me know if there are any questions or comments about this.

Thank you!