### PR TITLE
LPD-44798 For existing web contents, the Save as Draft is a button

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1189,7 +1189,7 @@ definition {
 		}
 
 		if (${saveAsDraft} == "true") {
-			WebContent.saveAsDraftWithPermissions();
+			PortletEntry.saveAsDraft();
 
 			AssertTextEquals.assertPartialText(
 				key_status = "Draft",


### PR DESCRIPTION
[Link to issue ](https://liferay.atlassian.net/browse/LPD-44798)

This pull fixes these tests: 

1. LocalFile.WebContent#PreviewDraftWebContentInWCD
2. LocalFile.WebContentArticleWithDisplayPage#ViewPreviewDraftViaURLFromNonAuthor
3. LocalFile.RecycleBinWithWebContent#RestoreWebContentWithArticleVersions