### PR TITLE
LPD-47429 Fix Web Content expiration

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6186,17 +6186,43 @@ public class JournalArticleLocalServiceImpl
 						_log.debug("Expiring article " + article.getId());
 					}
 
-					ServiceContext serviceContext = new ServiceContext();
+					if (isExpireAllArticleVersions(companyId)) {
+						List<JournalArticle> currentArticles =
+							journalArticleLocalService.getArticles(
+								article.getGroupId(), article.getArticleId(),
+								QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+								ArticleVersionComparator.getInstance(true));
 
-					serviceContext.setCommand(Constants.UPDATE);
-					serviceContext.setScopeGroupId(article.getGroupId());
+						for (JournalArticle currentArticle : currentArticles) {
+							if (currentArticle.getVersion() >=
+									article.getVersion()) {
 
-					journalArticleLocalService.expireArticle(
-						_portal.getValidUserId(
-							article.getCompanyId(),
-							article.getStatusByUserId()),
-						article.getGroupId(), article.getArticleId(), null,
-						serviceContext);
+								continue;
+							}
+
+							currentArticle.setExpirationDate(
+								article.getExpirationDate());
+							currentArticle.setStatus(
+								WorkflowConstants.STATUS_EXPIRED);
+
+							currentArticle = journalArticlePersistence.update(
+								currentArticle);
+
+							notifySubscribers(
+								0, currentArticle, "expired",
+								new ServiceContext());
+						}
+					}
+
+					article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+					article = journalArticleLocalService.updateJournalArticle(
+						article);
+
+					notifySubscribers(
+						0, article, "expired", new ServiceContext());
+
+					updatePreviousApprovedArticle(article);
 
 					if (indexer != null) {
 						indexableActionableDynamicQuery.addDocuments(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
@@ -289,6 +289,16 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 		JournalArticle article = addArticle(
 			_group.getGroupId(), false, approved, false);
 
+		// Add a new-to-expire version
+
+		article = updateArticle(article, mode);
+
+		Calendar calendar = getExpirationCalendar(Time.HOUR, -2);
+
+		article.setExpirationDate(calendar.getTime());
+
+		article = _journalArticleLocalService.updateJournalArticle(article);
+
 		// Add a version of the article, changing expire date
 
 		article = updateArticle(article, mode);


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-47429](https://liferay.atlassian.net/browse/LPD-47429)}

Fix the expiration, so that expiring an old version doesn't affect newer ones.
# How am I fixing it?

Partially reverting {[LPD-27556](https://liferay.atlassian.net/browse/LPD-27556)} Its refactorization wasn't needed because new code is equivalent to the older one from a functional perspective.

# How can you verify that it works?

Run the included automated tests. Execute the LPD provided steps.

 **LPD-47429 Create test to expose issue (there is no possible way to undo an article expiration). Current failure:
    1. Create a WC with an expiration date in a couple of minutes.
    2. Update the WC to set the expiration date in a year.
    3. After articles are checked the expiration date of the first version expires the second as well.**
 **LPD-47429 Revert https://github.com/liferay-content-management/liferay-portal/commit/f3855daf25a14f71063b259f8eddf7a5f558cf43. ExpireArticle does not perform the same logic, it expires all article versions, but the check article should only expire article versions equals or lower to the expired one to avoid expiring also newer versions.**