### PR TITLE
LPD-47709 Sitemap URLs for a disabled language

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/provider/JournalArticleSitemapURLProvider.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
@@ -247,6 +249,9 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 		String portalURL = _portal.getPortalURL(layoutSet, themeDisplay);
 
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			themeDisplay.getScopeGroupId());
+
 		for (JournalArticle journalArticle : journalArticles) {
 			if (processedArticleIds.contains(journalArticle.getArticleId()) ||
 				(journalArticle.getStatus() !=
@@ -304,7 +309,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
 				articleURL, themeDisplay, articleLayout,
-				_getAvailableLocales(journalArticle));
+				_getAvailableLocales(journalArticle, siteAvailableLocales));
 
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemapManager.addURLElement(
@@ -317,14 +322,23 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		}
 	}
 
-	private Set<Locale> _getAvailableLocales(JournalArticle journalArticle) {
+	private Set<Locale> _getAvailableLocales(
+		JournalArticle journalArticle, Set<Locale> siteAvailableLocales) {
+
 		Set<Locale> availableLocales = new HashSet<>();
+
+		if (SetUtil.isEmpty(siteAvailableLocales)) {
+			return availableLocales;
+		}
 
 		for (String availableLanguageId :
 				journalArticle.getAvailableLanguageIds()) {
 
-			availableLocales.add(
-				LocaleUtil.fromLanguageId(availableLanguageId));
+			Locale locale = LocaleUtil.fromLanguageId(availableLanguageId);
+
+			if (siteAvailableLocales.contains(locale)) {
+				availableLocales.add(locale);
+			}
 		}
 
 		return availableLocales;
@@ -373,6 +387,9 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 	@Reference
 	private JournalArticleService _journalArticleService;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/provider/test/JournalArticleSitemapURLProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/provider/test/JournalArticleSitemapURLProviderTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -33,10 +34,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
@@ -46,8 +51,11 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.provider.SitemapURLProvider;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -226,6 +234,44 @@ public class JournalArticleSitemapURLProviderTest {
 		_assertVisitLayoutDefaultLayout("noindex");
 	}
 
+	@Test
+	public void testJournalArticleSitemapWithADisabledLanguage()
+		throws Exception {
+
+		Element rootElement = _getRootElement();
+
+		JournalArticle article = JournalTestUtil.addArticleWithWorkflow(
+			_group.getGroupId(), true);
+
+		Assert.assertTrue(
+			ArrayUtil.contains(article.getAvailableLanguageIds(), "de_DE"));
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			_group.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"inheritLocales", Boolean.FALSE.toString());
+
+		typeSettingsUnicodeProperties.setProperty(
+			PropsKeys.LOCALES, "en_US,es_ES");
+
+		_groupLocalService.updateGroup(
+			_group.getGroupId(), typeSettingsUnicodeProperties.toString());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				article.getDDMStructureId(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		_assertRootElement(
+			article,
+			_layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid()),
+			rootElement,
+			FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE);
+	}
+
 	private void _assertRootElement(
 			JournalArticle article, Layout layout, Element rootElement,
 			String urlSeparator)
@@ -236,7 +282,7 @@ public class JournalArticleSitemapURLProviderTest {
 
 		Assert.assertTrue(rootElement.hasContent());
 
-		String[] availableLanguageIds = article.getAvailableLanguageIds();
+		String[] availableLanguageIds = _getAvailableLanguageIds(article);
 
 		List<Element> elements = rootElement.elements();
 
@@ -317,6 +363,29 @@ public class JournalArticleSitemapURLProviderTest {
 		Assert.assertFalse(rootElement.hasContent());
 	}
 
+	private String[] _getAvailableLanguageIds(JournalArticle journalArticle) {
+		Set<Locale> siteAvailableLocales = _language.getAvailableLocales(
+			_group.getGroupId());
+
+		if (SetUtil.isEmpty(siteAvailableLocales)) {
+			return new String[0];
+		}
+
+		List<String> availableLanguageIds = new ArrayList<>();
+
+		for (String availableLanguageId :
+				journalArticle.getAvailableLanguageIds()) {
+
+			if (siteAvailableLocales.contains(
+					LocaleUtil.fromLanguageId(availableLanguageId))) {
+
+				availableLanguageIds.add(availableLanguageId);
+			}
+		}
+
+		return ArrayUtil.toStringArray(availableLanguageIds);
+	}
+
 	private Element _getRootElement() {
 		Document document = _saxReader.createDocument();
 
@@ -362,6 +431,9 @@ public class JournalArticleSitemapURLProviderTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private JournalArticleLocalService _journalArticleLocalService;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47709

When we are disabling a language, for example German, when we are calling to http://localhost:8080/sitemap.xml poiting to the layout and we have a german translation for a content we should not return the sitemap url for the german url content.

# How am I fixing it?

Do not included content sitemap URLs for disabled languages.

# How can you verify that it works?

Run included tests.
