### PR TITLE
LPD-46007 Technical Task | Clean inline styles to support style-src '[NONCE]' directive - Document Library and Wiki 

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -25,7 +25,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
 	/>
 
-	<input id="<portlet:namespace />file" style="display: none;" type="file" />
+	<input class="hide" id="<portlet:namespace />file" type="file" />
 
 	<liferay-ui:search-container
 		id="repositoryEntries"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -11,7 +11,7 @@
 DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAccessFromDesktopDisplayContext(request);
 %>
 
-<div id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav" style="display: none;">
+<div class="hide" id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav">
 	<div class="portlet-document-library">
 		<liferay-ui:message key="<%= dlAccessFromDesktopDisplayContext.getWebDAVHelpMessage() %>" />
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
@@ -29,7 +29,13 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 
 		<c:choose>
 			<c:when test="<%= Validator.isNotNull(previewURL) %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+				<aui:style type="text/css">
+					.file-entry-abstract-asset-background-image {
+					background-image: url(<%= previewURL %>);
+					}
+				</aui:style>
+
+				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image file-entry-abstract-asset-background-image mb-4"></div>
 			</c:when>
 			<c:otherwise>
 				<div class="aspect-ratio aspect-ratio-8-to-3 bg-light mb-4">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
@@ -34,5 +34,11 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 	}
 	%>
 
-	<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+	<aui:style type="text/css">
+		.file-entry-abstract-info-item-background-image {
+			background-image: url(<%= previewURL %>);
+		}
+	</aui:style>
+
+	<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image file-entry-abstract-info-item-background-image mb-4"></div>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.document.library.kernel.processor.ImageProcessorUtil" %><%@
 page import="com.liferay.document.library.kernel.processor.PDFProcessorUtil" %><%@

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -7,7 +7,15 @@
 
 <%@ include file="/init.jsp" %>
 
-<div style="display: flex; justify-content: flex-start; overflow: hidden;">
+<aui:style type="text/css">
+	.fragment-video-streaming-display {
+		display: flex;
+		justify-content: flex-start;
+		overflow: hidden;
+	}
+</aui:style>
+
+<div class="fragment-video-streaming-display">
 	<div class="videojs-container">
 		<aui:link href="https://vjs.zencdn.net/8.6.1/video-js.min.css" rel="stylesheet" type="text/css" />
 		<aui:link href="https://unpkg.com/videojs-quality-selector-hls@1.1.1/dist/videojs-quality-selector-hls.css" rel="stylesheet" type="text/css" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -15,7 +15,13 @@ JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribu
 
 <div class="asset-summary">
 	<c:if test="<%= articleDisplay.isSmallImage() %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);"></div>
+		<aui:style type="text/css">
+			.journal-web-abstract-asset-background-image {
+				background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);
+			}
+		</aui:style>
+
+		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image journal-web-abstract-asset-background-image mb-4"></div>
 	</c:if>
 
 	<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -9,7 +9,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
@@ -22,7 +22,13 @@ AssetRenderer<?> assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASS
 	<c:otherwise>
 		<div class="asset-summary">
 			<c:if test="<%= article.isSmallImage() %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);"></div>
+				<aui:style type="text/css">
+					.journal-web-info-item-abstract-background-image {
+						background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);
+					}
+				</aui:style>
+
+				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image journal-web-info-item-abstract-background-image mb-4"></div>
 			</c:if>
 
 			<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
@@ -9,7 +9,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -1,11 +1,50 @@
-<div style="background-color: #f7f8f9; color: #6b6c7e; font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 20px; height: 100%; padding: 24px;">
-	<div style="background-color: white; border: solid 1px #e7e7ed; border-radius: 4px; margin: 0 auto; max-width: 800px; padding: 40px;">
-		<p style="line-height: 1.5; margin: 0;">
+<@liferay_aui["style"] type="text/css">
+	.sharing-notification-sharing-entry-added-1 {
+		background-color: #f7f8f9;
+		color: #6b6c7e;
+		font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+		font-size: 20px;
+		height: 100%;
+		padding: 24px;
+	}
+
+	.sharing-notification-sharing-entry-added-2 {
+		background-color: white;
+		border: solid 1px #e7e7ed;
+		border-radius: 4px;
+		margin: 0 auto;
+		max-width: 800px;
+		padding: 40px;
+	}
+
+	.sharing-notification-sharing-entry-added-3 {
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.sharing-notification-sharing-entry-added-4 {
+		background-color: #145ffb;
+		color: white;
+		border-radius: 4px;
+		box-sizing: border-box;
+		display: inline-block;
+		font-size: 16px;
+		height: 40px;
+		line-height: 24px;
+		margin-top: 24px;
+		padding: 7px 15px;
+		text-decoration: none;
+	}
+</@>
+
+<div class="sharing-notification-sharing-entry-added-1">
+	<div class="sharing-notification-sharing-entry-added-2">
+		<p class="sharing-notification-sharing-entry-added-3">
 			${content}
 		</p>
 
 		<#if sharingEntryURL?has_content>
-			<a href="${sharingEntryURL}" style="background-color: #145ffb; color: white; border-radius: 4px; box-sizing: border-box; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
+			<a href="${sharingEntryURL}" class="sharing-notification-sharing-entry-added-4">${actionTitle}</a>
 		</#if>
 	</div>
 </div>

--- a/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
+++ b/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
@@ -8,7 +8,7 @@
 	<h1 class="header-title">${entry.getTitle()}</h1>
 </div>
 
-<div style="float: right;">
+<div class="float-right">
 	<@getEditIcon />
 
 	<@getPageDetailsIcon />


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46007

Clean inline styles to support style-src '[NONCE]' directive - Document Library and Wiki 
# How am I fixing it?

Adding aui tag for some cases and for other ones replacing templates by the nonce

# How can you verify that it works?

This task does not need tests