### PR TITLE
LPD-44819 DDMFormValuesExportImportContentProcessor on importation of non ordered layouts giving NoSuchLayoutException when importing full site lar

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
@@ -23,6 +23,7 @@ import com.liferay.journal.exception.NoSuchArticleException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.layout.dynamic.data.mapping.form.field.type.constants.LayoutDDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -662,7 +663,11 @@ public class DDMFormValuesExportImportContentProcessor
 					_portletDataContext, jsonObject);
 
 				if (importedLayout != null) {
-					value.addString(locale, toJSON(importedLayout, locale));
+					value.addString(
+						locale,
+						toJSON(
+							importedLayout, locale,
+							jsonObject.getString("name")));
 
 					continue;
 				}
@@ -695,7 +700,11 @@ public class DDMFormValuesExportImportContentProcessor
 				}
 
 				if (importedLayout != null) {
-					value.addString(locale, toJSON(importedLayout, locale));
+					value.addString(
+						locale,
+						toJSON(
+							importedLayout, locale,
+							jsonObject.getString("name")));
 				}
 			}
 		}
@@ -720,7 +729,7 @@ public class DDMFormValuesExportImportContentProcessor
 			return layout;
 		}
 
-		protected String toJSON(Layout layout, Locale locale)
+		protected String toJSON(Layout layout, Locale locale, String name)
 			throws PortalException {
 
 			return JSONUtil.put(
@@ -730,12 +739,27 @@ public class DDMFormValuesExportImportContentProcessor
 			).put(
 				"layoutId", layout.getLayoutId()
 			).put(
-				"name", layout.getBreadcrumb(locale)
+				"name", _getName(layout, locale, name)
 			).put(
 				"privateLayout", layout.isPrivateLayout()
 			).put(
 				"value", layout.getFriendlyURL(locale)
 			).toString();
+		}
+
+		private String _getName(Layout layout, Locale locale, String name)
+			throws PortalException {
+
+			try {
+				return layout.getBreadcrumb(locale);
+			}
+			catch (NoSuchLayoutException noSuchLayoutException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(noSuchLayoutException);
+				}
+			}
+
+			return name;
 		}
 
 		private final PortletDataContext _portletDataContext;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/DDMFormValuesExportImportContentProcessor.java
@@ -114,6 +114,153 @@ public class DDMFormValuesExportImportContentProcessor
 		long groupId, DDMFormValues ddmFormValues) {
 	}
 
+	protected class LayoutImportDDMFormFieldValueTransformer
+		implements DDMFormFieldValueTransformer {
+
+		public LayoutImportDDMFormFieldValueTransformer(
+			PortletDataContext portletDataContext) {
+
+			_portletDataContext = portletDataContext;
+		}
+
+		@Override
+		public String getFieldType() {
+			return LayoutDDMFormFieldTypeConstants.LINK_TO_LAYOUT;
+		}
+
+		@Override
+		public void transform(DDMFormFieldValue ddmFormFieldValue)
+			throws PortalException {
+
+			Value value = ddmFormFieldValue.getValue();
+
+			for (Locale locale : value.getAvailableLocales()) {
+				String valueString = value.getString(locale);
+
+				JSONObject jsonObject = null;
+
+				try {
+					jsonObject = _jsonFactory.createJSONObject(valueString);
+				}
+				catch (JSONException jsonException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to parse JSON", jsonException);
+					}
+
+					continue;
+				}
+
+				if (jsonObject.length() == 0) {
+					continue;
+				}
+
+				Layout importedLayout = fetchImportedLayout(
+					_portletDataContext, jsonObject);
+
+				if (importedLayout != null) {
+					value.addString(
+						locale,
+						toJSON(
+							importedLayout, locale,
+							jsonObject.getString("name")));
+
+					continue;
+				}
+
+				Element missingReferencesElement =
+					_portletDataContext.getMissingReferencesElement();
+
+				List<Element> elements = missingReferencesElement.elements();
+
+				for (Element element : elements) {
+					String className = element.attributeValue("class-name");
+
+					if (className.equals(Layout.class.getName())) {
+						String uuid = element.attributeValue("uuid");
+
+						if (jsonObject.has("id") &&
+							!Objects.equals(uuid, jsonObject.getString("id"))) {
+
+							continue;
+						}
+
+						String privateLayout = element.attributeValue(
+							"private-layout");
+
+						importedLayout =
+							_layoutLocalService.fetchLayoutByUuidAndGroupId(
+								uuid, _portletDataContext.getScopeGroupId(),
+								Boolean.valueOf(privateLayout));
+					}
+				}
+
+				if (importedLayout != null) {
+					value.addString(
+						locale,
+						toJSON(
+							importedLayout, locale,
+							jsonObject.getString("name")));
+				}
+			}
+		}
+
+		protected Layout fetchImportedLayout(
+			PortletDataContext portletDataContext, JSONObject jsonObject) {
+
+			Map<Long, Layout> layouts =
+				(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(
+					Layout.class + ".layout");
+
+			long layoutId = jsonObject.getLong("layoutId");
+
+			Layout layout = layouts.get(layoutId);
+
+			if (layout == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to find layout with ID " + layoutId);
+				}
+			}
+
+			return layout;
+		}
+
+		protected String toJSON(Layout layout, Locale locale, String name)
+			throws PortalException {
+
+			return JSONUtil.put(
+				"groupId", layout.getGroupId()
+			).put(
+				"id", layout.getUuid()
+			).put(
+				"layoutId", layout.getLayoutId()
+			).put(
+				"name", _getName(layout, locale, name)
+			).put(
+				"privateLayout", layout.isPrivateLayout()
+			).put(
+				"value", layout.getFriendlyURL(locale)
+			).toString();
+		}
+
+		private String _getName(Layout layout, Locale locale, String name)
+			throws PortalException {
+
+			try {
+				return layout.getBreadcrumb(locale);
+			}
+			catch (NoSuchLayoutException noSuchLayoutException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(noSuchLayoutException);
+				}
+			}
+
+			return name;
+		}
+
+		private final PortletDataContext _portletDataContext;
+
+	}
+
 	private boolean _hasNotExportableStatus(
 		StagedModel stagedModel, int status) {
 
@@ -616,153 +763,6 @@ public class DDMFormValuesExportImportContentProcessor
 
 		private final PortletDataContext _portletDataContext;
 		private final StagedModel _stagedModel;
-
-	}
-
-	private class LayoutImportDDMFormFieldValueTransformer
-		implements DDMFormFieldValueTransformer {
-
-		public LayoutImportDDMFormFieldValueTransformer(
-			PortletDataContext portletDataContext) {
-
-			_portletDataContext = portletDataContext;
-		}
-
-		@Override
-		public String getFieldType() {
-			return LayoutDDMFormFieldTypeConstants.LINK_TO_LAYOUT;
-		}
-
-		@Override
-		public void transform(DDMFormFieldValue ddmFormFieldValue)
-			throws PortalException {
-
-			Value value = ddmFormFieldValue.getValue();
-
-			for (Locale locale : value.getAvailableLocales()) {
-				String valueString = value.getString(locale);
-
-				JSONObject jsonObject = null;
-
-				try {
-					jsonObject = _jsonFactory.createJSONObject(valueString);
-				}
-				catch (JSONException jsonException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Unable to parse JSON", jsonException);
-					}
-
-					continue;
-				}
-
-				if (jsonObject.length() == 0) {
-					continue;
-				}
-
-				Layout importedLayout = fetchImportedLayout(
-					_portletDataContext, jsonObject);
-
-				if (importedLayout != null) {
-					value.addString(
-						locale,
-						toJSON(
-							importedLayout, locale,
-							jsonObject.getString("name")));
-
-					continue;
-				}
-
-				Element missingReferencesElement =
-					_portletDataContext.getMissingReferencesElement();
-
-				List<Element> elements = missingReferencesElement.elements();
-
-				for (Element element : elements) {
-					String className = element.attributeValue("class-name");
-
-					if (className.equals(Layout.class.getName())) {
-						String uuid = element.attributeValue("uuid");
-
-						if (jsonObject.has("id") &&
-							!Objects.equals(uuid, jsonObject.getString("id"))) {
-
-							continue;
-						}
-
-						String privateLayout = element.attributeValue(
-							"private-layout");
-
-						importedLayout =
-							_layoutLocalService.fetchLayoutByUuidAndGroupId(
-								uuid, _portletDataContext.getScopeGroupId(),
-								Boolean.valueOf(privateLayout));
-					}
-				}
-
-				if (importedLayout != null) {
-					value.addString(
-						locale,
-						toJSON(
-							importedLayout, locale,
-							jsonObject.getString("name")));
-				}
-			}
-		}
-
-		protected Layout fetchImportedLayout(
-			PortletDataContext portletDataContext, JSONObject jsonObject) {
-
-			Map<Long, Layout> layouts =
-				(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(
-					Layout.class + ".layout");
-
-			long layoutId = jsonObject.getLong("layoutId");
-
-			Layout layout = layouts.get(layoutId);
-
-			if (layout == null) {
-				if (_log.isWarnEnabled()) {
-					_log.warn("Unable to find layout with ID " + layoutId);
-				}
-			}
-
-			return layout;
-		}
-
-		protected String toJSON(Layout layout, Locale locale, String name)
-			throws PortalException {
-
-			return JSONUtil.put(
-				"groupId", layout.getGroupId()
-			).put(
-				"id", layout.getUuid()
-			).put(
-				"layoutId", layout.getLayoutId()
-			).put(
-				"name", _getName(layout, locale, name)
-			).put(
-				"privateLayout", layout.isPrivateLayout()
-			).put(
-				"value", layout.getFriendlyURL(locale)
-			).toString();
-		}
-
-		private String _getName(Layout layout, Locale locale, String name)
-			throws PortalException {
-
-			try {
-				return layout.getBreadcrumb(locale);
-			}
-			catch (NoSuchLayoutException noSuchLayoutException) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(noSuchLayoutException);
-				}
-			}
-
-			return name;
-		}
-
-		private final PortletDataContext _portletDataContext;
 
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/LayoutImportDDMFormFieldValueTransformerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/LayoutImportDDMFormFieldValueTransformerTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.exportimport.content.processor;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Alicia García
+ */
+public class LayoutImportDDMFormFieldValueTransformerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testToJSONWhenNoSuchLayoutExceptionIsThrown()
+		throws PortalException {
+
+		Mockito.when(
+			_layout.getGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_layout.getUuid()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_layout.getLayoutId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_layout.isPrivateLayout()
+		).thenReturn(
+			false
+		);
+
+		Locale locale = LocaleUtil.US;
+
+		Mockito.when(
+			_layout.getFriendlyURL(locale)
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_layout.getBreadcrumb(locale)
+		).thenThrow(
+			new NoSuchLayoutException()
+		);
+
+		String name = RandomTestUtil.randomString();
+
+		MockDDMFormValuesExportImportContentProcessor
+			mockDDMFormValuesExportImportContentProcessor =
+				new MockDDMFormValuesExportImportContentProcessor();
+
+		DDMFormValuesExportImportContentProcessor.
+			LayoutImportDDMFormFieldValueTransformer
+				layoutImportDDMFormFieldValueTransformer =
+					mockDDMFormValuesExportImportContentProcessor.
+						getLayoutImportDDMFormFieldValueTransformer(
+							_portletDataContext);
+
+		Assert.assertEquals(
+			JSONUtil.put(
+				"groupId", _layout.getGroupId()
+			).put(
+				"id", _layout.getUuid()
+			).put(
+				"layoutId", _layout.getLayoutId()
+			).put(
+				"name", name
+			).put(
+				"privateLayout", _layout.isPrivateLayout()
+			).put(
+				"value", _layout.getFriendlyURL(locale)
+			).toString(),
+			layoutImportDDMFormFieldValueTransformer.toJSON(
+				_layout, locale, name));
+	}
+
+	private final Layout _layout = Mockito.mock(Layout.class);
+	private final PortletDataContext _portletDataContext = Mockito.mock(
+		PortletDataContext.class);
+
+	private static class MockDDMFormValuesExportImportContentProcessor
+		extends DDMFormValuesExportImportContentProcessor {
+
+		public LayoutImportDDMFormFieldValueTransformer
+			getLayoutImportDDMFormFieldValueTransformer(
+				PortletDataContext portletDataContext) {
+
+			return new LayoutImportDDMFormFieldValueTransformer(
+				portletDataContext);
+		}
+
+	}
+
+}


### PR DESCRIPTION
LPD-44819 NoSuchLayoutException when importing full site .lar

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44819

On some corner cases, as the lar attached on the LPP, the layout parent are not on database so geting the breadcrumb to put on the ddm name giver a NoSuchLayoutException

# How am I fixing it?

On the case that the method getBreadcrumb throws an exception return the fallback value.

# How can you verify that it works?

Run the included automated tests.


# Commits

- **LPD-44819 on the case that the method getBreadcrumb throws an exception return the fallback value**
- **LPD-44819 change to package visibility to test purposes**
- **LPD-44819 check that if the getBreadcrumb method throws a NoSuchLayoutException the toJSON method returns the name of the json**
