### PR TITLE
LPD-47185 Mime types wrongly handled on Media Gallery widget configuration

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.exception.NoSuchRepositoryEntryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.portlet.BaseJSPSettingsConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -28,7 +28,7 @@ import javax.portlet.PortletConfig;
  * @author Sergio González
  */
 public abstract class BaseValidateRootFolderConfigurationAction
-	extends DefaultConfigurationAction {
+	extends BaseJSPSettingsConfigurationAction {
 
 	@Override
 	public void processAction(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
@@ -21,8 +21,9 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
+import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.ActionRequest;
@@ -70,14 +71,14 @@ public class DLConfigurationAction
 
 	@Override
 	protected void postProcess(
-			long companyId, PortletRequest portletRequest,
-			PortletPreferences portletPreferences)
+			long companyId, PortletRequest portletRequest, Settings settings)
 		throws PortalException {
 
-		super.postProcess(companyId, portletRequest, portletPreferences);
+		PortletPreferencesSettings portletPreferencesSettings =
+			(PortletPreferencesSettings)settings.getParentSettings();
 
-		String[] displayViews = StringUtil.split(
-			portletPreferences.getValue("displayViews", null));
+		PortletPreferences portletPreferences =
+			portletPreferencesSettings.getPortletPreferences();
 
 		long rootFolderId = GetterUtil.getLong(
 			portletPreferences.getValue("rootFolderId", null));
@@ -86,8 +87,6 @@ public class DLConfigurationAction
 			portletPreferences.getValue("selectedRepositoryId", null));
 
 		try {
-			portletPreferences.setValues("displayViews", displayViews);
-
 			_setPortletPreferences(
 				portletPreferences, rootFolderId, selectedRepositoryId);
 		}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47185

In [LPD-33262](https://liferay.atlassian.net/browse/LPD-33262) a bug was introduced. Now the Media Gallery widget cannot be configured because its multi valued settting `mimeTypes` is not correctly handled.

# How am I fixing it?

I'm reverting the change of parent class in `BaseValidateRootFolderConfigurationAction`. This change was avoiding the correct handling of multi valued settings both in `DLConfigurationAction` and `IGDisplayConfigurationAction` due to the empty method `DefaultConfigurationAction.updateMultiValuedKeys()` .

# How can you verify that it works?

There are already several POSHI tests that were failing. One of them is:

`ant -f build-test.xml run-selenium-test -Dtest.class=DMMediaGallery#CanAddMGWidgetTemplate`