### PR TITLE
LPD-33262 apply ERC to documents & media widget configuration

### DIFF
--- a/modules/apps/document-library/document-library-test-util/bnd.bnd
+++ b/modules/apps/document-library/document-library-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Test Utilities
 Bundle-SymbolicName: com.liferay.document.library.test.util
-Bundle-Version: 4.1.4
+Bundle-Version: 4.2.0
 Export-Package:\
 	com.liferay.document.library.test.util,\
 	com.liferay.document.library.test.util.search

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLAppTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLAppTestUtil.java
@@ -6,19 +6,29 @@
 package com.liferay.document.library.test.util;
 
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
 
 import java.io.Serializable;
 
@@ -26,6 +36,39 @@ import java.io.Serializable;
  * @author Alexander Chow
  */
 public abstract class DLAppTestUtil {
+
+	public static FileEntry addFileEntry(Folder folder) throws Exception {
+		return addFileEntry(
+			TestPropsValues.getUserId(), folder.getGroupId(),
+			folder.getFolderId(), folder.getRepositoryId());
+	}
+
+	public static FileEntry addFileEntry(long groupId) throws Exception {
+		return addFileEntry(
+			TestPropsValues.getUserId(), groupId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, groupId);
+	}
+
+	public static FileEntry addFileEntry(
+			long userId, long groupId, long folderId, long repositoryId)
+		throws Exception {
+
+		return DLAppLocalServiceUtil.addFileEntry(
+			null, userId, repositoryId, folderId, RandomTestUtil.randomString(),
+			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			RandomTestUtil.randomBytes(), null, null, null,
+			ServiceContextTestUtil.getServiceContext(groupId, userId));
+	}
+
+	public static FileEntry addFileEntry(Repository repository)
+		throws Exception {
+
+		return addFileEntry(
+			TestPropsValues.getUserId(), repository.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			repository.getRepositoryId());
+	}
 
 	public static FileEntry addFileEntryWithWorkflow(
 			long userId, long groupId, long folderId, String sourceFileName,
@@ -58,6 +101,39 @@ public abstract class DLAppTestUtil {
 		finally {
 			WorkflowThreadLocal.setEnabled(workflowEnabled);
 		}
+	}
+
+	public static Folder addFolder(long groupId) throws PortalException {
+		return DLAppLocalServiceUtil.addFolder(
+			null, TestPropsValues.getUserId(), groupId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
+	public static Folder addFolder(Repository repository)
+		throws PortalException {
+
+		return DLAppLocalServiceUtil.addFolder(
+			null, TestPropsValues.getUserId(), repository.getRepositoryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				repository.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	public static Repository addRepository(long groupId)
+		throws PortalException {
+
+		return RepositoryLocalServiceUtil.addRepository(
+			null, TestPropsValues.getUserId(), groupId,
+			PortalUtil.getClassNameId(LiferayRepository.class),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new UnicodeProperties(), true,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
 	}
 
 	public static void populateNotificationsServiceContext(

--- a/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLAppTestUtil.java
+++ b/modules/apps/document-library/document-library-test-util/src/main/java/com/liferay/document/library/test/util/DLAppTestUtil.java
@@ -40,17 +40,17 @@ public abstract class DLAppTestUtil {
 	public static FileEntry addFileEntry(Folder folder) throws Exception {
 		return addFileEntry(
 			TestPropsValues.getUserId(), folder.getGroupId(),
-			folder.getFolderId(), folder.getRepositoryId());
+			folder.getRepositoryId(), folder.getFolderId());
 	}
 
 	public static FileEntry addFileEntry(long groupId) throws Exception {
 		return addFileEntry(
-			TestPropsValues.getUserId(), groupId,
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, groupId);
+			TestPropsValues.getUserId(), groupId, groupId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 	}
 
 	public static FileEntry addFileEntry(
-			long userId, long groupId, long folderId, long repositoryId)
+			long userId, long groupId, long repositoryId, long folderId)
 		throws Exception {
 
 		return DLAppLocalServiceUtil.addFileEntry(
@@ -66,8 +66,8 @@ public abstract class DLAppTestUtil {
 
 		return addFileEntry(
 			TestPropsValues.getUserId(), repository.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			repository.getRepositoryId());
+			repository.getRepositoryId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 	}
 
 	public static FileEntry addFileEntryWithWorkflow(

--- a/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
+++ b/modules/apps/document-library/document-library-test-util/src/main/resources/com/liferay/document/library/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -18,8 +18,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")
 	testIntegrationImplementation project(":apps:product-navigation:product-navigation-control-menu-api")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/document-library/document-library-web-test/build.gradle
+++ b/modules/apps/document-library/document-library-web-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -6,26 +6,35 @@
 package com.liferay.document.library.web.internal.exportimport.portlet.preferences.processor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.exportimport.controller.PortletExportController;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
+import com.liferay.exportimport.test.util.TestReaderWriter;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.CommentManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.IdentityServiceContextFunction;
-import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -33,17 +42,25 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.zip.ZipReader;
+import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.test.util.RatingsTestUtil;
 
+import java.io.Serializable;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -103,16 +120,9 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 	@Test
 	public void testExportDLFileEntryIdWithComments() throws Exception {
-		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
 
-		_portletPreferences.setValue(
-			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
-		_portletPreferences.setValue(
-			"selectedRepositoryId",
-			String.valueOf(fileEntry.getRepositoryId()));
-
-		_portletPreferences.store();
+		_setPortletPreferences(fileEntry);
 
 		User user = TestPropsValues.getUser();
 
@@ -122,13 +132,7 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			new IdentityServiceContextFunction(
 				ServiceContextTestUtil.getServiceContext()));
 
-		Document document = SAXReaderUtil.createDocument();
-
-		Element rootElement = document.addElement("root");
-
-		_portletExportController.exportPortlet(
-			_portletDataContextExport, _layout.getPlid(), rootElement, false,
-			false, true, true, false);
+		_exportPortlet();
 
 		Map<String, String[]> parameterMap =
 			_portletDataContextExport.getParameterMap();
@@ -158,27 +162,14 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 	@Test
 	public void testExportDLFileEntryIdWithRatings() throws Exception {
-		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
 
-		_portletPreferences.setValue(
-			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
-		_portletPreferences.setValue(
-			"selectedRepositoryId",
-			String.valueOf(fileEntry.getRepositoryId()));
-
-		_portletPreferences.store();
+		_setPortletPreferences(fileEntry);
 
 		RatingsEntry ratingsEntry = RatingsTestUtil.addEntry(
 			DLFileEntry.class.getName(), fileEntry.getFileEntryId());
 
-		Document document = SAXReaderUtil.createDocument();
-
-		Element rootElement = document.addElement("root");
-
-		_portletExportController.exportPortlet(
-			_portletDataContextExport, _layout.getPlid(), rootElement, false,
-			false, true, true, false);
+		_exportPortlet();
 
 		Map<String, String[]> parameterMap =
 			_portletDataContextExport.getParameterMap();
@@ -208,25 +199,12 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 	@Test
 	public void testExportDLFileEntryInDifferentGroup() throws Exception {
-		FileEntry fileEntry = _addDLFileEntry(
-			TestPropsValues.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			TestPropsValues.getGroupId());
 
-		_portletPreferences.setValue(
-			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
-		_portletPreferences.setValue(
-			"selectedRepositoryId",
-			String.valueOf(fileEntry.getRepositoryId()));
+		_setPortletPreferences(fileEntry);
 
-		_portletPreferences.store();
-
-		Document document = SAXReaderUtil.createDocument();
-
-		Element rootElement = document.addElement("root");
-
-		_portletExportController.exportPortlet(
-			_portletDataContextExport, _layout.getPlid(), rootElement, false,
-			false, true, true, false);
+		_exportPortlet();
 
 		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
 
@@ -241,24 +219,11 @@ public class DLExportImportPortletPreferencesProcessorTest {
 
 	@Test
 	public void testExportDLFileEntryInSameGroup() throws Exception {
-		FileEntry fileEntry = _addDLFileEntry(
-			_layout.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_layout.getGroupId());
 
-		_portletPreferences.setValue(
-			"rootFolderId", String.valueOf(fileEntry.getFolderId()));
-		_portletPreferences.setValue(
-			"selectedRepositoryId",
-			String.valueOf(fileEntry.getRepositoryId()));
+		_setPortletPreferences(fileEntry);
 
-		_portletPreferences.store();
-
-		Document document = SAXReaderUtil.createDocument();
-
-		Element rootElement = document.addElement("root");
-
-		_portletExportController.exportPortlet(
-			_portletDataContextExport, _layout.getPlid(), rootElement, false,
-			false, true, true, false);
+		_exportPortlet();
 
 		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
 
@@ -272,26 +237,54 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	}
 
 	@Test
-	public void testProcessExportPortletPreferencesDLFileEntryId()
-		throws Exception {
+	public void testExportHomeFolder() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
 
-		FileEntry fileEntry = _addDLFileEntry(
-			_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+	}
+
+	@Test
+	public void testExportImportAssetLibraryHomeFolder() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			depotEntry.getGroupId());
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportAssetLibrarySubfolder() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Folder folder = DLAppTestUtil.addFolder(depotEntry.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportCustomPreference() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
 
 		_portletPreferences.setValue(
 			"fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
 
 		_portletPreferences.store();
 
-		PortletPreferences exportedPortletPreferences =
-			_exportImportPortletPreferencesProcessor.
-				processExportPortletPreferences(
-					_portletDataContextExport, _portletPreferences);
-
 		PortletPreferences importedPortletPreferences =
-			_exportImportPortletPreferencesProcessor.
-				processImportPortletPreferences(
-					_portletDataContextImport, exportedPortletPreferences);
+			_exportImportPortletPreferences();
 
 		String importedfileEntryId = importedPortletPreferences.getValue(
 			"fileEntryId", "");
@@ -301,19 +294,425 @@ public class DLExportImportPortletPreferencesProcessorTest {
 			GetterUtil.getLong(importedfileEntryId));
 	}
 
-	private FileEntry _addDLFileEntry(long groupId, long folderId)
+	@Test
+	public void testExportImportHomeFolder() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportHomeFolderInAssetLibraryWithStagingInProcessFromLive()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(groupId);
+		DepotEntry depotEntry = _addDepotEntry();
 
-		return _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), groupId, folderId,
-			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK, RandomTestUtil.randomBytes(), null, null, null,
-			serviceContext);
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		FileEntry liveFileEntry = DLAppTestUtil.addFileEntry(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			liveFileEntry.getTitle());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPreferencesValues(liveFileEntry),
+			_getPreferencesValues(stagingFileEntry));
 	}
+
+	@Test
+	public void testExportImportHomeFolderInAssetLibraryWithStagingInProcessFromStaging()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		FileEntry liveFileEntry = DLAppTestUtil.addFileEntry(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			liveFileEntry.getTitle());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPreferencesValues(stagingFileEntry),
+			_getPreferencesValues(liveFileEntry));
+	}
+
+	@Test
+	public void testExportImportSubfolder() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportSubfolderInAssetLibraryWithStagingInProcessFromLive()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		Folder liveFolder = DLAppTestUtil.addFolder(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		Folder stagingFolder = _dlAppLocalService.getFolder(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPreferencesValues(liveFolder),
+			_getPreferencesValues(stagingFolder));
+	}
+
+	@Test
+	public void testExportImportSubfolderInAssetLibraryWithStagingInProcessFromStaging()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		Folder liveFolder = DLAppTestUtil.addFolder(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		Folder stagingFolder = _dlAppLocalService.getFolder(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPreferencesValues(stagingFolder),
+			_getPreferencesValues(liveFolder));
+	}
+
+	@Test
+	public void testExportImportSubfolderWithStagingInProcess()
+		throws Exception {
+
+		GroupTestUtil.enableLocalStaging(_group);
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Group stagingGroup = _group.getStagingGroup();
+
+			Folder folder = DLAppTestUtil.addFolder(stagingGroup.getGroupId());
+
+			TestReaderWriter testReaderWriter = _getReaderWriter();
+
+			Map<String, String> preferencesValues = _getPreferencesValues(
+				folder);
+
+			_setPortletPreferences(preferencesValues);
+
+			PortletPreferences exportedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processExportPortletPreferences(
+						_getExportPortletDataContext(
+							stagingGroup, testReaderWriter),
+						_portletPreferences);
+
+			Assert.assertEquals(
+				preferencesValues,
+				_getPreferencesValues(exportedPortletPreferences));
+
+			PortletDataContext importPortletDataContext =
+				_getImportPortletDataContext(_group, testReaderWriter);
+
+			Assert.assertNull(
+				importPortletDataContext.getZipEntryAsString(
+					String.format(
+						"%s/staging-preferences-mapping.json",
+						importPortletDataContext.getPortletId())));
+
+			PortletPreferences importedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processImportPortletPreferences(
+						importPortletDataContext, exportedPortletPreferences);
+
+			Assert.assertEquals(
+				preferencesValues,
+				_getPreferencesValues(importedPortletPreferences));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@Test
+	public void testExportRepository() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(repository);
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFolder.class.getName(), fileEntry.getFolderId())));
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					Repository.class.getName(), fileEntry.getRepositoryId())));
+	}
+
+	@Test
+	public void testExportSubfolder() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFolder.class.getName(), folder.getFolderId())));
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private PortletPreferences _exportImportPortletPreferences()
+		throws Exception {
+
+		PortletPreferences exportedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processExportPortletPreferences(
+					_portletDataContextExport, _portletPreferences);
+
+		return _exportImportPortletPreferencesProcessor.
+			processImportPortletPreferences(
+				_portletDataContextImport, exportedPortletPreferences);
+	}
+
+	private void _exportPortlet() throws Exception {
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		_portletExportController.exportPortlet(
+			_portletDataContextExport, _layout.getPlid(), rootElement, false,
+			false, true, true, false);
+	}
+
+	private PortletDataContext _getExportPortletDataContext(
+			Group group, ZipWriter zipWriter)
+		throws Exception {
+
+		PortletDataContext exportPortletDataContext =
+			ExportImportTestUtil.getExportPortletDataContext(
+				group.getGroupId());
+
+		exportPortletDataContext.setPortletId(DLPortletKeys.DOCUMENT_LIBRARY);
+		exportPortletDataContext.setZipWriter(zipWriter);
+
+		return exportPortletDataContext;
+	}
+
+	private PortletDataContext _getImportPortletDataContext(
+			Group group, ZipReader zipReader)
+		throws Exception {
+
+		PortletDataContext importPortletDataContext =
+			ExportImportTestUtil.getImportPortletDataContext(
+				group.getGroupId());
+
+		importPortletDataContext.setPortletId(DLPortletKeys.DOCUMENT_LIBRARY);
+		importPortletDataContext.setZipReader(zipReader);
+
+		return importPortletDataContext;
+	}
+
+	private Map<String, String> _getPreferencesValues(FileEntry fileEntry) {
+		return _getPreferencesValues(
+			String.valueOf(fileEntry.getFolderId()),
+			String.valueOf(fileEntry.getRepositoryId()));
+	}
+
+	private Map<String, String> _getPreferencesValues(Folder folder) {
+		return _getPreferencesValues(
+			String.valueOf(folder.getFolderId()),
+			String.valueOf(folder.getRepositoryId()));
+	}
+
+	private Map<String, String> _getPreferencesValues(
+		PortletPreferences portletPreferences) {
+
+		return _getPreferencesValues(
+			portletPreferences.getValue("rootFolderId", null),
+			portletPreferences.getValue("selectedRepositoryId", null));
+	}
+
+	private Map<String, String> _getPreferencesValues(
+		String rootFolderId, String selectedRepositoryId) {
+
+		return HashMapBuilder.put(
+			"rootFolderId", rootFolderId
+		).put(
+			"selectedRepositoryId", selectedRepositoryId
+		).build();
+	}
+
+	private String _getPrimaryKey(String className, Serializable classPK) {
+		return StringBundler.concat(
+			String.class.getName(), StringPool.POUND, className,
+			StringPool.POUND, classPK);
+	}
+
+	private TestReaderWriter _getReaderWriter() {
+		TestReaderWriter testReaderWriter = new TestReaderWriter();
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element manifestRootElement = document.addElement("root");
+
+		manifestRootElement.addElement("header");
+
+		testReaderWriter.addEntry("/manifest.xml", document.asXML());
+
+		return testReaderWriter;
+	}
+
+	private void _setPortletPreferences(FileEntry fileEntry) throws Exception {
+		_setPortletPreferences(_getPreferencesValues(fileEntry));
+	}
+
+	private void _setPortletPreferences(Map<String, String> preferencesValues)
+		throws Exception {
+
+		for (Map.Entry<String, String> entry : preferencesValues.entrySet()) {
+			_portletPreferences.setValue(entry.getKey(), entry.getValue());
+		}
+
+		_portletPreferences.store();
+	}
+
+	private void _testExportImport(FileEntry fileEntry) throws Exception {
+		Map<String, String> preferencesValues = _getPreferencesValues(
+			fileEntry);
+
+		_setPortletPreferences(preferencesValues);
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferences();
+
+		Assert.assertEquals(
+			preferencesValues,
+			_getPreferencesValues(importedPortletPreferences));
+	}
+
+	private void _testExportImportFolderInAssetLibraryWithStagingInProcess(
+			Map<String, String> originalPreferencesValues,
+			Map<String, String> expectedPreferencesValues)
+		throws Exception {
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			TestReaderWriter testReaderWriter = _getReaderWriter();
+
+			_setPortletPreferences(originalPreferencesValues);
+
+			PortletPreferences exportedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processExportPortletPreferences(
+						_getExportPortletDataContext(_group, testReaderWriter),
+						_portletPreferences);
+
+			Assert.assertEquals(
+				originalPreferencesValues,
+				_getPreferencesValues(exportedPortletPreferences));
+
+			PortletDataContext importPortletDataContext =
+				_getImportPortletDataContext(_group, testReaderWriter);
+
+			Assert.assertNotNull(
+				importPortletDataContext.getZipEntryAsString(
+					String.format(
+						"%s/staging-preferences-mapping.json",
+						importPortletDataContext.getPortletId())));
+
+			PortletPreferences importedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processImportPortletPreferences(
+						importPortletDataContext, exportedPortletPreferences);
+
+			Assert.assertEquals(
+				expectedPreferencesValues,
+				_getPreferencesValues(importedPortletPreferences));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
@@ -325,7 +724,14 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
+	@Inject
+	private GroupLocalService _groupLocalService;
+
 	private Layout _layout;
+
+	@Inject
+	private Portal _portal;
+
 	private PortletDataContext _portletDataContextExport;
 	private PortletDataContext _portletDataContextImport;
 
@@ -333,5 +739,8 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	private PortletExportController _portletExportController;
 
 	private PortletPreferences _portletPreferences;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -585,33 +585,96 @@ public class DLExportImportPortletPreferencesProcessorTest {
 		return importPortletDataContext;
 	}
 
-	private Map<String, String> _getPreferencesValues(FileEntry fileEntry) {
+	private Map<String, String> _getPreferencesValues(FileEntry fileEntry)
+		throws Exception {
+
+		String rootFolderExternalReferenceCode = StringPool.BLANK;
+
+		if (fileEntry.getFolderId() !=
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+
+			Folder folder = _dlAppLocalService.getFolder(
+				fileEntry.getFolderId());
+
+			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
+		}
+
+		Group selectedGroup;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			fileEntry.getRepositoryId());
+
+		if (selectedRepository == null) {
+			selectedGroup = _groupLocalService.getGroup(
+				fileEntry.getRepositoryId());
+		}
+		else {
+			selectedGroup = _groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+
 		return _getPreferencesValues(
-			String.valueOf(fileEntry.getFolderId()),
-			String.valueOf(fileEntry.getRepositoryId()));
+			rootFolderExternalReferenceCode,
+			selectedGroup.getExternalReferenceCode(),
+			selectedRepositoryExternalReferenceCode);
 	}
 
-	private Map<String, String> _getPreferencesValues(Folder folder) {
+	private Map<String, String> _getPreferencesValues(Folder folder)
+		throws Exception {
+
+		Group selectedGroup;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			folder.getRepositoryId());
+
+		if (selectedRepository == null) {
+			selectedGroup = _groupLocalService.getGroup(
+				folder.getRepositoryId());
+		}
+		else {
+			selectedGroup = _groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+
 		return _getPreferencesValues(
-			String.valueOf(folder.getFolderId()),
-			String.valueOf(folder.getRepositoryId()));
+			folder.getExternalReferenceCode(),
+			selectedGroup.getExternalReferenceCode(),
+			selectedRepositoryExternalReferenceCode);
 	}
 
 	private Map<String, String> _getPreferencesValues(
 		PortletPreferences portletPreferences) {
 
 		return _getPreferencesValues(
-			portletPreferences.getValue("rootFolderId", null),
-			portletPreferences.getValue("selectedRepositoryId", null));
+			portletPreferences.getValue(
+				"rootFolderExternalReferenceCode", null),
+			portletPreferences.getValue(
+				"selectedGroupExternalReferenceCode", null),
+			portletPreferences.getValue(
+				"selectedRepositoryExternalReferenceCode", null));
 	}
 
 	private Map<String, String> _getPreferencesValues(
-		String rootFolderId, String selectedRepositoryId) {
+		String rootFolderExternalReferenceCode,
+		String selectedGroupExternalReferenceCode,
+		String selectedRepositoryExternalReferenceCode) {
 
 		return HashMapBuilder.put(
-			"rootFolderId", rootFolderId
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode
 		).put(
-			"selectedRepositoryId", selectedRepositoryId
+			"selectedGroupExternalReferenceCode",
+			selectedGroupExternalReferenceCode
+		).put(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode
 		).build();
 	}
 

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -571,6 +571,34 @@ public class DLExportImportPortletPreferencesProcessorTest {
 		return exportPortletDataContext;
 	}
 
+	private String _getFolderExternalReferenceCode(long folderId)
+		throws Exception {
+
+		if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return StringPool.BLANK;
+		}
+
+		Folder folder = _dlAppLocalService.getFolder(folderId);
+
+		return folder.getExternalReferenceCode();
+	}
+
+	private String _getGroupExternalReferenceCode(
+			long groupId, Repository repository)
+		throws Exception {
+
+		Group group;
+
+		if (repository == null) {
+			group = _groupLocalService.getGroup(groupId);
+		}
+		else {
+			group = _groupLocalService.getGroup(repository.getGroupId());
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
 	private PortletDataContext _getImportPortletDataContext(
 			Group group, ZipReader zipReader)
 		throws Exception {
@@ -588,66 +616,27 @@ public class DLExportImportPortletPreferencesProcessorTest {
 	private Map<String, String> _getPreferencesValues(FileEntry fileEntry)
 		throws Exception {
 
-		String rootFolderExternalReferenceCode = StringPool.BLANK;
-
-		if (fileEntry.getFolderId() !=
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-
-			Folder folder = _dlAppLocalService.getFolder(
-				fileEntry.getFolderId());
-
-			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
-		}
-
-		Group selectedGroup;
-		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
-
-		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+		Repository repository = _repositoryLocalService.fetchRepository(
 			fileEntry.getRepositoryId());
 
-		if (selectedRepository == null) {
-			selectedGroup = _groupLocalService.getGroup(
-				fileEntry.getRepositoryId());
-		}
-		else {
-			selectedGroup = _groupLocalService.getGroup(
-				selectedRepository.getGroupId());
-
-			selectedRepositoryExternalReferenceCode =
-				selectedRepository.getExternalReferenceCode();
-		}
-
 		return _getPreferencesValues(
-			rootFolderExternalReferenceCode,
-			selectedGroup.getExternalReferenceCode(),
-			selectedRepositoryExternalReferenceCode);
+			_getFolderExternalReferenceCode(fileEntry.getFolderId()),
+			_getGroupExternalReferenceCode(
+				fileEntry.getRepositoryId(), repository),
+			_getRepositoryExternalReferenceCode(repository));
 	}
 
 	private Map<String, String> _getPreferencesValues(Folder folder)
 		throws Exception {
 
-		Group selectedGroup;
-		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
-
-		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+		Repository repository = _repositoryLocalService.fetchRepository(
 			folder.getRepositoryId());
-
-		if (selectedRepository == null) {
-			selectedGroup = _groupLocalService.getGroup(
-				folder.getRepositoryId());
-		}
-		else {
-			selectedGroup = _groupLocalService.getGroup(
-				selectedRepository.getGroupId());
-
-			selectedRepositoryExternalReferenceCode =
-				selectedRepository.getExternalReferenceCode();
-		}
 
 		return _getPreferencesValues(
 			folder.getExternalReferenceCode(),
-			selectedGroup.getExternalReferenceCode(),
-			selectedRepositoryExternalReferenceCode);
+			_getGroupExternalReferenceCode(
+				folder.getRepositoryId(), repository),
+			_getRepositoryExternalReferenceCode(repository));
 	}
 
 	private Map<String, String> _getPreferencesValues(
@@ -696,6 +685,14 @@ public class DLExportImportPortletPreferencesProcessorTest {
 		testReaderWriter.addEntry("/manifest.xml", document.asXML());
 
 		return testReaderWriter;
+	}
+
+	private String _getRepositoryExternalReferenceCode(Repository repository) {
+		if (repository == null) {
+			return StringPool.BLANK;
+		}
+
+		return repository.getExternalReferenceCode();
 	}
 
 	private void _setPortletPreferences(FileEntry fileEntry) throws Exception {

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Attila Bakay
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletPreferencesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, DLPortletKeys.DOCUMENT_LIBRARY);
+	}
+
+	@Test
+	public void testUpgradeHomeFolderSelected() throws Exception {
+		_testUpgrade(
+			_getMap(
+				StringPool.BLANK, _group.getExternalReferenceCode(),
+				StringPool.BLANK),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				_group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeInvalidRepository() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testUpgradeInvalidRootFolder() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			_getMap(RandomTestUtil.randomLong(), _group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeMissingRepository() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			HashMapBuilder.put(
+				"rootFolderId",
+				String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)
+			).build());
+	}
+
+	@Test
+	public void testUpgradeMissingRootFolder() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			HashMapBuilder.put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build());
+	}
+
+	@Test
+	public void testUpgradeRepositoryHomeFolderSelected() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		_testUpgrade(
+			_getMap(
+				StringPool.BLANK, _group.getExternalReferenceCode(),
+				repository.getExternalReferenceCode()),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				repository.getRepositoryId()));
+	}
+
+	@Test
+	public void testUpgradeRepositorySubfolderSelected() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		Folder folder = DLAppTestUtil.addFolder(repository);
+
+		_testUpgrade(
+			_getMap(
+				folder.getExternalReferenceCode(),
+				_group.getExternalReferenceCode(),
+				repository.getExternalReferenceCode()),
+			_getMap(folder.getFolderId(), repository.getRepositoryId()));
+	}
+
+	@Test
+	public void testUpgradeSubfolderSelected() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_testUpgrade(
+			_getMap(
+				folder.getExternalReferenceCode(),
+				_group.getExternalReferenceCode(), StringPool.BLANK),
+			_getMap(folder.getFolderId(), _group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeWithoutSelectedFolder() throws Exception {
+		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
+	}
+
+	private void _assertPortletPreferences(Map<String, String> expectedMap)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		Map<String, String[]> map = portletPreferences.getMap();
+
+		Assert.assertEquals(
+			MapUtil.toString(map), expectedMap.size(), map.size());
+
+		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
+			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
+
+			Assert.assertArrayEquals(
+				new String[] {entry.getValue()}, map.get(entry.getKey()));
+		}
+	}
+
+	private Map<String, String> _getMap(
+		long rootFolderId, long selectedRepositoryId) {
+
+		return HashMapBuilder.put(
+			"rootFolderId", String.valueOf(rootFolderId)
+		).put(
+			"selectedRepositoryId", String.valueOf(selectedRepositoryId)
+		).build();
+	}
+
+	private Map<String, String> _getMap(
+		String rootFolderExternalReferenceCode,
+		String selectedGroupExternalReferenceCode,
+		String selectedRepositoryExternalReferenceCode) {
+
+		return HashMapBuilder.put(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode
+		).put(
+			"selectedGroupExternalReferenceCode",
+			selectedGroupExternalReferenceCode
+		).put(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode
+		).build();
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _testUpgrade(
+			Map<String, String> expectedMap, Map<String, String> map)
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreferences(_layout, _portletId, map);
+
+		_assertPortletPreferences(map);
+
+		_runUpgrade();
+
+		_assertPortletPreferences(expectedMap);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.document.library.web.internal.upgrade.v1_1_0." +
+			"UpgradePortletPreferences";
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private String _portletId;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.document.library.web.internal.upgrade.registry.DLWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
@@ -95,6 +96,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.trash.TrashHelper;
 
@@ -347,7 +349,8 @@ public class DLAdminDisplayContext {
 			repositoryId = folder.getRepositoryId();
 		}
 		else {
-			repositoryId = _dlPortletInstanceSettings.getSelectedRepositoryId();
+			repositoryId =
+				_getSelectedRepositoryIdFromPortletInstanceSettings();
 		}
 
 		if (repositoryId == 0) {
@@ -413,7 +416,7 @@ public class DLAdminDisplayContext {
 		}
 
 		long repositoryId =
-			_dlPortletInstanceSettings.getSelectedRepositoryId();
+			_getSelectedRepositoryIdFromPortletInstanceSettings();
 
 		if (repositoryId != 0) {
 			_selectedRepositoryId = repositoryId;
@@ -560,18 +563,33 @@ public class DLAdminDisplayContext {
 
 	private void _computeRootFolder() {
 		_rootFolder = null;
-
-		_rootFolderId = _dlPortletInstanceSettings.getRootFolderId();
 		_rootFolderName = StringPool.BLANK;
 
-		if (_rootFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		String rootFolderExternalReferenceCode =
+			_dlPortletInstanceSettings.getRootFolderExternalReferenceCode();
+
+		if (Validator.isBlank(rootFolderExternalReferenceCode)) {
+			_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 			_rootFolderName = LanguageUtil.get(_httpServletRequest, "home");
 
 			return;
 		}
 
+		String selectedGroupExternalReferenceCode =
+			_dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode();
+
 		try {
-			_rootFolder = DLAppLocalServiceUtil.getFolder(_rootFolderId);
+			Group selectedGroup =
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					selectedGroupExternalReferenceCode,
+					_themeDisplay.getCompanyId());
+
+			_rootFolder = new LiferayFolder(
+				DLFolderLocalServiceUtil.getDLFolderByExternalReferenceCode(
+					rootFolderExternalReferenceCode,
+					selectedGroup.getGroupId()));
+
+			_rootFolderId = _rootFolder.getFolderId();
 
 			_rootFolderName = _rootFolder.getName();
 
@@ -597,7 +615,10 @@ public class DLAdminDisplayContext {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
-						"Could not find folder {folderId=", _rootFolderId, "}"),
+						"Could not find folder {folderExternalReferenceCode=",
+						rootFolderExternalReferenceCode,
+						", groupExternalReferenceCode=",
+						selectedGroupExternalReferenceCode, "}"),
 					noSuchFolderException);
 			}
 
@@ -1107,6 +1128,40 @@ public class DLAdminDisplayContext {
 			() -> _getSearchResults(hits), hits.getLength());
 
 		return searchContainer;
+	}
+
+	private long _getSelectedRepositoryIdFromPortletInstanceSettings() {
+		String selectedGroupExternalReferenceCode =
+			_dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode();
+
+		if (Validator.isBlank(selectedGroupExternalReferenceCode)) {
+			return 0;
+		}
+
+		try {
+			Group selectedGroup =
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					selectedGroupExternalReferenceCode,
+					_themeDisplay.getCompanyId());
+
+			String selectedRepositoryExternalReferenceCode =
+				_dlPortletInstanceSettings.
+					getSelectedRepositoryExternalReferenceCode();
+
+			if (Validator.isBlank(selectedRepositoryExternalReferenceCode)) {
+				return selectedGroup.getGroupId();
+			}
+
+			Repository selectedRepository =
+				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
+					selectedRepositoryExternalReferenceCode,
+					selectedGroup.getGroupId());
+
+			return selectedRepository.getRepositoryId();
+		}
+		catch (PortalException portalException) {
+			throw new SystemException(portalException);
+		}
 	}
 
 	private Sort _getSort(String orderByCol, String orderByType) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -172,7 +172,7 @@ public class DLExportImportPortletPreferencesProcessor
 			}
 		}
 
-		// Root folder ID is not set, we need to export everything
+		// Root folder ERC is not set, we need to export everything
 
 		try {
 			portletDataContext.addPortletPermissions(DLConstants.RESOURCE_NAME);
@@ -367,9 +367,6 @@ public class DLExportImportPortletPreferencesProcessor
 				try {
 					Element folderElement = folderElements.get(0);
 
-					long rootFolderId = _getFolderId(
-						folderElement, portletDataContext);
-
 					StagedModelDataHandlerUtil.importStagedModel(
 						portletDataContext, folderElement);
 
@@ -378,6 +375,9 @@ public class DLExportImportPortletPreferencesProcessor
 							portletDataContext.getNewPrimaryKeysMap(
 								Folder.class +
 									".folderIdsAndRepositoryEntryIds");
+
+					long rootFolderId = _getFolderId(
+						folderElement, portletDataContext);
 
 					long importedRootFolderId = MapUtil.getLong(
 						folderIds, rootFolderId, rootFolderId);

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -10,7 +10,6 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileShortcut;
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportHelper;
@@ -21,11 +20,15 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.exportimport.kernel.staging.StagingURLHelperUtil;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONException;
@@ -35,15 +38,23 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.auth.HttpPrincipal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
+import com.liferay.portal.service.http.GroupServiceHttp;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
 import java.util.List;
@@ -91,19 +102,27 @@ public class DLExportImportPortletPreferencesProcessor
 			return portletPreferences;
 		}
 
-		// Root folder ID is set, only export that
+		// Root folder ERC is set, only export that
 
-		long rootFolderId = GetterUtil.getLong(
-			portletPreferences.getValue("rootFolderId", null));
+		String rootFolderExternalReferenceCode = portletPreferences.getValue(
+			_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE, null);
 
-		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		String selectedGroupExternalReferenceCode = portletPreferences.getValue(
+			_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE, null);
+
+		if (!Validator.isBlank(rootFolderExternalReferenceCode)) {
 			try {
-				Folder folder = _getFolder(rootFolderId, portletDataContext);
+				Folder folder = _getFolder(
+					rootFolderExternalReferenceCode,
+					selectedGroupExternalReferenceCode, portletDataContext);
 
 				if (folder != null) {
+					String selectedRepositoryExternalReferenceCode =
+						_getRepositoryExternalReferenceCode(folder);
+
 					portletPreferences.setValue(
-						"selectedRepositoryId",
-						String.valueOf(folder.getRepositoryId()));
+						_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+						selectedRepositoryExternalReferenceCode);
 
 					if ((folder.getGroupId() ==
 							portletDataContext.getGroupId()) ||
@@ -115,8 +134,9 @@ public class DLExportImportPortletPreferencesProcessor
 					}
 					else {
 						_saveStagingPreferencesMapping(
-							folder.getRepositoryId(), folder.getUuid(),
-							portletDataContext);
+							portletDataContext, rootFolderExternalReferenceCode,
+							selectedGroupExternalReferenceCode,
+							selectedRepositoryExternalReferenceCode);
 					}
 				}
 
@@ -129,20 +149,27 @@ public class DLExportImportPortletPreferencesProcessor
 			}
 		}
 
-		long selectedRepositoryId = GetterUtil.getLong(
-			portletPreferences.getValue("selectedRepositoryId", null));
+		if (!Validator.isBlank(selectedGroupExternalReferenceCode)) {
+			Group selectedGroup =
+				_groupLocalService.fetchGroupByExternalReferenceCode(
+					selectedGroupExternalReferenceCode,
+					portletDataContext.getCompanyId());
 
-		if (!_exportImportHelper.isExportPortletData(portletDataContext) ||
-			(selectedRepositoryId != portletDataContext.getGroupId())) {
+			if (!_exportImportHelper.isExportPortletData(portletDataContext) ||
+				(selectedGroup.getGroupId() !=
+					portletDataContext.getGroupId())) {
 
-			if (ExportImportThreadLocal.isStagingInProcess() &&
-				(selectedRepositoryId > 0)) {
+				if (ExportImportThreadLocal.isStagingInProcess()) {
+					_saveStagingPreferencesMapping(
+						portletDataContext, null,
+						selectedGroupExternalReferenceCode,
+						portletPreferences.getValue(
+							_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+							null));
+				}
 
-				_saveStagingPreferencesMapping(
-					selectedRepositoryId, null, portletDataContext);
+				return portletPreferences;
 			}
-
-			return portletPreferences;
 		}
 
 		// Root folder ID is not set, we need to export everything
@@ -303,40 +330,34 @@ public class DLExportImportPortletPreferencesProcessor
 
 		if (stagingPreferencesMappingJSONObject != null) {
 			try {
-				long folderRepositoryId =
-					stagingPreferencesMappingJSONObject.getLong(
-						"folderRepositoryId");
-				String folderUuid =
-					stagingPreferencesMappingJSONObject.getString("folderUuid");
-
-				long folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
-
-				if (Validator.isNotNull(folderUuid)) {
-					DLFolder dlFolder =
-						_dlFolderLocalService.getDLFolderByUuidAndGroupId(
-							folderUuid, folderRepositoryId);
-
-					folderId = dlFolder.getFolderId();
-				}
+				portletPreferences.setValue(
+					_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE,
+					stagingPreferencesMappingJSONObject.getString(
+						_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE));
 
 				portletPreferences.setValue(
-					"rootFolderId", String.valueOf(folderId));
+					_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
+					stagingPreferencesMappingJSONObject.getString(
+						_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE));
+
 				portletPreferences.setValue(
-					"selectedRepositoryId", String.valueOf(folderRepositoryId));
+					_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+					stagingPreferencesMappingJSONObject.getString(
+						_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE));
 
 				return portletPreferences;
 			}
-			catch (PortalException | ReadOnlyException exception) {
-				throw new PortletDataException(exception);
+			catch (ReadOnlyException readOnlyException) {
+				throw new PortletDataException(readOnlyException);
 			}
 		}
 
-		// Root folder ID is set, only import that
+		// Root folder ERC is set, only import that
 
-		long rootFolderId = GetterUtil.getLong(
-			portletPreferences.getValue("rootFolderId", null));
+		String rootFolderExternalReferenceCode = portletPreferences.getValue(
+			_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE, null);
 
-		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		if (!Validator.isBlank(rootFolderExternalReferenceCode)) {
 			Element foldersElement =
 				portletDataContext.getImportDataGroupElement(DLFolder.class);
 
@@ -344,8 +365,13 @@ public class DLExportImportPortletPreferencesProcessor
 
 			if (!folderElements.isEmpty()) {
 				try {
+					Element folderElement = folderElements.get(0);
+
+					long rootFolderId = _getFolderId(
+						folderElement, portletDataContext);
+
 					StagedModelDataHandlerUtil.importStagedModel(
-						portletDataContext, folderElements.get(0));
+						portletDataContext, folderElement);
 
 					Map<Long, Long> folderIds =
 						(Map<Long, Long>)
@@ -356,16 +382,21 @@ public class DLExportImportPortletPreferencesProcessor
 					long importedRootFolderId = MapUtil.getLong(
 						folderIds, rootFolderId, rootFolderId);
 
-					portletPreferences.setValue(
-						"rootFolderId", String.valueOf(importedRootFolderId));
-
 					Folder folder = _getFolder(
 						importedRootFolderId, portletDataContext);
 
 					if (folder != null) {
 						portletPreferences.setValue(
-							"selectedRepositoryId",
-							String.valueOf(folder.getRepositoryId()));
+							_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE,
+							folder.getExternalReferenceCode());
+
+						portletPreferences.setValue(
+							_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
+							_getGroupExternalReferenceCode(folder));
+
+						portletPreferences.setValue(
+							_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+							_getRepositoryExternalReferenceCode(folder));
 					}
 
 					return portletPreferences;
@@ -376,22 +407,6 @@ public class DLExportImportPortletPreferencesProcessor
 						readOnlyException);
 				}
 			}
-		}
-
-		try {
-			long selectedRepositoryId = GetterUtil.getLong(
-				portletPreferences.getValue("selectedRepositoryId", null));
-
-			if (selectedRepositoryId == portletDataContext.getSourceGroupId()) {
-				portletPreferences.setValue(
-					"selectedRepositoryId",
-					String.valueOf(portletDataContext.getGroupId()));
-			}
-		}
-		catch (ReadOnlyException readOnlyException) {
-			throw new PortletDataException(
-				"Unable to update portlet preferences during import",
-				readOnlyException);
 		}
 
 		// Root folder is not set, need to import everything
@@ -530,35 +545,172 @@ public class DLExportImportPortletPreferencesProcessor
 		return folder;
 	}
 
-	private long _getMirrorRepositoryId(long repositoryId) {
-		Group group = _groupLocalService.fetchGroup(repositoryId);
+	private Folder _getFolder(
+			String folderExternalReferenceCode,
+			String groupExternalReferenceCode,
+			PortletDataContext portletDataContext)
+		throws PortletDataException {
+
+		try {
+			Group group = _groupLocalService.getGroupByExternalReferenceCode(
+				groupExternalReferenceCode, portletDataContext.getCompanyId());
+
+			DLFolder dlFolder =
+				_dlFolderLocalService.getDLFolderByExternalReferenceCode(
+					folderExternalReferenceCode, group.getGroupId());
+
+			if (!dlFolder.isInTrash()) {
+				return new LiferayFolder(dlFolder);
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Portlet ", portletDataContext.getPortletId(),
+						" refers to an invalid root folder ERC ",
+						folderExternalReferenceCode, " with group ERC ",
+						groupExternalReferenceCode),
+					portalException);
+			}
+		}
+
+		return null;
+	}
+
+	private long _getFolderId(
+		Element folderElement, PortletDataContext portletDataContext) {
+
+		Folder folder = (Folder)portletDataContext.getZipEntryAsObject(
+			folderElement, folderElement.attributeValue("path"));
+
+		return folder.getFolderId();
+	}
+
+	private String _getGroupExternalReferenceCode(Folder folder) {
+		Group group = _groupLocalService.fetchGroup(folder.getGroupId());
 
 		if (group == null) {
-			return repositoryId;
+			return StringPool.BLANK;
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	private String _getMirrorGroupExternalReferenceCode(
+		PortletDataContext portletDataContext,
+		String groupExternalReferenceCode) {
+
+		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+			groupExternalReferenceCode, portletDataContext.getCompanyId());
+
+		if (group == null) {
+			return groupExternalReferenceCode;
 		}
 
 		Group stagingGroup = group.getStagingGroup();
 
 		if (stagingGroup != null) {
-			return stagingGroup.getGroupId();
+			return stagingGroup.getExternalReferenceCode();
 		}
 
-		long liveGroupId = group.getLiveGroupId();
+		if (ExportImportThreadLocal.isStagingInProcess() &&
+			group.isStagedRemotely()) {
 
-		if (group.isStagedRemotely()) {
-			liveGroupId = group.getRemoteLiveGroupId();
+			UnicodeProperties typeSettingsUnicodeProperties =
+				group.getTypeSettingsProperties();
+
+			String remoteGroupExternalReferenceCode =
+				typeSettingsUnicodeProperties.get(
+					"remoteGroupExternalReferenceCode");
+
+			if (Validator.isNull(remoteGroupExternalReferenceCode)) {
+				remoteGroupExternalReferenceCode =
+					_getRemoteGroupExternalReferenceCode(
+						typeSettingsUnicodeProperties);
+			}
+
+			if (Validator.isNotNull(remoteGroupExternalReferenceCode)) {
+				groupExternalReferenceCode = remoteGroupExternalReferenceCode;
+			}
 		}
 
-		if (liveGroupId == GroupConstants.DEFAULT_LIVE_GROUP_ID) {
-			liveGroupId = group.getGroupId();
+		Group liveGroup = _groupLocalService.fetchGroup(group.getLiveGroupId());
+
+		if (liveGroup == null) {
+			return groupExternalReferenceCode;
 		}
 
-		return liveGroupId;
+		return liveGroup.getExternalReferenceCode();
+	}
+
+	private String _getRemoteGroupExternalReferenceCode(
+		UnicodeProperties typeSettingsUnicodeProperties) {
+
+		String remoteAddress = GetterUtil.getString(
+			typeSettingsUnicodeProperties.get("remoteAddress"));
+		long remoteGroupId = GetterUtil.getLong(
+			typeSettingsUnicodeProperties.get("remoteGroupId"));
+
+		if (Validator.isNull(remoteAddress) || (remoteGroupId <= 0)) {
+			return null;
+		}
+
+		int remotePort = GetterUtil.getInteger(
+			typeSettingsUnicodeProperties.get("remotePort"));
+		String remotePathContext = GetterUtil.getString(
+			typeSettingsUnicodeProperties.get("remotePathContext"));
+		boolean secureConnection = GetterUtil.getBoolean(
+			typeSettingsUnicodeProperties.get("secureConnection"));
+
+		String remoteURL = StagingURLHelperUtil.buildRemoteURL(
+			remoteAddress, remotePort, remotePathContext, secureConnection);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		User user = permissionChecker.getUser();
+
+		try {
+			HttpPrincipal httpPrincipal = new HttpPrincipal(
+				remoteURL, user.getLogin(), user.getPassword(),
+				user.isPasswordEncrypted());
+
+			try (SafeCloseable safeCloseable =
+					ThreadContextClassLoaderUtil.swap(
+						PortalClassLoaderUtil.getClassLoader())) {
+
+				Group group = GroupServiceHttp.getGroup(
+					httpPrincipal, remoteGroupId);
+
+				return group.getExternalReferenceCode();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return null;
+	}
+
+	private String _getRepositoryExternalReferenceCode(Folder folder) {
+		Repository repository = _repositoryLocalService.fetchRepository(
+			folder.getRepositoryId());
+
+		if (repository == null) {
+			return StringPool.BLANK;
+		}
+
+		return repository.getExternalReferenceCode();
 	}
 
 	private void _saveStagingPreferencesMapping(
-		long folderRepositoryId, String folderUuid,
-		PortletDataContext portletDataContext) {
+		PortletDataContext portletDataContext,
+		String rootFolderExternalReferenceCode,
+		String selectedGroupExternalReferenceCode,
+		String selectedRepositoryExternalReferenceCode) {
 
 		if (ExportImportThreadLocal.isStagingInProcess()) {
 			portletDataContext.addZipEntry(
@@ -566,13 +718,30 @@ public class DLExportImportPortletPreferencesProcessor
 					"%s/staging-preferences-mapping.json",
 					portletDataContext.getPortletId()),
 				JSONUtil.put(
-					"folderRepositoryId",
-					_getMirrorRepositoryId(folderRepositoryId)
+					_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE,
+					rootFolderExternalReferenceCode
 				).put(
-					"folderUuid", folderUuid
+					_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
+					_getMirrorGroupExternalReferenceCode(
+						portletDataContext, selectedGroupExternalReferenceCode)
+				).put(
+					_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE,
+					selectedRepositoryExternalReferenceCode
 				).toString());
 		}
 	}
+
+	private static final String
+		_PREFERENCE_KEY_ROOT_FOLDER_EXTERNAL_REFERENCE_CODE =
+			"rootFolderExternalReferenceCode";
+
+	private static final String
+		_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE =
+			"selectedGroupExternalReferenceCode";
+
+	private static final String
+		_PREFERENCE_KEY_SELECTED_REPOSITORY_EXTERNAL_REFERENCE_CODE =
+			"selectedRepositoryExternalReferenceCode";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLExportImportPortletPreferencesProcessor.class);
@@ -607,5 +776,8 @@ public class DLExportImportPortletPreferencesProcessor
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.exception.NoSuchRepositoryEntryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.portlet.BaseJSPSettingsConfigurationAction;
+import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -28,7 +28,7 @@ import javax.portlet.PortletConfig;
  * @author Sergio González
  */
 public abstract class BaseValidateRootFolderConfigurationAction
-	extends BaseJSPSettingsConfigurationAction {
+	extends DefaultConfigurationAction {
 
 	@Override
 	public void processAction(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
@@ -6,17 +6,30 @@
 package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.display.context.DLAdminDisplayContext;
 import com.liferay.document.library.web.internal.display.context.DLAdminDisplayContextProvider;
 import com.liferay.item.selector.ItemSelector;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.PortletConfig;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+import javax.portlet.ReadOnlyException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -56,12 +69,90 @@ public class DLConfigurationAction
 	}
 
 	@Override
+	protected void postProcess(
+			long companyId, PortletRequest portletRequest,
+			PortletPreferences portletPreferences)
+		throws PortalException {
+
+		super.postProcess(companyId, portletRequest, portletPreferences);
+
+		try {
+			String[] displayViews = StringUtil.split(
+				portletPreferences.getValue("displayViews", null));
+
+			portletPreferences.setValues("displayViews", displayViews);
+		}
+		catch (ReadOnlyException readOnlyException) {
+			throw new SystemException(readOnlyException);
+		}
+
+		long rootFolderId = GetterUtil.getLong(
+			portletPreferences.getValue("rootFolderId", null));
+
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", null));
+
+		try {
+			_setPortletPreferences(
+				portletPreferences, rootFolderId, selectedRepositoryId);
+
+			portletPreferences.reset("rootFolderId");
+			portletPreferences.reset("selectedRepositoryId");
+		}
+		catch (ReadOnlyException readOnlyException) {
+			throw new SystemException(readOnlyException);
+		}
+	}
+
+	@Override
 	protected void validate(ActionRequest actionRequest)
 		throws PortalException {
 
 		_validateDisplayStyleViews(actionRequest);
 
 		super.validate(actionRequest);
+	}
+
+	private void _setPortletPreferences(
+			PortletPreferences portletPreferences, long rootFolderId,
+			long selectedRepositoryId)
+		throws PortalException, ReadOnlyException {
+
+		String rootFolderExternalReferenceCode = StringPool.BLANK;
+
+		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+
+			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
+		}
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
+
+		Group selectedGroup;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			selectedRepositoryId);
+
+		if (selectedRepository == null) {
+			selectedGroup = _groupLocalService.getGroup(selectedRepositoryId);
+		}
+		else {
+			selectedGroup = _groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode",
+			selectedGroup.getExternalReferenceCode());
+
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode);
 	}
 
 	private void _validateDisplayStyleViews(ActionRequest actionRequest) {
@@ -77,6 +168,15 @@ public class DLConfigurationAction
 	private DLAdminDisplayContextProvider _dlAdminDisplayContextProvider;
 
 	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
 	private ItemSelector _itemSelector;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
@@ -76,15 +76,8 @@ public class DLConfigurationAction
 
 		super.postProcess(companyId, portletRequest, portletPreferences);
 
-		try {
-			String[] displayViews = StringUtil.split(
-				portletPreferences.getValue("displayViews", null));
-
-			portletPreferences.setValues("displayViews", displayViews);
-		}
-		catch (ReadOnlyException readOnlyException) {
-			throw new SystemException(readOnlyException);
-		}
+		String[] displayViews = StringUtil.split(
+			portletPreferences.getValue("displayViews", null));
 
 		long rootFolderId = GetterUtil.getLong(
 			portletPreferences.getValue("rootFolderId", null));
@@ -93,11 +86,10 @@ public class DLConfigurationAction
 			portletPreferences.getValue("selectedRepositoryId", null));
 
 		try {
+			portletPreferences.setValues("displayViews", displayViews);
+
 			_setPortletPreferences(
 				portletPreferences, rootFolderId, selectedRepositoryId);
-
-			portletPreferences.reset("rootFolderId");
-			portletPreferences.reset("selectedRepositoryId");
 		}
 		catch (ReadOnlyException readOnlyException) {
 			throw new SystemException(readOnlyException);
@@ -153,6 +145,9 @@ public class DLConfigurationAction
 		portletPreferences.setValue(
 			"selectedRepositoryExternalReferenceCode",
 			selectedRepositoryExternalReferenceCode);
+
+		portletPreferences.reset("rootFolderId");
+		portletPreferences.reset("selectedRepositoryId");
 	}
 
 	private void _validateDisplayStyleViews(ActionRequest actionRequest) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/settings/DLPortletInstanceSettings.java
@@ -83,9 +83,22 @@ public class DLPortletInstanceSettings {
 		return _typedSettings.getValues("mimeTypes", _MIME_TYPES_DEFAULT);
 	}
 
+	public String getRootFolderExternalReferenceCode() {
+		return _typedSettings.getValue("rootFolderExternalReferenceCode");
+	}
+
 	public long getRootFolderId() {
 		return _typedSettings.getLongValue(
 			"rootFolderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+	}
+
+	public String getSelectedGroupExternalReferenceCode() {
+		return _typedSettings.getValue("selectedGroupExternalReferenceCode");
+	}
+
+	public String getSelectedRepositoryExternalReferenceCode() {
+		return _typedSettings.getValue(
+			"selectedRepositoryExternalReferenceCode");
 	}
 
 	public long getSelectedRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
@@ -6,11 +6,13 @@
 package com.liferay.document.library.web.internal.upgrade.registry;
 
 import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradeAdminPortlets;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.document.library.web.internal.upgrade.v1_0_0.UpgradePortletSettings;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.upgrade.BaseStagingGroupTypeSettingsUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -40,13 +42,26 @@ public class DLWebUpgradeStepRegistrator implements UpgradeStepRegistrator {
 				DLPortletKeys.DOCUMENT_LIBRARY_ADMIN));
 
 		registry.register("1.0.1", "1.0.2", new UpgradePortletPreferences());
+
+		registry.register(
+			"1.0.2", "1.1.0",
+			new com.liferay.document.library.web.internal.upgrade.v1_1_0.
+				UpgradePortletPreferences(
+					_dlAppLocalService, _groupLocalService,
+					_repositoryLocalService));
 	}
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
 
 	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
 
 	@Reference
 	private SettingsLocatorHelper _settingsLocatorHelper;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_1_0;
+
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import javax.portlet.PortletPreferences;
+
+/**
+ * @author Attila Bakay
+ */
+public class UpgradePortletPreferences
+	extends BasePortletPreferencesUpgradeProcess {
+
+	public UpgradePortletPreferences(
+		DLAppLocalService dlAppLocalService,
+		GroupLocalService groupLocalService,
+		RepositoryLocalService repositoryLocalService) {
+
+		_dlAppLocalService = dlAppLocalService;
+		_groupLocalService = groupLocalService;
+		_repositoryLocalService = repositoryLocalService;
+	}
+
+	@Override
+	protected String[] getPortletIds() {
+		return new String[] {DLPortletKeys.DOCUMENT_LIBRARY + "_INSTANCE_%"};
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		long rootFolderId = GetterUtil.getLong(
+			portletPreferences.getValue("rootFolderId", "-1"));
+
+		if (rootFolderId == -1) {
+			return _toXML(portletPreferences);
+		}
+
+		String rootFolderExternalReferenceCode = StringPool.BLANK;
+
+		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			try {
+				Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+
+				rootFolderExternalReferenceCode =
+					folder.getExternalReferenceCode();
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to get rootFolderId ", rootFolderId, ": ",
+							portalException));
+				}
+
+				return _toXML(portletPreferences);
+			}
+		}
+
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", "-1"));
+
+		if (selectedRepositoryId == -1) {
+			return _toXML(portletPreferences);
+		}
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			selectedRepositoryId);
+
+		Group selectedGroup;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		if (selectedRepository != null) {
+			selectedGroup = _groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+		else {
+			selectedGroup = _groupLocalService.fetchGroup(selectedRepositoryId);
+
+			if (selectedGroup == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to get selectedRepositoryId " +
+							selectedRepositoryId);
+				}
+
+				return _toXML(portletPreferences);
+			}
+		}
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode",
+			selectedGroup.getExternalReferenceCode());
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode);
+
+		return _toXML(portletPreferences);
+	}
+
+	private String _toXML(PortletPreferences portletPreferences)
+		throws Exception {
+
+		portletPreferences.reset("rootFolderId");
+		portletPreferences.reset("selectedRepositoryId");
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletPreferences.class);
+
+	private final DLAppLocalService _dlAppLocalService;
+	private final GroupLocalService _groupLocalService;
+	private final RepositoryLocalService _repositoryLocalService;
+
+}


### PR DESCRIPTION
This PR is the same as #6244 I only changed the name of the branch in my repo because it seems that CI doesn't like characters like the `&`

-------

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33262

Add externalReferenceCode to the portlet preferences to match current ID references for the batch framework.

# How am I fixing it?
I stored the ERCs in the portlet Preferences and converted them to ids for the frontend components. Modified the staging process to work based on ERCs.

# How can you verify that it works?

Integration tests in folder `modules/apps/document-library/document-library-web-test`
`gw testIntegration --tests DLExportImportPortletPreferencesProcessorTest`
` gw testIntegration --tests UpgradePortletPreferencesTest`