### PR TITLE
LPD-46395 Non active Sites should not appear on item selector

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -59,6 +59,8 @@ public class GroupItemSelectorProviderImpl
 
 		LinkedHashMap<String, Object> groupParams =
 			LinkedHashMapBuilder.<String, Object>put(
+				"active", Boolean.TRUE
+			).put(
 				"site", Boolean.TRUE
 			).build();
 
@@ -90,6 +92,8 @@ public class GroupItemSelectorProviderImpl
 			companyId, _getClassNameIds(), keywords,
 			LinkedHashMapBuilder.<String, Object>put(
 				"actionId", ActionKeys.VIEW
+			).put(
+				"active", Boolean.TRUE
 			).put(
 				"site", Boolean.TRUE
 			).build());

--- a/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
+++ b/modules/apps/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/provider/test/GroupItemSelectorProviderImplTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -70,6 +71,50 @@ public class GroupItemSelectorProviderImplTest {
 	}
 
 	@Test
+	public void testGetGroupsShouldNotReturnInactiveGroups() throws Exception {
+		List<Group> groups = _groupItemSelectorProvider.getGroups(
+			_group.getCompanyId(), _group.getGroupId(), null, 0, 20);
+
+		int originalGroupsSize = groups.size();
+
+		Assert.assertEquals(
+			groups.toString(), originalGroupsSize, groups.size());
+
+		Assert.assertEquals(
+			originalGroupsSize,
+			_groupItemSelectorProvider.getGroupsCount(
+				_group.getCompanyId(), _group.getGroupId(), null));
+
+		Group childGroup = GroupTestUtil.addGroup(_group.getGroupId());
+
+		groups = _groupItemSelectorProvider.getGroups(
+			_group.getCompanyId(), _group.getGroupId(), null, 0, 20);
+
+		Assert.assertEquals(
+			groups.toString(), originalGroupsSize + 1, groups.size());
+
+		Assert.assertEquals(
+			originalGroupsSize + 1,
+			_groupItemSelectorProvider.getGroupsCount(
+				_group.getCompanyId(), _group.getGroupId(), null));
+
+		childGroup.setActive(false);
+
+		_groupLocalService.updateGroup(childGroup);
+
+		groups = _groupItemSelectorProvider.getGroups(
+			_group.getCompanyId(), _group.getGroupId(), null, 0, 20);
+
+		Assert.assertEquals(
+			groups.toString(), originalGroupsSize, groups.size());
+
+		Assert.assertEquals(
+			originalGroupsSize,
+			_groupItemSelectorProvider.getGroupsCount(
+				_group.getCompanyId(), _group.getGroupId(), null));
+	}
+
+	@Test
 	public void testGetIcon() {
 		Assert.assertEquals("sites", _groupItemSelectorProvider.getIcon());
 	}
@@ -87,6 +132,9 @@ public class GroupItemSelectorProviderImplTest {
 		filter = "component.name=com.liferay.item.selector.internal.provider.GroupItemSelectorProviderImpl"
 	)
 	private GroupItemSelectorProvider _groupItemSelectorProvider;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	private User _user;
 


### PR DESCRIPTION
LPD-46395 This is the pull request title

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46395

Group Item selector shows inactive Sites on selector

# How am I fixing it?

Filter the groups by the active ones too.

# How can you verify that it works?

Run the included automated tests.



# Commits


- **LPD-46395 filter groups only by active**
- **LPD-46395 add test to check that an inactive group is not returned on the selector**
