### PR TITLE
LPD-44895 comply with the NONCE strategy

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/entry_cover_image_caption.jsp
@@ -18,7 +18,9 @@ String viewEntryURL = ParamUtil.getString(request, "viewEntryURL");
 		<a href="<%= HtmlUtil.escape(viewEntryURL) %>">
 	</c:if>
 
-	<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
+	<liferay-ui:csp>
+		<div <c:if test="<%= Validator.isNotNull(coverImageCaption) %>">aria-label="<%= HtmlUtil.escapeAttribute(HtmlUtil.stripHtml(coverImageCaption)) %>" role="img"</c:if> class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image" style="background-image: url(<%= coverImageURL %>);"></div>
+	</liferay-ui:csp>
 
 	<c:if test="<%= Validator.isNotNull(viewEntryURL) %>">
 		</a>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/abstract.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/abstract.jsp
@@ -14,7 +14,9 @@ BlogsEntry entry = (BlogsEntry)request.getAttribute(WebKeys.BLOGS_ENTRY);
 
 <div class="asset-summary">
 	<c:if test="<%= entry.isSmallImage() %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= entry.getSmallImageURL(themeDisplay) %>);"></div>
+		<liferay-ui:csp>
+			<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= entry.getSmallImageURL(themeDisplay) %>);"></div>
+		</liferay-ui:csp>
 	</c:if>
 
 	<%

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/info/item/renderer/init.jsp
@@ -11,6 +11,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -186,7 +186,7 @@ Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 					</div>
 
 					<c:if test="<%= commentTreeDisplayContext.isEditControlsVisible() %>">
-						<div class="lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>" style="display: none;">
+						<div class="hide lfr-discussion-form lfr-discussion-form-edit" id="<%= namespace %>editForm<%= index %>">
 							<div class="editor-wrapper"></div>
 
 							<aui:button-row>
@@ -241,7 +241,7 @@ Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 			</div>
 		</div>
 
-		<div class="lfr-discussion lfr-discussion-form-reply" id="<%= namespace %>postReplyForm<%= index %>" style="display: none;">
+		<div class="hide lfr-discussion lfr-discussion-form-reply" id="<%= namespace %>postReplyForm<%= index %>">
 			<div class="lfr-discussion-reply-container">
 				<clay:content-row
 					noGutters="true"

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.content.dashboard.document.library.internal.item.display.context.ContentDashboardFileExtensionItemSelectorViewDisplayContext" %>
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/view_content_dashboard_file_extensions.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/resources/META-INF/resources/view_content_dashboard_file_extensions.jsp
@@ -12,7 +12,9 @@ ContentDashboardFileExtensionItemSelectorViewDisplayContext contentDashboardFile
 %>
 
 <section class="h-100">
-	<span aria-hidden="true" class="loading-animation mt-0 tree-filter-loader" style="top: 50%; transform: translateY(-50%);"></span>
+	<liferay-ui:csp>
+		<span aria-hidden="true" class="loading-animation mt-0 tree-filter-loader" style="top: 50%; transform: translateY(-50%);"></span>
+	</liferay-ui:csp>
 
 	<react:component
 		module="{SelectFileExtensionWrapper} from content-dashboard-document-library-impl"

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_attachment.jspf
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_attachment.jspf
@@ -24,9 +24,11 @@
 	%>
 
 	<div align="right">
-		<a href="javascript:void(0);" id="view-removed-attachments-link" style='display: <%= (deletedAttachmentsFileEntriesCount > 0) ? "initial" : "none" %>;'>
-			<liferay-ui:message arguments="<%= deletedAttachmentsFileEntriesCount %>" key='<%= (deletedAttachmentsFileEntriesCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments" %>' /> &raquo;
-		</a>
+		<liferay-ui:csp>
+			<a href="javascript:void(0);" id="view-removed-attachments-link" style='display: <%= (deletedAttachmentsFileEntriesCount > 0) ? "initial" : "none" %>;'>
+				<liferay-ui:message arguments="<%= deletedAttachmentsFileEntriesCount %>" key='<%= (deletedAttachmentsFileEntriesCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments" %>' /> &raquo;
+			</a>
+		</liferay-ui:csp>
 	</div>
 </c:if>
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_thread.jsp
@@ -67,17 +67,19 @@ if (portletTitleBasedNavigation) {
 					<aui:input disabled="<%= thread.isLocked() %>" helpMessage='<%= thread.isLocked() ? LanguageUtil.get(request, "unlock-thread-to-add-an-explanation-post") : StringPool.BLANK %>' label="add-explanation-post" name="addExplanationPost" onClick='<%= liferayPortletResponse.getNamespace() + "toggleExplanationPost();" %>' type="checkbox" />
 
 					<div class="hide" id="<portlet:namespace />explanationPost">
-						<aui:input maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="subject" style="width: 350px;" value="">
-							<aui:validator name="required">
-								function () {
-									var addExplanationPostCheckbox = document.getElementById('<portlet:namespace />addExplanationPost');
+						<liferay-ui:csp>
+							<aui:input maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="subject" style="width: 350px;" value="">
+								<aui:validator name="required">
+									function () {
+										var addExplanationPostCheckbox = document.getElementById('<portlet:namespace />addExplanationPost');
 
-									if (addExplanationPostCheckbox) {
-										return addExplanationPostCheckbox.checked;
+										if (addExplanationPostCheckbox) {
+											return addExplanationPostCheckbox.checked;
+										}
 									}
-								}
-							</aui:validator>
-						</aui:input>
+								</aui:validator>
+							</aui:input>
+						</liferay-ui:csp>
 
 						<div>
 							<c:choose>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/split_thread.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/split_thread.jsp
@@ -92,7 +92,7 @@ if (portletTitleBasedNavigation) {
 
 					<aui:input disabled="<%= thread.isLocked() %>" helpMessage='<%= thread.isLocked() ? LanguageUtil.get(request, "unlock-thread-to-add-an-explanation-post") : StringPool.BLANK %>' label="add-explanation-post-to-the-source-thread" name="addExplanationPost" onClick='<%= liferayPortletResponse.getNamespace() + "toggleExplanationPost();" %>' type="checkbox" />
 
-					<div id="<portlet:namespace />explanationPost" style="display: none;">
+					<div class="hide" id="<portlet:namespace />explanationPost">
 						<div class="alert alert-info">
 							<liferay-ui:message key="the-following-post-will-be-added-in-place-of-the-moved-message" />
 						</div>

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
@@ -32,74 +32,83 @@ if (threadFlag != null) {
 
 <c:if test="<%= (message.getMessageId() != selMessage.getMessageId()) || MBUtil.isViewableMessage(themeDisplay, message) %>">
 	<tr>
-		<td class="table-cell" style="padding-left: <%= (depth > 0) ? depth * 10 : 5 %>px; width: 90%;" valign="middle">
-			<c:if test="<%= !message.isRoot() %>">
-				<c:choose>
-					<c:when test="<%= !lastNode %>">
-						<img alt="" src="<%= themeDisplay.getPathThemeImages() %>/message_boards/t.png" />
-					</c:when>
-					<c:otherwise>
-						<img alt="" src="<%= themeDisplay.getPathThemeImages() %>/message_boards/l.png" />
-					</c:otherwise>
-				</c:choose>
-			</c:if>
 
-			<%
-			String rowHREF = null;
+		<%
+		String rowHREF = null;
 
-			if (portletName.equals(MBPortletKeys.MESSAGE_BOARDS_ADMIN)) {
-				rowHREF = MBUtil.getMBMessageURL(selMessage.getMessageId(), renderResponse);
+		if (portletName.equals(MBPortletKeys.MESSAGE_BOARDS_ADMIN)) {
+			rowHREF = MBUtil.getMBMessageURL(selMessage.getMessageId(), renderResponse);
+		}
+		else {
+			rowHREF = MBUtil.getMBMessageURL(selMessage.getMessageId(), PortalUtil.getLayoutFullURL(themeDisplay), renderResponse);
+		}
+
+		boolean readThread = true;
+
+		if (themeDisplay.isSignedIn()) {
+			Date messageModifiedDate = message.getModifiedDate();
+
+			if (threadFlagModifiedTime < messageModifiedDate.getTime()) {
+				readThread = false;
 			}
-			else {
-				rowHREF = MBUtil.getMBMessageURL(selMessage.getMessageId(), PortalUtil.getLayoutFullURL(themeDisplay), renderResponse);
-			}
+		}
+		%>
 
-			boolean readThread = true;
-
-			if (themeDisplay.isSignedIn()) {
-				Date messageModifiedDate = message.getModifiedDate();
-
-				if (threadFlagModifiedTime < messageModifiedDate.getTime()) {
-					readThread = false;
-				}
-			}
-			%>
-
-			<a href="<%= rowHREF %>">
-				<c:if test="<%= !readThread %>">
-					<strong>
+		<liferay-ui:csp>
+			<td class="table-cell" style="padding-left: <%= (depth > 0) ? depth * 10 : 5 %>px; width: 90%;" valign="middle">
+				<c:if test="<%= !message.isRoot() %>">
+					<c:choose>
+						<c:when test="<%= !lastNode %>">
+							<img alt="" src="<%= themeDisplay.getPathThemeImages() %>/message_boards/t.png" />
+						</c:when>
+						<c:otherwise>
+							<img alt="" src="<%= themeDisplay.getPathThemeImages() %>/message_boards/l.png" />
+						</c:otherwise>
+					</c:choose>
 				</c:if>
 
-				<%= HtmlUtil.escape(message.getSubject()) %>
+				<a href="<%= rowHREF %>">
+					<c:if test="<%= !readThread %>">
+						<strong>
+					</c:if>
 
-				<c:if test="<%= !readThread %>">
-					</strong>
-				</c:if>
-			</a>
-		</td>
-		<td class="table-cell" style="white-space: nowrap;">
-			<a href="<%= rowHREF %>">
-				<c:if test="<%= !readThread %>">
-					<strong>
-				</c:if>
+					<%= HtmlUtil.escape(message.getSubject()) %>
 
-				<c:choose>
-					<c:when test="<%= message.isAnonymous() %>">
-						<liferay-ui:message key="anonymous" />
-					</c:when>
-					<c:otherwise>
-						<%= HtmlUtil.escape(PortalUtil.getUserName(message)) %>
-					</c:otherwise>
-				</c:choose>
+					<c:if test="<%= !readThread %>">
+						</strong>
+					</c:if>
+				</a>
+			</td>
+		</liferay-ui:csp>
 
-				<c:if test="<%= !readThread %>">
-					</strong>
-				</c:if>
-			</a>
-		</td>
-		<td class="table-cell" style="white-space: nowrap;">
-			<a href="<%= rowHREF %>"><%= dateTimeFormat.format(message.getModifiedDate()) %></a>
-		</td>
+		<liferay-ui:csp>
+			<td class="table-cell" style="white-space: nowrap;">
+				<a href="<%= rowHREF %>">
+					<c:if test="<%= !readThread %>">
+						<strong>
+					</c:if>
+
+					<c:choose>
+						<c:when test="<%= message.isAnonymous() %>">
+							<liferay-ui:message key="anonymous" />
+						</c:when>
+						<c:otherwise>
+							<%= HtmlUtil.escape(PortalUtil.getUserName(message)) %>
+						</c:otherwise>
+					</c:choose>
+
+					<c:if test="<%= !readThread %>">
+						</strong>
+					</c:if>
+				</a>
+			</td>
+		</liferay-ui:csp>
+
+		<liferay-ui:csp>
+			<td class="table-cell" style="white-space: nowrap;">
+				<a href="<%= rowHREF %>"><%= dateTimeFormat.format(message.getModifiedDate()) %></a>
+			</td>
+		</liferay-ui:csp>
 	</tr>
 </c:if>
 


### PR DESCRIPTION
LPD-44895 Clean inline styles to support style-src '[NONCE]' directive - Blog, Content Dashboard & MB

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44349

Remove inline styles, so customers can define Content Security Policies with a restrictive directive such as:


# How am I fixing it?

Clean inline styles to support style-src '[NONCE]' directive - Blog, Content Dashboard & MB


to check that it works:
Enable feature.flag.LPS-134060
go to Instance Settings -> Content Security Policy
Enable the checkbox
Put on Content Security Policy:
```
script-src '[$NONCE$]'; 
script-src-attr 'none'; 
style-src-elem '[$NONCE$]'; 
style-src-attr 'unsafe-inline';
```

# Why doesn't this include any test?
UI issue


# Commits

- **LPD-44895 to comply with the NONCE strategy, using csp tag on blogs**
- **LPD-44895 comply with the NONCE strategy on comment-taglib**
- **LPD-44895 to comply with the NONCE strategy, using csp tag on content-dashboard-document-library**
- **LPD-44895 to comply with the NONCE strategy, using csp tag on message boards**
