### PR TITLE
LPD-46007 Leave styles inline because for emails it does not apply non change

### DIFF
--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -1,50 +1,11 @@
-<@liferay_aui["style"] type="text/css">
-	.sharing-notification-sharing-entry-added-1 {
-		background-color: #f7f8f9;
-		color: #6b6c7e;
-		font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-		font-size: 20px;
-		height: 100%;
-		padding: 24px;
-	}
-
-	.sharing-notification-sharing-entry-added-2 {
-		background-color: white;
-		border: solid 1px #e7e7ed;
-		border-radius: 4px;
-		margin: 0 auto;
-		max-width: 800px;
-		padding: 40px;
-	}
-
-	.sharing-notification-sharing-entry-added-3 {
-		line-height: 1.5;
-		margin: 0;
-	}
-
-	.sharing-notification-sharing-entry-added-4 {
-		background-color: #145ffb;
-		color: white;
-		border-radius: 4px;
-		box-sizing: border-box;
-		display: inline-block;
-		font-size: 16px;
-		height: 40px;
-		line-height: 24px;
-		margin-top: 24px;
-		padding: 7px 15px;
-		text-decoration: none;
-	}
-</@>
-
-<div class="sharing-notification-sharing-entry-added-1">
-	<div class="sharing-notification-sharing-entry-added-2">
-		<p class="sharing-notification-sharing-entry-added-3">
+<div style="background-color: #f7f8f9; color: #6b6c7e; font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 20px; height: 100%; padding: 24px;">
+	<div style="background-color: white; border: solid 1px #e7e7ed; border-radius: 4px; margin: 0 auto; max-width: 800px; padding: 40px;">
+		<p style="line-height: 1.5; margin: 0;">
 			${content}
 		</p>
 
 		<#if sharingEntryURL?has_content>
-			<a href="${sharingEntryURL}" class="sharing-notification-sharing-entry-added-4">${actionTitle}</a>
+			<a href="${sharingEntryURL}" style="background-color: #145ffb; color: white; border-radius: 4px; box-sizing: border-box; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
 		</#if>
 	</div>
 </div>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46007

Clean inline styles to support style-src '[NONCE]' directive - Document Library and Wiki 

# How am I fixing it?

Leave styles inline because for emails does not apply non change

# How can you verify that it works?

This task does not need tests