### PR TITLE
LPD-46773 Technical Task | Fix test failure in WebContentDisplay#ChangeTemplate after FF LPD-15596 removal

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -331,7 +331,7 @@ Welcome to Liferay Community Edition Portal 7.4.0 CE GA1''';
 				structureName = "Basic Web Content",
 				templateName = "Basic Web Content");
 
-			PortletEntry.publish();
+			WebContent.publishExistingWCArticleWithPermissions();
 		}
 
 		task ("View web content is shown in Web Content Display") {


### PR DESCRIPTION
LPD-46773 Fix test failure in WebContentDisplay#ChangeTemplate after FF LPD-15596 removal

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46773

Now the button has change so we can not use the PortletEntry.publish method

# How am I fixing it?

using WebContent.publishExistingWCArticleWithPermissions

# How can you verify that it works?

Run  WebContentDisplay#ChangeTemplatetests. 