### PR TITLE
LPD-46007 Clean inline styles to support style-src '[NONCE]' directive

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -25,7 +25,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 		breadcrumbEntries="<%= repositoryBrowserTagDisplayContext.getBreadcrumbEntries() %>"
 	/>
 
-	<input id="<portlet:namespace />file" style="display: none;" type="file" />
+	<input class="hide" id="<portlet:namespace />file" type="file" />
 
 	<liferay-ui:search-container
 		id="repositoryEntries"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -11,7 +11,7 @@
 DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAccessFromDesktopDisplayContext(request);
 %>
 
-<div id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav" style="display: none;">
+<div class="hide" id="<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav">
 	<div class="portlet-document-library">
 		<liferay-ui:message key="<%= dlAccessFromDesktopDisplayContext.getWebDAVHelpMessage() %>" />
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
@@ -29,7 +29,9 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 
 		<c:choose>
 			<c:when test="<%= Validator.isNotNull(previewURL) %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+				<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
+					<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= previewURL %>" />
+				</div>
 			</c:when>
 			<c:otherwise>
 				<div class="aspect-ratio aspect-ratio-8-to-3 bg-light mb-4">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp
@@ -29,9 +29,9 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 
 		<c:choose>
 			<c:when test="<%= Validator.isNotNull(previewURL) %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
-					<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= previewURL %>" />
-				</div>
+				<liferay-ui:csp>
+					<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+				</liferay-ui:csp>
 			</c:when>
 			<c:otherwise>
 				<div class="aspect-ratio aspect-ratio-8-to-3 bg-light mb-4">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
@@ -34,5 +34,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 	}
 	%>
 
-	<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+	<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
+		<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= previewURL %>" />
+	</div>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp
@@ -34,7 +34,7 @@ FileVersion fileVersion = (FileVersion)request.getAttribute(WebKeys.DOCUMENT_LIB
 	}
 	%>
 
-	<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
-		<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= previewURL %>" />
-	</div>
+	<liferay-ui:csp>
+		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= previewURL %>);"></div>
+	</liferay-ui:csp>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.document.library.kernel.processor.ImageProcessorUtil" %><%@
 page import="com.liferay.document.library.kernel.processor.PDFProcessorUtil" %><%@

--- a/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/init.jsp" %>
 
-<div style="display: flex; justify-content: flex-start; overflow: hidden;">
+<div class="d-flex justify-content-start overflow-hidden">
 	<div class="videojs-container">
 		<aui:link href="https://vjs.zencdn.net/8.6.1/video-js.min.css" rel="stylesheet" type="text/css" />
 		<aui:link href="https://unpkg.com/videojs-quality-selector-hls@1.1.1/dist/videojs-quality-selector-hls.css" rel="stylesheet" type="text/css" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -15,9 +15,9 @@ JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribu
 
 <div class="asset-summary">
 	<c:if test="<%= articleDisplay.isSmallImage() %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
-			<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>" />
-		</div>
+		<liferay-ui:csp>
+			<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);"></div>
+		</liferay-ui:csp>
 	</c:if>
 
 	<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -15,7 +15,9 @@ JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribu
 
 <div class="asset-summary">
 	<c:if test="<%= articleDisplay.isSmallImage() %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>);"></div>
+		<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
+			<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= articleDisplay.getArticleDisplayImageURL(themeDisplay) %>" />
+		</div>
 	</c:if>
 
 	<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
@@ -22,9 +22,9 @@ AssetRenderer<?> assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASS
 	<c:otherwise>
 		<div class="asset-summary">
 			<c:if test="<%= article.isSmallImage() %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
-					<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= article.getArticleImageURL(themeDisplay) %>" />
-				</div>
+				<liferay-ui:csp>
+					<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);"></div>
+				</liferay-ui:csp>
 			</c:if>
 
 			<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
@@ -22,7 +22,9 @@ AssetRenderer<?> assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASS
 	<c:otherwise>
 		<div class="asset-summary">
 			<c:if test="<%= article.isSmallImage() %>">
-				<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= article.getArticleImageURL(themeDisplay) %>);"></div>
+				<div class="aspect-ratio aspect-ratio-8-to-3 mb-4">
+					<img alt="" class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid aspect-ratio-item-flush" src="<%= article.getArticleImageURL(themeDisplay) %>" />
+				</div>
 			</c:if>
 
 			<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
@@ -11,7 +11,8 @@
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@
 page import="com.liferay.journal.model.JournalArticle" %><%@

--- a/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
+++ b/modules/apps/wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl
@@ -8,7 +8,7 @@
 	<h1 class="header-title">${entry.getTitle()}</h1>
 </div>
 
-<div style="float: right;">
+<div class="float-right">
 	<@getEditIcon />
 
 	<@getPageDetailsIcon />


### PR DESCRIPTION
>[!NOTE]
> - [x] I'm not able to review all the fixes locally 
> - [x] update poshi tests still pending because doesn't work for me locally
> - [x] Some files like `access_from_desktop.jsp` and `journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp` are falling on master 😞 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46007

Clean inline styles to support style-src '[NONCE]' directive

# How am I fixing it?

Trying to move all cases of inline style to css classes or images sources to avoid '[NONCE]' directive

| Status | Comments                                      | Reviwed locally                                                         | File                                                                                                                                    |
| ------ | --------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| ✅      | moved from inline style to CSS class          | ✅                                                                       | document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp                    |
| ✅      | moved from inline style background to img src | ✅                                                                       | document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_abstract.jsp              |
| ✅      | moved from inline style background to img src | ✅                                                                       | document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info/item/renderer/file_entry_abstract.jsp |
| ✅      | moved from inline style to CSS class          | ❌                                                                       | document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp                              |
| ✅      | moved from inline style to CSS classes        | ❌<br>Not tested but not needed, it's behind a FF and it will be deleted | fragment/fragment-video-streaming/src/main/resources/META-INF/resources/page.jsp                                                        |
| ✅      | moved from inline style to CSS class          | ✅                                                                       | wiki/wiki-web/src/main/resources/com/liferay/wiki/web/portlet/display/template/dependencies/portlet_display_template_social.ftl         |
| ❌      | Discarded is an email template                |                                                                         | wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_updated_body.tmpl                               |
| ❌      | Discarded is an email template                |                                                                         | wiki/wiki-api/src/main/resources/com/liferay/wiki/configuration/dependencies/email_page_added_body.tmpl                                 |
| ✅      | moved from inline style background to img src | ✅                                                                       | journal/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp                                                            |
| ✅      | moved from inline style background to img src | ✅                                                                       | journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp                                               |
| ❌      | Discarded is an email template                |                                                                         | sharing/sharing-notifications/src/main/resources/com/liferay/sharing/notifications/dependencies/sharing_entry_added_email_body.ftl      |





# Test
~~We have some tests on Poshi but unfortunately, they are failing locally~~
~~Tests are now fixed (at least some).~~
>[!NOTE]
> I try to avoid some markup changes 83823d8e7523d24a2e9968ec749425eed527a227 to avoid test failures 
> ![image](https://github.com/user-attachments/assets/75acb173-8fa3-487d-8bbc-1e7ece0e669b)
> ![image](https://github.com/user-attachments/assets/8351e1c5-9d67-4ed0-9216-d73c8bea4a3c)


# Current Master failures
## `access_from_desktop.jsp`
Issue: https://liferay.atlassian.net/browse/LPD-47606
Only works once 

## `journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp`

>[!WARNING]
> This is only failing with Featured image from Documents and Media

Issue: https://liferay.atlassian.net/browse/LPD-47649
