### PR TITLE
LPD-44786 Fix blogEntry.spec.ts failures

### DIFF
--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
@@ -16,12 +16,12 @@ export class AssetPublisherPage {
 		this.page = page;
 
 		this.configurationIframe = this.page.frameLocator(
-			'iframe[title*="Asset Publisher"]'
+			'iframe[title*="Configuration"]'
 		);
 	}
 
 	async changeAssetSelection(type: 'Collection' | 'Dynamic' | 'Manual') {
-		await this.configurationIframe.getByLabel(type, {exact: true}).click();
+		await this.configurationIframe.getByLabel(type).click();
 
 		await waitForAlert(
 			this.configurationIframe,

--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
@@ -64,4 +64,15 @@ export class AssetPublisherPage {
 			.first()
 			.waitFor();
 	}
+
+	async saveConfiguration() {
+		await this.configurationIframe
+			.getByRole('button', {name: 'Save'})
+			.click();
+
+		await waitForAlert(
+			this.configurationIframe,
+			'Success:You have successfully updated the setup.'
+		);
+	}
 }

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -9,7 +9,6 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 import {blogsCategorizedFriendlyUrlSetup} from './utils/blogsCategorizedFriendlyUrlSetup';
@@ -20,7 +19,6 @@ const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	blogsPagesTest,
-	pageEditorPagesTest,
 	loginTest(),
 	featureFlagsTest({
 		'LPD-11147': true,
@@ -77,7 +75,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -92,7 +89,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});
@@ -147,7 +143,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -162,7 +157,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});
@@ -203,7 +197,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -218,7 +211,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});
@@ -276,7 +268,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -291,7 +282,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});
@@ -335,7 +325,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -350,7 +339,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});
@@ -407,7 +395,6 @@ test(
 		blogsEditBlogEntryPage,
 		displayPageTemplatesPage,
 		page,
-		pageEditorPage,
 		site,
 	}) => {
 		const vocabularyName = getRandomString();
@@ -422,7 +409,6 @@ test(
 			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
-			pageEditorPage,
 			site,
 			vocabularyName,
 		});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -70,13 +70,7 @@ test(
 	{
 		tag: '@LPD-26752',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'category-1'},
@@ -86,7 +80,6 @@ test(
 
 		await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,
@@ -138,13 +131,7 @@ test(
 	{
 		tag: '@LPD-24858',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'category 1'},
@@ -154,7 +141,6 @@ test(
 
 		await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,
@@ -192,13 +178,7 @@ test(
 	{
 		tag: '@LPD-26753',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'category-1'},
@@ -208,7 +188,6 @@ test(
 
 		const {categories} = await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,
@@ -263,13 +242,7 @@ test(
 	{
 		tag: '@LPS-26755',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'lifestyle', name_i18n: {['ES-es']: 'estilo-de-vida'}},
@@ -279,7 +252,6 @@ test(
 
 		await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,
@@ -320,13 +292,7 @@ test(
 	{
 		tag: '@LPD-26659',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'category-1'},
@@ -336,7 +302,6 @@ test(
 
 		await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,
@@ -390,13 +355,7 @@ test(
 	{
 		tag: '@LPD-26659',
 	},
-	async ({
-		apiHelpers,
-		blogsEditBlogEntryPage,
-		displayPageTemplatesPage,
-		page,
-		site,
-	}) => {
+	async ({apiHelpers, blogsEditBlogEntryPage, page, site}) => {
 		const vocabularyName = getRandomString();
 		const friendlyUrlCategories = [
 			{name: 'category-1'},
@@ -406,7 +365,6 @@ test(
 
 		await blogsCategorizedFriendlyUrlSetup({
 			apiHelpers,
-			displayPageTemplatesPage,
 			friendlyUrlCategories,
 			page,
 			site,

--- a/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
+++ b/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
@@ -9,7 +9,7 @@ import {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admi
 import {BlogsEditBlogEntryPage} from '../pages/BlogsEditBlogEntryPage';
 import {BlogsPage} from '../pages/BlogsPage';
 
-const blogsPagesTest = test.extend<{
+export const blogsPagesTest = test.extend<{
 	blogsEditBlogEntryPage: BlogsEditBlogEntryPage;
 	blogsPage: BlogsPage;
 	displayPageTemplatesPage: DisplayPageTemplatesPage;
@@ -24,5 +24,3 @@ const blogsPagesTest = test.extend<{
 		await use(new DisplayPageTemplatesPage(page));
 	},
 });
-
-export {blogsPagesTest};

--- a/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
@@ -8,7 +8,6 @@ import {createAssetPublisherAndConfigure} from './createAssetPublisherAndConfigu
 import {createDPTandMarkAsDefault} from './createDPTandMarkAsDefault';
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
-import type {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 
 export async function blogsCategorizedFriendlyUrlSetup({
@@ -16,7 +15,6 @@ export async function blogsCategorizedFriendlyUrlSetup({
 	displayPageTemplatesPage,
 	friendlyUrlCategories,
 	page,
-	pageEditorPage,
 	site,
 	vocabularyName,
 }: {
@@ -24,7 +22,6 @@ export async function blogsCategorizedFriendlyUrlSetup({
 	displayPageTemplatesPage: DisplayPageTemplatesPage;
 	friendlyUrlCategories: TCategory[];
 	page;
-	pageEditorPage: PageEditorPage;
 	site: Site;
 	vocabularyName: string;
 }) {
@@ -38,7 +35,6 @@ export async function blogsCategorizedFriendlyUrlSetup({
 	await createAssetPublisherAndConfigure({
 		apiHelpers,
 		page,
-		pageEditorPage,
 		site,
 	});
 

--- a/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/blogsCategorizedFriendlyUrlSetup.ts
@@ -8,18 +8,15 @@ import {createAssetPublisherAndConfigure} from './createAssetPublisherAndConfigu
 import {createDPTandMarkAsDefault} from './createDPTandMarkAsDefault';
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
-import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 
 export async function blogsCategorizedFriendlyUrlSetup({
 	apiHelpers,
-	displayPageTemplatesPage,
 	friendlyUrlCategories,
 	page,
 	site,
 	vocabularyName,
 }: {
 	apiHelpers: ApiHelpers;
-	displayPageTemplatesPage: DisplayPageTemplatesPage;
 	friendlyUrlCategories: TCategory[];
 	page;
 	site: Site;
@@ -31,7 +28,7 @@ export async function blogsCategorizedFriendlyUrlSetup({
 		site,
 		vocabularyName,
 	});
-	await createDPTandMarkAsDefault({displayPageTemplatesPage, site});
+	await createDPTandMarkAsDefault({page, site});
 	await createAssetPublisherAndConfigure({
 		apiHelpers,
 		page,

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -6,28 +6,26 @@
 import {Page} from '@playwright/test';
 
 import {AssetPublisherPage} from '../../../pages/asset-publisher-web/AssetPublisherPage';
+import {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
-import {waitForAlert} from '../../../utils/waitForAlert';
 import getPageDefinition from '../../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getWidgetDefinition';
 
 import type {ApiHelpers} from '../../../helpers/ApiHelpers';
-import type {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 
 export async function createAssetPublisherAndConfigure({
 	apiHelpers,
 	page,
-	pageEditorPage,
 	site,
 }: {
 	apiHelpers: ApiHelpers;
 	page: Page;
-	pageEditorPage: PageEditorPage;
 	site: Site;
 }) {
-	const widgetId = getRandomString();
 	const assetPublisherPage = new AssetPublisherPage(page);
+	const pageEditorPage = new PageEditorPage(page);
+	const widgetId = getRandomString();
 
 	const widgetDefinition = getWidgetDefinition({
 		id: widgetId,

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -5,7 +5,7 @@
 
 import {Page} from '@playwright/test';
 
-import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {AssetPublisherPage} from '../../../pages/asset-publisher-web/AssetPublisherPage';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -27,6 +27,7 @@ export async function createAssetPublisherAndConfigure({
 	site: Site;
 }) {
 	const widgetId = getRandomString();
+	const assetPublisherPage = new AssetPublisherPage(page);
 
 	const widgetDefinition = getWidgetDefinition({
 		id: widgetId,
@@ -42,48 +43,21 @@ export async function createAssetPublisherAndConfigure({
 
 	await pageEditorPage.goto(layout, site.friendlyUrlPath);
 
-	const topper = pageEditorPage.getTopper(widgetId);
-	await topper.hover();
-	await clickAndExpectToBeVisible({
-		autoClick: true,
-		target: page.getByRole('menuitem', {
-			exact: true,
-			name: 'Configuration',
-		}),
-		trigger: topper.locator('.portlet-options'),
-	});
+	const configurationIframe = await assetPublisherPage.configurationIframe;
 
-	const configurationModal = await page.frameLocator(
-		'iframe[title*="Asset Publisher"][title*="Configuration"]'
-	);
-	await configurationModal.locator('.portlet-body').waitFor();
+	await pageEditorPage.goToWidgetConfiguration(widgetId);
+	await configurationIframe.locator('.portlet-body').waitFor();
 
-	const configurationDynamicInput = await configurationModal.getByLabel(
-		'Dynamic',
-		{exact: true}
-	);
-	if (await configurationDynamicInput.isHidden()) {
-		await configurationModal
-			.getByRole('link', {name: 'Asset Selection'})
-			.click();
-	}
-	if (!(await configurationDynamicInput.isChecked())) {
-		await configurationDynamicInput.click();
+	await assetPublisherPage.changeAssetSelection('Dynamic');
 
-		await waitForAlert(
-			configurationModal,
-			'Success:You have successfully updated the setup.'
-		);
-	}
-
-	await openFieldset(configurationModal, 'Source');
-	await configurationModal.getByLabel('Asset Type').selectOption({
+	await openFieldset(configurationIframe, 'Source');
+	await configurationIframe.getByLabel('Asset Type').selectOption({
 		label: 'Blogs Entry',
 	});
 
-	await configurationModal.getByRole('button', {name: 'Save'}).click();
+	await configurationIframe.getByRole('button', {name: 'Save'}).click();
 	await waitForAlert(
-		configurationModal,
+		configurationIframe,
 		'Success:You have successfully updated the setup.'
 	);
 	await page.getByLabel('close', {exact: true}).click();

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -55,11 +55,7 @@ export async function createAssetPublisherAndConfigure({
 		label: 'Blogs Entry',
 	});
 
-	await configurationIframe.getByRole('button', {name: 'Save'}).click();
-	await waitForAlert(
-		configurationIframe,
-		'Success:You have successfully updated the setup.'
-	);
+	await assetPublisherPage.saveConfiguration();
 	await page.getByLabel('close', {exact: true}).click();
 
 	await pageEditorPage.publishPage();

--- a/modules/test/playwright/tests/blogs-web/utils/createDPTandMarkAsDefault.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createDPTandMarkAsDefault.ts
@@ -3,17 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {Page} from '@playwright/test';
+
+import {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import getRandomString from '../../../utils/getRandomString';
 
-import type {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
-
 export async function createDPTandMarkAsDefault({
-	displayPageTemplatesPage,
+	page,
 	site,
 }: {
-	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	page: Page;
 	site: Site;
 }) {
+	const displayPageTemplatesPage = new DisplayPageTemplatesPage(page);
+
 	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
 
 	const displayPageTemplateName = getRandomString();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44786

Test broken by feature (outdated UI) https://liferay.atlassian.net/browse/LPD-32047

# How am I fixing it?

Updating the test to fit with the new UI and interactions. Used new methods that page management added to pageEditorPage and assetPublisherPage.

# How can you verify that it works?

Runt the test
```sh
npm run playwright -- test tests/blogs-web --grep-invert Permission
```

# Locally test passed
![image](https://github.com/user-attachments/assets/9ea24ca3-d911-4b30-ab51-4fa31e5a6343)
