### PR TITLE
LPD-46495 Use redirect as default value in case URL gets shortened as this is a common pattern

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
@@ -78,7 +78,8 @@ public class JournalHistoryDisplayContext {
 			return _backURL;
 		}
 
-		_backURL = ParamUtil.getString(_renderRequest, "backURL");
+		_backURL = ParamUtil.getString(
+			_httpServletRequest, "backURL", _getRedirect());
 
 		return _backURL;
 	}


### PR DESCRIPTION
# What is this trying to solve?
[LPD-46495](https://liferay.atlassian.net/browse/LPD-46495)
Paginated Web Content listing produces such a long URL, that `PortletURLImpl` choses to cut off `backURL` param from it, making View History Page's back button to be uninteractable.

# How am I fixing it?
We can fall back to the `redirect` param. As this is a common pattern, tests are not included.

# How can you verify that it works?
Follow the steps described in [LPD-46495](https://liferay.atlassian.net/browse/LPD-46495)

Cheers,
Balázs