### PR TITLE
LPD-44952 Update paths to not be dependent on text as this will fail in different locales (LocalizationWithSites#ViewPortletInteractWithLocalization)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1804,7 +1804,7 @@ definition {
 
 	@summary = "Default summary"
 	macro publishWithPermissions(viewableBy = null) {
-		Button.clickPublish();
+		Click(locator1 = "WCEditWebContent#PUBLISH_DROPDOWN_BUTTON");
 
 		Click(locator1 = "WCEditWebContent#PUBLISH_WITH_PERMISSIONS_BUTTON");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
@@ -61,7 +61,7 @@ definition {
 			webContentContent = ${webContentContent},
 			webContentTitle = ${webContentTitle});
 
-		Click(locator1 = "Button#PUBLISH_LOCALIZED");
+		WebContent.publishWithPermissions();
 
 		SelectFrame(value1 = "relative=top");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
@@ -109,13 +109,18 @@
 	<td></td>
 </tr>
 <tr>
+	<td>PUBLISH_DROPDOWN_BUTTON</td>
+	<td>//div[contains(@class,'journal-article-button-row')]//button[contains(@class,'dropdown-toggle')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>PUBLISH_WITH_PERMISSIONS_BUTTON</td>
-	<td>//button[contains(@class, 'dropdown-item') and contains(text(), 'Publish With Permissions')]</td>
+	<td>//button[contains(@class, 'dropdown-item') and span/*[name()='svg'][contains(@class,'lexicon-icon-arrow-right-full')]]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PUBLISH_IN_MODAL</td>
-	<td>//div[contains(@class,'modal-content')]//button[contains(text(),'Publish')]</td>
+	<td>//div[contains(@class,'modal-content')]//button[@type='submit']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44952

# How am I fixing it?

The paths for the updated publish button in Web Content are hard coded to use English text. This fails if the test changes the locale and tries to publish an article. These changes update the paths to find the buttons despite the locale.

I would assume the other macros would need to be updated as well (eg publishExistingWCArticleWithPermissions, scheduleExistingWCArticleWithPermissions) but my failing test didn't go through these methods so I didn't have a good way to test to ensure they were working properly.

# How can you verify that it works?

In the root folder run `ant -f build-test.xml run-selenium-test -Dtest.class=LocalizationWithSites#ViewPortletInteractWithLocalization`