### PR TITLE
LPD-43781 use url message instead label message for the url

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/FolderActionDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/FolderActionDisplayContext.java
@@ -200,7 +200,7 @@ public class FolderActionDisplayContext {
 							dropdownItem.putData(
 								"learnMessage", learnMessage.getMessage());
 							dropdownItem.putData(
-								"learnURL", learnMessage.getMessage());
+								"learnURL", learnMessage.getURL());
 
 							ThemeDisplay themeDisplay =
 								(ThemeDisplay)_httpServletRequest.getAttribute(


### PR DESCRIPTION
LPD-43781 URL 'Learn more' link on Folder dropdown menu has the title not the URL

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-57029

On the folder dropdown menu the link to the learn article of the modal of the 'Access from Desktop' action is not the url, is the title so do not go to any page.

# How am I fixing it?

Changing the erroneous href url to the correct one

# How can you verify that it works?

Steps to reproduce:

1. Access to Document & media in Liferay DXP site.
2. Create one folder
3. Click in the dropdown menú of the new folder
4. Click in 'Access from Desktop'
5. Click 'Learn More'


# Why doesn't this include any test?

- I do not think is possible to create an integration test. There is no action command that call the display context in particular and that display context is not easily accesible.
- On my opinion, a functional test to check that the link is the correct one it's not only expensive because you have to create a folder and see that the link on a modal is correct.and if the url changes it will fail. 
- Unitary test are pointless on this case. The LearnMessage is correct but to check it we should mock the LearnMessageUtil and then, check a mocked message is no use.



# Commits

- **LPD-43781 put the url instead the message on the url**
