### PR TITLE
LPD-47471 DM: subscribe button alignment

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -61,22 +61,16 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 				<li class="autofit-col">
 					<liferay-util:include page="/document_library/subscribe_file_entry.jsp" servletContext="<%= application %>" />
 				</li>
-			</ul>
-		</clay:content-col>
 
-		<%
-		DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(dlRequestHelper);
-		%>
+				<% DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper=new DLPortletInstanceSettingsHelper(dlRequestHelper); %>
 
-		<c:if test="<%= !hideActions && dlPortletInstanceSettingsHelper.isShowActions() %>">
-			<clay:content-col>
-				<ul class="autofit-padded-no-gutters autofit-row">
+				<c:if test="<%= !hideActions && dlPortletInstanceSettingsHelper.isShowActions() %>">
 					<li class="autofit-col">
 						<liferay-util:include page="/document_library/file_entry_action.jsp" servletContext="<%= application %>" />
 					</li>
-				</ul>
-			</clay:content-col>
-		</c:if>
+				</c:if>
+			</ul>
+		</clay:content-col>
 	</clay:content-row>
 </div>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/info_panel_file_entry.jsp
@@ -62,7 +62,9 @@ long assetClassPK = DLAssetHelperUtil.getAssetClassPK(fileEntry, fileVersion);
 					<liferay-util:include page="/document_library/subscribe_file_entry.jsp" servletContext="<%= application %>" />
 				</li>
 
-				<% DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper=new DLPortletInstanceSettingsHelper(dlRequestHelper); %>
+				<%
+				DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(dlRequestHelper);
+				%>
 
 				<c:if test="<%= !hideActions && dlPortletInstanceSettingsHelper.isShowActions() %>">
 					<li class="autofit-col">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_file_entry.jsp
@@ -36,13 +36,21 @@ FileEntry fileEntry = (FileEntry)request.getAttribute("info_panel.jsp-fileEntry"
 					/>
 				</c:when>
 				<c:otherwise>
-					<clay:icon
-						aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-						cssClass="lfr-portal-tooltip mt-0"
+					<clay:button
+						borderless="<%= true %>"
+						cssClass="lfr-portal-tooltip"
+						disabled="<%= true %>"
+						displayType="secondary"
 						monospaced="<%= true %>"
-						symbol="bell-off"
-						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-					/>
+						small="<%= true %>"
+						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+					>
+						<clay:icon
+							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+							symbol="bell-off"
+							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+						/>
+					</clay:button>
 				</c:otherwise>
 			</c:choose>
 		</c:when>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_file_entry.jsp
@@ -43,7 +43,7 @@ FileEntry fileEntry = (FileEntry)request.getAttribute("info_panel.jsp-fileEntry"
 						displayType="secondary"
 						monospaced="<%= true %>"
 						small="<%= true %>"
-						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
 					>
 						<clay:icon
 							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_folder.jsp
@@ -80,7 +80,7 @@ boolean emailFileEntryAnyEventEnabled = dlGroupServiceSettings.isEmailFileEntryA
 						displayType="secondary"
 						monospaced="<%= true %>"
 						small="<%= true %>"
-						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
 					>
 						<clay:icon
 							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/subscribe_folder.jsp
@@ -73,13 +73,21 @@ boolean emailFileEntryAnyEventEnabled = dlGroupServiceSettings.isEmailFileEntryA
 					/>
 				</c:when>
 				<c:otherwise>
-					<clay:icon
-						aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-						cssClass="lfr-portal-tooltip mt-0"
+					<clay:button
+						borderless="<%= true %>"
+						cssClass="lfr-portal-tooltip"
+						disabled="<%= true %>"
+						displayType="secondary"
 						monospaced="<%= true %>"
-						symbol="bell-off"
-						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-					/>
+						small="<%= true %>"
+						title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+					>
+						<clay:icon
+							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+							symbol="bell-off"
+							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+						/>
+					</clay:button>
 				</c:otherwise>
 			</c:choose>
 		</c:when>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
@@ -88,13 +88,21 @@ String unsubscribeActionName = StringPool.BLANK;
 						/>
 					</c:when>
 					<c:otherwise>
-						<clay:icon
-							aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-							cssClass="lfr-portal-tooltip mt-0"
+						<clay:button
+							borderless="<%= true %>"
+							cssClass="lfr-portal-tooltip"
+							disabled="<%= true %>"
+							displayType="secondary"
 							monospaced="<%= true %>"
-							symbol="bell-off"
-							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
-						/>
+							small="<%= true %>"
+							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+						>
+							<clay:icon
+								aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+								symbol="bell-off"
+								title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
+							/>
+						</clay:button>
 					</c:otherwise>
 				</c:choose>
 			</c:when>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/subscribe.jsp
@@ -95,7 +95,7 @@ String unsubscribeActionName = StringPool.BLANK;
 							displayType="secondary"
 							monospaced="<%= true %>"
 							small="<%= true %>"
-							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder" ) %>'
+							title='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'
 						>
 							<clay:icon
 								aria-label='<%= LanguageUtil.get(request, "subscribed-to-a-parent-folder") %>'


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-47471)

### What is it trying to fix
The subscribe button for file entries and folders inside a subcribed folder was not aligned correctly, and should be disabled. 

**BEFORE:** 
![Screenshot 2025-01-29 at 10 47 28](https://github.com/user-attachments/assets/56e0c4e6-c104-453b-8b54-18e8d7558a37)

**AFTER:** 
![Screenshot 2025-01-29 at 12 35 04](https://github.com/user-attachments/assets/a6708a03-a8aa-4067-8448-ccc00a9b27f8)

This bug does not need tests, as they are only visual improvements