### PR TITLE
[Release Blocker] LPD-43274 Check NPE 

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewKBArticleMVCRenderCommand.java
@@ -54,8 +54,10 @@ public class ViewKBArticleMVCRenderCommand implements MVCRenderCommand {
 		KBArticle kbArticle = (KBArticle)renderRequest.getAttribute(
 			KBWebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-		CTTimelineUtil.setCTTimelineKeys(
-			renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+		if (kbArticle != null) {
+			CTTimelineUtil.setCTTimelineKeys(
+				renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+		}
 
 		if (rootPortletId.equals(KBPortletKeys.KNOWLEDGE_BASE_ADMIN)) {
 			return "/admin/view_kb_article.jsp";

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -56,8 +56,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			KBArticle kbArticle = (KBArticle)renderRequest.getAttribute(
 				KBWebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-			CTTimelineUtil.setCTTimelineKeys(
-				renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+			if (kbArticle != null) {
+				CTTimelineUtil.setCTTimelineKeys(
+					renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+			}
 
 			return "/article/view.jsp";
 		}
@@ -66,8 +68,10 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			KBArticle kbArticle = (KBArticle)renderRequest.getAttribute(
 				KBWebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-			CTTimelineUtil.setCTTimelineKeys(
-				renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+			if (kbArticle != null) {
+				CTTimelineUtil.setCTTimelineKeys(
+					renderRequest, KBArticle.class, kbArticle.getKbArticleId());
+			}
 
 			return "/display/view.jsp";
 		}


### PR DESCRIPTION
LPD-43274 KB display Widget NullPointerException when KB is empty 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43274

After https://liferay.atlassian.net/browse/LPD-39430 there is a use of a object that can be null so we should check if is or not null

# How am I fixing it?

Checking if the object (kbArticle) is null before obtaining the id 

# How can you verify that it works?

This is covered by

LocalFile.KBDisplayWidget#CanDeleteArticle
LocalFile.KBDisplayWidget#CanViewEmptyState	
LocalFile.KBDisplayWidget#CanViewArticleAfterRestoring




# Commits

**LPD-43274 check NPE**