### PR TITLE
LPD-44997 Performance of fetchDisplayArticle

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -96,6 +96,7 @@ import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -1840,24 +1841,42 @@ public class JournalArticleLocalServiceImpl
 
 	@Override
 	public JournalArticle fetchDisplayArticle(long groupId, String articleId) {
-		List<JournalArticle> articles = journalArticlePersistence.findByG_A_ST(
-			groupId, articleId, WorkflowConstants.STATUS_APPROVED);
+		Date now = new Date();
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			JournalArticleTable.INSTANCE
+		).from(
+			JournalArticleTable.INSTANCE
+		).where(
+			JournalArticleTable.INSTANCE.groupId.eq(
+				groupId
+			).and(
+				JournalArticleTable.INSTANCE.articleId.eq(articleId)
+			).and(
+				JournalArticleTable.INSTANCE.displayDate.isNull(
+				).or(
+					JournalArticleTable.INSTANCE.displayDate.lt(now)
+				).withParentheses()
+			).and(
+				JournalArticleTable.INSTANCE.expirationDate.isNull(
+				).or(
+					JournalArticleTable.INSTANCE.expirationDate.gt(now)
+				).withParentheses()
+			).and(
+				JournalArticleTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_APPROVED)
+			)
+		).orderBy(
+			JournalArticleTable.INSTANCE.id.descending()
+		).limit(
+			0, 1
+		);
+
+		List<JournalArticle> articles = journalArticlePersistence.dslQuery(
+			dslQuery);
 
 		if (articles.isEmpty()) {
 			return null;
-		}
-
-		Date date = new Date();
-
-		for (JournalArticle article : articles) {
-			Date displayDate = article.getDisplayDate();
-			Date expirationDate = article.getExpirationDate();
-
-			if (((displayDate == null) || displayDate.before(date)) &&
-				((expirationDate == null) || expirationDate.after(date))) {
-
-				return article;
-			}
 		}
 
 		return articles.get(0);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -1209,6 +1209,54 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testFetchDisplayArticle() throws Exception {
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0);
+
+		article = _journalArticleLocalService.fetchDisplayArticle(
+			_group.getGroupId(), article.getArticleId());
+
+		Assert.assertEquals(
+			"Returns the only approved version", 1, article.getVersion(), 0);
+
+		article = JournalTestUtil.updateArticle(article);
+
+		article = JournalTestUtil.updateArticle(article);
+
+		JournalArticle articleToExpire = JournalTestUtil.updateArticle(article);
+
+		article = _journalArticleLocalService.fetchDisplayArticle(
+			_group.getGroupId(), article.getArticleId());
+
+		Assert.assertEquals(
+			"Returns the latest approved version", 1.3, article.getVersion(),
+			0);
+
+		JournalTestUtil.expireArticle(
+			_group.getGroupId(), articleToExpire, articleToExpire.getVersion());
+
+		article = _journalArticleLocalService.fetchDisplayArticle(
+			_group.getGroupId(), article.getArticleId());
+
+		Assert.assertEquals(
+			"Returns the latest approved version when an expired newer " +
+				"version exists",
+			1.2, article.getVersion(), 0);
+
+		articleToExpire.setDisplayDate(
+			new Date(System.currentTimeMillis() + (60 * 60 * 1000)));
+		articleToExpire.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		JournalTestUtil.updateArticle(articleToExpire);
+
+		article = _journalArticleLocalService.fetchDisplayArticle(
+			_group.getGroupId(), article.getArticleId());
+
+		Assert.assertEquals(
+			"Does not return a future article", 1.2, article.getVersion(), 0);
+	}
+
+	@Test
 	public void testFetchLatestArticleByExternalReferenceCodeWithStatus()
 		throws Exception {
 


### PR DESCRIPTION
# What is this trying to solve?
[LPD-44997](https://liferay.atlassian.net/browse/LPD-44997)
[previous PR](https://github.com/liferay-content-management/liferay-portal/pull/6220), thanks @jkappler for the DSLQuery info!

When a JournalArticle has a huge version history, 
[JournalArticleLocalServiceImpl#fetchDisplayArticle](https://github.com/liferay/liferay-portal/blob/3163a318497b71a29560f0ecf448270e92726b8c/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L1842-L1864) loads all of them to the memory, which reduces performance.

# How am I fixing it?
Moving the displayDate and expirationDate filtering to the Database level

# How can you verify that it works?
```
cd modules/apps/journal/journal-test
gw testIntegration --tests JournalArticleLocalServiceTest.testFetchDisplayArticle
```

Cheers,
Balázs