### PR TITLE
LPD-47372 Use BaseDB existing type

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/UpgradeAssetVocabulary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_3_x/UpgradeAssetVocabulary.java
@@ -26,7 +26,7 @@ public class UpgradeAssetVocabulary extends UpgradeProcess {
 	protected UpgradeStep[] getPreUpgradeSteps() {
 		return new UpgradeStep[] {
 			UpgradeProcessFactory.addColumns(
-				"AssetVocabulary", "visibilityType INT")
+				"AssetVocabulary", "visibilityType INTEGER")
 		};
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -558,6 +558,11 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(31, 14, 1),
 			UpgradeProcessFactory.dropColumns("Company", "system_"));
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 14, 2),
+			UpgradeProcessFactory.alterColumnType(
+				"AssetVocabulary", "visibilityType", "INTEGER"));
 	}
 
 }


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-47372](https://liferay.atlassian.net/browse/LPD-47372)}

Use a defined DDBB type, since INT is not defined in BaseDB.

# How am I fixing it?

Fix typo and use INTEGER type instead of INT.

# How can you verify that it works?

Run LPD steps and execute Upgrade test suite. Tes will be implemented by the upgrade team in https://liferay.atlassian.net/browse/LPD-46771

- **LPD-47372 Use proper type, since INT is not defined in BaseDB.**