### PR TITLE
LPD-45428 Search container path header column disappear 

### DIFF
--- a/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/display/test/JournalDisplayContextTest.java
+++ b/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/display/test/JournalDisplayContextTest.java
@@ -8,6 +8,9 @@ package com.liferay.journal.web.internal.display.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.service.JournalFolderLocalService;
+import com.liferay.journal.test.util.JournalFolderFixture;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -107,6 +110,26 @@ public class JournalDisplayContextTest {
 		Assert.assertEquals(count, searchContainer.getTotal());
 	}
 
+	@Test
+	public void testIsShowBreadcrumb() throws Exception {
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			_journalFolderLocalService);
+
+		Assert.assertTrue(
+			_isShowBreadcrumb(
+				"test",
+				journalFolderFixture.addFolder(
+					_group.getGroupId(), RandomTestUtil.randomString())));
+
+		Assert.assertFalse(
+			_isShowBreadcrumb(
+				"",
+				journalFolderFixture.addFolder(
+					_group.getGroupId(), RandomTestUtil.randomString())));
+
+		Assert.assertFalse(_isShowBreadcrumb("test", null));
+	}
+
 	private void _addJournalArticle(String title) throws Exception {
 		JournalTestUtil.addArticle(
 			_group.getGroupId(),
@@ -194,6 +217,23 @@ public class JournalDisplayContextTest {
 		return themeDisplay;
 	}
 
+	private boolean _isShowBreadcrumb(
+			String keywords, JournalFolder journalFolder)
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_renderPortlet();
+
+		mockLiferayPortletRenderRequest.setParameter("keywords", keywords);
+
+		return ReflectionTestUtil.invoke(
+			mockLiferayPortletRenderRequest.getAttribute(
+				"com.liferay.journal.web.internal.display.context." +
+					"JournalDisplayContext"),
+			"isShowBreadcrumb", new Class<?>[] {JournalFolder.class},
+			journalFolder);
+	}
+
 	private MockLiferayPortletRenderRequest _renderPortlet() throws Exception {
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			_getMockLiferayPortletRenderRequest();
@@ -214,6 +254,9 @@ public class JournalDisplayContextTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private JournalFolderLocalService _journalFolderLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.journal.web.internal.portlet.JournalPortlet"

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1323,6 +1323,21 @@ public class JournalDisplayContext {
 		return false;
 	}
 
+	public boolean isShowBreadcrumb(JournalFolder journalFolder)
+		throws PortalException {
+
+		if (isSearch() && (journalFolder != null) &&
+			((journalFolder.getFolderId() <= 0) ||
+			 JournalFolderPermission.contains(
+				 _themeDisplay.getPermissionChecker(), journalFolder,
+				 ActionKeys.VIEW))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isShowComments() throws PortalException {
 		if (Objects.equals(_getSearchIn(), "comments")) {
 			return true;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -126,7 +126,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 								<%= journalDisplayContext.getArticleSubtitle(curArticle) %>
 							</span>
 
-							<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
+							<c:if test="<%= journalDisplayContext.isShowBreadcrumb(curArticle.getFolder()) %>">
 								<c:choose>
 									<c:when test="<%= curArticle.getFolderId() != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID %>">
 										<liferay-site-navigation:breadcrumb
@@ -251,7 +251,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							cssClass="table-cell-expand-smallest table-cell-minw-200"
 							name="path"
 						>
-							<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
+							<c:if test="<%= journalDisplayContext.isShowBreadcrumb(curArticle.getFolder()) %>">
 								<c:choose>
 									<c:when test="<%= curArticle.getFolderId() != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID %>">
 										<liferay-site-navigation:breadcrumb
@@ -399,7 +399,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 								<%= journalDisplayContext.getFolderSubtitle(curFolder) %>
 							</span>
 
-							<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
+							<c:if test="<%= journalDisplayContext.isShowBreadcrumb(curFolder.getParentFolder()) %>">
 								<liferay-site-navigation:breadcrumb
 									breadcrumbEntries="<%= JournalPortletUtil.getPortletBreadcrumbEntries(curFolder.getParentFolder(), request, true, liferayPortletResponse) %>"
 									cssClass="c-pl-0 c-pt-0"
@@ -485,7 +485,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							cssClass="table-cell-expand-smallest table-cell-minw-200"
 							name="path"
 						>
-							<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
+							<c:if test="<%= journalDisplayContext.isShowBreadcrumb(curFolder.getParentFolder()) %>">
 								<liferay-site-navigation:breadcrumb
 									breadcrumbEntries="<%= JournalPortletUtil.getPortletBreadcrumbEntries(curFolder.getParentFolder(), request, true, liferayPortletResponse) %>"
 									cssClass="c-pl-0 c-pt-0"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -247,11 +247,11 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							/>
 						</c:if>
 
-						<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smallest table-cell-minw-200"
-								name="path"
-							>
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smallest table-cell-minw-200"
+							name="path"
+						>
+							<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
 								<c:choose>
 									<c:when test="<%= curArticle.getFolderId() != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID %>">
 										<liferay-site-navigation:breadcrumb
@@ -266,8 +266,8 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 										/>
 									</c:otherwise>
 								</c:choose>
-							</liferay-ui:search-container-column-text>
-						</c:if>
+							</c:if>
+						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-text
 							cssClass="table-cell-expand-smallest table-cell-minw-100"
@@ -481,17 +481,17 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							/>
 						</c:if>
 
-						<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smallest table-cell-minw-200"
-								name="path"
-							>
+						<liferay-ui:search-container-column-text
+							cssClass="table-cell-expand-smallest table-cell-minw-200"
+							name="path"
+						>
+							<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
 								<liferay-site-navigation:breadcrumb
 									breadcrumbEntries="<%= JournalPortletUtil.getPortletBreadcrumbEntries(curFolder.getParentFolder(), request, true, liferayPortletResponse) %>"
 									cssClass="c-pl-0 c-pt-0"
 								/>
-							</liferay-ui:search-container-column-text>
-						</c:if>
+							</c:if>
+						</liferay-ui:search-container-column-text>
 
 						<liferay-ui:search-container-column-text
 							cssClass="table-cell-expand-smallest table-cell-minw-150"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45428

Search container path header column disappear when the first element is not showed.

# How am I fixing it?

Showing column path always but show the row content only if it is necessary.

# How can you verify that it works?

Running included test.