### PR TITLE
LPD-45653 Use correct content type

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/portlet/action/test/EditFileEntryMVCActionCommandTest.java
@@ -111,7 +111,7 @@ public class EditFileEntryMVCActionCommandTest {
 			true, TestPropsValues.getUser(),
 			UploadTestUtil.createUploadPortletRequest(
 				UploadTestUtil.createUploadServletRequest(
-					new MockHttpServletRequest(), null,
+					_getMockHttpServletRequest(), null,
 					HashMapBuilder.put(
 						"groupId",
 						Collections.singletonList(
@@ -157,7 +157,7 @@ public class EditFileEntryMVCActionCommandTest {
 		UploadPortletRequest uploadPortletRequest =
 			UploadTestUtil.createUploadPortletRequest(
 				UploadTestUtil.createUploadServletRequest(
-					new MockHttpServletRequest(), null,
+					_getMockHttpServletRequest(), null,
 					HashMapBuilder.put(
 						"groupId",
 						Collections.singletonList(
@@ -225,7 +225,7 @@ public class EditFileEntryMVCActionCommandTest {
 		UploadPortletRequest uploadPortletRequest =
 			UploadTestUtil.createUploadPortletRequest(
 				UploadTestUtil.createUploadServletRequest(
-					new MockHttpServletRequest(), null,
+					_getMockHttpServletRequest(), null,
 					HashMapBuilder.put(
 						"groupId",
 						Collections.singletonList(
@@ -293,7 +293,7 @@ public class EditFileEntryMVCActionCommandTest {
 		UploadPortletRequest uploadPortletRequest =
 			UploadTestUtil.createUploadPortletRequest(
 				UploadTestUtil.createUploadServletRequest(
-					new MockHttpServletRequest(), null,
+					_getMockHttpServletRequest(), null,
 					HashMapBuilder.put(
 						"groupId",
 						Collections.singletonList(
@@ -404,6 +404,16 @@ public class EditFileEntryMVCActionCommandTest {
 
 		return (LiferayPortletConfig)PortletConfigFactoryUtil.create(
 			portlet, null);
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setContentType(
+			"multipart/form-data;boundary=" + System.currentTimeMillis());
+
+		return mockHttpServletRequest;
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(


### PR DESCRIPTION
Warning messages are thrown in the console log

https://testray.liferay.com/#/project/35392/routines/1021677/build/104260952/case-result/104264296

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-45652)

# How am I fixing it?

Setting the correct content type

# How can you verify that it works?

Run EditFileEntryMVCActionCommandTest and check there are no warnings in the console log