### PR TITLE
LPD-46275 Handle the fileName and the title as it should in all cases

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/util/test/DLTest.java
@@ -7,16 +7,30 @@ package com.liferay.document.library.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
+import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
 
 import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +47,13 @@ public class DLTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_dlFolder = DLTestUtil.addDLFolder(_group.getGroupId());
+	}
+
 	@Test
 	public void testGetAllMediaGalleryMimeTypesContainsSVG() {
 		Set<String> allMediaGalleryMimeTypes =
@@ -41,6 +62,40 @@ public class DLTest {
 		Assert.assertTrue(
 			allMediaGalleryMimeTypes.toString(),
 			allMediaGalleryMimeTypes.contains(ContentTypes.IMAGE_SVG_XML));
+	}
+
+	@Test
+	public void testGetUniqueFileName() throws Exception {
+		String fileName = "dummy text for test 1.0.txt";
+
+		Assert.assertEquals(
+			fileName,
+			DLUtil.getUniqueFileName(
+				_group.getGroupId(), _dlFolder.getFolderId(), fileName, false));
+
+		_addFileEntry(fileName, RandomTestUtil.randomString());
+
+		Assert.assertEquals(
+			"dummy text for test 1.0 (1).txt",
+			DLUtil.getUniqueFileName(
+				_group.getGroupId(), _dlFolder.getFolderId(), fileName, false));
+	}
+
+	@Test
+	public void testGetUniqueTitle() throws Exception {
+		String title = "dummy text for test 1.0";
+
+		Assert.assertEquals(
+			title,
+			DLUtil.getUniqueTitle(
+				_group.getGroupId(), _dlFolder.getFolderId(), title));
+
+		_addFileEntry(RandomTestUtil.randomString(), title);
+
+		Assert.assertEquals(
+			"dummy text for test 1.0 (1)",
+			DLUtil.getUniqueTitle(
+				_group.getGroupId(), _dlFolder.getFolderId(), title));
 	}
 
 	@Test
@@ -55,5 +110,26 @@ public class DLTest {
 			DLUtil.isValidVersion(
 				DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION));
 	}
+
+	private void _addFileEntry(String sourceFileName, String title)
+		throws Exception {
+
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+		DLFileEntryLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			_dlFolder.getRepositoryId(), _dlFolder.getFolderId(),
+			sourceFileName, ContentTypes.TEXT_PLAIN, title, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private DLFolder _dlFolder;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -696,7 +696,7 @@ public class DLImpl implements DL {
 		int i = 1;
 
 		while (_existsFileEntryByTitle(groupId, folderId, uniqueFileTitle)) {
-			uniqueFileTitle = FileUtil.appendParentheticalSuffix(
+			uniqueFileTitle = StringUtil.appendParentheticalSuffix(
 				title, String.valueOf(i));
 
 			i++;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -683,7 +683,7 @@ public class DLImpl implements DL {
 			}
 
 			uniqueFileTitle = FileUtil.appendParentheticalSuffix(
-				FileUtil.stripExtension(fileName), String.valueOf(i));
+				fileName, String.valueOf(i));
 		}
 
 		return getTitleWithExtension(uniqueFileTitle, extension);


### PR DESCRIPTION

# What is this trying to solve?

[{url}
](https://liferay.atlassian.net/browse/LPD-46275)

Avoid malformed title and fileNames with some name patterns (asdf1.0.txt)

# How am I fixing it?

Adjusting both methods so they call the proper logic in each case

# How can you verify that it works?

Run the included automated tests.
