### PR TITLE
LPD-45199 Add a dataFilter to BBcodeDataProcessor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_data_processor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/bbcode/bbcode_data_processor.js
@@ -119,6 +119,8 @@
 
 	const BBCodeDataProcessor = function (editor) {
 		this._editor = editor;
+
+		this.dataFilter = new CKEDITOR.htmlParser.filter();
 	};
 
 	BBCodeDataProcessor.prototype = {

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -185,6 +185,24 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async postMessageBoardMessage({
+		articleBody,
+		messageBoardThreadId,
+	}: {
+		articleBody: string;
+		messageBoardThreadId: string;
+	}): Promise<MessageBoardMessage> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/message-board-threads/${messageBoardThreadId}/message-board-messages`,
+			{
+				data: {
+					articleBody,
+				},
+				failOnStatusCode: true,
+			}
+		);
+	}
+
 	async postStructuredContent({
 		categoryIds,
 		contentStructureId,

--- a/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {messageBoardsPagesTest} from '../../fixtures/messageBoardsTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 
 export const test = mergeTests(
@@ -66,5 +67,60 @@ test(
 		);
 
 		expect(page.getByText('&nbsp;')).toBeHidden();
+	}
+);
+
+test(
+	'Can open two different replies',
+	{
+		tag: '@LPD-45199',
+	},
+	async ({
+		apiHelpers,
+		messageBoardsEditThreadPage,
+		messageBoardsPage,
+		page,
+		site,
+	}) => {
+		const threadTitle = 'MB Thread title';
+		const messageBody = 'MB Thread message';
+
+		const messageBoardThread =
+			await apiHelpers.headlessDelivery.postMessageBoardThread({
+				articleBody: getRandomString(),
+				headline: threadTitle,
+				siteId: site.id,
+			});
+
+		await apiHelpers.headlessDelivery.postMessageBoardMessage({
+			articleBody: messageBody,
+			messageBoardThreadId: messageBoardThread.id,
+		});
+
+		await messageBoardsPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('link', {name: threadTitle}).click();
+
+		await page.getByRole('button', {name: 'Reply'}).click();
+
+		await expect(messageBoardsEditThreadPage.bodyTextBox).toBeVisible();
+
+		const actionsButton = page
+			.locator('.panel-heading')
+			.filter({hasText: 'RE: ' + threadTitle})
+			.getByRole('button', {name: 'Actions'});
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('link', {
+				exact: true,
+				name: 'Reply',
+			}),
+			trigger: actionsButton,
+		});
+
+		const editors = await page.locator('iframe');
+
+		await expect(editors).toHaveCount(2);
 	}
 );

--- a/modules/test/playwright/types/message-board-message.d.ts
+++ b/modules/test/playwright/types/message-board-message.d.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type MessageBoardMessage = {
+	articleBody: string;
+	messageBoardThreadId: string;
+};


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-45199)

### What was the issue

It was not possible to initialize two ckeditors in MB at the same time. This was only happening in MB because here is the only place where bbcode plugin is being used. 

This fix has been agreed with @markocikos after https://liferay.atlassian.net/browse/PTR-6020

### How to test it 
Follow the steps: 
1. Go to Content & Data > Message Boards
2. Add a thread named "main thread"
3. Add reply “Reply 1“ to "main thread"
4. Click "Reply" button
5. Click on reply "main thread" and then cancel
6. Click on reply to “Reply 1“
7. Assert the body input doesn’t load

Or run the functional test: 

```
> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-45199 --reporter list --repeat-each=5


Running 5 tests using 1 worker

  ✓  1 [message-boards-web] › message-boards-web/mbThread.spec.ts:73:1 › Can open two different replies (28.8s)
  ✓  2 [message-boards-web] › message-boards-web/mbThread.spec.ts:73:1 › Can open two different replies (21.3s)
  ✓  3 [message-boards-web] › message-boards-web/mbThread.spec.ts:73:1 › Can open two different replies (20.2s)
  ✓  4 [message-boards-web] › message-boards-web/mbThread.spec.ts:73:1 › Can open two different replies (18.9s)
  ✓  5 [message-boards-web] › message-boards-web/mbThread.spec.ts:73:1 › Can open two different replies (21.0s)

  5 passed (2.1m)
```