### PR TITLE
LPD-44784 Back button doesn't work in Documents and Media's View History 

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
@@ -8,12 +8,14 @@
 <%@ include file="/document_library/init.jsp" %>
 
 <%
+String redirect = ParamUtil.getString(request, "redirect");
+
 DLViewEntryHistoryDisplayContext dlViewEntryHistoryDisplayContext = (DLViewEntryHistoryDisplayContext)request.getAttribute(DLViewEntryHistoryDisplayContext.class.getName());
 
 FileEntry fileEntry = dlViewEntryHistoryDisplayContext.getFileEntry();
 
 portletDisplay.setShowBackIcon(true);
-portletDisplay.setURLBack(dlViewEntryHistoryDisplayContext.getBackURL());
+portletDisplay.setURLBack(redirect);
 
 renderResponse.setTitle(fileEntry.getTitle());
 %>

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -196,6 +196,21 @@ export class DocumentLibraryPage {
 			.waitFor();
 	}
 
+	async goToViewHistoryFileEntry(entryTitle: string) {
+		await this.page
+			.getByRole('link', {exact: true, name: entryTitle})
+			.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'View History',
+			}),
+			trigger: this.page.getByRole('button', {name: 'Show Actions'}),
+		});
+	}
+
 	async goToEditFileEntry(entryTitle: string) {
 		await this.page
 			.getByRole('link', {exact: true, name: entryTitle})

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -510,3 +510,25 @@ test(
 		});
 	}
 );
+
+test(
+	'Back button works when viewing file entry history',
+	{
+		tag: '@LPD-44784',
+	},
+	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
+		const title = getRandomString();
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			title,
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryPage.goToViewHistoryFileEntry(title);
+
+		await page.getByRole('link', {name: 'Back'}).click();
+
+		await expect(
+			page.getByRole('button', {name: 'Versions'})
+		).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
LPD-44784 Back button doesn't work in Documents and Media's View History
# What is this trying to solve?

[Link to ticket](https://liferay.atlassian.net/browse/LPD-44784)

# How am I fixing it?
Use redirect instead of getBackURL

# How can I test it?
Follow the steps in the bug
![image](https://github.com/user-attachments/assets/bcb5e1eb-ed9a-4808-9a44-3e6462dcc48b)
