### PR TITLE
LPD-44642 Use a different function to publish existing web contents

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
@@ -483,7 +483,7 @@ definition {
 			webContentContent = "WC WebContent Contenido editar",
 			webContentTitle = "WC WebContent Título editar");
 
-		WebContent.publishWithPermissions();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithFirstComplexStructure.testcase
@@ -293,7 +293,7 @@ definition {
 
 		Button.clickSaveAsDraft();
 
-		WebContent.publishWithPermissions();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgradeWithWithSecondComplexStructure.testcase
@@ -319,7 +319,7 @@ definition {
 					index = 2);
 			}
 
-			WebContent.publishWithPermissions();
+			WebContent.publishExistingWCArticleWithPermissions();
 		}
 
 		task ("Remove duplicates") {
@@ -432,7 +432,7 @@ definition {
 
 			Button.clickSaveAsDraft();
 
-			WebContent.publishWithPermissions();
+			WebContent.publishExistingWCArticleWithPermissions();
 		}
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
@@ -484,7 +484,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Complex Title 1");
 
-			WebContent.publishWithPermissions();
+			WebContent.publishExistingWCArticleWithPermissions();
 		}
 	}
 


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-44642)

This pull fixes these tests: 
- LocalFile.TranslationsInterface#EditedValuesArePreservedInSideBySideUI
- LocalFile.WebContentUpgradeWithWithFirstComplexStructure#CanPreviewWebContent
- LocalFile.WebContentUpgradeWithWithSecondComplexStructure#CanDuplicateRepeatableFieldsAndRemoveThem
- LocalFile.WebContentUpgradeWithWithSecondComplexStructure#CanPreviewWebContent
- LocalFile.WebContentUpgradeWithWithSecondComplexStructure#CanPublishDraftWebContentAndViewOtherVersions