### PR TITLE
LPD-44614 Fix setup error in POSHI test case DepotDisplayPage

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/fragment/FragmentsAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/fragment/FragmentsAdmin.macro
@@ -158,7 +158,7 @@ definition {
 		SystemSettings.gotoConfiguration(
 			configurationCategory = "Feature Flags",
 			configurationName = "Deprecation",
-			configurationScope = "Virtual Instance Scope");
+			configurationScope = "System Scope");
 
 		if (IsElementPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = "Featured Content Fragment Set", toggle_state = "Disabled")) {
 			Check.checkToggleSwitch(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44613

During the setup of the POSHI test case DepotDisplayPage there is an error related to setting a deprecated feature flag.

# How am I fixing it?

Setting the correct Configuration Scope when trying to find a deprecation FF in System Settings.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=DepotDisplayPage#CanViewDepotDMUsingDepotType`
