### PR TITLE
 [Release Blocker] LPD-44101 add icon on translation entry renderer getIconCssClass method

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/asset/model/TranslationEntryAssetRendererFactory.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/asset/model/TranslationEntryAssetRendererFactory.java
@@ -54,6 +54,11 @@ public class TranslationEntryAssetRendererFactory
 	}
 
 	@Override
+	public String getIconCssClass() {
+		return "automatic-translate";
+	}
+
+	@Override
 	public String getType() {
 		return "translation";
 	}


### PR DESCRIPTION
LPD-44101 add the method to show the translation icon on the workflow task

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44101

The clay:icon from 'edit_workflow_task.jsp' is throwing a NPE id cssClass is null.

# How am I fixing it?

Adding the _getIconCssClass_ method to show the translation icon on the workflow task

# How can you verify that it works?

1. Enable workflow for Translations (for left product menu: Configuration > Workflow > Translations > Single Approver)
2. Create a Basic Web Content and Publish 
3. From the options menu, select Translate 
4. Once translated, click Submit for Workflow 
5. Go to user profile icon, and select My workflow task 
6. Access to the translation task 


Covered by : 
LocalFile.TranslationsWorkflow#CanApproveEntry
LocalFile.TranslationsWorkflow#CanResubmitRejectedEntries


# Commits

LPD-44101 clay:icon form edit_workflow_task is throwing a NPE id cssClass is null. So on TranslationEntryAssetRendererFactory add the method to show the translation icon on the workflow task