### PR TITLE
LPD-43926 Make QuestionsEntryTag#QuestionTagsCanBeSearchedInTagsTab more robust

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/questions/QuestionsEntryTag.testcase
@@ -472,6 +472,10 @@ definition {
 				layoutName = "questions-page",
 				siteURLKey = "guest");
 
+			WaitForElementPresent(
+				key_tagName = "tag1",
+				locator1 = "Questions#TAGS_LIST_TAB_NAMES");
+
 			Questions.search(
 				searchKey = "tag1",
 				searchTag = "true");


### PR DESCRIPTION
LPD-43926 Make QuestionsEntryTag#QuestionTagsCanBeSearchedInTagsTab more robust
# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-43926)

# How am I fixing it?

Wait until teh tags are a loaded because sometimes the widget takes some time to load the tags

# How can I test it?