### PR TITLE
LPD-46197 This is the pull request title

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -36,6 +36,8 @@
 			(KBArticle.urlTitle = ?) AND
 			(KBFolder.urlTitle = ?) AND
 			(KBArticle.status IN ([$WORKFLOW_STATUS$]))
+		ORDER BY
+			KBArticle.version DESC
 	</sql>
 	<sql id="com.liferay.knowledge.base.service.persistence.KBFolderFinder.countA_ByG_P">
 		SELECT

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -1120,6 +1120,36 @@ public class KBArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testFetchKBArticleByUrlTitle() throws Exception {
+		KBFolder kbFolder = _kbFolderLocalService.addKBFolder(
+			null, _user.getUserId(), _group.getGroupId(), _kbFolderClassNameId,
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			StringUtil.randomString(), StringUtil.randomString(),
+			_serviceContext);
+
+		KBArticle kbArticle = _kbArticleLocalService.addKBArticle(
+			null, _user.getUserId(), _kbFolderClassNameId,
+			kbFolder.getKbFolderId(), "Article with versions",
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, new Date(), null, null, null,
+			_serviceContext);
+
+		Assert.assertEquals(1, kbArticle.getVersion());
+
+		kbArticle.setVersion(2);
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
+
+		Assert.assertEquals(2, kbArticle.getVersion());
+
+		kbArticle = _kbArticleLocalService.fetchKBArticleByUrlTitle(
+			kbArticle.getGroupId(), kbFolder.getUrlTitle(),
+			kbArticle.getUrlTitle());
+
+		Assert.assertEquals(2, kbArticle.getVersion());
+	}
+
+	@Test
 	public void testFetchPersistedModelByResourcePrimKey() throws Exception {
 		KBArticle kBArticle = _addKbArticle();
 

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -1136,9 +1136,11 @@ public class KBArticleLocalServiceTest {
 
 		Assert.assertEquals(1, kbArticle.getVersion());
 
-		kbArticle.setVersion(2);
-
-		kbArticle = _kbArticleLocalService.updateKBArticle(kbArticle);
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			_user.getUserId(), kbArticle.getResourcePrimKey(),
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), null, null, kbArticle.getDisplayDate(),
+			null, null, null, null, _serviceContext);
 
 		Assert.assertEquals(2, kbArticle.getVersion());
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46197

When fetching by URL title, KBArticles are not returned in any specific order so any version can be returned.

# How am I fixing it?

We need to order the results of the query by version.

# How can you verify that it works?

Run the test KBArticleLocalServiceTest.testFetchKBArticleByUrlTitle