### PR TITLE
LPD-47196 Use batch preparedStatements to improve upgrade performance

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
@@ -94,7 +94,7 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(2, (Long)values[0]);
 				preparedStatement.setLong(3, fieldAttributeId);
 
-				preparedStatement.executeUpdate();
+				preparedStatement.addBatch();
 
 				if (_log.isInfoEnabled()) {
 					_log.info(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
@@ -90,7 +90,7 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 				preparedStatement.setLong(2, (Long)values[0]);
 				preparedStatement.setLong(3, fieldId);
 
-				preparedStatement.executeUpdate();
+				preparedStatement.addBatch();
 
 				if (_log.isInfoEnabled()) {
 					_log.info(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -125,12 +124,12 @@ public class DDMFieldAttributeUpgradeProcessTest {
 			RandomTestUtil.randomString());
 
 		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
-			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			null, _group.getCreatorUserId(), _group.getGroupId(), 0,
 			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
 			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
 			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
 			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
-			ServiceContextTestUtil.getServiceContext());
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -91,12 +90,12 @@ public class DDMFieldUpgradeProcessTest {
 			RandomTestUtil.randomString());
 
 		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
-			null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			null, _group.getCreatorUserId(), _group.getGroupId(), 0,
 			PortalUtil.getClassNameId(DDLRecordSet.class.getName()),
 			"CUSTOM-META-TAGS", RandomTestUtil.randomLocaleStringMap(), null,
 			ddmForm, _ddm.getDefaultDDMFormLayout(ddmForm),
 			StorageType.DEFAULT.toString(), DDMStructureConstants.TYPE_DEFAULT,
-			ServiceContextTestUtil.getServiceContext());
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		List<DDMStructureVersion> structureVersions =
 			_ddmStructureVersionLocalService.getStructureVersions(


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-47196](https://liferay.atlassian.net/browse/LPD-47196)}

Improve the performance of upgrade processes executing them in batch mode.
# How am I fixing it?

Avoiding use this initial version in some cases as default value.
# How can you verify that it works?

Run the included automated tests.

- **LPD-47196 Use proper group when creating DDMStructure.**
- **LPD-47196 Add as batch, do not execute each upgrade independently.**