### PR TITLE
LPD-46007 Use nonce attribute directly

### DIFF
--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -1,4 +1,4 @@
-<@liferay_aui["style"] type="text/css">
+<style ${nonceAttribute} type="text/css">
 	.sharing-notification-sharing-entry-added-1 {
 		background-color: #f7f8f9;
 		color: #6b6c7e;
@@ -35,7 +35,7 @@
 		padding: 7px 15px;
 		text-decoration: none;
 	}
-</@>
+</style>
 
 <div class="sharing-notification-sharing-entry-added-1">
 	<div class="sharing-notification-sharing-entry-added-2">


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46007

Clean inline styles to support style-src '[NONCE]' directive - Document Library and Wiki 

# How am I fixing it?

Use nonce attribute directly since we are replacing it for templates

# How can you verify that it works?

This task does not need tests