### PR TITLE
LPD-45552  Wrong content page behaviour after editing a content on the fly from a Content Display fragment 

### DIFF
--- a/modules/apps/asset/asset-info-display-impl/src/main/java/com/liferay/asset/info/display/internal/url/provider/AssetInfoEditURLProviderImpl.java
+++ b/modules/apps/asset/asset-info-display-impl/src/main/java/com/liferay/asset/info/display/internal/url/provider/AssetInfoEditURLProviderImpl.java
@@ -85,6 +85,24 @@ public class AssetInfoEditURLProviderImpl implements AssetInfoEditURLProvider {
 				}
 			}
 
+			if (Validator.isNotNull(redirect)) {
+				String backURL = ParamUtil.getString(
+					httpServletRequest, "backURL");
+
+				if (Validator.isNotNull(backURL)) {
+					redirect = HttpComponentsUtil.addParameter(
+						redirect, "p_l_back_url", backURL);
+				}
+
+				String backURLTitle = ParamUtil.getString(
+					httpServletRequest, "backURLTitle");
+
+				if (Validator.isNotNull(backURLTitle)) {
+					redirect = HttpComponentsUtil.addParameter(
+						redirect, "p_l_back_url_title", backURLTitle);
+				}
+			}
+
 			PortletURL editAssetEntryURL = assetRenderer.getURLEdit(
 				httpServletRequest, LiferayWindowState.NORMAL, redirect);
 

--- a/modules/apps/asset/asset-test/build.gradle
+++ b/modules/apps/asset/asset-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-entry-rel-api")
 	testIntegrationImplementation project(":apps:asset:asset-info-api")
+	testIntegrationImplementation project(":apps:asset:asset-info-display-api")
 	testIntegrationImplementation project(":apps:asset:asset-link-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/display/internal/url/provider/test/AssetInfoEditURLProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/display/internal/url/provider/test/AssetInfoEditURLProviderTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.info.display.internal.url.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.info.display.url.provider.AssetInfoEditURLProvider;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class AssetInfoEditURLProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetURL() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		String backURL = "http://localhost:8080/test";
+		String backURLTitle = "Go to test page";
+
+		mockHttpServletRequest.setParameter("backURL", backURL);
+		mockHttpServletRequest.setParameter("backURLTitle", backURLTitle);
+		mockHttpServletRequest.setParameter(
+			"redirect", "http://localhost:8080/redirect");
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		String url = _assetInfoEditURLProvider.getURL(
+			JournalArticle.class.getName(), journalArticle.getResourcePrimKey(),
+			mockHttpServletRequest);
+
+		Assert.assertNotNull(url);
+
+		Assert.assertTrue(
+			url.contains("articleId=" + journalArticle.getArticleId()));
+		Assert.assertTrue(
+			url.contains(
+				"portletResource=com_liferay_journal_web_portlet_" +
+					"JournalPortlet"));
+		Assert.assertTrue(
+			url.contains("version=" + journalArticle.getVersion()));
+
+		String redirect = HttpComponentsUtil.getParameter(
+			url, "_com_liferay_journal_web_portlet_JournalPortlet_redirect",
+			false);
+
+		Assert.assertNotNull(redirect);
+
+		redirect = URLCodec.decodeURL(redirect);
+
+		Assert.assertTrue(
+			redirect.contains("p_l_back_url=" + URLCodec.encodeURL(backURL)));
+		Assert.assertTrue(
+			redirect.contains(
+				"p_l_back_url_title=" + URLCodec.encodeURL(backURLTitle)));
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private AssetInfoEditURLProvider _assetInfoEditURLProvider;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -143,7 +143,6 @@ import java.util.Set;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderResponse;
-import javax.portlet.ResourceURL;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -1785,12 +1784,22 @@ public class ContentPageEditorDisplayContext {
 	}
 
 	private String _getResourceURL(String resourceID) {
-		ResourceURL resourceURL = renderResponse.createResourceURL();
-
-		resourceURL.setResourceID(resourceID);
-
-		return HttpComponentsUtil.addParameter(
-			resourceURL.toString(), "p_l_mode", Constants.EDIT);
+		return ResourceURLBuilder.createResourceURL(
+			renderResponse.createResourceURL()
+		).setBackURL(
+			ParamUtil.getString(
+				portal.getOriginalServletRequest(httpServletRequest),
+				"p_l_back_url", themeDisplay.getURLCurrent())
+		).setParameter(
+			"backURLTitle",
+			ParamUtil.getString(
+				portal.getOriginalServletRequest(httpServletRequest),
+				"p_l_back_url_title")
+		).setParameter(
+			"p_l_mode", Constants.EDIT
+		).setResourceID(
+			resourceID
+		).buildString();
 	}
 
 	private List<String> _getRestrictedItemIds() throws Exception {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45552

# How am I fixing it?

Propagate back url and back url title in order to have them when it come back after editing the article.

# How can you verify that it works?

Run included tests.