### PR TITLE
LPD-44904 Web Content Schedule Publication Feature Flag is only in UTC and wrong time is displayed after scheduled

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -33,7 +33,12 @@ export default function ScheduleOptions({
 
 			const date = new Date(displayDate);
 
-			if (date.valueOf() <= new Date().valueOf()) {
+			if (
+				date.valueOf() <=
+				new Date(
+					new Date().toLocaleString('en-US', {timeZone})
+				).valueOf()
+			) {
 				setError(
 					Liferay.Language.get('the-date-entered-is-in-the-past')
 				);
@@ -42,7 +47,7 @@ export default function ScheduleOptions({
 				setError('');
 			}
 		}
-	}, [setError, displayDate]);
+	}, [displayDate, setError, timeZone]);
 
 	return (
 		<>

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -210,6 +210,74 @@ baseTest(
 	}
 );
 
+baseTest(
+	'Web Content Schedule Publication Feature Flag is only in UTC and wrong time is displayed after scheduled',
+	{
+		tag: '@LPD-31427',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		page.on('dialog', (dialog) => dialog.accept());
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.content.waitFor();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await expect(async () => {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					name: 'Schedule Publication',
+				}),
+				trigger: page.getByRole('button', {
+					name: /select and confirm publish settings|sélectionnez et confirmez les/i,
+				}),
+			});
+
+			await expect(page.getByLabel('Date and Time')).toBeVisible({
+				timeout: 2000,
+			});
+		}).toPass();
+
+		const currentDate = new Date();
+
+		currentDate.setMinutes(currentDate.getMinutes() - 5);
+
+		const beforeCurrentDateUTC = new Date(
+			currentDate.toLocaleString('en-US', {timeZone: 'UTC'})
+		);
+
+		await page
+			.getByPlaceholder('YYYY-MM-DD HH:mm')
+			.fill(
+				`${beforeCurrentDateUTC.getFullYear()}-${String(beforeCurrentDateUTC.getMonth() + 1).padStart(2, '0')}-${String(beforeCurrentDateUTC.getDate()).padStart(2, '0')} ${String(beforeCurrentDateUTC.getHours()).padStart(2, '0')}:${String(beforeCurrentDateUTC.getMinutes()).padStart(2, '0')}`
+			);
+
+		await expect(
+			page.getByText('Error: The date entered is in the past.')
+		).toBeVisible();
+
+		currentDate.setMinutes(currentDate.getMinutes() + 10);
+
+		const afterCurrentDateUTC = new Date(
+			currentDate.toLocaleString('en-US', {timeZone: 'UTC'})
+		);
+
+		await page
+			.getByPlaceholder('YYYY-MM-DD HH:mm')
+			.fill(
+				`${afterCurrentDateUTC.getFullYear()}-${String(afterCurrentDateUTC.getMonth() + 1).padStart(2, '0')}-${String(afterCurrentDateUTC.getDate()).padStart(2, '0')} ${String(afterCurrentDateUTC.getHours()).padStart(2, '0')}:${String(afterCurrentDateUTC.getMinutes()).padStart(2, '0')}`
+			);
+
+		await expect(
+			page.getByText('Error: The date entered is in the past.')
+		).not.toBeVisible();
+	}
+);
+
 translationAndAutosaveTest(
 	'Article selector should only list approved content',
 	{


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-57156

# How am I fixing it?

Change the creation of the new date taking into account the timezone in the date time validation.

# How can you verify that it works?

Run the included test.
