### PR TITLE
LPD-46241 Remove Web Content Display Geolocation Poshi Tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/contentdisplay/ContentDisplayWithWebContentTemplate.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/contentdisplay/ContentDisplayWithWebContentTemplate.testcase
@@ -518,66 +518,6 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-101248. Display web content with Geolocation field in Content Display."
-	@priority = 3
-	test ViewSelectedWebContentWithGeolocationField {
-		task ("Add a web content structure with a Geolocation field") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			NavItem.gotoStructures();
-
-			WebContentStructures.addCP(structureName = "WC Structure Name");
-
-			DataEngine.addField(
-				fieldFieldLabel = "Geolocation",
-				fieldName = "Geolocation");
-
-			WebContentStructures.saveCP();
-		}
-
-		task ("Add a template for new structure") {
-			WebContentNavigator.gotoManageTemplatesViaStructures(structureName = "WC Structure Name");
-
-			WebContentTemplates.addCP(
-				templateFieldNames = "Geolocation",
-				templateName = "WC Template Name");
-		}
-
-		task ("Add a web content based on new structure") {
-			NavItem.click(navItem = "Web Content");
-
-			WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-			WebContent.addWithStructureCP(webContentTitle = "Web Content Title");
-
-			WebContent.publishWithPermissions();
-		}
-
-		task ("Add a Content Display to a content page") {
-			ContentPagesNavigator.openEditContentPage(
-				pageName = "Content Page Name",
-				siteName = "Test Site Name");
-
-			PageEditor.addFragment(
-				collectionName = "Content Display",
-				fragmentName = "Content Display");
-		}
-
-		task ("Select the web content and template in Content Display") {
-			PageEditor.editContentDisplay(
-				fragmentName = "Content Display",
-				template = "WC Template Name",
-				webcontent = "true",
-				webContentTitle = "Web Content Title");
-		}
-
-		task ("View the Geolocation field is shown in Content Display") {
-			AssertVisible(
-				key_content = "//div[contains(@id,'Geolocation')]",
-				locator1 = "WCD#WEB_CONTENT_CONTENT_ANY");
-		}
-	}
-
 	@description = "This is a test for LPS-101248. Display web content with Grid field in Content Display."
 	@priority = 3
 	test ViewSelectedWebContentWithGridField {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -637,52 +637,6 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 		}
 	}
 
-	@description = "This is a use case for LPS-130033. Display web content with Geolocation field in Web Content Display."
-	@priority = 4
-	test DisplayWebContentWithGeolocationField {
-		task ("Add a web content structure with a Geolocation field") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			NavItem.gotoStructures();
-
-			WebContentStructures.addCP(structureName = "WC Structure Name");
-
-			DataEngine.addField(
-				fieldFieldLabel = "Geolocation",
-				fieldName = "Geolocation");
-
-			WebContentStructures.saveCP();
-		}
-
-		task ("Add a web content based on new structure") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			WebContentNavigator.gotoAddWithStructureCP(structureName = "WC Structure Name");
-
-			WebContent.addWithStructureCP(webContentTitle = "Web Content Title");
-
-			WebContent.publishWithPermissions();
-		}
-
-		task ("Select the web content in Web Content Display") {
-			Navigator.gotoSitePage(
-				pageName = "Test Page Name",
-				siteName = "Test Site Name");
-
-			WebContentDisplayPortlet.selectWebContent(webContentTitle = "Web Content Title");
-
-			IFrame.closeFrame();
-		}
-
-		task ("View the web content is shown in Web Content Display") {
-			Portlet.viewTitle(portletName = "Web Content Title");
-
-			AssertVisible(
-				key_content = "//div[contains(@id,'Geolocation')]",
-				locator1 = "WCD#WEB_CONTENT_CONTENT_ANY");
-		}
-	}
-
 	@description = "This is a test for LPS-97189. A user can edit displayed content in a Web Content Display widget through Contents panel."
 	@priority = 5
 	test EditDisplayedWebContentInWebContentDisplay {


### PR DESCRIPTION
Fix Web Geolocation Web Content Display Poshi Test

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-46241)

Comment for @ambrinchaudhary :see_no_evil: : It doesn't make sense to have these tests, and we also have this covered in other tests. They depend on a browser configuration to be available and can fail at any time

LocalFile.WebContentDisplay#DisplayWebContentWithGeolocationField
LocalFile.ContentDisplayWithWebContentTemplate#ViewSelectedWebContentWithGeolocationField