### PR TITLE
LPD-46759 | Deleted asset types in global vocabulary are back after restart

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetVocabularyMVCActionCommand.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetVocabularyMVCActionCommand.java
@@ -177,8 +177,20 @@ public class EditAssetVocabularyMVCActionCommand extends BaseMVCActionCommand {
 			}
 		}
 
-		AssetVocabularySettingsHelper vocabularySettingsHelper =
-			new AssetVocabularySettingsHelper();
+		long vocabularyId = ParamUtil.getLong(actionRequest, "vocabularyId");
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyService.fetchVocabulary(vocabularyId);
+
+		AssetVocabularySettingsHelper vocabularySettingsHelper = null;
+
+		if (assetVocabulary != null) {
+			vocabularySettingsHelper = new AssetVocabularySettingsHelper(
+				assetVocabulary.getSettings());
+		}
+		else {
+			vocabularySettingsHelper = new AssetVocabularySettingsHelper();
+		}
 
 		vocabularySettingsHelper.setClassNameIdsAndClassTypePKs(
 			classNameIds, classTypePKs, depotRequireds, requireds);

--- a/modules/apps/content-dashboard/content-dashboard-test/build.gradle
+++ b/modules/apps/content-dashboard/content-dashboard-test/build.gradle
@@ -18,5 +18,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/instance/test/AddDefaultAssetVocabulariesInitialRequestPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/instance/test/AddDefaultAssetVocabulariesInitialRequestPortalInstanceLifecycleListenerTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.content.dashboard.web.internal.instance.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Attila Bakay
+ */
+@RunWith(Arquillian.class)
+public class
+	AddDefaultAssetVocabulariesInitialRequestPortalInstanceLifecycleListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testPortalInstanceRegistered() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.fetchGroupVocabulary(
+				company.getGroupId(), "audience");
+
+		long[] originalClassNameIdClassNameIds =
+			assetVocabulary.getSelectedClassNameIds();
+
+		long classNameId = originalClassNameIdClassNameIds[0];
+
+		Set<Long> classNameIds = SetUtil.fromArray(
+			originalClassNameIdClassNameIds);
+
+		classNameIds.remove(classNameId);
+
+		_updateVocabulary(assetVocabulary, ArrayUtil.toLongArray(classNameIds));
+
+		try {
+			_portalInstanceLifecycleListener.portalInstanceRegistered(company);
+
+			assetVocabulary = _assetVocabularyLocalService.fetchGroupVocabulary(
+				company.getGroupId(), "audience");
+
+			Assert.assertFalse(
+				ArrayUtil.contains(
+					assetVocabulary.getSelectedClassNameIds(), classNameId));
+		}
+		finally {
+			_updateVocabulary(assetVocabulary, originalClassNameIdClassNameIds);
+		}
+	}
+
+	private void _updateVocabulary(
+			AssetVocabulary assetVocabulary, long[] classNameIds)
+		throws Exception {
+
+		long[] classTypePKs = new long[classNameIds.length];
+		boolean[] requireds = new boolean[classNameIds.length];
+
+		Arrays.fill(classTypePKs, AssetCategoryConstants.ALL_CLASS_TYPE_PK);
+		Arrays.fill(requireds, false);
+
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper(assetVocabulary.getSettings());
+
+		assetVocabularySettingsHelper.setClassNameIdsAndClassTypePKs(
+			classNameIds, classTypePKs, requireds);
+
+		_assetVocabularyLocalService.updateVocabulary(
+			assetVocabulary.getVocabularyId(), assetVocabulary.getTitleMap(),
+			assetVocabulary.getDescriptionMap(),
+			assetVocabularySettingsHelper.toString(),
+			assetVocabulary.getVisibilityType());
+	}
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.content.dashboard.web.internal.instance.lifecycle.AddDefaultAssetVocabulariesInitialRequestPortalInstanceLifecycleListener"
+	)
+	private PortalInstanceLifecycleListener _portalInstanceLifecycleListener;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/util/AssetVocabularyUtil.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/util/AssetVocabularyUtil.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -94,6 +95,9 @@ public class AssetVocabularyUtil {
 		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
 			new AssetVocabularySettingsHelper();
 
+		assetVocabularySettingsHelper.setRegisteredClassNameIds(
+			ArrayUtil.toLongArray(classNameIdsCollection));
+
 		if (classNameIdsCollection != null) {
 			long[] classNameIds = new long[classNameIdsCollection.size()];
 			long[] classTypePKs = new long[classNameIdsCollection.size()];
@@ -129,12 +133,23 @@ public class AssetVocabularyUtil {
 			Collection<Long> classNameIdsCollection) {
 
 		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
-			new AssetVocabularySettingsHelper();
+			new AssetVocabularySettingsHelper(assetVocabulary.getSettings());
+
+		Set<Long> filteredClassNameIds = new LinkedHashSet<>(
+			classNameIdsCollection);
+
+		Set<Long> registeredClassNameIds = SetUtil.fromArray(
+			assetVocabularySettingsHelper.getRegisteredClassNameIds());
+
+		filteredClassNameIds.removeAll(registeredClassNameIds);
+
+		assetVocabularySettingsHelper.setRegisteredClassNameIds(
+			ArrayUtil.toLongArray(filteredClassNameIds));
 
 		Set<Long> classNameIds = SetUtil.fromArray(
 			assetVocabulary.getSelectedClassNameIds());
 
-		classNameIds.addAll(classNameIdsCollection);
+		classNameIds.addAll(filteredClassNameIds);
 
 		long[] selectedClassNameIds = ArrayUtil.toArray(
 			classNameIds.toArray(new Long[0]));

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularySettingsHelper.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularySettingsHelper.java
@@ -11,6 +11,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
@@ -48,6 +49,17 @@ public class AssetVocabularySettingsHelper {
 
 	public long[] getClassTypePKs() {
 		return getClassTypePKs(getClassNameIdsAndClassTypePKs());
+	}
+
+	public long[] getRegisteredClassNameIds() {
+		String value = _unicodeProperties.getProperty(
+			_KEY_REGISTERED_CLASS_NAME_IDS_AND_CLASS_TYPE_PKS);
+
+		if (Validator.isNull(value)) {
+			return new long[0];
+		}
+
+		return getClassNameIds(StringUtil.split(value));
 	}
 
 	public long[] getRequiredClassNameIds() {
@@ -182,6 +194,19 @@ public class AssetVocabularySettingsHelper {
 			_KEY_MULTI_VALUED, String.valueOf(multiValued));
 	}
 
+	public void setRegisteredClassNameIds(long[] classNameIds) {
+		Set<Long> registeredClassNameIds = SetUtil.fromArray(
+			getRegisteredClassNameIds());
+
+		for (long classNameId : classNameIds) {
+			registeredClassNameIds.add(classNameId);
+		}
+
+		_unicodeProperties.setProperty(
+			_KEY_REGISTERED_CLASS_NAME_IDS_AND_CLASS_TYPE_PKS,
+			StringUtil.merge(registeredClassNameIds));
+	}
+
 	@Override
 	public String toString() {
 		return _unicodeProperties.toString();
@@ -301,6 +326,10 @@ public class AssetVocabularySettingsHelper {
 			"depotRequiredClassNameIds";
 
 	private static final String _KEY_MULTI_VALUED = "multiValued";
+
+	private static final String
+		_KEY_REGISTERED_CLASS_NAME_IDS_AND_CLASS_TYPE_PKS =
+			"registeredClassNameIds";
 
 	private static final String
 		_KEY_REQUIRED_CLASS_NAME_IDS_AND_CLASS_TYPE_PKS =

--- a/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-46759

### How am I fixing it?
The root cause of the issue is that if the OSGI State folder is deleted somehow the AddDefaultAssetVocabularies is executed as a result the original configuration of the assetVocabuleries is restored even if we removed some assetTypes. I fixed it by creating a registry list inside the vocabularySettings which contains what classes were registered in the past. This way new services can still register themselves through the listener but we do not roll back asset types because of repeated registries. 


### How can you verify that it works?

To test run:
`gw testIntegration --tests AddDefaultAssetVocabulariesInitialRequestPortalInstanceLifecycleListenerTest`

Or manually test based on the LPD steps.