### PR TITLE
[Release Blocker] LPD-46925 Send displayDate with current date when publishing an article

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
@@ -21,7 +21,7 @@ export default function PublishModalDisplayDate({
 				form={formId}
 				name={`${portletNamespace}displayDateDay`}
 				type="hidden"
-				value={currentDate.getDay()}
+				value={currentDate.getDate()}
 			/>
 
 			<ClayInput

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import React from 'react';
+
+export default function PublishModalDisplayDate({formId, portletNamespace}) {
+	const currentDate = new Date();
+
+	return (
+		<>
+			<ClayInput
+				form={formId}
+				name={`${portletNamespace}displayDateDay`}
+				type="hidden"
+				value={currentDate.getDay()}
+			/>
+
+			<ClayInput
+				form={formId}
+				name={`${portletNamespace}displayDateHour`}
+				type="hidden"
+				value={currentDate.getHours()}
+			/>
+
+			<ClayInput
+				form={formId}
+				name={`${portletNamespace}displayDateMinute`}
+				type="hidden"
+				value={currentDate.getMinutes()}
+			/>
+
+			<ClayInput
+				form={formId}
+				name={`${portletNamespace}displayDateMonth`}
+				type="hidden"
+				value={currentDate.getMonth()}
+			/>
+
+			<ClayInput
+				form={formId}
+				name={`${portletNamespace}displayDateYear`}
+				type="hidden"
+				value={currentDate.getFullYear()}
+			/>
+		</>
+	);
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/PublishModalDisplayDate.js
@@ -6,8 +6,14 @@
 import {ClayInput} from '@clayui/form';
 import React from 'react';
 
-export default function PublishModalDisplayDate({formId, portletNamespace}) {
-	const currentDate = new Date();
+export default function PublishModalDisplayDate({
+	formId,
+	portletNamespace,
+	timeZone,
+}) {
+	const currentDate = new Date(
+		new Date().toLocaleString('en-US', {timeZone})
+	);
 
 	return (
 		<>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -9,6 +9,7 @@ import ClayModal, {useModal} from '@clayui/modal';
 import React, {useState} from 'react';
 
 import PermissionsOptions from '../PermissionsOptions';
+import PublishModalDisplayDate from '../PublishModalDisplayDate';
 import ScheduleOptions from '../ScheduleOptions';
 
 export default function PublishModal({
@@ -68,7 +69,12 @@ export default function PublishModal({
 						setError={setDateError}
 						timeZone={timeZone}
 					/>
-				) : null}
+				) : (
+					<PublishModalDisplayDate
+						formId={formId}
+						portletNamespace={portletNamespace}
+					/>
+				)}
 
 				{(!articleId || Liferay.FeatureFlags['LPD-11228']) &&
 					showPermissionsOptions && (

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -73,6 +73,7 @@ export default function PublishModal({
 					<PublishModalDisplayDate
 						formId={formId}
 						portletNamespace={portletNamespace}
+						timeZone={timeZone}
 					/>
 				)}
 


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-46925)

The issue is that the displayDate is only sent when scheduling article. With this fix, on publish we set the displayDate with the current date. 

Test that covers this: WebContent#ViewReservedVariablesDisplayOnWebContent