### PR TITLE
[Release Blocker]  LPD-44157 if parts has one element can have article, so only skip if there is none

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
@@ -110,7 +110,7 @@ public class KBArticleLayoutDisplayPageProvider
 		try {
 			List<String> parts = StringUtil.split(urlTitle, CharPool.SLASH);
 
-			if (parts.size() <= 1) {
+			if (parts.isEmpty()) {
 				return null;
 			}
 


### PR DESCRIPTION
LPD-44157 KB is not shown when accessing from FriendlyURL on Display Page

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44157

On some cases (/web/site-name/k/knowledge-base-article-title) the friendlyURL comes this way and arrives as /knowledge-base-article-title.

# How am I fixing it?

Allow to search of the kbartricle if the url title can be divided on at least one direction

# How can you verify that it works?

Covered by: 
[LocalFile.KBDisplayPage#CanUpdateMaxNestingForArticleNavigation](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/85270592/case-result/85601045)

[LocalFile.KBDisplayPage#CanViewArticlesViaKBNavigation](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/85270592/case-result/85526421)

[LocalFile.KBDisplayPage#CanViewArticleWithDefaultTemplate](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/85270592/case-result/85534864)
and KBArticleLayoutDisplayPageProviderTest
 

- Steps to reproduce:

- Go to Design > Page Templates > Display Page Templates and create one for Knowledge Base
- Name: DPT for KB 
- Content Type: Knowledge Base Article
- Add a Knowledge Base Navigation fragment on it. 
- Go to Content & Data > Knowledge Base and create an article with the previous Display Page Template
- Title: KB Article (friendly url will be kb-article)
- Try to access http://localhost:8080/web/guest/k/kb-article 

# Commits

LPD-44157 if parts has one element can have article, so only skip if there is none