### PR TITLE
LPD-43466 Data Migration is not applied on additional database partitions

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
@@ -42,13 +42,8 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 		_transfer(sourceStore, targetStore, true);
 	}
 
-	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
-		throws PortalException {
-
-		int count = _amImageEntryLocalService.getAMImageEntriesCount();
-
-		MaintenanceUtil.appendStatus(
-			"Migrating images in " + count + " adaptive media image entries");
+	private ActionableDynamicQuery _getActionableDynamicQuery(
+		Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_amImageEntryLocalService.getActionableDynamicQuery();
@@ -87,6 +82,20 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 					}
 				}
 			});
+
+		return actionableDynamicQuery;
+	}
+
+	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
+		throws PortalException {
+
+		int count = _amImageEntryLocalService.getAMImageEntriesCount();
+
+		MaintenanceUtil.appendStatus(
+			"Migrating images in " + count + " adaptive media image entries");
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_getActionableDynamicQuery(sourceStore, targetStore, delete);
 
 		actionableDynamicQuery.performActions();
 	}

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
@@ -12,8 +12,11 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.util.MaintenanceUtil;
 
 import java.io.IOException;
@@ -43,10 +46,14 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 	}
 
 	private ActionableDynamicQuery _getActionableDynamicQuery(
-		Store sourceStore, Store targetStore, boolean delete) {
+		long companyId, Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_amImageEntryLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("companyId", companyId)));
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(AMImageEntry amImageEntry) -> {
@@ -86,22 +93,38 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 		return actionableDynamicQuery;
 	}
 
+	private long _getCount(long companyId) {
+		DynamicQuery dynamicQuery = _amImageEntryLocalService.dynamicQuery();
+
+		dynamicQuery.add(RestrictionsFactoryUtil.eq("companyId", companyId));
+
+		return _amImageEntryLocalService.dynamicQueryCount(dynamicQuery);
+	}
+
 	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
 		throws PortalException {
 
-		int count = _amImageEntryLocalService.getAMImageEntriesCount();
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				MaintenanceUtil.appendStatus(
+					String.format(
+						"Migrating images in %d adaptive media image entries " +
+							"for company %d",
+						_getCount(companyId), companyId));
 
-		MaintenanceUtil.appendStatus(
-			"Migrating images in " + count + " adaptive media image entries");
+				ActionableDynamicQuery actionableDynamicQuery =
+					_getActionableDynamicQuery(
+						companyId, sourceStore, targetStore, delete);
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			_getActionableDynamicQuery(sourceStore, targetStore, delete);
-
-		actionableDynamicQuery.performActions();
+				actionableDynamicQuery.performActions();
+			});
 	}
 
 	@Reference
 	private AMImageEntryLocalService _amImageEntryLocalService;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private DLAppService _dlAppService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLFileVersionDLStoreConvertProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLFileVersionDLStoreConvertProcess.java
@@ -42,13 +42,8 @@ public class DLFileVersionDLStoreConvertProcess
 		_transfer(sourceStore, targetStore, true);
 	}
 
-	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
-		throws PortalException {
-
-		int count = _dlFileVersionLocalService.getDLFileVersionsCount();
-
-		MaintenanceUtil.appendStatus(
-			"Migrating " + count + " documents and media files");
+	private ActionableDynamicQuery _getActionableDynamicQuery(
+		Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_dlFileVersionLocalService.getActionableDynamicQuery();
@@ -79,6 +74,20 @@ public class DLFileVersionDLStoreConvertProcess
 						exception);
 				}
 			});
+
+		return actionableDynamicQuery;
+	}
+
+	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
+		throws PortalException {
+
+		int count = _dlFileVersionLocalService.getDLFileVersionsCount();
+
+		MaintenanceUtil.appendStatus(
+			"Migrating " + count + " documents and media files");
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_getActionableDynamicQuery(sourceStore, targetStore, delete);
 
 		actionableDynamicQuery.performActions();
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLFileVersionDLStoreConvertProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLFileVersionDLStoreConvertProcess.java
@@ -13,9 +13,12 @@ import com.liferay.document.library.kernel.service.DLFileVersionLocalService;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.util.MaintenanceUtil;
 
 import org.osgi.service.component.annotations.Component;
@@ -43,10 +46,14 @@ public class DLFileVersionDLStoreConvertProcess
 	}
 
 	private ActionableDynamicQuery _getActionableDynamicQuery(
-		Store sourceStore, Store targetStore, boolean delete) {
+		long companyId, Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_dlFileVersionLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("companyId", companyId)));
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(DLFileVersion dlFileVersion) -> {
@@ -78,22 +85,37 @@ public class DLFileVersionDLStoreConvertProcess
 		return actionableDynamicQuery;
 	}
 
+	private long _getCount(long companyId) {
+		DynamicQuery dynamicQuery = _dlFileVersionLocalService.dynamicQuery();
+
+		dynamicQuery.add(RestrictionsFactoryUtil.eq("companyId", companyId));
+
+		return _dlFileVersionLocalService.dynamicQueryCount(dynamicQuery);
+	}
+
 	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
 		throws PortalException {
 
-		int count = _dlFileVersionLocalService.getDLFileVersionsCount();
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				MaintenanceUtil.appendStatus(
+					String.format(
+						"Migrating %d documents and media files for company %d",
+						_getCount(companyId), companyId));
 
-		MaintenanceUtil.appendStatus(
-			"Migrating " + count + " documents and media files");
+				ActionableDynamicQuery actionableDynamicQuery =
+					_getActionableDynamicQuery(
+						companyId, sourceStore, targetStore, delete);
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			_getActionableDynamicQuery(sourceStore, targetStore, delete);
-
-		actionableDynamicQuery.performActions();
+				actionableDynamicQuery.performActions();
+			});
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFileVersionDLStoreConvertProcess.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/ImageDLStoreConvertProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/ImageDLStoreConvertProcess.java
@@ -39,12 +39,8 @@ public class ImageDLStoreConvertProcess implements DLStoreConvertProcess {
 		_transfer(sourceStore, targetStore, true);
 	}
 
-	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
-		throws PortalException {
-
-		int count = _imageLocalService.getImagesCount();
-
-		MaintenanceUtil.appendStatus("Migrating " + count + " images");
+	private ActionableDynamicQuery _getActionableDynamicQuery(
+		Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_imageLocalService.getActionableDynamicQuery();
@@ -64,6 +60,19 @@ public class ImageDLStoreConvertProcess implements DLStoreConvertProcess {
 					_log.error("Unable to migrate " + fileName, exception);
 				}
 			});
+
+		return actionableDynamicQuery;
+	}
+
+	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
+		throws PortalException {
+
+		int count = _imageLocalService.getImagesCount();
+
+		MaintenanceUtil.appendStatus("Migrating " + count + " images");
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_getActionableDynamicQuery(sourceStore, targetStore, delete);
 
 		actionableDynamicQuery.performActions();
 	}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/ImageDLStoreConvertProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/ImageDLStoreConvertProcess.java
@@ -9,10 +9,13 @@ import com.liferay.document.library.kernel.store.Store;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.util.MaintenanceUtil;
 
@@ -40,10 +43,14 @@ public class ImageDLStoreConvertProcess implements DLStoreConvertProcess {
 	}
 
 	private ActionableDynamicQuery _getActionableDynamicQuery(
-		Store sourceStore, Store targetStore, boolean delete) {
+		long companyId, Store sourceStore, Store targetStore, boolean delete) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_imageLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("companyId", companyId)));
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(Image image) -> {
@@ -64,23 +71,39 @@ public class ImageDLStoreConvertProcess implements DLStoreConvertProcess {
 		return actionableDynamicQuery;
 	}
 
+	private long _getCount(long companyId) {
+		DynamicQuery dynamicQuery = _imageLocalService.dynamicQuery();
+
+		dynamicQuery.add(RestrictionsFactoryUtil.eq("companyId", companyId));
+
+		return _imageLocalService.dynamicQueryCount(dynamicQuery);
+	}
+
 	private void _transfer(Store sourceStore, Store targetStore, boolean delete)
 		throws PortalException {
 
-		int count = _imageLocalService.getImagesCount();
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				MaintenanceUtil.appendStatus(
+					String.format(
+						"Migrating %d images for company %d",
+						_getCount(companyId), companyId));
 
-		MaintenanceUtil.appendStatus("Migrating " + count + " images");
+				ActionableDynamicQuery actionableDynamicQuery =
+					_getActionableDynamicQuery(
+						companyId, sourceStore, targetStore, delete);
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			_getActionableDynamicQuery(sourceStore, targetStore, delete);
-
-		actionableDynamicQuery.performActions();
+				actionableDynamicQuery.performActions();
+			});
 	}
 
 	private static final long _REPOSITORY_ID = 0L;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ImageDLStoreConvertProcess.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private ImageLocalService _imageLocalService;

--- a/modules/apps/document-library/document-library-test/build.gradle
+++ b/modules/apps/document-library/document-library-test/build.gradle
@@ -4,6 +4,8 @@ dependencies {
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	testIntegrationImplementation project(":apps:adaptive-media:adaptive-media-api")
+	testIntegrationImplementation project(":apps:adaptive-media:adaptive-media-image-api")
 	testIntegrationImplementation project(":apps:asset:asset-auto-tagger-api")
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
@@ -7,13 +7,13 @@ package com.liferay.document.library.convert.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.document.library.content.exception.NoSuchContentException;
 import com.liferay.document.library.content.service.DLContentLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.processor.ImageProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.message.boards.constants.MBCategoryConstants;
@@ -21,15 +21,20 @@ import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.message.boards.test.util.MBTestUtil;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.convert.ConvertProcess;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -37,10 +42,9 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -49,10 +53,10 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.store.DLStoreImpl;
 
-import java.io.InputStream;
-
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -87,7 +91,9 @@ public class DocumentLibraryConvertProcessTest {
 
 		DLStoreImpl.setStore(_fileSystemStore);
 
-		_group = GroupTestUtil.addGroup();
+		_companyLocalService.forEachCompanyId(
+			companyId -> _groups.add(
+				GroupTestUtil.addGroupToCompany(companyId)));
 	}
 
 	@After
@@ -116,115 +122,122 @@ public class DocumentLibraryConvertProcessTest {
 
 	@Test
 	public void testMigrateDLAndDeleteFilesInSourceStore() throws Exception {
-		testMigrateAndCheckOldRepositoryFiles(Boolean.TRUE);
+		_testMigrateAndCheckOldRepositoryFiles(Boolean.TRUE);
 	}
 
 	@Test
 	public void testMigrateDLAndKeepFilesInSourceStore() throws Exception {
-		testMigrateAndCheckOldRepositoryFiles(Boolean.FALSE);
+		_testMigrateAndCheckOldRepositoryFiles(Boolean.FALSE);
 	}
 
 	@Test
 	public void testMigrateDLWhenFileEntryEmpty() throws Exception {
-		FileEntry fileEntry = _dlAppService.addFileEntry(
-			null, _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(),
-			ContentTypes.APPLICATION_OCTET_STREAM,
-			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), (byte[])null, null, null, null,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		Map<Long, FileEntry> fileEntries = new HashMap<>();
+
+		_forEach(
+			_groups,
+			group -> {
+				User user = UserTestUtil.getAdminUser(group.getCompanyId());
+
+				fileEntries.put(
+					group.getCompanyId(),
+					_addFileEntry(
+						group, user, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+						RandomTestUtil.randomString(),
+						ContentTypes.APPLICATION_OCTET_STREAM, null));
+			});
 
 		_convertProcess.convert();
 
-		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
-
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
-
-		_dlContentLocalService.getContent(
-			dlFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				dlFileEntry.getRepositoryId(), dlFileEntry.getFolderId()),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+		_companyLocalService.forEachCompanyId(
+			companyId -> _getContent(fileEntries.get(companyId)));
 	}
 
 	@Test
 	public void testMigrateDLWhenFileEntryInFolder() throws Exception {
-		Folder folder = _dlAppService.addFolder(
-			null, _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		Map<Long, FileEntry> fileEntries = new HashMap<>();
 
-		FileEntry fileEntry = addFileEntry(
-			folder.getFolderId(), RandomTestUtil.randomString() + ".txt",
-			ContentTypes.TEXT_PLAIN, TestDataConstants.TEST_BYTE_ARRAY);
+		_forEach(
+			_groups,
+			group -> {
+				User user = UserTestUtil.getAdminUser(group.getCompanyId());
+
+				Folder folder = _addFolder(group, user);
+
+				fileEntries.put(
+					group.getCompanyId(),
+					_addFileEntry(
+						group, user, folder.getFolderId(),
+						RandomTestUtil.randomString() + ".txt",
+						ContentTypes.TEXT_PLAIN,
+						TestDataConstants.TEST_BYTE_ARRAY));
+			});
 
 		_convertProcess.convert();
 
-		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
-
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
-
-		_dlContentLocalService.getContent(
-			dlFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				dlFileEntry.getRepositoryId(), dlFileEntry.getFolderId()),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+		_companyLocalService.forEachCompanyId(
+			companyId -> _getContent(fileEntries.get(companyId)));
 	}
 
 	@Test
 	public void testMigrateDLWhenFileEntryInRootFolder() throws Exception {
-		FileEntry fileEntry = addFileEntry(
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
-			TestDataConstants.TEST_BYTE_ARRAY);
+		Map<Long, FileEntry> fileEntries = new HashMap<>();
+
+		_forEach(
+			_groups,
+			group -> fileEntries.put(
+				group.getCompanyId(),
+				_addFileEntry(
+					group, UserTestUtil.getAdminUser(group.getCompanyId()),
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+					RandomTestUtil.randomString() + ".txt",
+					ContentTypes.TEXT_PLAIN,
+					TestDataConstants.TEST_BYTE_ARRAY)));
 
 		_convertProcess.convert();
 
-		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
-
-		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
-
-		_dlContentLocalService.getContent(
-			dlFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				dlFileEntry.getRepositoryId(), dlFileEntry.getFolderId()),
-			dlFileEntry.getName(), dlFileVersion.getStoreFileName());
+		_companyLocalService.forEachCompanyId(
+			companyId -> _getContent(fileEntries.get(companyId)));
 	}
 
 	@Test
 	public void testMigrateImages() throws Exception {
-		_image = _imageLocalService.updateImage(
-			_group.getCompanyId(), _counterLocalService.increment(),
-			FileUtil.getBytes(getClass(), "dependencies/liferay.jpg"));
+		_companyLocalService.forEachCompanyId(
+			companyId -> _images.add(
+				_imageLocalService.updateImage(
+					companyId, _counterLocalService.increment(),
+					FileUtil.getBytes(
+						getClass(), "dependencies/liferay.jpg"))));
 
 		_convertProcess.convert();
 
-		_dlContentLocalService.getContent(
-			_group.getCompanyId(), _REPOSITORY_ID, _image.getImageId() + ".jpg",
-			Store.VERSION_DEFAULT);
+		_forEach(
+			_images,
+			image -> _dlContentLocalService.getContent(
+				image.getCompanyId(), _REPOSITORY_ID,
+				image.getImageId() + ".jpg", Store.VERSION_DEFAULT));
 	}
 
 	@Test
 	public void testMigrateMB() throws Exception {
-		MBMessage mbMessage = addMBMessageAttachment();
+		List<MBMessage> mbMessages = new ArrayList<>();
+
+		_forEach(
+			_groups, group -> mbMessages.add(_addMBMessageAttachment(group)));
 
 		_convertProcess.convert();
 
-		DLFileEntry dlFileEntry = getDLFileEntry(mbMessage);
+		_forEach(
+			mbMessages,
+			mbMessage -> {
+				DLFileEntry dlFileEntry = _getDLFileEntry(mbMessage);
 
-		String title = dlFileEntry.getTitle();
+				String title = dlFileEntry.getTitle();
 
-		Assert.assertTrue(title.endsWith(".docx"));
+				Assert.assertTrue(title.endsWith(".docx"));
 
-		_dlContentLocalService.getContent(
-			dlFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				dlFileEntry.getRepositoryId(), dlFileEntry.getFolderId()),
-			dlFileEntry.getName());
+				_getContent(dlFileEntry, StringPool.BLANK);
+			});
 	}
 
 	@Test
@@ -234,42 +247,76 @@ public class DocumentLibraryConvertProcessTest {
 		Assert.assertEquals(_CLASS_NAME_DB_STORE, PropsValues.DL_STORE_IMPL);
 	}
 
-	protected FileEntry addFileEntry(
-			long folderId, String fileName, String mimeType, byte[] bytes)
+	private FileEntry _addFileEntry(
+			Group group, User user, long folderId, String fileName,
+			String mimeType, byte[] bytes)
 		throws Exception {
 
 		return _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _group.getGroupId(), folderId,
-			fileName, mimeType, bytes, null, null, null,
+			null, user.getUserId(), group.getGroupId(), folderId, fileName,
+			mimeType, bytes, null, null, null,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+				group.getGroupId(), user.getUserId()));
 	}
 
-	protected MBMessage addMBMessageAttachment() throws Exception {
-		List<ObjectValuePair<String, InputStream>> objectValuePairs =
-			MBTestUtil.getInputStreamOVPs(
-				"OSX_Test.docx", getClass(), StringPool.BLANK);
+	private Folder _addFolder(Group group, User user) throws PortalException {
+		return _dlAppLocalService.addFolder(
+			null, user.getUserId(), group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), user.getUserId()));
+	}
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
-
-		User user = TestPropsValues.getUser();
+	private MBMessage _addMBMessageAttachment(Group group) throws Exception {
+		User user = UserTestUtil.getAdminUser(group.getCompanyId());
 
 		return _mbMessageLocalService.addMessage(
-			user.getUserId(), user.getFullName(), _group.getGroupId(),
+			user.getUserId(), user.getFullName(), group.getGroupId(),
 			MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, "Subject", "Body",
-			MBMessageConstants.DEFAULT_FORMAT, objectValuePairs, false, 0,
-			false, serviceContext);
+			MBMessageConstants.DEFAULT_FORMAT,
+			MBTestUtil.getInputStreamOVPs(
+				"OSX_Test.docx", getClass(), StringPool.BLANK),
+			false, 0, false,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
-	protected DLFileEntry getDLFileEntry(Object object) throws Exception {
-		List<FileEntry> fileEntries = new ArrayList<>();
+	private <T extends ShardedModel> void _forEach(
+			List<T> entries, UnsafeConsumer<T, Exception> unsafeConsumer)
+		throws Exception {
 
-		if (object instanceof MBMessage) {
-			MBMessage mbMessage = (MBMessage)object;
+		for (T entry : entries) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						entry.getCompanyId())) {
 
-			fileEntries = mbMessage.getAttachmentsFileEntries(0, 1);
+				unsafeConsumer.accept(entry);
+			}
 		}
+	}
+
+	private void _getContent(DLFileEntry dlFileEntry, String version)
+		throws NoSuchContentException {
+
+		_dlContentLocalService.getContent(
+			dlFileEntry.getCompanyId(),
+			DLFolderConstants.getDataRepositoryId(
+				dlFileEntry.getRepositoryId(), dlFileEntry.getFolderId()),
+			dlFileEntry.getName(), version);
+	}
+
+	private void _getContent(FileEntry fileEntry) throws PortalException {
+		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+		DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+		_getContent(dlFileEntry, dlFileVersion.getStoreFileName());
+	}
+
+	private DLFileEntry _getDLFileEntry(MBMessage mbMessage)
+		throws PortalException {
+
+		List<FileEntry> fileEntries = mbMessage.getAttachmentsFileEntries(0, 1);
 
 		Assert.assertFalse(fileEntries.toString(), fileEntries.isEmpty());
 
@@ -279,71 +326,61 @@ public class DocumentLibraryConvertProcessTest {
 			fileEntry.getFileEntryId());
 	}
 
-	protected void testMigrateAndCheckOldRepositoryFiles(Boolean delete)
+	private void _testMigrateAndCheckOldRepositoryFiles(Boolean delete)
 		throws Exception {
 
 		_convertProcess.setParameterValues(
 			new String[] {_CLASS_NAME_DB_STORE, delete.toString()});
 
-		FileEntry rootFileEntry = addFileEntry(
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString() + ".txt", ContentTypes.TEXT_PLAIN,
-			TestDataConstants.TEST_BYTE_ARRAY);
+		List<FileEntry> fileEntries = new ArrayList<>();
 
-		Folder folder = _dlAppService.addFolder(
-			null, _group.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId()));
+		_forEach(
+			_groups,
+			group -> {
+				User user = UserTestUtil.getAdminUser(group.getCompanyId());
 
-		FileEntry folderFileEntry = addFileEntry(
-			folder.getFolderId(), "liferay.jpg", ContentTypes.IMAGE_JPEG,
-			FileUtil.getBytes(getClass(), "dependencies/liferay.jpg"));
+				fileEntries.add(
+					_addFileEntry(
+						group, user, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+						RandomTestUtil.randomString() + ".txt",
+						ContentTypes.TEXT_PLAIN,
+						TestDataConstants.TEST_BYTE_ARRAY));
 
-		ImageProcessorUtil.generateImages(
-			null, folderFileEntry.getFileVersion());
+				Folder folder = _addFolder(group, user);
+
+				FileEntry folderFileEntry = _addFileEntry(
+					group, user, folder.getFolderId(), "liferay.jpg",
+					ContentTypes.IMAGE_JPEG,
+					FileUtil.getBytes(getClass(), "dependencies/liferay.jpg"));
+
+				ImageProcessorUtil.generateImages(
+					null, folderFileEntry.getFileVersion());
+
+				fileEntries.add(folderFileEntry);
+			});
 
 		_convertProcess.convert();
 
-		DLFileEntry rootDLFileEntry = (DLFileEntry)rootFileEntry.getModel();
+		for (FileEntry fileEntry : fileEntries) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						fileEntry.getCompanyId())) {
 
-		DLFileVersion rootDLFileVersion = rootDLFileEntry.getFileVersion();
+				DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		Assert.assertNotEquals(
-			delete,
-			_fileSystemStore.hasFile(
-				rootDLFileEntry.getCompanyId(),
-				rootDLFileEntry.getDataRepositoryId(),
-				rootDLFileEntry.getName(),
-				rootDLFileVersion.getStoreFileName()));
+				DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
 
-		DLFileEntry folderDLFileEntry = (DLFileEntry)folderFileEntry.getModel();
+				Assert.assertNotEquals(
+					delete,
+					_fileSystemStore.hasFile(
+						dlFileEntry.getCompanyId(),
+						dlFileEntry.getDataRepositoryId(),
+						dlFileEntry.getName(),
+						dlFileVersion.getStoreFileName()));
 
-		DLFileVersion folderDLFileVersion = folderDLFileEntry.getFileVersion();
-
-		Assert.assertNotEquals(
-			delete,
-			_fileSystemStore.hasFile(
-				folderDLFileEntry.getCompanyId(),
-				folderDLFileEntry.getDataRepositoryId(),
-				folderDLFileEntry.getName(),
-				folderDLFileVersion.getStoreFileName()));
-
-		_dlContentLocalService.getContent(
-			folderDLFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				folderDLFileEntry.getRepositoryId(),
-				folderDLFileEntry.getFolderId()),
-			folderDLFileEntry.getName(),
-			folderDLFileVersion.getStoreFileName());
-
-		_dlContentLocalService.getContent(
-			rootDLFileEntry.getCompanyId(),
-			DLFolderConstants.getDataRepositoryId(
-				rootDLFileEntry.getRepositoryId(),
-				rootDLFileEntry.getFolderId()),
-			rootDLFileEntry.getName(), rootDLFileVersion.getStoreFileName());
+				_getContent(dlFileEntry, dlFileVersion.getStoreFileName());
+			}
+		}
 	}
 
 	private static final String _CLASS_NAME_DB_STORE =
@@ -353,6 +390,9 @@ public class DocumentLibraryConvertProcessTest {
 		"com.liferay.portal.store.file.system.FileSystemStore";
 
 	private static final long _REPOSITORY_ID = 0;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.document.library.internal.convert.document.library.DocumentLibraryConvertProcess"
@@ -371,9 +411,6 @@ public class DocumentLibraryConvertProcessTest {
 	private DLAppLocalService _dlAppLocalService;
 
 	@Inject
-	private DLAppService _dlAppService;
-
-	@Inject
 	private DLContentLocalService _dlContentLocalService;
 
 	@Inject
@@ -383,13 +420,13 @@ public class DocumentLibraryConvertProcessTest {
 	private Store _fileSystemStore;
 
 	@DeleteAfterTestRun
-	private Group _group;
-
-	@DeleteAfterTestRun
-	private Image _image;
+	private final List<Group> _groups = new ArrayList<>();
 
 	@Inject
 	private ImageLocalService _imageLocalService;
+
+	@DeleteAfterTestRun
+	private final List<Image> _images = new ArrayList<>();
 
 	@Inject
 	private MBMessageLocalService _mbMessageLocalService;

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
@@ -5,6 +5,10 @@
 
 package com.liferay.document.library.convert.test;
 
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
+import com.liferay.adaptive.media.image.configuration.AMImageConfigurationHelper;
+import com.liferay.adaptive.media.image.model.AMImageEntry;
+import com.liferay.adaptive.media.image.service.AMImageEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.document.library.content.exception.NoSuchContentException;
@@ -23,14 +27,18 @@ import com.liferay.message.boards.service.MBMessageLocalService;
 import com.liferay.message.boards.test.util.MBTestUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.convert.ConvertProcess;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -45,6 +53,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -53,7 +62,10 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.store.DLStoreImpl;
 
+import java.io.IOException;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,12 +104,23 @@ public class DocumentLibraryConvertProcessTest {
 		DLStoreImpl.setStore(_fileSystemStore);
 
 		_companyLocalService.forEachCompanyId(
-			companyId -> _groups.add(
-				GroupTestUtil.addGroupToCompany(companyId)));
+			companyId -> {
+				_groups.add(GroupTestUtil.addGroupToCompany(companyId));
+
+				_amImageConfigurationEntries.put(
+					companyId, _deleteAMImageConfigurationEntries(companyId));
+			});
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				_deleteAMImageConfigurationEntries(companyId);
+				_addAMImageConfigurationEntries(
+					companyId, _amImageConfigurationEntries.get(companyId));
+			});
+
 		ReflectionTestUtil.setFieldValue(_convertProcess, "_store", _dbStore);
 
 		DLStoreImpl.setStore(_dbStore);
@@ -118,6 +141,57 @@ public class DocumentLibraryConvertProcessTest {
 
 			DLStoreImpl.setStore(_defaultStore);
 		}
+	}
+
+	@Test
+	public void testMigrateAMImageEntries() throws Exception {
+		List<AMImageEntry> amImageEntries = new ArrayList<>();
+
+		_forEach(
+			_groups,
+			group -> {
+				User user = UserTestUtil.getAdminUser(group.getCompanyId());
+
+				byte[] bytes = FileUtil.getBytes(
+					getClass(), "dependencies/liferay.jpg");
+
+				FileEntry fileEntry = _addFileEntry(
+					group, user, DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+					RandomTestUtil.randomString() + ".jpg",
+					ContentTypes.IMAGE_JPEG, bytes);
+
+				AMImageConfigurationEntry amImageConfigurationEntry =
+					_amImageConfigurationHelper.addAMImageConfigurationEntry(
+						group.getCompanyId(), RandomTestUtil.randomString(),
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString(),
+						HashMapBuilder.put(
+							"max-height", String.valueOf(100)
+						).put(
+							"max-width", String.valueOf(200)
+						).build());
+
+				amImageEntries.add(
+					_amImageEntryLocalService.addAMImageEntry(
+						amImageConfigurationEntry, fileEntry.getFileVersion(),
+						100, 200, new UnsyncByteArrayInputStream(bytes),
+						12345));
+			});
+
+		_convertProcess.convert();
+
+		_forEach(
+			amImageEntries,
+			amImageEntry -> {
+				FileVersion fileVersion = _dlAppLocalService.getFileVersion(
+					amImageEntry.getFileVersionId());
+
+				_dlContentLocalService.getContent(
+					amImageEntry.getCompanyId(), CompanyConstants.SYSTEM,
+					_getFileVersionPath(
+						fileVersion, amImageEntry.getConfigurationUuid()),
+					fileVersion.getVersion());
+			});
 	}
 
 	@Test
@@ -247,6 +321,22 @@ public class DocumentLibraryConvertProcessTest {
 		Assert.assertEquals(_CLASS_NAME_DB_STORE, PropsValues.DL_STORE_IMPL);
 	}
 
+	private void _addAMImageConfigurationEntries(
+			long companyId,
+			Collection<AMImageConfigurationEntry> amImageConfigurationEntries)
+		throws IOException, PortalException {
+
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				amImageConfigurationEntries) {
+
+			_amImageConfigurationHelper.addAMImageConfigurationEntry(
+				companyId, amImageConfigurationEntry.getName(),
+				amImageConfigurationEntry.getDescription(),
+				amImageConfigurationEntry.getUUID(),
+				amImageConfigurationEntry.getProperties());
+		}
+	}
+
 	private FileEntry _addFileEntry(
 			Group group, User user, long folderId, String fileName,
 			String mimeType, byte[] bytes)
@@ -279,6 +369,24 @@ public class DocumentLibraryConvertProcessTest {
 				"OSX_Test.docx", getClass(), StringPool.BLANK),
 			false, 0, false,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private Collection<AMImageConfigurationEntry>
+			_deleteAMImageConfigurationEntries(long companyId)
+		throws IOException {
+
+		Collection<AMImageConfigurationEntry> amImageConfigurationEntries =
+			_amImageConfigurationHelper.getAMImageConfigurationEntries(
+				companyId);
+
+		for (AMImageConfigurationEntry amImageConfigurationEntry :
+				amImageConfigurationEntries) {
+
+			_amImageConfigurationHelper.forceDeleteAMImageConfigurationEntry(
+				companyId, amImageConfigurationEntry.getUUID());
+		}
+
+		return amImageConfigurationEntries;
 	}
 
 	private <T extends ShardedModel> void _forEach(
@@ -324,6 +432,15 @@ public class DocumentLibraryConvertProcessTest {
 
 		return _dlFileEntryLocalService.getDLFileEntry(
 			fileEntry.getFileEntryId());
+	}
+
+	private String _getFileVersionPath(
+		FileVersion fileVersion, String configurationUuid) {
+
+		return StringBundler.concat(
+			"adaptive/", configurationUuid, "/", fileVersion.getGroupId(), "/",
+			fileVersion.getRepositoryId(), "/", fileVersion.getFileEntryId(),
+			"/", fileVersion.getFileVersionId(), "/");
 	}
 
 	private void _testMigrateAndCheckOldRepositoryFiles(Boolean delete)
@@ -390,6 +507,15 @@ public class DocumentLibraryConvertProcessTest {
 		"com.liferay.portal.store.file.system.FileSystemStore";
 
 	private static final long _REPOSITORY_ID = 0;
+
+	private final Map<Long, Collection<AMImageConfigurationEntry>>
+		_amImageConfigurationEntries = new HashMap<>();
+
+	@Inject
+	private AMImageConfigurationHelper _amImageConfigurationHelper;
+
+	@Inject
+	private AMImageEntryLocalService _amImageEntryLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43466

The migration of documents to a different store type doesn't work when files exist in different DB partitions.

# How am I fixing it?

I'm fixing 3 convert processes that do not take into account having different partitions (companies) by iterating on each company and executing the conversion process by having the company in the thread local variable.

# How can you verify that it works?

Follow the manual instructions in JIRA issue or execute the integration test:

`cd modules/apps/document-library/document-library-test`
`gw tI --tests DocumentLibraryConvertProcessTest.testMigrateImages`

