### PR TITLE
LPD-44895 no need to use the liferay-ui:csp encapsulate on this style to be compilant with [NONCE] a class can be used instead

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_shortcut.jsp
@@ -81,34 +81,29 @@ if (threadFlag != null) {
 			</td>
 		</liferay-ui:csp>
 
-		<liferay-ui:csp>
-			<td class="table-cell" style="white-space: nowrap;">
-				<a href="<%= rowHREF %>">
-					<c:if test="<%= !readThread %>">
-						<strong>
-					</c:if>
+		<td class="table-cell text-nowrap">
+			<a href="<%= rowHREF %>">
+				<c:if test="<%= !readThread %>">
+					<strong>
+				</c:if>
 
-					<c:choose>
-						<c:when test="<%= message.isAnonymous() %>">
-							<liferay-ui:message key="anonymous" />
-						</c:when>
-						<c:otherwise>
-							<%= HtmlUtil.escape(PortalUtil.getUserName(message)) %>
-						</c:otherwise>
-					</c:choose>
+				<c:choose>
+					<c:when test="<%= message.isAnonymous() %>">
+						<liferay-ui:message key="anonymous" />
+					</c:when>
+					<c:otherwise>
+						<%= HtmlUtil.escape(PortalUtil.getUserName(message)) %>
+					</c:otherwise>
+				</c:choose>
 
-					<c:if test="<%= !readThread %>">
-						</strong>
-					</c:if>
-				</a>
-			</td>
-		</liferay-ui:csp>
-
-		<liferay-ui:csp>
-			<td class="table-cell" style="white-space: nowrap;">
-				<a href="<%= rowHREF %>"><%= dateTimeFormat.format(message.getModifiedDate()) %></a>
-			</td>
-		</liferay-ui:csp>
+				<c:if test="<%= !readThread %>">
+					</strong>
+				</c:if>
+			</a>
+		</td>
+		<td class="table-cell text-nowrap">
+			<a href="<%= rowHREF %>"><%= dateTimeFormat.format(message.getModifiedDate()) %></a>
+		</td>
 	</tr>
 </c:if>
 


### PR DESCRIPTION

 LPD-44349 Clean inline styles to support style-src '[NONCE]' directive - Blog, Content Dashboard & MB

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44895

Remove inline styles, so customers can define Content Security Policies with a restrictive directive such as:


# How am I fixing it?

no need to use the liferay-ui:csp encapsulate on this style to be compilant with [NONCE] a class can be used instead

# How can you verify that it works?


- Enable feature.flag.LPS-134060
- go to Instance Settings -> Content Security Policy
- Enable the checkbox
- Put on Content Security Policy:
```
script-src '[$NONCE$]'; 
script-src-attr 'none'; 
style-src-elem '[$NONCE$]'; 
style-src-attr 'unsafe-inline';
```

# Why doesn't this include any test?

UI issue



# Commits


- **LPD-44895 no need to use the liferay-ui:csp encapsulate on this style to be compilant with [NONCE] a class can be used instead**
