### PR TITLE
LPD-46666 Fix com.liferay.questions.web.internal.upgrade.v1_1_0.test.UpgradePortletPreferencesTest

### DIFF
--- a/modules/apps/questions/questions-test/src/testIntegration/java/com/liferay/questions/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/questions/questions-test/src/testIntegration/java/com/liferay/questions/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
@@ -124,7 +124,7 @@ public class UpgradePortletPreferencesTest {
 			UpgradeProcess[] upgradeProcesses = UpgradeTestUtil.getUpgradeSteps(
 				_upgradeStepRegistrator, new Version(1, 1, 0));
 
-			upgradeProcesses[1].upgrade();
+			upgradeProcesses[0].upgrade();
 
 			_entityCache.clearCache();
 			_multiVMPool.clear();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46666

The 1.1.0 upgrade step previously contained two processes, but it was
split in two.  The test needs to be updated to reflect that.

# How can you verify that it works?

Run the modified test and see it passing.