### PR TITLE
LPD-45264 Back button doesn't work in Content Dashboard's View Versions

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
@@ -8,14 +8,12 @@
 <%@ include file="/document_library/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
-
 DLViewEntryHistoryDisplayContext dlViewEntryHistoryDisplayContext = (DLViewEntryHistoryDisplayContext)request.getAttribute(DLViewEntryHistoryDisplayContext.class.getName());
 
 FileEntry fileEntry = dlViewEntryHistoryDisplayContext.getFileEntry();
 
 portletDisplay.setShowBackIcon(true);
-portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBack(dlViewEntryHistoryDisplayContext.getBackURL());
 
 renderResponse.setTitle(fileEntry.getTitle());
 %>


### PR DESCRIPTION
LPD-45264 Back button doesn't work in Content Dashboard's View Versions
# What is this trying to solve?
Fix back button when clicking on View More versions for a document in Content Dashboard

[Link to ticket](https://liferay.atlassian.net/browse/LPD-45264)

# How am I fixing it?
Use back URL from display context 
# How can I test it?
Follow steps in the bug or run Poshi test ContentDashboard#DocumentsVersionHistoryClickBack

## The test is in ContentDashboard#DocumentsVersionHistoryClickBack
