### PR TITLE
LPD-45737 Fix the "Check alert message of duplicated friendly URL in french" test

### DIFF
--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -154,19 +154,15 @@ export class JournalEditArticlePage {
 		viewableBy?: 'Site Members' | 'Owner'
 	) {
 		if (existingArticle) {
-			await expect(async () => {
-				await clickAndExpectToBeVisible({
-					autoClick: true,
-					target: this.page.getByRole('menuitem', {
-						name: /publish|publier/i,
-					}),
-					trigger: this.publishDropdown,
-				});
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.page.getByRole('menuitem', {
+					name: /publish|publier/i,
+				}),
+				trigger: this.publishDropdown,
+			});
 
-				await waitForAlert(this.page, 'was updated successfully', {
-					timeout: 2000,
-				});
-			}).toPass();
+			await this.page.locator('.alert-success').waitFor({timeout: 2000});
 
 			return;
 		}

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -26,6 +26,7 @@ export class JournalEditArticlePage {
 	readonly historyButton: Locator;
 	readonly journalPage: JournalPage;
 	readonly propertiesTab: Locator;
+	readonly publishDropdown: Locator;
 	readonly publishButton: Locator;
 	readonly redoButton: Locator;
 	readonly selectButton: Locator;
@@ -56,6 +57,9 @@ export class JournalEditArticlePage {
 		this.journalPage = new JournalPage(page);
 		this.propertiesTab = page.getByRole('tab', {
 			name: /properties|propriétés/i,
+		});
+		this.publishDropdown = page.getByRole('button', {
+			name: /select and confirm publish settings|sélectionnez et confirmez les/i,
 		});
 		this.publishButton = page.locator(
 			'#_com_liferay_journal_web_portlet_JournalPortlet_publishButton'
@@ -156,9 +160,7 @@ export class JournalEditArticlePage {
 					target: this.page.getByRole('menuitem', {
 						name: /publish|publier/i,
 					}),
-					trigger: this.page.getByRole('button', {
-						name: /select and confirm publish settings|sélectionnez et confirmez les/i,
-					}),
+					trigger: this.publishDropdown,
 				});
 
 				await waitForAlert(this.page, 'was updated successfully', {
@@ -169,26 +171,24 @@ export class JournalEditArticlePage {
 			return;
 		}
 
-			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: this.page.getByRole('menuitem', {
-					name: /publish with permissions|publier avec permissions/i,
-				}),
-				trigger: this.page.getByRole('button', {
-					name: /select and confirm publish settings|sélectionnez et confirmez les/i,
-				}),
-			});
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				name: /publish with permissions|publier avec permissions/i,
+			}),
+			trigger: this.publishDropdown,
+		});
 
-		await expect(
-			this.page.getByLabel(/Viewable By|Visualisable avec/i)
-		).toBeVisible({
-				timeout: 2000,
-			});
+		const viewableBySelect = this.page.getByLabel(
+			/Viewable By|Visualisable avec/i
+		);
+
+		await expect(viewableBySelect).toBeVisible({
+			timeout: 2000,
+		});
 
 		if (viewableBy) {
-			await this.page
-				.getByLabel(/Viewable By|Visualisable avec/i)
-				.selectOption(viewableBy);
+			await viewableBySelect.selectOption(viewableBy);
 		}
 
 		await this.page

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -169,7 +169,6 @@ export class JournalEditArticlePage {
 			return;
 		}
 
-		await expect(async () => {
 			await clickAndExpectToBeVisible({
 				autoClick: true,
 				target: this.page.getByRole('menuitem', {
@@ -180,13 +179,16 @@ export class JournalEditArticlePage {
 				}),
 			});
 
-			await expect(this.page.getByLabel('Viewable By')).toBeVisible({
+		await expect(
+			this.page.getByLabel(/Viewable By|Visualisable avec/i)
+		).toBeVisible({
 				timeout: 2000,
 			});
-		}).toPass();
 
 		if (viewableBy) {
-			await this.page.getByLabel('Viewable By').selectOption(viewableBy);
+			await this.page
+				.getByLabel(/Viewable By|Visualisable avec/i)
+				.selectOption(viewableBy);
 		}
 
 		await this.page


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45737

Fix the "Check alert message of duplicated friendly URL in French" test

# How am I fixing it?

The problem is that part of the UI locators isn't and is broken when used in FR.
The long-term solution is to try to move the French tests to the unit/integration backend test https://liferay.atlassian.net/browse/LPD-45987

# How can you verify that it works?

run the test

```sh
npm run playwright -- test -g "Check alert message of duplicated friendly URL in french"
```

# Tested several times in local
![image](https://github.com/user-attachments/assets/72eabc40-239f-47b8-b351-7f84c826288f)
