### PR TITLE
LPD-46688 Fix test AutoTranslationGoogle#CanTranslateNumericAndDecimalFieldsIndependently

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationGoogle.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/AutoTranslationGoogle.testcase
@@ -317,7 +317,7 @@ definition {
 			webContentNumeric = 10,
 			webContentTitle = "This is the title of the numeric field");
 
-		PortletEntry.publish();
+		WebContent.publishWithPermissions();
 
 		Translations.openToTranslateEntry(
 			groupName = "Site Name",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46688

Fix POSHI test `AutoTranslationGoogle#CanTranslateNumericAndDecimalFieldsIndependently`

# How am I fixing it?

Using the correct publish function for Web Content

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=AutoTranslationGoogle#CanTranslateNumericAndDecimalFieldsIndependently`
