### PR TITLE
LPD-45117 Fix tests related to add required Categories to Web Content

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -210,8 +210,6 @@ definition {
 
 		AssertElementPresent(locator1 = "Icon#ASTERISK");
 
-		Alert.viewRequestFailedToComplete();
-
 		Panel.expandPanel(panel = "Categorization");
 
 		AssertTextEquals.assertPartialText(


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-45116)

This pull fixes: 
LocalFile.WebContent#CanConfigureRequiredVocabularyInAnAssetLibraryOnTheSiteConnected
LocalFile.WebContent#CanDisconnectAndConnectTheSiteToTheAssetLibraryInRequiredVocabulary
LocalFile.CategoriesUseCase#AddWebContentWithRequiredCategory


I removed an irrelevant step that was failing (probably because some timeouts, because the alert is shown), we are currently checking the error in the next line
