### PR TITLE
LPD-45282 Technical Task | Fix Add error message in Translation for concurrent users

### DIFF
--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -289,11 +289,6 @@ export class JournalEditArticlePage {
 		await this.fillTitle(title);
 
 		await this.publishArticle(true);
-
-		await waitForAlert(
-			this.page,
-			`Success:${title} was updated successfully.`
-		);
 	}
 
 	async openDMItemSelectorForImages() {


### PR DESCRIPTION
The problem with the test was we are waiting for the alert 2 times when editing a web content, and waitForAlert() closes the alert making the second waitForAlert() fail.

Please review it.

<img width="908" alt="Screenshot 2025-01-02 at 11 22 43" src="https://github.com/user-attachments/assets/660d4282-f2ec-455a-a983-bf6d8f49fad4" />
