### PR TITLE
LPD-46280

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/display/context/test/DefaultDLViewFileVersionDisplayContextTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/display/context/test/DefaultDLViewFileVersionDisplayContextTest.java
@@ -190,6 +190,7 @@ public class DefaultDLViewFileVersionDisplayContextTest {
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
 		themeDisplay.setScopeGroupId(_group.getGroupId());
 		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -206,7 +207,7 @@ public class DefaultDLViewFileVersionDisplayContextTest {
 		List<DropdownItem> dropdownGroupItems = _getDropdownGroupItems(
 			_getDropdownItems(), 1);
 
-		return dropdownGroupItems.get(2);
+		return dropdownGroupItems.get(3);
 	}
 
 	private Company _company;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46280

The `DefaultDLViewFileVersionDisplayContextTest` integration test is failing.

After adding the subscription option to DM dropdowns, the relative position of the view usages option changed. Also, the subscription option requires the user to be present in the theme display. These issues made the test fail.

# How am I fixing it?

By updating the position index and adding the user to the theme display.

# How can you verify that it works?

See `DefaultDLViewFileVersionDisplayContextTest` complete successfully.