### PR TITLE
LPD-46492 Translate Learn More for web dav links

### DIFF
--- a/learn-resources/data/document-library-web.json
+++ b/learn-resources/data/document-library-web.json
@@ -1,7 +1,71 @@
 {
-	"webdav": {
+	"general": {
+		"ar_SA": {
+			"message": "لمعرفة المزيد.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"ca_ES": {
+			"message": "Aprèn més.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"de_DE": {
+			"message": "Mehr erfahren.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
 		"en_US": {
 			"message": "Learn more.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"es_ES": {
+			"message": "Aprender más.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"eu": {
+			"message": "Irasi gehiago.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"fi_FI": {
+			"message": "Lisää.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"fr_CA": {
+			"message": "Pour en savoir plus.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"fr_FR": {
+			"message": "Pour en savoir plus.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"gl_ES": {
+			"message": "Ler máis.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"hu_HU": {
+			"message": "További információk.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"ja_JP": {
+			"message": "詳細ヘルプ。",
+			"url": "https://learn.liferay.com/ja/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"nl_NL": {
+			"message": "Meer weten.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"pt_BR": {
+			"message": "Aprender mais.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"sv_SE": {
+			"message": "Läs mer.",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"zh_CN": {
+			"message": "了解更多。",
+			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
+		},
+		"zh_TW": {
+			"message": "學習更多。",
 			"url": "https://learn.liferay.com/w/dxp/content-authoring-and-management/documents-and-media/publishing-and-sharing/accessing-documents-with-webdav"
 		}
 	}


### PR DESCRIPTION
LPD-46492 Translate Learn More for web dav links

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46492

Learn More for web dav is only translated to english 

# How am I fixing it?

adding translation to learn-resources/data/document-library-web.json.



# Commits


- **LPD-46492 Translate Learn More for web dav links**
