### PR TITLE
LPD-44995 Fix WebContent poshi failures

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingWC.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotLocalStagingWC.testcase
@@ -132,7 +132,7 @@ definition {
 
 		SelectFrame(value1 = "relative=top");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name-staging");
 
@@ -222,7 +222,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "friendlyUrledit");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingWC.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRemoteStagingWC.testcase
@@ -154,7 +154,7 @@ definition {
 
 		SelectFrame(value1 = "relative=top");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "site-name");
 
@@ -265,7 +265,7 @@ definition {
 
 		WebContent.editFriendlyURL(webContentFriendlyURL = "friendlyUrledit");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		DepotNavigator.switchStagingStatus(stagingItem = "Publish to Live");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/accessiblity/WebContentAdminAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/accessiblity/WebContentAdminAccessibility.testcase
@@ -170,7 +170,7 @@ definition {
 				webContentText = "LXC",
 				webContentTitle = "LXC");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 		}
 
 		task ("When the site administrator navigates to the configuration page") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -173,7 +173,7 @@ definition {
 				dmFolderName = "Provided by Liferay",
 				imageFileName = "moon.png");
 
-			WebContent.publishWithPermissions();
+			WebContent.publishExistingWCArticleWithPermissions();
 
 			LexiconEntry.changeDisplayStyle(displayStyle = "cards");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentAdmin.testcase
@@ -921,7 +921,7 @@ definition {
 				webContentText = "LXC",
 				webContentTitle = "LXC");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 		}
 
 		task ("When the site administrator navigates to the configuration page") {
@@ -1731,7 +1731,7 @@ definition {
 				webContentText = "LXC",
 				webContentTitle = "LXC");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 		}
 
 		task ("When the site administrator navigates to the highlighted structure sheet") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentExportImport.testcase
@@ -319,7 +319,7 @@ definition {
 				webContentImage = "Document Title",
 				webContentTitle = "WC Title");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "global");
 
@@ -570,7 +570,7 @@ definition {
 			webContentTitle = "WC WebContent Title",
 			webContentWebContent = "Basic WebContent Title");
 
-		PortletEntry.publish();
+		WebContent.publishWithPermissions();
 
 		WebContent.viewTitle(webContentTitle = "WC WebContent Title");
 
@@ -609,7 +609,7 @@ definition {
 			fieldName = "TestName",
 			webContentTitle = "WC WebContent 1 Title");
 
-		PortletEntry.publish();
+		WebContent.publishWithPermissions();
 
 		WebContent.viewTitle(webContentTitle = "WC WebContent 1 Title");
 
@@ -707,7 +707,7 @@ definition {
 			var count = ${count} + 1;
 		}
 
-		PortletEntry.publish();
+		WebContent.publishWithPermissions();
 
 		WebContent.viewTitle(webContentTitle = "Agricultural Science Front Page");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentWithStaging.testcase
@@ -130,7 +130,7 @@ definition {
 				webContentUpload = "Document_3.doc",
 				webContentWebContent = "WC 1");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 
 			WebContent.viewTitle(webContentTitle = "WC WebContent Title 2");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentWithCustomStructures.testcase
@@ -945,7 +945,7 @@ definition {
 				webContentTitle = "Web Content Title 2",
 				webContentWebContent = "Web Content Title 1");
 
-			PortletEntry.publish();
+			WebContent.publishWithPermissions();
 		}
 
 		task ("View web content and geolocation field are shown") {


### PR DESCRIPTION

Issues (parent tasks) : 
https://liferay.atlassian.net/browse/LPD-44994
https://liferay.atlassian.net/browse/LPD-45009
https://liferay.atlassian.net/browse/LPD-45016
https://liferay.atlassian.net/browse/LPD-45019

This pull fixes these tests: 

- LocalFile.WebContentAdminAccessibility#ViewAccessibilityOfHighlightedStructures
- LocalFile.WebContentAdmin#ManageWebContentsByStructuresInAssetLibrary
- LocalFile.WebContentAdmin#ViewInfoPanelOfWebContentsInHighlightedStructureSheet
- LocalFile.WebContent#AddWebContentWithFeaturedImageFromDocumentsAndMedia
- LocalFile.WebContentExportImport#ImportAndUseGlobalStructureAndTemplate
- LocalFile.WebContentWithCustomStructures#AddWebContentWithWebContentAndGeolocationFields
- LocalFile.WebContentExportImport#ExportLARWithNestedWebContent
- LocalFile.WebContentWithStaging#AssertWebContentFromStructureNotBeDeletedOnLiveViaSAP
- LocalFile.WebContentExportImport#CanShowExportedGlobalStructuresImageBetweenInstances
- LocalFile.WebContentExportImport#ExportWebContentWithEditedStructure
- LocalFile.DepotLocalStagingWC#CanDeleteWCInlineImage
- LocalFile.DepotRemoteStagingWC#CanDeleteWCInlineImage
- LocalFile.DepotLocalStagingWC#CanEditFriendlyURL
- LocalFile.DepotRemoteStagingWC#CanEditFriendlyURL