### PR TITLE
LPD-33262 Apply ERC to Documents & Media widget configuration

### DIFF
--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -13,8 +13,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")
 	testIntegrationImplementation project(":apps:product-navigation:product-navigation-control-menu-api")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/GetExternalReferenceCodeMVCResourceCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/GetExternalReferenceCodeMVCResourceCommandTest.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Attila Bakay
+ */
+@RunWith(Arquillian.class)
+public class GetExternalReferenceCodeMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Test
+	public void testGetHomeFolderExternalReferenceCode() throws Exception {
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(_group.getGroupId(), 0),
+			mockLiferayResourceResponse);
+
+		JSONObject jsonObject = _getResponseJSONObject(
+			mockLiferayResourceResponse);
+
+		Assert.assertEquals(
+			_group.getGroupId(), jsonObject.getLong("repositoryGroupId"));
+		Assert.assertEquals(
+			_group.getExternalReferenceCode(),
+			jsonObject.getString("selectedRepositoryExternalReferenceCode"));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			jsonObject.getString("rootFolderExternalReferenceCode"));
+	}
+
+	@Test
+	public void testGetSpecificFolderExternalReferenceCode() throws Exception {
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(
+				_group.getGroupId(), _folder.getFolderId()),
+			mockLiferayResourceResponse);
+
+		JSONObject jsonObject = _getResponseJSONObject(
+			mockLiferayResourceResponse);
+
+		Assert.assertEquals(
+			_group.getGroupId(), jsonObject.getLong("repositoryGroupId"));
+		Assert.assertEquals(
+			_group.getExternalReferenceCode(),
+			jsonObject.getString("selectedRepositoryExternalReferenceCode"));
+		Assert.assertEquals(
+			_folder.getExternalReferenceCode(),
+			jsonObject.getString("rootFolderExternalReferenceCode"));
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
+			long selectedRepositoryId, long rootFolderId)
+		throws Exception {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		mockLiferayResourceRequest.setParameter(
+			"selectedRepositoryId", String.valueOf(selectedRepositoryId));
+		mockLiferayResourceRequest.setParameter(
+			"rootFolderId", String.valueOf(rootFolderId));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private JSONObject _getResponseJSONObject(
+			MockLiferayResourceResponse mockLiferayResourceResponse)
+		throws Exception {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			(ByteArrayOutputStream)
+				mockLiferayResourceResponse.getPortletOutputStream();
+
+		return JSONFactoryUtil.createJSONObject(
+			new String(byteArrayOutputStream.toByteArray()));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	private Folder _folder;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "mvc.command.name=/document_library/get_external_reference_code"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+}

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Attila Bakay
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletPreferencesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_folder = _dlAppLocalService.addFolder(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, DLPortletKeys.DOCUMENT_LIBRARY);
+	}
+
+	@Test
+	public void testUpgradeHomeFolderSelected() throws Exception {
+		_testUpgrade(
+			HashMapBuilder.put(
+				"repositoryGroupId", String.valueOf(_group.getGroupId())
+			).put(
+				"rootFolderExternalReferenceCode", StringPool.BLANK
+			).put(
+				"rootFolderId", "0"
+			).put(
+				"selectedRepositoryExternalReferenceCode",
+				_group.getExternalReferenceCode()
+			).put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build(),
+			HashMapBuilder.put(
+				"rootFolderId", "0"
+			).put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build());
+	}
+
+	@Test
+	public void testUpgradeWithoutSelectedFolder() throws Exception {
+		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
+	}
+
+	@Test
+	public void testUpgradeWithSelectedFolder() throws Exception {
+		_testUpgrade(
+			HashMapBuilder.put(
+				"repositoryGroupId", String.valueOf(_group.getGroupId())
+			).put(
+				"rootFolderExternalReferenceCode",
+				_folder.getExternalReferenceCode()
+			).put(
+				"rootFolderId", String.valueOf(_folder.getFolderId())
+			).put(
+				"selectedRepositoryExternalReferenceCode",
+				_group.getExternalReferenceCode()
+			).put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build(),
+			HashMapBuilder.put(
+				"rootFolderId", String.valueOf(_folder.getFolderId())
+			).put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build());
+	}
+
+	private void _assertPortletPreferences(Map<String, String> expectedMap)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		Map<String, String[]> map = portletPreferences.getMap();
+
+		Assert.assertEquals(
+			MapUtil.toString(map), expectedMap.size(), map.size());
+
+		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
+			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
+
+			Assert.assertArrayEquals(
+				new String[] {entry.getValue()}, map.get(entry.getKey()));
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _testUpgrade(
+			Map<String, String> expectedMap, Map<String, String> map)
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreferences(_layout, _portletId, map);
+
+		_assertPortletPreferences(map);
+
+		_runUpgrade();
+
+		_assertPortletPreferences(expectedMap);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.document.library.web.internal.upgrade.v1_1_0." +
+			"UpgradePortletPreferences";
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	private Folder _folder;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private String _portletId;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.document.library.web.internal.upgrade.registry.DLWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
@@ -11,12 +11,16 @@ import com.liferay.document.library.web.internal.display.context.DLAdminDisplayC
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.PortletConfig;
+import javax.portlet.PortletRequest;
+import javax.portlet.ResourceURL;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -51,6 +55,20 @@ public class DLConfigurationAction
 				httpServletRequest, httpServletResponse));
 		httpServletRequest.setAttribute(
 			ItemSelector.class.getName(), _itemSelector);
+
+		ResourceURL getExternalReferenceCodeURL =
+			(ResourceURL)PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					httpServletRequest, DLPortletKeys.DOCUMENT_LIBRARY,
+					PortletRequest.RESOURCE_PHASE)
+			).buildPortletURL();
+
+		getExternalReferenceCodeURL.setResourceID(
+			"/document_library/get_external_reference_code");
+
+		httpServletRequest.setAttribute(
+			"getExternalReferenceCodeURL",
+			getExternalReferenceCodeURL.toString());
 
 		super.include(portletConfig, httpServletRequest, httpServletResponse);
 	}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/GetExternalReferenceCodeMVCResourceCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/GetExternalReferenceCodeMVCResourceCommand.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.portlet.action;
+
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Attila Bakay
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY,
+		"javax.portlet.name=" + DLPortletKeys.DOCUMENT_LIBRARY_ADMIN,
+		"mvc.command.name=/document_library/get_external_reference_code"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetExternalReferenceCodeMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	public void doServeResource(
+		ResourceRequest resourceRequest, ResourceResponse resourceResponse) {
+
+		try {
+			HttpServletRequest httpServletRequest =
+				_portal.getOriginalServletRequest(
+					_portal.getHttpServletRequest(resourceRequest));
+
+			long selectedRepositoryId = ParamUtil.getLong(
+				httpServletRequest, "selectedRepositoryId");
+
+			long rootFolderId = ParamUtil.getLong(
+				httpServletRequest, "rootFolderId");
+
+			String folderExternalReferenceCode = "";
+
+			if (rootFolderId != 0) {
+				Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+
+				folderExternalReferenceCode = folder.getExternalReferenceCode();
+			}
+
+			Repository selectedRepository =
+				_repositoryLocalService.fetchRepository(selectedRepositoryId);
+
+			String selectedRepositoryExternalReferenceCode = "";
+			long repositoryGroupId = 0;
+
+			if (selectedRepository != null) {
+				selectedRepositoryExternalReferenceCode =
+					selectedRepository.getExternalReferenceCode();
+				repositoryGroupId = selectedRepository.getGroupId();
+			}
+			else {
+				Group group = _groupLocalService.getGroup(selectedRepositoryId);
+
+				selectedRepositoryExternalReferenceCode =
+					group.getExternalReferenceCode();
+
+				repositoryGroupId = selectedRepositoryId;
+			}
+
+			HttpServletResponse httpServletResponse =
+				_portal.getHttpServletResponse(resourceResponse);
+
+			httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"repositoryGroupId", repositoryGroupId
+				).put(
+					"rootFolderExternalReferenceCode",
+					folderExternalReferenceCode
+				).put(
+					"selectedRepositoryExternalReferenceCode",
+					selectedRepositoryExternalReferenceCode
+				));
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetExternalReferenceCodeMVCResourceCommand.class);
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
@@ -83,9 +83,22 @@ public class DLPortletInstanceSettings {
 		return _typedSettings.getValues("mimeTypes", _MIME_TYPES_DEFAULT);
 	}
 
+	public long getRepositoryGroupId() {
+		return _typedSettings.getLongValue("repositoryGroupId");
+	}
+
+	public String getRootFolderExternalReferenceCode() {
+		return _typedSettings.getValue("rootFolderExternalReferenceCodes");
+	}
+
 	public long getRootFolderId() {
 		return _typedSettings.getLongValue(
 			"rootFolderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
+	public String getSelectedRepositoryExternalReferenceCode() {
+		return _typedSettings.getValue(
+			"selectedRepositoryExternalReferenceCodes");
 	}
 
 	public long getSelectedRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
@@ -6,11 +6,13 @@
 package com.liferay.document.library.web.internal.upgrade.registry;
 
 import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradeAdminPortlets;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletSettings;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.upgrade.BaseStagingGroupTypeSettingsUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -40,13 +42,26 @@ public class DLWebUpgradeStepRegistrator implements UpgradeStepRegistrator {
 				DLPortletKeys.DOCUMENT_LIBRARY_ADMIN));
 
 		registry.register("1.0.1", "1.0.2", new UpgradePortletPreferences());
+
+		registry.register(
+			"1.0.2", "1.1.0",
+			new com.liferay.document.library.web.internal.upgrade.v1_1_0.
+				UpgradePortletPreferences(
+					_dlAppLocalService, _groupLocalService,
+					_repositoryLocalService));
 	}
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
 
 	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
 
 	@Reference
 	private SettingsLocatorHelper _settingsLocatorHelper;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_1_0;
+
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import javax.portlet.PortletPreferences;
+
+/**
+ * @author Attila Bakay
+ */
+public class UpgradePortletPreferences
+	extends BasePortletPreferencesUpgradeProcess {
+
+	public UpgradePortletPreferences(
+		DLAppLocalService dlAppLocalService,
+		GroupLocalService groupLocalService,
+		RepositoryLocalService repositoryLocalService) {
+
+		_dlAppLocalService = dlAppLocalService;
+		_groupLocalService = groupLocalService;
+		_repositoryLocalService = repositoryLocalService;
+	}
+
+	@Override
+	protected String[] getPortletIds() {
+		return new String[] {DLPortletKeys.DOCUMENT_LIBRARY + "_INSTANCE_%"};
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		long rootFolderId = GetterUtil.getLong(
+			portletPreferences.getValue("rootFolderId", "-1"));
+
+		if (rootFolderId == -1) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+
+		String rootFolderExternalReferenceCode = "";
+
+		if (rootFolderId != 0) {
+			Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+
+			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
+		}
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
+
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", null));
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			selectedRepositoryId);
+
+		String selectedRepositoryExternalReferenceCode = "";
+		long repositoryGroupId = 0;
+
+		if (selectedRepository != null) {
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+			repositoryGroupId = selectedRepository.getGroupId();
+		}
+		else {
+			Group group = _groupLocalService.getGroup(selectedRepositoryId);
+
+			selectedRepositoryExternalReferenceCode =
+				group.getExternalReferenceCode();
+
+			repositoryGroupId = selectedRepositoryId;
+		}
+
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode);
+
+		portletPreferences.setValue(
+			"repositoryGroupId", String.valueOf(repositoryGroupId));
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+
+	private final DLAppLocalService _dlAppLocalService;
+	private final GroupLocalService _groupLocalService;
+	private final RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -32,7 +32,10 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 	<liferay-ui:error key="rootFolderIdInvalid" message="please-enter-a-valid-root-folder" />
 
 	<liferay-frontend:edit-form-body>
-		<aui:input name="preferences--selectedRepositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getSelectedRepositoryId() %>" />
+		<aui:input id="selectedRepositoryId" name="preferences--selectedRepositoryId--" type="hidden" value="<%= dlAdminDisplayContext.getSelectedRepositoryId() %>" />
+		<aui:input id="selectedRepositoryExternalReferenceCode" name="preferences--selectedRepositoryExternalReferenceCode--" type="hidden" />
+		<aui:input id="rootFolderExternalReferenceCode" name="preferences--rootFolderExternalReferenceCode--" type="hidden" />
+		<aui:input id="repositoryGroupId" name="preferences--repositoryGroupId--" type="hidden" />
 		<aui:input name="preferences--displayViews--" type="hidden" />
 		<aui:input name="preferences--entryColumns--" type="hidden" />
 
@@ -180,15 +183,55 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 		var Util = Liferay.Util;
 
-		Util.postForm(form, {
-			data: {
-				displayViews: Util.getSelectedOptionValues(
-					Util.getFormElement(form, 'currentDisplayViews')
-				),
-				entryColumns: Util.getSelectedOptionValues(
-					Util.getFormElement(form, 'currentEntryColumns')
-				),
-			},
-		});
+		var selectedRepositoryIdInput = Util.getFormElement(
+			form,
+			'selectedRepositoryId'
+		);
+
+		var rootFolderIdInput = Util.getFormElement(
+			form,
+			'preferences--rootFolderId--'
+		);
+
+		var rootFolderExternalReferenceCodeInput = Util.getFormElement(
+			form,
+			'rootFolderExternalReferenceCode'
+		);
+
+		var repositoryGroupIdInput = Util.getFormElement(form, 'repositoryGroupId');
+
+		var selectedRepositoryExternalReferenceCodeInput = Util.getFormElement(
+			form,
+			'selectedRepositoryExternalReferenceCode'
+		);
+
+		Util.fetch(
+			'<%= (String)request.getAttribute("getExternalReferenceCodeURL") %>&selectedRepositoryId=' +
+				selectedRepositoryIdInput.value +
+				'&rootFolderId=' +
+				rootFolderIdInput.value
+		)
+			.then((response) => {
+				return response.json();
+			})
+			.then((response) => {
+				selectedRepositoryExternalReferenceCodeInput.value =
+					response.selectedRepositoryExternalReferenceCode;
+				rootFolderExternalReferenceCodeInput.value =
+					response.rootFolderExternalReferenceCode;
+				repositoryGroupIdInput.value = response.repositoryGroupId;
+			})
+			.then((response) => {
+				Util.postForm(form, {
+					data: {
+						displayViews: Util.getSelectedOptionValues(
+							Util.getFormElement(form, 'currentDisplayViews')
+						),
+						entryColumns: Util.getSelectedOptionValues(
+							Util.getFormElement(form, 'currentEntryColumns')
+						),
+					},
+				});
+			});
 	}
 </aui:script>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33262

Add externalReferenceCode to the portlet preferences to match current ID references for the batch framework.

# How am I fixing it?

I'm adding a resource command to provide the ERC I could not remove the IDs as the current widget framework and a few taglibs heavily depend on it.

# How can you verify that it works?


Integration tests
` gw testIntegration --tests UpgradePortletPreferencesTest`
` gw testIntegration --tests GetExternalReferenceCodeMVCResourceCommandTest`
