### PR TITLE
LPD-44341 Fix poshi test WebContent#ViewDoAsUserIdNotShownInURLFieldAfterAddPageLinkToText

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
@@ -151,7 +151,7 @@ definition {
 		if (isSet(entryExternalURL)) {
 			AssertTextEquals(
 				key_text = "URL",
-				locator1 = "TextInput#ANY",
+				locator1 = "CKEditor#MODAL_INPUT",
 				value1 = ${entryExternalURL});
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -336,6 +336,14 @@
 	<td>//*[contains(@class,'cke_dialog_contents')]//*[contains(@class,'CodeMirror-wrap')]</td>
 	<td></td>
 </tr>
+
+<!--MODAL-->
+
+<tr>
+	<td>MODAL_INPUT</td>
+	<td>//div[label[contains(.,'${key_text}')]]//input[contains(@class, 'cke_dialog_ui')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44341

Fix Poshi test `WebContent#ViewDoAsUserIdNotShownInURLFieldAfterAddPageLinkToText`

# How am I fixing it?

The generic path is resolving in three UI elements now, I added one specific for CKEditor modal input

# How can you verify that it works?

Run Poshi test `WebContent#ViewDoAsUserIdNotShownInURLFieldAfterAddPageLinkToText`

# Tested in local
![image](https://github.com/user-attachments/assets/959de723-bc5a-4c79-ad1e-26077b440459)

