### PR TITLE
LPD-44108 Improve journalArticle.spec.ts > Can paginate Web Content in an Asset Publisher

### DIFF
--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1565,6 +1565,7 @@ assetPublisherDeprecationTest(
 		tag: '@LPD-35348',
 	},
 	async ({
+		apiHelpers,
 		journalEditArticlePage,
 		journalPage,
 		page,
@@ -1588,11 +1589,12 @@ assetPublisherDeprecationTest(
 
 		await pagesAdminPage.goto(site.friendlyUrlPath);
 
-		const name = getRandomString();
-		await pagesAdminPage.addWidgetPage({name});
+		const widgetLayout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
 
-		await pagesAdminPage.goto(site.friendlyUrlPath);
-		await page.getByLabel(name, {exact: true}).click();
+		await widgetPagePage.goto(widgetLayout, site.friendlyUrlPath);
 
 		await widgetPagePage.addPortlet('Asset Publisher');
 		await page
@@ -1621,8 +1623,7 @@ assetPublisherDeprecationTest(
 		await configurationFrame.getByRole('button', {name: 'Save'}).click();
 		await page.getByLabel('close', {exact: true}).click();
 
-		await pagesAdminPage.goto(site.friendlyUrlPath);
-		await page.getByLabel(name, {exact: true}).click();
+		await widgetPagePage.goto(widgetLayout, site.friendlyUrlPath);
 
 		await page.getByLabel('Go to page, 2').click();
 


### PR DESCRIPTION
LPD-44108 Improve journalArticle.spec.ts > Can paginate Web Content in an Asset Publisher

# What is this trying to solve?
The test failed because when clicking in the widget page name it finds two locators, soI have improved the test creating and accessing the widget page by API and friendly URL.
The test failed on the release test failures and since then it has been passing but I found it interesting to improve the test.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-44108)

# How can I test it?
Run the PW test 
![image](https://github.com/user-attachments/assets/7665b8c8-a7a6-4718-a760-e29df3c8cb96)
