### PR TITLE
LPD-46924 The asset category selector does not include site vocabularies

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
@@ -115,6 +115,7 @@ public class SelectAssetVocabularyDisplayContext {
 		List<Long> groupIds = new ArrayList<>();
 
 		groupIds.add(_themeDisplay.getCompanyGroupId());
+		groupIds.add(_themeDisplay.getScopeGroupId());
 
 		List<DepotEntry> depotEntries =
 			DepotEntryServiceUtil.getCurrentAndGroupConnectedDepotEntries(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-46924

Hi Team,

We've identified a bug causing some of our Playwright tests to fail. This issue is caused by https://liferay.atlassian.net/browse/LPD-46409.

I'm attaching a straightforward solution that has already been covered by multiple Playwright tests that failed yesterday, such as:

[Enables search field in dropdown list of Collection Filter](https://testray.liferay.com/#/project/35392/routines/985092/build/115378906/case-result/115386270)
[Filters a web content collection by single and multiple categories](https://testray.liferay.com/#/project/35392/routines/985092/build/115378906/case-result/115386287)
[Reset collection filter using applied filters](https://testray.liferay.com/#/project/35392/routines/985092/build/115378906/case-result/115386263)


Please review the proposed solution.

Thanks in advance!