### PR TITLE
LPD-33785 Fix test for LPP-53324

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
@@ -47,7 +47,7 @@ export class DocumentLibraryEditDocumentTypesPage {
 		siteUrl?: Site['friendlyUrlPath']
 	) {
 		await this.goto(siteUrl);
-		await this.addField('Text');
+		await this.addField('Text', siteUrl);
 		await this.page.getByRole('tab', {name: 'Basic'}).click();
 		await this.page.getByLabel('Required Field').check();
 		await this.page.getByRole('tab', {name: 'Advanced'}).click();

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -574,12 +574,10 @@ test(
 			site.friendlyUrlPath
 		);
 
-		await page.getByLabel('Title Required').click();
 		await page.getByLabel('Title Required').fill(getRandomString());
-		await page.getByLabel('Text').click();
 		await page.getByLabel('Text').fill(getRandomString());
 
-		await page.getByRole('button', {name: 'Publish'}).click();
+		await documentLibraryEditFilePage.publishButton.click();
 
 		await waitForAlert(
 			page,


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-33785 Adding missing test from LPP-53324

### How am I fixing it?
Creating a new functional test that follows these steps:
- The global site should have English as its main language.
- From the Global site, create a new content type called GlobalFileType.
- Add a non-localizable and required text field to it.
- Create a website with Spanish as its language.
- Remove the rest of the available languages on that website and leave only Spanish.
- From the spanish site, go to the document library and add a new document of the GlobalFileType type.

### How can you verify that it works?
1. Running the test