### PR TITLE
LPD-46935 Documents and Media thumbnails are broken in the Asset publisher

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -25,7 +25,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
 	/>
 
-	<input class="hide" id="<portlet:namespace />file" type="file" />
+	<input id="<portlet:namespace />file" style="display: none;" type="file" />
 
 	<liferay-ui:search-container
 		id="repositoryEntries"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -11,7 +11,7 @@
 DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAccessFromDesktopDisplayContext(request);
 %>
 
-<div class="hide" id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav">
+<div id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav" style="display: none;">
 	<div class="portlet-document-library">
 		<liferay-ui:message key="<%= dlAccessFromDesktopDisplayContext.getWebDAVHelpMessage() %>" />
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
@@ -29,13 +29,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 
 		<c:choose>
 			<c:when test="<%= Validator.isNotNull(previewURL) %>">
-				<aui:style type="text/css">
-					.file-entry-abstract-asset-background-image {
-					background-image: url(<%= previewURL %>);
-					}
-				</aui:style>
-
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image file-entry-abstract-asset-background-image mb-4"></div>
+				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
 			</c:when>
 			<c:otherwise>
 				<div class="aspect-ratio aspect-ratio-8-to-3 bg-light mb-4">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
@@ -34,11 +34,5 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 	}
 	%>
 
-	<aui:style type="text/css">
-		.file-entry-abstract-info-item-background-image {
-			background-image: url(<%= previewURL %>);
-		}
-	</aui:style>
-
-	<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image file-entry-abstract-info-item-background-image mb-4"></div>
+	<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
@@ -7,8 +7,7 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.document.library.kernel.processor.ImageProcessorUtil" %><%@
 page import="com.liferay.document.library.kernel.processor.PDFProcessorUtil" %><%@

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -7,15 +7,7 @@
 
 <%@ include file="/init.jsp" %>
 
-<aui:style type="text/css">
-	.fragment-video-streaming-display {
-		display: flex;
-		justify-content: flex-start;
-		overflow: hidden;
-	}
-</aui:style>
-
-<div class="fragment-video-streaming-display">
+<div style="display: flex; justify-content: flex-start; overflow: hidden;">
 	<div class="videojs-container">
 		<aui:link href="https://vjs.zencdn.net/8.6.1/video-js.min.css" rel="stylesheet" type="text/css" />
 		<aui:link href="https://unpkg.com/videojs-quality-selector-hls@1.1.1/dist/videojs-quality-selector-hls.css" rel="stylesheet" type="text/css" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -15,13 +15,7 @@ JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribu
 
 <div class="asset-summary">
 	<c:if test="<%= articleDisplay.isSmallImage() %>">
-		<aui:style type="text/css">
-			.journal-web-abstract-asset-background-image {
-				background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);
-			}
-		</aui:style>
-
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image journal-web-abstract-asset-background-image mb-4"></div>
+		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);"></div>
 	</c:if>
 
 	<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/init.jsp
@@ -9,8 +9,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
+<%@ taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
@@ -22,13 +22,7 @@ AssetRenderer<?> assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASS
 	<c:otherwise>
 		<div class="asset-summary">
 			<c:if test="<%= article.isSmallImage() %>">
-				<aui:style type="text/css">
-					.journal-web-info-item-abstract-background-image {
-						background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);
-					}
-				</aui:style>
-
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image journal-web-info-item-abstract-background-image mb-4"></div>
+				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);"></div>
 			</c:if>
 
 			<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
@@ -9,8 +9,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -1,11 +1,50 @@
-<div style="background-color: #f7f8f9; color: #6b6c7e; font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 20px; height: 100%; padding: 24px;">
-	<div style="background-color: white; border: solid 1px #e7e7ed; border-radius: 4px; margin: 0 auto; max-width: 800px; padding: 40px;">
-		<p style="line-height: 1.5; margin: 0;">
+<@liferay_aui["style"] type="text/css">
+	.sharing-notification-sharing-entry-added-1 {
+		background-color: #f7f8f9;
+		color: #6b6c7e;
+		font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+		font-size: 20px;
+		height: 100%;
+		padding: 24px;
+	}
+
+	.sharing-notification-sharing-entry-added-2 {
+		background-color: white;
+		border: solid 1px #e7e7ed;
+		border-radius: 4px;
+		margin: 0 auto;
+		max-width: 800px;
+		padding: 40px;
+	}
+
+	.sharing-notification-sharing-entry-added-3 {
+		line-height: 1.5;
+		margin: 0;
+	}
+
+	.sharing-notification-sharing-entry-added-4 {
+		background-color: #145ffb;
+		color: white;
+		border-radius: 4px;
+		box-sizing: border-box;
+		display: inline-block;
+		font-size: 16px;
+		height: 40px;
+		line-height: 24px;
+		margin-top: 24px;
+		padding: 7px 15px;
+		text-decoration: none;
+	}
+</@>
+
+<div class="sharing-notification-sharing-entry-added-1">
+	<div class="sharing-notification-sharing-entry-added-2">
+		<p class="sharing-notification-sharing-entry-added-3">
 			${content}
 		</p>
 
 		<#if sharingEntryURL?has_content>
-			<a href="${sharingEntryURL}" style="background-color: #145ffb; color: white; border-radius: 4px; box-sizing: border-box; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
+			<a href="${sharingEntryURL}" class="sharing-notification-sharing-entry-added-4">${actionTitle}</a>
 		</#if>
 	</div>
 </div>

--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -1,50 +1,11 @@
-<@liferay_aui["style"] type="text/css">
-	.sharing-notification-sharing-entry-added-1 {
-		background-color: #f7f8f9;
-		color: #6b6c7e;
-		font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-		font-size: 20px;
-		height: 100%;
-		padding: 24px;
-	}
-
-	.sharing-notification-sharing-entry-added-2 {
-		background-color: white;
-		border: solid 1px #e7e7ed;
-		border-radius: 4px;
-		margin: 0 auto;
-		max-width: 800px;
-		padding: 40px;
-	}
-
-	.sharing-notification-sharing-entry-added-3 {
-		line-height: 1.5;
-		margin: 0;
-	}
-
-	.sharing-notification-sharing-entry-added-4 {
-		background-color: #145ffb;
-		color: white;
-		border-radius: 4px;
-		box-sizing: border-box;
-		display: inline-block;
-		font-size: 16px;
-		height: 40px;
-		line-height: 24px;
-		margin-top: 24px;
-		padding: 7px 15px;
-		text-decoration: none;
-	}
-</@>
-
-<div class="sharing-notification-sharing-entry-added-1">
-	<div class="sharing-notification-sharing-entry-added-2">
-		<p class="sharing-notification-sharing-entry-added-3">
+<div style="background-color: #f7f8f9; color: #6b6c7e; font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol; font-size: 20px; height: 100%; padding: 24px;">
+	<div style="background-color: white; border: solid 1px #e7e7ed; border-radius: 4px; margin: 0 auto; max-width: 800px; padding: 40px;">
+		<p style="line-height: 1.5; margin: 0;">
 			${content}
 		</p>
 
 		<#if sharingEntryURL?has_content>
-			<a href="${sharingEntryURL}" class="sharing-notification-sharing-entry-added-4">${actionTitle}</a>
+			<a href="${sharingEntryURL}" style="background-color: #145ffb; color: white; border-radius: 4px; box-sizing: border-box; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
 		</#if>
 	</div>
 </div>

--- a/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
+++ b/modules/apps/sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl
@@ -5,7 +5,7 @@
 		</p>
 
 		<#if sharingEntryURL?has_content>
-			<a href="${sharingEntryURL}" style="background-color: #145ffb; border-radius: 4px; box-sizing: border-box; color: white; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
+			<a href="${sharingEntryURL}" style="background-color: #145ffb; color: white; border-radius: 4px; box-sizing: border-box; display: inline-block; font-size: 16px; height: 40px; line-height: 24px; margin-top: 24px; padding: 7px 15px; text-decoration: none;">${actionTitle}</a>
 		</#if>
 	</div>
 </div>

--- a/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
+++ b/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
@@ -8,7 +8,7 @@
 	<h1 class="header-title">${entry.getTitle()}</h1>
 </div>
 
-<div class="float-right">
+<div style="float: right;">
 	<@getEditIcon />
 
 	<@getPageDetailsIcon />


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46935

When we implemented `[LPD-46007](https://liferay.atlassian.net/browse/LPD-46007) Clean inline styles to support style-src '[NONCE]' directive - Document Library and Wiki` we used CSS classes as substitutes to inline-style but this doesn't work in loops, because we are overwritten the background value X times, and the last one value it is applied on all.

# How am I fixing it?

Revert the [LPD-46007](https://liferay.atlassian.net/browse/LPD-46007)

# How can you verify that it works?

Check the steps to reproduce it https://liferay.atlassian.net/browse/LPD-46935, we need to update the test when we try to implement the `[NONCE]` directive in the future

# Before the PR
![image](https://github.com/user-attachments/assets/3bfe1504-21c1-4951-baa6-84a6abfbe9ba)

# After the PR (revert)
![image](https://github.com/user-attachments/assets/0635c70d-5e55-449d-8e08-d8c227ebb727)
