### PR TITLE
LPD-46961 Do not asume that 1.0 exists in all cases

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -1184,6 +1184,52 @@ public class DLFileEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testExpireFileVersionKeepsLatestVersion() throws Exception {
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					DLConfiguration.class.getName(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"maximumNumberOfVersions", 1
+					).build())) {
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId());
+
+			FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, StringPool.BLANK,
+				ContentTypes.TEXT_PLAIN, "FE1.exe", StringPool.BLANK,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				(byte[])null, null, null, null, serviceContext);
+
+			fileEntry = DLAppLocalServiceUtil.updateFileEntry(
+				TestPropsValues.getUserId(), fileEntry.getFileEntryId(),
+				"FE2.txt", ContentTypes.TEXT_PLAIN, "FE1.exe", StringPool.BLANK,
+				fileEntry.getDescription(), RandomTestUtil.randomString(),
+				DLVersionNumberIncrease.MINOR,
+				TestDataConstants.TEST_BYTE_ARRAY, fileEntry.getDisplayDate(),
+				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
+				serviceContext);
+
+			FileVersion fileVersion = fileEntry.getFileVersion();
+
+			Assert.assertEquals("1.1", fileEntry.getVersion());
+			Assert.assertEquals(
+				1,
+				fileEntry.getFileVersionsCount(
+					WorkflowConstants.STATUS_APPROVED));
+
+			DLFileEntry dlFileEntry = DLFileEntryLocalServiceUtil.updateStatus(
+				TestPropsValues.getUserId(), fileVersion.getFileVersionId(),
+				WorkflowConstants.STATUS_EXPIRED, serviceContext,
+				new HashMap<>());
+
+			Assert.assertEquals("1.1", dlFileEntry.getVersion());
+		}
+	}
+
+	@Test
 	public void testExtensionValidationWithSystemScopedFileEntryType()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2117,8 +2117,6 @@ public class DLFileEntryLocalServiceImpl
 				Objects.equals(
 					dlFileEntry.getVersion(), dlFileVersion.getVersion())) {
 
-				String newVersion = DLFileEntryConstants.VERSION_DEFAULT;
-
 				List<DLFileVersion> approvedFileVersions =
 					_dlFileVersionPersistence.findByF_S(
 						dlFileEntry.getFileEntryId(),
@@ -2128,10 +2126,10 @@ public class DLFileEntryLocalServiceImpl
 					DLFileVersion firstApprovedFileVersion =
 						approvedFileVersions.get(0);
 
-					newVersion = firstApprovedFileVersion.getVersion();
+					dlFileEntry.setVersion(
+						firstApprovedFileVersion.getVersion());
 				}
 
-				dlFileEntry.setVersion(newVersion);
 				dlFileEntry.setDisplayDate(dlFileVersion.getDisplayDate());
 				dlFileEntry.setExpirationDate(
 					dlFileVersion.getExpirationDate());


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-46961](https://liferay.atlassian.net/browse/LPD-46961)}

Currently in some cases when the file is expired and the initial version (1.0) doesn't exist, the portal fails

# How am I fixing it?

Avoiding use this initial version in some cases as default value.

# How can you verify that it works?

Run the included automated tests.



- **LPD-46961 Do not assume that initial version will exist in all cases. Use current as default and only change it if there's an approved one**
- **LPD-46961 Tests**
