### PR TITLE
LPD-44997 Performance of fetchDisplayArticle

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleFinder.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleFinder.java
@@ -72,6 +72,13 @@ public interface JournalArticleFinder {
 			com.liferay.portal.kernel.dao.orm.QueryDefinition
 				<com.liferay.journal.model.JournalArticle> queryDefinition);
 
+	public java.util.List<com.liferay.journal.model.JournalArticle>
+		filterFindByG_A_LtDD_GtED_ST(
+			long groupId, String articleId, java.util.Date displayDate,
+			java.util.Date expirationDate, int status,
+			com.liferay.portal.kernel.dao.orm.QueryDefinition
+				<com.liferay.journal.model.JournalArticle> queryDefinition);
+
 	public java.util.List<com.liferay.journal.model.JournalArticle> findByG_F_L(
 		long groupId, java.util.List<Long> folderIds, java.util.Locale locale,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1843,12 +1843,12 @@ public class JournalArticleLocalServiceImpl
 		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
 			WorkflowConstants.STATUS_APPROVED, 0, 1, null);
 
-		Date date = new Date();
+		Date now = new Date();
 
 		List<JournalArticle> articles =
 			journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
-				groupId, articleId, date, date,
-				WorkflowConstants.STATUS_APPROVED, queryDefinition);
+				groupId, articleId, now, now, WorkflowConstants.STATUS_APPROVED,
+				queryDefinition);
 
 		if (articles.isEmpty()) {
 			return null;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1840,24 +1840,18 @@ public class JournalArticleLocalServiceImpl
 
 	@Override
 	public JournalArticle fetchDisplayArticle(long groupId, String articleId) {
-		List<JournalArticle> articles = journalArticlePersistence.findByG_A_ST(
-			groupId, articleId, WorkflowConstants.STATUS_APPROVED);
-
-		if (articles.isEmpty()) {
-			return null;
-		}
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			WorkflowConstants.STATUS_APPROVED, 0, 1, null);
 
 		Date date = new Date();
 
-		for (JournalArticle article : articles) {
-			Date displayDate = article.getDisplayDate();
-			Date expirationDate = article.getExpirationDate();
+		List<JournalArticle> articles =
+			journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
+				groupId, articleId, date, date,
+				WorkflowConstants.STATUS_APPROVED, queryDefinition);
 
-			if (((displayDate == null) || displayDate.before(date)) &&
-				((expirationDate == null) || expirationDate.after(date))) {
-
-				return article;
-			}
+		if (articles.isEmpty()) {
+			return null;
 		}
 
 		return articles.get(0);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -69,6 +70,9 @@ public class JournalArticleFinderImpl
 
 	public static final String FIND_BY_G_F_C_S_L =
 		JournalArticleFinder.class.getName() + ".findByG_F_C_S_L";
+
+	public static final String FIND_BY_G_A_LTDD_GTED_ST =
+		JournalArticleFinder.class.getName() + ".findByG_A_LtDD_GtED_ST";
 
 	@Override
 	public int countByG_F(
@@ -156,6 +160,16 @@ public class JournalArticleFinderImpl
 		return doFindByG_C_S_L(
 			groupId, folderIds, classNameId, ddmStructureId, locale,
 			queryDefinition, true);
+	}
+
+	@Override
+	public List<JournalArticle> filterFindByG_A_LtDD_GtED_ST(
+		long groupId, String articleId, Date displayDate, Date expirationDate,
+		int status, QueryDefinition<JournalArticle> queryDefinition) {
+
+		return doFindByG_A_LtDD_GtED_ST(
+			groupId, articleId, displayDate, expirationDate, status,
+			queryDefinition, false);
 	}
 
 	@Override
@@ -799,6 +813,54 @@ public class JournalArticleFinderImpl
 			}
 
 			queryPos.add(queryDefinition.getStatus());
+
+			return (List<JournalArticle>)QueryUtil.list(
+				sqlQuery, getDialect(), queryDefinition.getStart(),
+				queryDefinition.getEnd());
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected List<JournalArticle> doFindByG_A_LtDD_GtED_ST(
+		long groupId, String articleId, Date displayDate, Date expirationDate,
+		int status, QueryDefinition<JournalArticle> queryDefinition,
+		boolean inlineSQLHelper) {
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = _customSQL.get(
+				getClass(), FIND_BY_G_A_LTDD_GTED_ST, queryDefinition,
+				"JournalArticle");
+
+			sql = _customSQL.replaceOrderBy(
+				sql, queryDefinition.getOrderByComparator());
+
+			if (inlineSQLHelper) {
+				sql = InlineSQLHelperUtil.replacePermissionCheck(
+					sql, JournalArticle.class.getName(),
+					"JournalArticle.resourcePrimKey", groupId);
+			}
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addEntity(
+				JournalArticleImpl.TABLE_NAME, JournalArticleImpl.class);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+			queryPos.add(articleId);
+			queryPos.add(status);
+			queryPos.add(displayDate);
+			queryPos.add(expirationDate);
 
 			return (List<JournalArticle>)QueryUtil.list(
 				sqlQuery, getDialect(), queryDefinition.getStart(),

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -218,6 +218,28 @@
 				JournalArticle.id_ ASC
 		]]>
 	</sql>
+	<sql id="com.liferay.journal.service.persistence.JournalArticleFinder.findByG_A_LtDD_GtED_ST">
+		<![CDATA[
+			SELECT
+				JournalArticle.*
+			FROM
+				JournalArticle
+			WHERE
+				(JournalArticle.groupId = ?) AND
+				(JournalArticle.articleId = ?) AND
+				(JournalArticle.status = ?) AND
+				(
+					(JournalArticle.displayDate IS NULL) OR
+					(JournalArticle.displayDate < ?)
+				) AND
+				(
+					(JournalArticle.expirationDate IS NULL) OR
+					(JournalArticle.expirationDate > ?)
+				)
+			ORDER BY
+				JournalArticle.version DESC
+		]]>
+	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.countA_ByG_U_F_DDMSI_NotS">
 		<![CDATA[
 			SELECT

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleFinderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleFinderTest.java
@@ -15,6 +15,7 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.persistence.JournalArticleFinder;
+import com.liferay.journal.service.persistence.JournalArticlePersistence;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.comparator.ArticleCreateDateComparator;
 import com.liferay.journal.util.comparator.ArticleDisplayDateComparator;
@@ -46,6 +47,7 @@ import com.liferay.portal.test.rule.TransactionalTestRule;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
@@ -192,6 +194,73 @@ public class JournalArticleFinderTest {
 		testQueryByG_C(
 			_group.getGroupId(), Collections.<Long>emptyList(),
 			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, queryDefinition, 0);
+	}
+
+	@Test
+	public void testFindByG_A_LtDD_GtED_ST() throws Exception {
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0);
+
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			WorkflowConstants.STATUS_APPROVED, 0, 1, null);
+
+		article = _journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
+			_group.getGroupId(), article.getArticleId(), new Date(), new Date(),
+			WorkflowConstants.STATUS_APPROVED, queryDefinition
+		).get(
+			0
+		);
+
+		Assert.assertEquals(
+			"Returns the only approved version", 1, article.getVersion(), 0);
+
+		article = JournalTestUtil.updateArticle(article);
+
+		article = JournalTestUtil.updateArticle(article);
+
+		JournalArticle articleToExpire = JournalTestUtil.updateArticle(article);
+
+		article = _journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
+			_group.getGroupId(), article.getArticleId(), new Date(), new Date(),
+			WorkflowConstants.STATUS_APPROVED, queryDefinition
+		).get(
+			0
+		);
+
+		Assert.assertEquals(
+			"Returns the latest approved version", 1.3, article.getVersion(),
+			0);
+
+		JournalTestUtil.expireArticle(
+			_group.getGroupId(), articleToExpire, articleToExpire.getVersion());
+
+		article = _journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
+			_group.getGroupId(), article.getArticleId(), new Date(), new Date(),
+			WorkflowConstants.STATUS_APPROVED, queryDefinition
+		).get(
+			0
+		);
+
+		Assert.assertEquals(
+			"Returns the latest approved version when an expired newer " +
+				"version exists",
+			1.2, article.getVersion(), 0);
+
+		articleToExpire.setDisplayDate(
+			new Date(System.currentTimeMillis() + (60 * 60 * 1000)));
+		articleToExpire.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		JournalTestUtil.updateArticle(articleToExpire);
+
+		article = _journalArticleFinder.filterFindByG_A_LtDD_GtED_ST(
+			_group.getGroupId(), article.getArticleId(), new Date(), new Date(),
+			WorkflowConstants.STATUS_APPROVED, queryDefinition
+		).get(
+			0
+		);
+
+		Assert.assertEquals(
+			"Does not return a future article", 1.2, article.getVersion(), 0);
 	}
 
 	@Test
@@ -514,5 +583,8 @@ public class JournalArticleFinderTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private JournalArticlePersistence _journalArticlePersistence;
 
 }


### PR DESCRIPTION
# What is this trying to solve?
[LPD-44997](https://liferay.atlassian.net/browse/LPD-44997)

When a JournalArticle has a huge version history, 
[JournalArticleLocalServiceImpl#fetchDisplayArticle](https://github.com/liferay/liferay-portal/blob/3163a318497b71a29560f0ecf448270e92726b8c/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L1842-L1864) loads all of them to the memory, which reduces performance.

# How am I fixing it?
Moving the displayDate and expirationDate filtering to the Database level

# How can you verify that it works?
```
cd modules/apps/journal/journal-test
gw testIntegration --tests JournalArticleFinderTest.testFindByG_A_LtDD_GtED_ST
```

Cheers,
Balázs