### PR TITLE
LPD-33785 Add test for LPP-53324

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {DocumentLibraryPage} from './DocumentLibraryPage';
 
 export class DocumentLibraryEditDocumentTypesPage {
@@ -26,9 +27,9 @@ export class DocumentLibraryEditDocumentTypesPage {
 		await this.documentLibraryPage.openNewDLTypeButton();
 	}
 
-	async addField(type: string) {
-		await this.goto();
-		await this.page.getByTitle(type).dblclick();
+	async addField(type: string, siteUrl?: Site['friendlyUrlPath']) {
+		await this.goto(siteUrl);
+		await this.page.getByTitle(type, {exact: true}).dblclick();
 	}
 
 	async createNewDLTypeWithNumericField(
@@ -36,8 +37,22 @@ export class DocumentLibraryEditDocumentTypesPage {
 		siteUrl?: Site['friendlyUrlPath']
 	) {
 		await this.goto(siteUrl);
-		await this.addField('Numeric');
+		await this.addField('Numeric', siteUrl);
 		await this.titleSelector.fill(title);
+		await this.saveButton.click();
+	}
+
+	async createNewDLTypeWithTextFieldRequiredNonLocalizable(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
+		await this.addField('Text');
+		await this.page.getByRole('tab', {name: 'Basic'}).click();
+		await this.page.getByLabel('Required Field').check();
+		await this.page.getByRole('tab', {name: 'Advanced'}).click();
+		await this.page.getByLabel('Localizable').uncheck();
+		await fillAndClickOutside(this.page, this.titleSelector, title);
 		await this.saveButton.click();
 	}
 
@@ -46,7 +61,7 @@ export class DocumentLibraryEditDocumentTypesPage {
 		siteUrl?: Site['friendlyUrlPath']
 	) {
 		await this.goto(siteUrl);
-		await this.addField('Upload');
+		await this.addField('Upload', siteUrl);
 		await this.titleSelector.fill(title);
 		await this.saveButton.click();
 	}

--- a/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
@@ -70,4 +70,32 @@ export class SiteSettingsLocalizationPage {
 
 		await this.page.waitForLoadState();
 	}
+
+	async disableAllLanguagesExceptSp(siteUrl?: Site['friendlyUrlPath']) {
+		await this.goto(siteUrl);
+
+		await this.page.getByLabel('Transfer Item Left to Right').click();
+
+		await this.page
+			.getByRole('listbox')
+			.first()
+			.selectOption([
+				'en_US',
+				'ar_SA',
+				'ca_ES',
+				'nl_NL',
+				'zh_CN',
+				'fi_FI',
+				'fr_FR',
+				'de_DE',
+				'hu_HU',
+				'ja_JP',
+				'pt_BR',
+				'sv_SE',
+			]);
+
+		await this.page.getByLabel('Transfer Item Left to Right').click();
+
+		await this.siteSettingsPage.saveConfiguration();
+	}
 }

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -8,10 +8,12 @@ import {createReadStream} from 'fs';
 import path from 'path';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {siteSettingsPagesTest} from '../../fixtures/siteSettingsPagesTest';
 import {createCategories} from '../../helpers/CreateCategories';
 import {DLFILE_STATUS} from '../../helpers/json-web-services/JSONWebServicesDocumentLibraryApiHelper';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
@@ -24,12 +26,14 @@ import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidg
 
 const test = mergeTests(
 	apiHelpersTest,
+	applicationsMenuPageTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
-	loginTest()
+	loginTest(),
+	siteSettingsPagesTest
 );
 
 test(
@@ -530,5 +534,65 @@ test(
 		await expect(
 			page.getByRole('button', {name: 'Versions'})
 		).not.toBeVisible();
+	}
+);
+
+test(
+	'A non-localizable field in a Document Type cannot be entered if accessed from a site that does not use the global site language',
+	{
+		tag: '@LPP-53324',
+	},
+
+	async ({
+		apiHelpers,
+		applicationsMenuPage,
+		documentLibraryEditDocumentTypesPage,
+		documentLibraryEditFilePage,
+		documentLibraryPage,
+		page,
+		site,
+		siteSettingsLocalizationPage,
+	}) => {
+		const dTypeTitle = getRandomString();
+
+		await documentLibraryEditDocumentTypesPage.createNewDLTypeWithTextFieldRequiredNonLocalizable(
+			dTypeTitle,
+			'/global'
+		);
+
+		await siteSettingsLocalizationPage.setCustomDefaultLanguage(
+			'Spanish (Spain)',
+			site.friendlyUrlPath
+		);
+
+		await siteSettingsLocalizationPage.disableAllLanguagesExceptSp(
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryEditFilePage.goToNewFileDifferentType(
+			dTypeTitle,
+			site.friendlyUrlPath
+		);
+
+		await page.getByLabel('Title Required').click();
+		await page.getByLabel('Title Required').fill(getRandomString());
+		await page.getByLabel('Text').click();
+		await page.getByLabel('Text').fill(getRandomString());
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await waitForAlert(
+			page,
+			'Success:Your request completed successfully.'
+		);
+
+		await apiHelpers.headlessSite.deleteSite(site.id);
+		await applicationsMenuPage.goToGlobalSite();
+		await documentLibraryPage.deleteDocumentType(dTypeTitle);
+
+		await waitForAlert(
+			page,
+			'Success:Your request completed successfully.'
+		);
 	}
 );


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-33785 Adding missing test from LPP-53324

### How am I fixing it?
Creating a new functional test that follows these steps:
- The global site should have English as its main language.
- From the Global site, create a new content type called GlobalFileType.
- Add a non-localizable and required text field to it.
- Create a website with Spanish as its language.
- Remove the rest of the available languages on that website and leave only Spanish.
- From the spanish site, go to the document library and add a new document of the GlobalFileType type.

### How can you verify that it works?
1. Running the test