### PR TITLE
LPD-46745 Fix test failure in DepotDisplayPage#CanMapWCWithOpenGraph

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDisplayPage.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDisplayPage.testcase
@@ -361,7 +361,7 @@ definition {
 			webContentText = "Asset Library Text",
 			webContentTitle = "Web Content Title");
 
-		PortletEntry.publish();
+		WebContent.publishWithPermissions();
 
 		WebContentNavigator.openToEditWCInSite(
 			groupName = "Test Site Name",
@@ -372,7 +372,7 @@ definition {
 
 		WebContent.addFeaturedImageFromURL(imageSourceURL = "https://dummyimage.com/600x400/000/fff.jpg");
 
-		PortletEntry.publish();
+		WebContent.publishExistingWCArticleWithPermissions();
 
 		Navigator.openSpecificURL(url = "${portalURL}/c/portal/logout");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46745

Fix POSHI test `DepotDisplayPage#CanMapWCWithOpenGraph`

# How am I fixing it?

Using the correct publish function for Web Content

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=DepotDisplayPage#CanMapWCWithOpenGraph`

