### PR TITLE
LPD-45783 Web Content Portlet no more properly configured via site initializer JSON configuration

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -376,9 +376,7 @@ public class JournalContentDisplayContext {
 		String ddmTemplateKey = ParamUtil.getString(
 			_portletRequest, "ddmTemplateKey");
 
-		if (Validator.isNotNull(ddmTemplateExternalReferenceCode) &&
-			Validator.isNull(ddmTemplateKey)) {
-
+		if (Validator.isNotNull(ddmTemplateExternalReferenceCode)) {
 			DDMTemplate ddmTemplate =
 				_ddmTemplateLocalService.
 					fetchDDMTemplateByExternalReferenceCode(
@@ -772,6 +770,13 @@ public class JournalContentDisplayContext {
 	}
 
 	public boolean isDefaultTemplate() {
+		String ddmTemplateKey = ParamUtil.getString(
+			_portletRequest, "ddmTemplateKey");
+
+		if (Validator.isNotNull(ddmTemplateKey)) {
+			return false;
+		}
+
 		String ddmTemplateExternalReferenceCode = ParamUtil.getString(
 			_portletRequest, "ddmTemplateExternalReferenceCode");
 

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -30,7 +30,9 @@ import com.liferay.journal.content.web.internal.constants.JournalContentWebKeys;
 import com.liferay.journal.content.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
+import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.service.JournalArticleResourceLocalServiceUtil;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
@@ -164,29 +166,40 @@ public class JournalContentDisplayContext {
 			return _article;
 		}
 
-		if (articleResourcePrimKey == 0) {
-			if (Validator.isBlank(getArticleExternalReferenceCode())) {
-				return null;
+		JournalArticle article = null;
+
+		if (articleResourcePrimKey != 0) {
+			article = JournalArticleLocalServiceUtil.fetchLatestArticle(
+				articleResourcePrimKey, WorkflowConstants.STATUS_ANY, true);
+		}
+		else if (!Validator.isBlank(getArticleId())) {
+			JournalArticleResource articleResource =
+				JournalArticleResourceLocalServiceUtil.fetchArticleResource(
+					getArticleGroupId(), getArticleId());
+
+			if (articleResource != null) {
+				articleResourcePrimKey = articleResource.getResourcePrimKey();
 			}
 
-			_article =
+			article = JournalArticleLocalServiceUtil.fetchLatestArticle(
+				articleResourcePrimKey, WorkflowConstants.STATUS_ANY, true);
+		}
+		else if (!Validator.isBlank(getArticleExternalReferenceCode())) {
+			article =
 				JournalArticleLocalServiceUtil.
 					fetchLatestArticleByExternalReferenceCode(
 						getArticleGroupId(), getArticleExternalReferenceCode(),
 						WorkflowConstants.STATUS_ANY, true);
 
-			if ((_article != null) &&
+			if ((article != null) &&
 				Objects.equals(
-					_article.getStatus(), WorkflowConstants.STATUS_IN_TRASH)) {
+					article.getStatus(), WorkflowConstants.STATUS_IN_TRASH)) {
 
-				_article = null;
+				article = null;
 			}
-
-			return _article;
 		}
 
-		_article = JournalArticleLocalServiceUtil.fetchLatestArticle(
-			articleResourcePrimKey, WorkflowConstants.STATUS_ANY, true);
+		_article = article;
 
 		return _article;
 	}

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -761,6 +761,16 @@ public class JournalContentDisplayContext {
 			articleDisplay.getResourcePrimKey());
 	}
 
+	public boolean isArticleVisible() {
+		if (Validator.isNotNull(getArticleExternalReferenceCode()) ||
+			Validator.isNotNull(getArticleId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isDefaultTemplate() {
 		String ddmTemplateExternalReferenceCode = ParamUtil.getString(
 			_portletRequest, "ddmTemplateExternalReferenceCode");

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -608,6 +608,19 @@ public class JournalContentDisplayContext {
 		PortletPreferences portletPreferences =
 			_portletRequest.getPreferences();
 
+		long assetEntryId = GetterUtil.getLong(
+			portletPreferences.getValue("assetEntryId", StringPool.BLANK));
+
+		if (assetEntryId > 0) {
+			AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchAssetEntry(
+				assetEntryId);
+
+			if (assetEntry != null) {
+				return JournalArticleLocalServiceUtil.fetchLatestArticle(
+					assetEntry.getClassPK());
+			}
+		}
+
 		String articleExternalReferenceCode = portletPreferences.getValue(
 			"articleExternalReferenceCode", null);
 		String groupExternalReferenceCode = GetterUtil.getString(

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,7 +25,7 @@ if (journalContentDisplayContext.isShowArticle()) {
 <c:choose>
 	<c:when test="<%= article == null %>">
 		<c:choose>
-			<c:when test="<%= Validator.isNull(journalContentDisplayContext.getArticleExternalReferenceCode()) %>">
+			<c:when test="<%= !journalContentDisplayContext.isArticleVisible() %>">
 				<clay:alert
 					displayType="info"
 				>
@@ -110,7 +110,7 @@ if (journalContentDisplayContext.isShowArticle()) {
 					message="you-do-not-have-the-roles-required-to-access-this-web-content-entry"
 				/>
 			</c:when>
-			<c:when test="<%= Validator.isNotNull(journalContentDisplayContext.getArticleExternalReferenceCode()) %>">
+			<c:when test="<%= journalContentDisplayContext.isArticleVisible() %>">
 				<c:choose>
 					<c:when test="<%= journalContentDisplayContext.isExpired() %>">
 						<clay:alert

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalContentDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalContentDisplayContextTest.java
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.test.MockLiferayPortletContext;
+
+import javax.portlet.Portlet;
+import javax.portlet.RenderRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class JournalContentDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
+	@Test
+	public void testGetArticle() throws Exception {
+		_testGetArticleWithoutParameters();
+		_testGetArticleWithArticleId();
+		_testGetArticleWithArticleResourcePrimKey();
+		_testGetArticleWithExternalReferenceCode();
+	}
+
+	private JournalArticle _getArticle(RenderRequest renderRequest)
+		throws Exception {
+
+		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
+
+		mvcPortlet.render(
+			renderRequest, new MockLiferayPortletRenderResponse());
+
+		Object journalContentDisplayContext = renderRequest.getAttribute(
+			"JOURNAL_CONTENT_DISPLAY_CONTEXT#");
+
+		return ReflectionTestUtil.invoke(
+			journalContentDisplayContext, "getArticle", new Class<?>[0]);
+	}
+
+	private MockLiferayPortletRenderRequest
+			_getMockLiferayPortletRenderRequest()
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		String path = "/view.jsp";
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			MVCRenderConstants.
+				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
+			new MockLiferayPortletContext(path));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
+
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		User user = UserTestUtil.getAdminUser(_group.getCompanyId());
+
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		themeDisplay.setRealUser(user);
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(user);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockLiferayPortletRenderRequest.setParameter("mvcPath", path);
+
+		return mockLiferayPortletRenderRequest;
+	}
+
+	private void _testGetArticleWithArticleId() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"articleId", String.valueOf(_journalArticle.getArticleId()));
+
+		Assert.assertEquals(
+			_journalArticle, _getArticle(mockLiferayPortletRenderRequest));
+	}
+
+	private void _testGetArticleWithArticleResourcePrimKey() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"articleResourcePrimKey",
+			String.valueOf(_journalArticle.getResourcePrimKey()));
+
+		Assert.assertEquals(
+			_journalArticle, _getArticle(mockLiferayPortletRenderRequest));
+	}
+
+	private void _testGetArticleWithExternalReferenceCode() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"articleExternalReferenceCode",
+			_journalArticle.getExternalReferenceCode());
+		mockLiferayPortletRenderRequest.setParameter(
+			"goupId", String.valueOf(_group.getGroupId()));
+
+		Assert.assertEquals(
+			_journalArticle, _getArticle(mockLiferayPortletRenderRequest));
+	}
+
+	private void _testGetArticleWithoutParameters() throws Exception {
+		Assert.assertNull(_getArticle(_getMockLiferayPortletRenderRequest()));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private JournalArticle _journalArticle;
+
+	@Inject(
+		filter = "component.name=com.liferay.journal.content.web.internal.portlet.JournalContentPortlet"
+	)
+	private Portlet _portlet;
+
+}


### PR DESCRIPTION
Web Content Portlet no more properly configured via site initializer JSON configuration

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-45783)

Web Content Display Widget appears unconfigured for speedwell site initializer

# How am I fixing it?

Doing a fallback to old configuration like articleId and not only ERC

# How can you verify that it works?

* Start the portal
* Create a new site based on speedwell site initializer
* Go to the Home page
* Check that all web content display widgets are configured