### PR TITLE
LPD-46925 Always send the displayDate

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/schedule.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/schedule.jsp
@@ -26,6 +26,8 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = (JournalEdit
 		<liferay-ui:message arguments="<%= journalEditArticleDisplayContext.getTimeZoneName() %>" key="time-zone-x" />
 	</div>
 
+	<aui:input formName="fm1" name="displayDate" wrapperCssClass="mb-3" />
+
 	<aui:input dateTogglerCheckboxLabel="never-expire" disabled="<%= journalEditArticleDisplayContext.isNeverExpire() %>" formName="fm1" name="expirationDate" wrapperCssClass="expiration-date mb-3" />
 
 	<aui:input dateTogglerCheckboxLabel="never-review" disabled="<%= journalEditArticleDisplayContext.isNeverReview() %>" formName="fm1" name="reviewDate" wrapperCssClass="mb-3 review-date" />


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-46925)

Test that covers this case: WebContent#ViewReservedVariablesDisplayOnWebContent (no need to add extra tests)

This input was removed on [commit](https://github.com/ambrinchaudhary/liferay-portal/commit/d329e761d0cf75b3539a2421869150268cacc42a#diff-edaf358f86d8e2aede7fd2759ed6f88fb2feeb4ba563051a1a640f81d73b3826.) 

![Screenshot 2025-01-22 at 10 20 45](https://github.com/user-attachments/assets/b27855a0-f68e-4dff-a1eb-5933f485e4df)

I think that the previous condition was wrong, and that the displayDate must be send to the backend always. Any other thought? 

