### PR TITLE
LPD-47557 View staging should not be enough to publish documents to live

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -48,6 +48,8 @@ import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -851,7 +853,11 @@ public class UIItemsBuilder {
 		StagingGroupHelper stagingGroupHelper =
 			StagingGroupHelperUtil.getStagingGroupHelper();
 
-		if (!stagingGroupHelper.isStagingGroup(
+		if (!GroupPermissionUtil.contains(
+				_themeDisplay.getPermissionChecker(),
+				_themeDisplay.getScopeGroupId(),
+				ActionKeys.EXPORT_IMPORT_PORTLET_INFO) ||
+			!stagingGroupHelper.isStagingGroup(
 				_themeDisplay.getScopeGroupId()) ||
 			!stagingGroupHelper.isStagedPortlet(
 				_themeDisplay.getScopeGroupId(),

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilderTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilderTest.java
@@ -5,18 +5,29 @@
 
 package com.liferay.document.library.web.internal.display.context.logic;
 
+import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -24,10 +35,13 @@ import java.net.URISyntaxException;
 import org.assertj.core.api.AbstractUriAssert;
 import org.assertj.core.api.Assertions;
 
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -42,7 +56,11 @@ public class UIItemsBuilderTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@BeforeClass
-	public static void setUpClass() {
+	public static void setUpClass() throws Exception {
+		_setUpGroupPermissionUtil();
+		_setUpStagedModelDataHandlerRegistryUtil();
+		_setUpStagingGroupHelper();
+
 		_dlurlHelper = Mockito.mock(DLURLHelper.class);
 
 		Mockito.when(
@@ -58,6 +76,12 @@ public class UIItemsBuilderTest {
 		_fileEntry = Mockito.mock(FileEntry.class);
 		_fileVersion = Mockito.mock(FileVersion.class);
 
+		Mockito.when(
+			_fileEntry.getLatestFileVersion()
+		).thenReturn(
+			_fileVersion
+		);
+
 		LanguageUtil languageUtil = new LanguageUtil();
 
 		languageUtil.setLanguage(Mockito.mock(Language.class));
@@ -65,6 +89,13 @@ public class UIItemsBuilderTest {
 		PortalUtil portalUtil = new PortalUtil();
 
 		portalUtil.setPortal(new PortalImpl());
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_groupPermissionUtilMockedStatic.close();
+		_stagedModelDataHandlerRegistryUtilMockedStatic.close();
+		_stagingGroupHelperUtilMockedStatic.close();
 	}
 
 	@Test
@@ -105,6 +136,93 @@ public class UIItemsBuilderTest {
 		abstractUriAssert.hasNoParameter("doAsUserId");
 	}
 
+	@Test
+	public void testIsPublishActionAvailable() throws PortalException {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		portletDisplay.setPortletName(DLPortletKeys.DOCUMENT_LIBRARY_ADMIN);
+
+		UIItemsBuilder uiItemsBuilder = _getUIItemsBuilder(themeDisplay);
+
+		_addExportImportPortletInfoPermission(themeDisplay, false);
+
+		Assert.assertFalse(uiItemsBuilder.isPublishActionAvailable());
+
+		_addExportImportPortletInfoPermission(themeDisplay, true);
+
+		Assert.assertTrue(uiItemsBuilder.isPublishActionAvailable());
+	}
+
+	private static void _setUpGroupPermissionUtil() {
+		PropsUtil.setProps(Mockito.mock(Props.class));
+
+		_groupPermissionUtilMockedStatic = Mockito.mockStatic(
+			GroupPermissionUtil.class);
+	}
+
+	private static void _setUpStagedModelDataHandlerRegistryUtil() {
+		_stagedModelDataHandlerRegistryUtilMockedStatic = Mockito.mockStatic(
+			StagedModelDataHandlerRegistryUtil.class);
+
+		StagedModelDataHandler<FileEntry> stagedModelDataHandler = Mockito.mock(
+			StagedModelDataHandler.class);
+
+		Mockito.when(
+			stagedModelDataHandler.getExportableStatuses()
+		).thenReturn(
+			new int[] {0}
+		);
+
+		Mockito.<StagedModelDataHandler>when(
+			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+				FileEntry.class.getName())
+		).thenReturn(
+			stagedModelDataHandler
+		);
+	}
+
+	private static void _setUpStagingGroupHelper() {
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			StagingGroupHelperUtil.getStagingGroupHelper()
+		).thenReturn(
+			stagingGroupHelper
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isStagingGroup(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isStagedPortlet(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
+	}
+
+	private void _addExportImportPortletInfoPermission(
+		ThemeDisplay themeDisplay, boolean contains) {
+
+		_groupPermissionUtilMockedStatic.when(
+			() -> GroupPermissionUtil.contains(
+				themeDisplay.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(),
+				ActionKeys.EXPORT_IMPORT_PORTLET_INFO)
+		).thenReturn(
+			contains
+		);
+	}
+
 	private UIItemsBuilder _getUIItemsBuilder(ThemeDisplay themeDisplay) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
@@ -120,5 +238,11 @@ public class UIItemsBuilderTest {
 	private static DLURLHelper _dlurlHelper;
 	private static FileEntry _fileEntry;
 	private static FileVersion _fileVersion;
+	private static MockedStatic<GroupPermissionUtil>
+		_groupPermissionUtilMockedStatic;
+	private static MockedStatic<StagedModelDataHandlerRegistryUtil>
+		_stagedModelDataHandlerRegistryUtilMockedStatic;
+	private static MockedStatic<StagingGroupHelperUtil>
+		_stagingGroupHelperUtilMockedStatic;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-47557](https://liferay.atlassian.net/browse/LPD-47557)}

Users with only view staging permission should not be able to publish documents to live.
# How am I fixing it?

As in other assets, taking into account `ActionKeys.EXPORT_IMPORT_PORTLET_INFO`
# How can you verify that it works?

Run the included automated tests. Execute the LPD provided steps.

**LPD-47557 Create test to expose expected behaviour with publish to live option.**
**LPD-47557 View staging must not be enough to publish to live.**