### PR TITLE
LPD-46142 Adds integration and unit tests to cover poshi test cases

### DIFF
--- a/modules/apps/asset/asset-tags-admin-web/src/test/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContextTest.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/test/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContextTest.java
@@ -1,0 +1,222 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.tags.admin.web.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
+
+import java.util.List;
+
+import javax.portlet.RenderRequest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class AssetTagsDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_portletURLUtilMockedStatic.close();
+		_stagingGroupHelperUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpLanguage();
+		_setUpPortletURLUtil();
+	}
+
+	@Test
+	public void testGetAssetTagActionDropdownItems() throws Exception {
+		_testGetAssetTagActionDropdownItemsInLiveGroup();
+		_testGetAssetTagActionDropdownItemsInStagingGroup();
+	}
+
+	private void _assertDropdownItem(
+		DropdownItem dropdownItem, String icon, String label) {
+
+		DropdownItemList dropdownItemList = (DropdownItemList)dropdownItem.get(
+			"items");
+
+		DropdownItem childDropdownItem = dropdownItemList.get(0);
+
+		Assert.assertEquals(icon, childDropdownItem.get("icon"));
+		Assert.assertEquals(label, childDropdownItem.get("label"));
+	}
+
+	private void _assertEmptyDropdownItemList(DropdownItem dropdownItem) {
+		DropdownItemList dropdownItemList = (DropdownItemList)dropdownItem.get(
+			"items");
+
+		Assert.assertTrue(dropdownItemList.isEmpty());
+	}
+
+	private AssetTag _getAssetTag() {
+		AssetTag assetTag = Mockito.mock(AssetTag.class);
+
+		Mockito.when(
+			assetTag.getTagId()
+		).thenReturn(
+			1L
+		);
+
+		return assetTag;
+	}
+
+	private AssetTagsDisplayContext _getAssetTagsDisplayContext(
+		boolean liveGroup) {
+
+		_setUpStagingGroupHelper(liveGroup);
+
+		Group group = Mockito.mock(Group.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			group
+		);
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return new AssetTagsDisplayContext(
+			httpServletRequest, Mockito.mock(RenderRequest.class),
+			new MockLiferayPortletRenderResponse());
+	}
+
+	private void _setUpLanguage() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Mockito.when(
+			_language.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenAnswer(
+			(Answer<String>)invocationOnMock -> invocationOnMock.getArgument(
+				1, String.class)
+		);
+
+		languageUtil.setLanguage(_language);
+	}
+
+	private void _setUpPortletURLUtil() throws Exception {
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+
+		Mockito.when(
+			PortletURLUtil.clone(
+				Mockito.any(LiferayPortletURL.class), Mockito.anyString(),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+	}
+
+	private void _setUpStagingGroupHelper(boolean liveGroup) {
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			stagingGroupHelper.isLocalLiveGroup(Mockito.any(Group.class))
+		).thenReturn(
+			liveGroup
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isRemoteStagingGroup(Mockito.any(Group.class))
+		).thenReturn(
+			liveGroup
+		);
+
+		_stagingGroupHelperUtilMockedStatic.when(
+			StagingGroupHelperUtil::getStagingGroupHelper
+		).thenReturn(
+			stagingGroupHelper
+		);
+	}
+
+	private void _testGetAssetTagActionDropdownItemsInLiveGroup() {
+		AssetTagsDisplayContext assetTagsDisplayContext =
+			_getAssetTagsDisplayContext(true);
+
+		List<DropdownItem> assetTagActionDropdownItems =
+			assetTagsDisplayContext.getAssetTagActionDropdownItems(
+				_getAssetTag());
+
+		Assert.assertEquals(
+			assetTagActionDropdownItems.toString(), 3,
+			assetTagActionDropdownItems.size());
+
+		_assertEmptyDropdownItemList(assetTagActionDropdownItems.get(0));
+		_assertEmptyDropdownItemList(assetTagActionDropdownItems.get(1));
+
+		_assertDropdownItem(
+			assetTagActionDropdownItems.get(2), "trash", "delete");
+	}
+
+	private void _testGetAssetTagActionDropdownItemsInStagingGroup() {
+		AssetTagsDisplayContext assetTagsDisplayContext =
+			_getAssetTagsDisplayContext(false);
+
+		List<DropdownItem> assetTagActionDropdownItems =
+			assetTagsDisplayContext.getAssetTagActionDropdownItems(
+				_getAssetTag());
+
+		Assert.assertEquals(
+			assetTagActionDropdownItems.toString(), 3,
+			assetTagActionDropdownItems.size());
+
+		_assertDropdownItem(
+			assetTagActionDropdownItems.get(0), "pencil", "edit");
+		_assertDropdownItem(
+			assetTagActionDropdownItems.get(1), "merge", "merge");
+		_assertDropdownItem(
+			assetTagActionDropdownItems.get(2), "trash", "delete");
+	}
+
+	private static MockedStatic<PortletURLUtil> _portletURLUtilMockedStatic;
+	private static final MockedStatic<StagingGroupHelperUtil>
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
+
+	private final Language _language = Mockito.mock(Language.class);
+
+}

--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/admin/web/internal/portlet/test/AssetTagsAdminPortletTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/admin/web/internal/portlet/test/AssetTagsAdminPortletTest.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.tags.admin.web.internal.portlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.exception.AssetTagNameException;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionResponse;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.Portlet;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class AssetTagsAdminPortletTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testDeleteTag() throws Exception {
+		AssetTag assetTag = _assetTagLocalService.addTag(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			"tagId", String.valueOf(assetTag.getTagId()));
+
+		_invoke("deleteTag", mockLiferayPortletActionRequest);
+
+		Assert.assertNull(
+			_assetTagLocalService.fetchAssetTag(assetTag.getTagId()));
+	}
+
+	@Test
+	public void testEditTagAddTag() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter("name", name);
+
+		_invoke("editTag", mockLiferayPortletActionRequest);
+
+		Assert.assertNotNull(
+			_assetTagLocalService.fetchTag(_group.getGroupId(), name));
+	}
+
+	@Test
+	public void testEditTagUpdateTag() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		AssetTag assetTag = _assetTagLocalService.addTag(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), name,
+			ServiceContextTestUtil.getServiceContext());
+
+		String newName = RandomTestUtil.randomString();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter("name", newName);
+		mockLiferayPortletActionRequest.setParameter(
+			"tagId", String.valueOf(assetTag.getTagId()));
+
+		_invoke("editTag", mockLiferayPortletActionRequest);
+
+		assetTag = _assetTagLocalService.getAssetTag(assetTag.getTagId());
+
+		Assert.assertEquals(newName, assetTag.getName());
+	}
+
+	@Test(expected = AssetTagNameException.class)
+	public void testEditTagWithEmptyName() throws Exception {
+		_invoke("editTag", _getMockLiferayPortletActionRequest());
+	}
+
+	@Test
+	public void testMergeTag() throws Exception {
+		AssetTag mergeAssetTag = _assetTagLocalService.addTag(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		AssetTag targetAssetTag = _assetTagLocalService.addTag(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockLiferayPortletActionRequest.setParameter(
+			"mergeTagNames", new String[] {mergeAssetTag.getName()});
+		mockLiferayPortletActionRequest.setParameter(
+			"targetTagName", targetAssetTag.getName());
+
+		_invoke("mergeTag", mockLiferayPortletActionRequest);
+
+		Assert.assertNull(
+			_assetTagLocalService.fetchAssetTag(mergeAssetTag.getTagId()));
+		Assert.assertNotNull(
+			_assetTagLocalService.fetchAssetTag(targetAssetTag.getTagId()));
+	}
+
+	private MockLiferayPortletActionRequest
+			_getMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private void _invoke(
+		String deleteTag,
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
+
+		ReflectionTestUtil.invoke(
+			_portlet, deleteTag,
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest, new MockActionResponse());
+	}
+
+	@Inject
+	private AssetTagLocalService _assetTagLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.asset.tags.admin.web.internal.portlet.AssetTagsAdminPortlet"
+	)
+	private Portlet _portlet;
+
+}


### PR DESCRIPTION
Adds unit and integration tests to cover poshi test cases

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-46142)

We are trying to migrate from poshi, so we are trying to increase the coverage of unit and integration tests to replace the test cases

# How am I fixing it?

* Adds tests for action command that includes creating, updating and deleting tags
* Adds tests to cover which actions are shown in the UI if in staging or live environments

# How can you verify that it works?

Run the provided tests