### PR TITLE
LPD-45614 Only show alert messages on DL if it comes from DLAdmin portlet

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/session_messages.jspf
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/session_messages.jspf
@@ -5,35 +5,38 @@
  */
 --%>
 
-<%
-String friendlyURLChangedMessage = GetterUtil.getString(SessionMessages.get(request, "friendlyURLChanged_requestProcessedWarning"));
-String scheduledDocumentMessage = GetterUtil.getString(SessionMessages.get(request, "scheduledDocument_requestProcessedSuccess"));
-%>
+<c:if test="<%= Objects.equals(dlRequestHelper.getResourcePortletName(), DLPortletKeys.DOCUMENT_LIBRARY_ADMIN) %>">
 
-<c:if test="<%= Validator.isNotNull(friendlyURLChangedMessage) %>">
-	<liferay-frontend:component
-		context='<%=
-			HashMapBuilder.<String, Object>put(
-				"autoClose", 20000
-			).put(
-				"message", friendlyURLChangedMessage
-			).put(
-				"type", "warning"
-			).build()
-		%>'
-		module="{openToast} from frontend-js-web"
-	/>
-</c:if>
+	<%
+	String friendlyURLChangedMessage = GetterUtil.getString(SessionMessages.get(request, "friendlyURLChanged_requestProcessedWarning"));
+	String scheduledDocumentMessage = GetterUtil.getString(SessionMessages.get(request, "scheduledDocument_requestProcessedSuccess"));
+	%>
 
-<c:if test="<%= Validator.isNotNull(scheduledDocumentMessage) %>">
-	<liferay-frontend:component
-		context='<%=
-			HashMapBuilder.<String, Object>put(
-				"autoClose", 20000
-			).put(
-				"message", scheduledDocumentMessage
-			).build()
-		%>'
-		module="{openToast} from frontend-js-web"
-	/>
+	<c:if test="<%= Validator.isNotNull(friendlyURLChangedMessage) %>">
+		<liferay-frontend:component
+			context='<%=
+				HashMapBuilder.<String, Object>put(
+					"autoClose", 20000
+				).put(
+					"message", friendlyURLChangedMessage
+				).put(
+					"type", "warning"
+				).build()
+			%>'
+			module="{openToast} from frontend-js-web"
+		/>
+	</c:if>
+
+	<c:if test="<%= Validator.isNotNull(scheduledDocumentMessage) %>">
+		<liferay-frontend:component
+			context='<%=
+				HashMapBuilder.<String, Object>put(
+					"autoClose", 20000
+				).put(
+					"message", scheduledDocumentMessage
+				).build()
+			%>'
+			module="{openToast} from frontend-js-web"
+		/>
+	</c:if>
 </c:if>

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -188,13 +188,16 @@ export class DocumentLibraryEditFilePage {
 		await this.publishButton.click();
 	}
 
-	async publishNewFileWithScheduleDate(
+	async goToPublishNewFileWithScheduleDate(
 		scheduleDate: string,
 		title: string,
 		siteUrl?: Site['friendlyUrlPath']
 	) {
 		await this.goto(siteUrl);
+		await this.publishNewFileWithScheduleDate(scheduleDate, title);
+	}
 
+	async publishNewFileWithScheduleDate(scheduleDate: string, title: string) {
 		await this.titleSelector.fill(title);
 
 		const isClosed =

--- a/modules/test/playwright/tests/document-library-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/document-library-web/env/portal-ext.properties
@@ -1,1 +1,3 @@
+dl.actions.visible=true
+
 captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -359,16 +359,17 @@ test(
 );
 
 test(
-	'Only one success message on scheduling file from widget page',
-	{tag: ['@LPD-45614', '@LPD-45658']},
+	'Only one well formatted success message on scheduling file from widget page',
+	{
+		tag: ['@LPD-45614', '@LPD-45658'],
+	},
 	async ({
-			   apiHelpers,
-			   documentLibraryEditFilePage,
-			   documentLibraryPage,
-			   page,
-			   site,
-		   }) => {
-
+		apiHelpers,
+		documentLibraryEditFilePage,
+		documentLibraryPage,
+		page,
+		site,
+	}) => {
 		const portletId = getRandomString();
 		const widgetDefinition = getWidgetDefinition({
 			id: portletId,
@@ -396,8 +397,6 @@ test(
 
 		const toastAlertContainer = page.locator('[id="ToastAlertContainer"]');
 
-		await expect(toastAlertContainer).toBeVisible();
-
 		await expect(toastAlertContainer).not.toContainText(`<strong>`);
 		await expect(toastAlertContainer).toContainText(`Success:${title}`);
 
@@ -409,6 +408,27 @@ test(
 			}).format(new Date(scheduleDate))
 		);
 
+		let firstAlertAppear = false;
+		let moreAlertsAppear = false;
+
+		await expect(async () => {
+			const toastAlertContainers = await page
+				.locator('.alert-success', {
+					hasText: `Success:${title}`,
+				})
+				.all();
+
+			if (toastAlertContainers.length >= 1) {
+				firstAlertAppear = true;
+			}
+
+			if (toastAlertContainers.length > 1) {
+				moreAlertsAppear = true;
+			}
+
+			expect(firstAlertAppear).toBe(true);
+			expect(moreAlertsAppear).toBe(false);
+		}).toPass();
 	}
 );
 

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -204,7 +204,7 @@ test(
 		const scheduleDate = `01/01/${new Date().getFullYear() + 1}`;
 		const title = getRandomString();
 
-		await documentLibraryEditFilePage.publishNewFileWithScheduleDate(
+		await documentLibraryEditFilePage.goToPublishNewFileWithScheduleDate(
 			scheduleDate,
 			title,
 			site.friendlyUrlPath

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -359,6 +359,60 @@ test(
 );
 
 test(
+	'Only one success message on scheduling file from widget page',
+	{tag: ['@LPD-45614', '@LPD-45658']},
+	async ({
+			   apiHelpers,
+			   documentLibraryEditFilePage,
+			   documentLibraryPage,
+			   page,
+			   site,
+		   }) => {
+
+		const portletId = getRandomString();
+		const widgetDefinition = getWidgetDefinition({
+			id: portletId,
+			widgetName: 'com_liferay_document_library_web_portlet_DLPortlet',
+		});
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await page.goto(`/web/${site.name}${layout.friendlyUrlPath}`);
+
+		await documentLibraryPage.goToCreateNewFile();
+
+		const scheduleDate = `01/01/${new Date().getFullYear() + 1}`;
+		const title = getRandomString();
+
+		await documentLibraryEditFilePage.publishNewFileWithScheduleDate(
+			scheduleDate,
+			title
+		);
+
+		await expect(page.getByRole('link', {name: title})).toBeVisible();
+
+		const toastAlertContainer = page.locator('[id="ToastAlertContainer"]');
+
+		await expect(toastAlertContainer).toBeVisible();
+
+		await expect(toastAlertContainer).not.toContainText(`<strong>`);
+		await expect(toastAlertContainer).toContainText(`Success:${title}`);
+
+		await expect(toastAlertContainer).toContainText(
+			new Intl.DateTimeFormat('en-US', {
+				day: 'numeric',
+				month: 'numeric',
+				year: '2-digit',
+			}).format(new Date(scheduleDate))
+		);
+
+	}
+);
+
+test(
 	'Search in DL portlet does not show results in card view',
 	{tag: ['@LPD-31694', '@LPD-202909']},
 	async ({


### PR DESCRIPTION
LPD-45614 This is the pull request title

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45614

On some cases, when the file is created/edited from a page ie. there is 2 toast messages instead of 1 because layout treat it separately.

# How am I fixing it?

Only showing the toast message if the portlet is DLAdminPortlet

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-45614 do not show the toast message if we are not on DL Admin**
- **LPD-45614 refactor method to use it with different scenarios**
- **LPD-45614 create a test to check that the message is well formatted**
- **LPD-45614 add check to test that the popup only has to appears one time**
- **LPD-45614 SF**
