### PR TITLE
LPD-44895 comply with the NONCE strategy

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
@@ -18,7 +18,13 @@ String viewEntryURL = ParamUtil.getString(request, "viewEntryURL");
 		<a href="<%= HtmlUtil.escape(viewEntryURL) %>">
 	</c:if>
 
-	<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
+	<aui:style type="text/css">
+		.blogs-entry-cover-image-caption-background-image {
+			background-image: url(<%= coverImageURL %>);
+		}
+	</aui:style>
+
+	<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image blogs-entry-cover-image-caption-background-image" ></div>
 
 	<c:if test="<%= Validator.isNotNull(viewEntryURL) %>">
 		</a>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/abstract.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/abstract.jsp
@@ -14,7 +14,13 @@ BlogsEntry entry = (BlogsEntry)request.getAttribute(WebKeys.BLOGS_ENTRY);
 
 <div class="asset-summary">
 	<c:if test="<%= entry.isSmallImage() %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= entry.getSmallImageURL(themeDisplay) %>);"></div>
+		<aui:style type="text/css">
+			.blogs-abstract-background-image {
+				background-image: url(<%= entry.getSmallImageURL(themeDisplay) %>);
+			}
+		</aui:style>
+
+		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover blogs-abstract-background-image cover-image mb-4"></div>
 	</c:if>
 
 	<%

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
@@ -9,7 +9,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -186,7 +186,7 @@ Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 					</div>
 
 					<c:if test="<%= commentTreeDisplayContext.isEditControlsVisible() %>">
-						<div class="lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>" style="display: none;">
+						<div class="hide lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>">
 							<div class="editor-wrapper"></div>
 
 							<aui:button-row>
@@ -241,7 +241,7 @@ Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 			</div>
 		</div>
 
-		<div class="lfr-discussion lfr-discussion-form-reply" id="<%= namespace %>postReplyForm<%= index %>" style="display: none;">
+		<div class="hide lfr-discussion lfr-discussion-form-reply" id="<%= namespace %>postReplyForm<%= index %>">
 			<div class="lfr-discussion-reply-container">
 				<clay:content-row
 					noGutters="true"

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/init.jsp
@@ -5,7 +5,8 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/view_content_dashboard_file_extensions.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/view_content_dashboard_file_extensions.jsp
@@ -12,7 +12,14 @@ ContentDashboardFileExtensionItemSelectorViewDisplayContext contentDashboardFile
 %>
 
 <section class="h-100">
-	<span aria-hidden="true" class="loading-animation mt-0 tree-filter-loader" style="top: 50%; transform: translateY(-50%);"></span>
+	<aui:style type="text/css">
+		.view-content-dashboard-file-extensions {
+			top: 50%;
+			transform: translateY(-50%);
+		}
+	</aui:style>
+
+	<span aria-hidden="true" class="loading-animation mt-0 tree-filter-loader view-content-dashboard-file-extensions"></span>
 
 	<react:component
 		module="{SelectFileExtensionWrapper} from content-dashboard-document-library-impl"

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_attachment.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_attachment.jspf
@@ -23,8 +23,14 @@
 	}
 	%>
 
+	<aui:style type="text/css">
+		.edit-message-attachment {
+			display: <%= (deletedAttachmentsFileEntriesCount > 0) ? "initial" : "none" %>
+		}
+	</aui:style>
+
 	<div align="right">
-		<a href="javascript:void(0);" id="view-removed-attachments-link" style='display: <%= (deletedAttachmentsFileEntriesCount > 0) ? "initial" : "none" %>;'>
+		<a class="edit-message-attachment" href="javascript:void(0);" id="view-removed-attachments-link">
 			<liferay-ui:message arguments="<%= deletedAttachmentsFileEntriesCount %>" key='<%= (deletedAttachmentsFileEntriesCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments" %>' /> &raquo;
 		</a>
 	</div>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
@@ -67,7 +67,13 @@ if (portletTitleBasedNavigation) {
 					<aui:input disabled="<%= thread.isLocked() %>" helpMessage='<%= thread.isLocked() ? LanguageUtil.get(request, "unlock-thread-to-add-an-explanation-post") : StringPool.BLANK %>' label="add-explanation-post" name="addExplanationPost" onClick='<%= liferayPortletResponse.getNamespace() + "toggleExplanationPost();" %>' type="checkbox" />
 
 					<div class="hide" id="<portlet:namespace />explanationPost">
-						<aui:input maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="subject" style="width: 350px;" value="">
+						<aui:style type="text/css">
+							.move-thread-subject-input {
+								width: 350px;
+							}
+						</aui:style>
+
+						<aui:input class="move-thread-subject-input" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="subject" value="">
 							<aui:validator name="required">
 								function () {
 									var addExplanationPostCheckbox = document.getElementById('<portlet:namespace />addExplanationPost');

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/split_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/split_thread.jsp
@@ -92,7 +92,7 @@ if (portletTitleBasedNavigation) {
 
 					<aui:input disabled="<%= thread.isLocked() %>" helpMessage='<%= thread.isLocked() ? LanguageUtil.get(request, "unlock-thread-to-add-an-explanation-post") : StringPool.BLANK %>' label="add-explanation-post-to-the-source-thread" name="addExplanationPost" onClick='<%= liferayPortletResponse.getNamespace() + "toggleExplanationPost();" %>' type="checkbox" />
 
-					<div id="<portlet:namespace />explanationPost" style="display: none;">
+					<div class="hide" id="<portlet:namespace />explanationPost">
 						<div class="alert alert-info">
 							<liferay-ui:message key="the-following-post-will-be-added-in-place-of-the-moved-message" />
 						</div>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
@@ -31,8 +31,18 @@ if (threadFlag != null) {
 %>
 
 <c:if test="<%= (message.getMessageId() != selMessage.getMessageId()) || MBUtil.isViewableMessage(themeDisplay, message) %>">
+	<aui:style type="text/css">
+		.view-thread-shortcut-nowrap {
+			white-space: nowrap;
+		}
+		.view-thread-shortcut-td-subject {
+			padding-left: <%= (depth > 0) ? depth * 10 : 5 %>px;
+			width: 90%;
+		}
+	</aui:style>
+
 	<tr>
-		<td class="table-cell" style="padding-left: <%= (depth > 0) ? depth * 10 : 5 %>px; width: 90%;" valign="middle">
+		<td class="table-cell view-thread-shortcut-td-subject" valign="middle">
 			<c:if test="<%= !message.isRoot() %>">
 				<c:choose>
 					<c:when test="<%= !lastNode %>">
@@ -77,7 +87,7 @@ if (threadFlag != null) {
 				</c:if>
 			</a>
 		</td>
-		<td class="table-cell" style="white-space: nowrap;">
+		<td class="table-cell view-thread-shortcut-nowrap">
 			<a href="<%= rowHREF %>">
 				<c:if test="<%= !readThread %>">
 					<strong>
@@ -97,7 +107,7 @@ if (threadFlag != null) {
 				</c:if>
 			</a>
 		</td>
-		<td class="table-cell" style="white-space: nowrap;">
+		<td class="table-cell view-thread-shortcut-nowrap">
 			<a href="<%= rowHREF %>"><%= dateTimeFormat.format(message.getModifiedDate()) %></a>
 		</td>
 	</tr>


### PR DESCRIPTION
LPD-44895 Clean inline styles to support style-src '[NONCE]' directive - Blog, Content Dashboard & MB

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44349

Remove inline styles, so customers can define Content Security Policies with a restrictive directive such as:


# How am I fixing it?

Clean inline styles to support style-src '[NONCE]' directive - Blog, Content Dashboard & MB


# Why doesn't this include any test?
UI issue


# Commits

- **LPD-44895 Change inline style to a css class in order to comply with the NONCE strategy using aui tag on blogs**
- **LPD-44895 Change inline style to a css class in order to comply with the NONCE strategy using aui tag on comment taglib**
- **LPD-44895 Change inline style to a css class in order to comply with the NONCE strategy using aui tag on content dashboard**
- **LPD-44895 Change inline style to a css class in order to comply with the NONCE strategy using aui tag on message boards**
