### PR TITLE
LPD-45800 Support permissions import/export for vocabularies leveraging Batch

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
@@ -662,6 +662,53 @@ public class TaxonomyVocabulary implements Serializable {
 	@JsonIgnore
 	private Supplier<Integer> _numberOfTaxonomyCategoriesSupplier;
 
+	@Schema
+	@Valid
+	public com.liferay.portal.vulcan.permission.Permission[] getPermissions() {
+		if (_permissionsSupplier != null) {
+			permissions = _permissionsSupplier.get();
+
+			_permissionsSupplier = null;
+		}
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.portal.vulcan.permission.Permission[] permissions) {
+
+		this.permissions = permissions;
+
+		_permissionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.portal.vulcan.permission.Permission[], Exception>
+				permissionsUnsafeSupplier) {
+
+		_permissionsSupplier = () -> {
+			try {
+				return permissionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected com.liferay.portal.vulcan.permission.Permission[] permissions;
+
+	@JsonIgnore
+	private Supplier<com.liferay.portal.vulcan.permission.Permission[]>
+		_permissionsSupplier;
+
 	@Schema(
 		description = "The external reference code of the site to which this vocabulary is scoped."
 	)
@@ -1056,6 +1103,29 @@ public class TaxonomyVocabulary implements Serializable {
 			sb.append("\"numberOfTaxonomyCategories\": ");
 
 			sb.append(numberOfTaxonomyCategories);
+		}
+
+		com.liferay.portal.vulcan.permission.Permission[] permissions =
+			getPermissions();
+
+		if (permissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < permissions.length; i++) {
+				sb.append(permissions[i]);
+
+				if ((i + 1) < permissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		String siteExternalReferenceCode = getSiteExternalReferenceCode();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
@@ -324,6 +324,35 @@ public class TaxonomyVocabulary implements Cloneable, Serializable {
 
 	protected Integer numberOfTaxonomyCategories;
 
+	public com.liferay.headless.admin.taxonomy.client.permission.Permission[]
+		getPermissions() {
+
+		return permissions;
+	}
+
+	public void setPermissions(
+		com.liferay.headless.admin.taxonomy.client.permission.Permission[]
+			permissions) {
+
+		this.permissions = permissions;
+	}
+
+	public void setPermissions(
+		UnsafeSupplier
+			<com.liferay.headless.admin.taxonomy.client.permission.Permission[],
+			 Exception> permissionsUnsafeSupplier) {
+
+		try {
+			permissions = permissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected com.liferay.headless.admin.taxonomy.client.permission.Permission[]
+		permissions;
+
 	public String getSiteExternalReferenceCode() {
 		return siteExternalReferenceCode;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
@@ -249,6 +249,28 @@ public class TaxonomyVocabularySerDes {
 			sb.append(taxonomyVocabulary.getNumberOfTaxonomyCategories());
 		}
 
+		if (taxonomyVocabulary.getPermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"permissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < taxonomyVocabulary.getPermissions().length;
+				 i++) {
+
+				sb.append(taxonomyVocabulary.getPermissions()[i]);
+
+				if ((i + 1) < taxonomyVocabulary.getPermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (taxonomyVocabulary.getSiteExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -432,6 +454,15 @@ public class TaxonomyVocabularySerDes {
 					taxonomyVocabulary.getNumberOfTaxonomyCategories()));
 		}
 
+		if (taxonomyVocabulary.getPermissions() == null) {
+			map.put("permissions", null);
+		}
+		else {
+			map.put(
+				"permissions",
+				String.valueOf(taxonomyVocabulary.getPermissions()));
+		}
+
 		if (taxonomyVocabulary.getSiteExternalReferenceCode() == null) {
 			map.put("siteExternalReferenceCode", null);
 		}
@@ -522,6 +553,9 @@ public class TaxonomyVocabularySerDes {
 			else if (Objects.equals(
 						jsonParserFieldName, "numberOfTaxonomyCategories")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
 			else if (Objects.equals(
@@ -641,6 +675,26 @@ public class TaxonomyVocabularySerDes {
 				if (jsonParserFieldValue != null) {
 					taxonomyVocabulary.setNumberOfTaxonomyCategories(
 						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "permissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					com.liferay.headless.admin.taxonomy.client.permission.
+						Permission[] permissionsArray = new
+						com.liferay.headless.admin.taxonomy.client.permission.
+							Permission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < permissionsArray.length; i++) {
+						permissionsArray[i] =
+							com.liferay.headless.admin.taxonomy.client.
+								permission.Permission.toDTO(
+									(String)jsonParserFieldValues[i]);
+					}
+
+					taxonomyVocabulary.setPermissions(permissionsArray);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -387,6 +387,10 @@ components:
                         The number of categories that directly depend on this vocabulary.
                     readOnly: true
                     type: integer
+                permissions:
+                    items:
+                        type: permission
+                    type: array
                 siteExternalReferenceCode:
                     description:
                         The external reference code of the site to which this vocabulary is scoped.

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -433,7 +433,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryTaxonomyVocabularyByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryTaxonomyVocabularyByExternalReferenceCode(assetLibraryId: ___, externalReferenceCode: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, permissions, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the asset library's taxonomy vocabulary by external reference code."
@@ -510,7 +510,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabularyByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabularyByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, permissions, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves the site's taxonomy vocabulary by external reference code."
@@ -552,7 +552,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabulary(taxonomyVocabularyId: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabulary(taxonomyVocabularyId: ___){actions, assetLibraryKey, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, permissions, siteExternalReferenceCode, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a taxonomy vocabulary.")
 	public TaxonomyVocabulary taxonomyVocabulary(
@@ -584,33 +584,6 @@ public class Query {
 			taxonomyVocabularyResource -> new TaxonomyVocabularyPage(
 				taxonomyVocabularyResource.getTaxonomyVocabularyPermissionsPage(
 					taxonomyVocabularyId, roleNames)));
-	}
-
-	@GraphQLTypeExtension(TaxonomyVocabulary.class)
-	public class GetTaxonomyVocabularyPermissionsPageTypeExtension {
-
-		public GetTaxonomyVocabularyPermissionsPageTypeExtension(
-			TaxonomyVocabulary taxonomyVocabulary) {
-
-			_taxonomyVocabulary = taxonomyVocabulary;
-		}
-
-		@GraphQLField
-		public TaxonomyVocabularyPage permissions(
-				@GraphQLName("roleNames") String roleNames)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_taxonomyVocabularyResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				taxonomyVocabularyResource -> new TaxonomyVocabularyPage(
-					taxonomyVocabularyResource.
-						getTaxonomyVocabularyPermissionsPage(
-							_taxonomyVocabulary.getId(), roleNames)));
-		}
-
-		private TaxonomyVocabulary _taxonomyVocabulary;
-
 	}
 
 	@GraphQLTypeExtension(TaxonomyVocabulary.class)

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -431,11 +431,6 @@ public class ServletDataImpl implements ServletData {
 							"getTaxonomyVocabularyPermissionsPage"));
 
 					put(
-						"query#TaxonomyVocabulary.permissions",
-						new ObjectValuePair<>(
-							TaxonomyVocabularyResourceImpl.class,
-							"getTaxonomyVocabularyPermissionsPage"));
-					put(
 						"query#TaxonomyVocabulary.taxonomyCategories",
 						new ObjectValuePair<>(
 							TaxonomyCategoryResourceImpl.class,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -250,7 +250,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -437,7 +437,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the asset library's taxonomy vocabulary with the given external reference code, or creates it if it not exists."
@@ -808,7 +808,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Inserts a new taxonomy vocabulary in a Site."
@@ -995,7 +995,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the site's taxonomy vocabulary with the given external reference code, or creates it if it not exists."
@@ -1317,7 +1317,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body. Any other fields are left untouched."
@@ -1375,6 +1375,11 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getName_i18n());
 		}
 
+		if (taxonomyVocabulary.getPermissions() != null) {
+			existingTaxonomyVocabulary.setPermissions(
+				taxonomyVocabulary.getPermissions());
+		}
+
 		if (taxonomyVocabulary.getViewableBy() != null) {
 			existingTaxonomyVocabulary.setViewableBy(
 				taxonomyVocabulary.getViewableBy());
@@ -1389,7 +1394,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}' -d $'{"assetTypes": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "permissions": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Replaces the taxonomy vocabulary with the information sent in the request body. Any missing fields are deleted unless they are required."

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.PermissionService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -286,7 +285,10 @@ public class TaxonomyVocabularyResourceImpl
 				taxonomyVocabulary.getDescription(),
 				taxonomyVocabulary.getDescription_i18n()),
 			_getSettings(assetTypes, assetVocabulary.getGroupId()),
-			new ServiceContext());
+			ServiceContextBuilder.create(
+				assetVocabulary.getGroupId(), contextHttpServletRequest,
+				taxonomyVocabulary.getViewableByAsString()
+			).build());
 
 		Permission[] permissions = taxonomyVocabulary.getPermissions();
 
@@ -825,7 +827,10 @@ public class TaxonomyVocabularyResourceImpl
 			_getSettings(
 				taxonomyVocabulary.getAssetTypes(),
 				assetVocabulary.getGroupId()),
-			new ServiceContext());
+			ServiceContextBuilder.create(
+				assetVocabulary.getGroupId(), contextHttpServletRequest,
+				taxonomyVocabulary.getViewableByAsString()
+			).build());
 
 		Permission[] permissions = taxonomyVocabulary.getPermissions();
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -273,21 +273,35 @@ public class TaxonomyVocabularyResourceImpl
 				assetVocabulary.getGroupId());
 		}
 
-		return _toTaxonomyVocabulary(
-			_assetVocabularyService.updateVocabulary(
-				assetVocabulary.getVocabularyId(), null,
-				LocalizedMapUtil.patchLocalizedMap(
-					assetVocabulary.getTitleMap(),
-					contextAcceptLanguage.getPreferredLocale(),
-					taxonomyVocabulary.getName(),
-					taxonomyVocabulary.getName_i18n()),
-				LocalizedMapUtil.patchLocalizedMap(
-					assetVocabulary.getDescriptionMap(),
-					contextAcceptLanguage.getPreferredLocale(),
-					taxonomyVocabulary.getDescription(),
-					taxonomyVocabulary.getDescription_i18n()),
-				_getSettings(assetTypes, assetVocabulary.getGroupId()),
-				new ServiceContext()));
+		assetVocabulary = _assetVocabularyService.updateVocabulary(
+			assetVocabulary.getVocabularyId(), null,
+			LocalizedMapUtil.patchLocalizedMap(
+				assetVocabulary.getTitleMap(),
+				contextAcceptLanguage.getPreferredLocale(),
+				taxonomyVocabulary.getName(),
+				taxonomyVocabulary.getName_i18n()),
+			LocalizedMapUtil.patchLocalizedMap(
+				assetVocabulary.getDescriptionMap(),
+				contextAcceptLanguage.getPreferredLocale(),
+				taxonomyVocabulary.getDescription(),
+				taxonomyVocabulary.getDescription_i18n()),
+			_getSettings(assetTypes, assetVocabulary.getGroupId()),
+			new ServiceContext());
+
+		Permission[] permissions = taxonomyVocabulary.getPermissions();
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-41304") &&
+			(permissions != null)) {
+
+			putTaxonomyVocabularyPermissionsPage(
+				assetVocabulary.getVocabularyId(),
+				taxonomyVocabulary.getPermissions());
+
+			assetVocabulary = _assetVocabularyService.getVocabulary(
+				assetVocabulary.getVocabularyId());
+		}
+
+		return _toTaxonomyVocabulary(assetVocabulary);
 	}
 
 	@Override
@@ -806,12 +820,27 @@ public class TaxonomyVocabularyResourceImpl
 			false, LocaleUtil.getSiteDefault(), "Taxonomy vocabulary", titleMap,
 			new HashSet<>(descriptionMap.keySet()));
 
-		return _assetVocabularyService.updateVocabulary(
+		assetVocabulary = _assetVocabularyService.updateVocabulary(
 			assetVocabulary.getVocabularyId(), null, titleMap, descriptionMap,
 			_getSettings(
 				taxonomyVocabulary.getAssetTypes(),
 				assetVocabulary.getGroupId()),
 			new ServiceContext());
+
+		Permission[] permissions = taxonomyVocabulary.getPermissions();
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-41304") &&
+			(permissions != null)) {
+
+			putTaxonomyVocabularyPermissionsPage(
+				assetVocabulary.getVocabularyId(),
+				taxonomyVocabulary.getPermissions());
+
+			assetVocabulary = _assetVocabularyService.getVocabulary(
+				assetVocabulary.getVocabularyId());
+		}
+
+		return assetVocabulary;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -23,6 +23,9 @@ import com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0.Vocabulary
 import com.liferay.headless.admin.taxonomy.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
@@ -32,6 +35,8 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.service.PermissionService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -46,6 +51,8 @@ import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.action.DTOActionProvider;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
+import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.ContentLanguageUtil;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -54,6 +61,7 @@ import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
 import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -723,6 +731,37 @@ public class TaxonomyVocabularyResourceImpl
 
 						return 0;
 					});
+				setPermissions(
+					() -> {
+						if (!FeatureFlagManagerUtil.isEnabled("LPD-41304")) {
+							return null;
+						}
+
+						try {
+							_permissionService.checkPermission(
+								assetVocabulary.getGroupId(),
+								AssetVocabulary.class.getName(),
+								assetVocabulary.getVocabularyId());
+
+							Collection<Permission> permissions =
+								PermissionUtil.getPermissions(
+									assetVocabulary.getCompanyId(),
+									_resourceActionLocalService.
+										getResourceActions(
+											AssetVocabulary.class.getName()),
+									assetVocabulary.getVocabularyId(),
+									AssetVocabulary.class.getName(), null);
+
+							return permissions.toArray(new Permission[0]);
+						}
+						catch (Exception exception) {
+							if (_log.isDebugEnabled()) {
+								_log.debug(exception);
+							}
+
+							return null;
+						}
+					});
 				setSiteId(() -> GroupUtil.getSiteId(group));
 			}
 		};
@@ -754,6 +793,9 @@ public class TaxonomyVocabularyResourceImpl
 				assetVocabulary.getGroupId()),
 			new ServiceContext());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TaxonomyVocabularyResourceImpl.class);
 
 	private static final Map<String, String> _assetTypeTypeToClassNames =
 		new HashMap<>();
@@ -789,7 +831,13 @@ public class TaxonomyVocabularyResourceImpl
 	private DTOActionProvider _dtoActionProvider;
 
 	@Reference
+	private PermissionService _permissionService;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.PermissionService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -51,6 +52,7 @@ import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.action.DTOActionProvider;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.ContentLanguageUtil;
@@ -411,6 +413,8 @@ public class TaxonomyVocabularyResourceImpl
 			ServiceContextBuilder.create(
 				siteId, contextHttpServletRequest,
 				taxonomyVocabulary.getViewableByAsString()
+			).permissions(
+				_getModelPermissions(taxonomyVocabulary)
 			).build());
 	}
 
@@ -602,6 +606,22 @@ public class TaxonomyVocabularyResourceImpl
 		}
 
 		throw new BadRequestException("Invalid subtype " + subtype);
+	}
+
+	private ModelPermissions _getModelPermissions(
+			TaxonomyVocabulary taxonomyVocabulary)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-41304")) {
+			return null;
+		}
+
+		return ModelPermissionsUtil.toModelPermissions(
+			contextCompany.getCompanyId(), taxonomyVocabulary.getPermissions(),
+			getPermissionCheckerResourceId(taxonomyVocabulary.getId()),
+			getPermissionCheckerResourceName(taxonomyVocabulary.getId()),
+			resourceActionLocalService, resourcePermissionLocalService,
+			roleLocalService);
 	}
 
 	private String _getModelResource(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -2744,6 +2744,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (taxonomyVocabulary.getPermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"siteExternalReferenceCode", additionalAssertFieldName)) {
 
@@ -3027,6 +3035,17 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				if (!Objects.deepEquals(
 						taxonomyVocabulary1.getNumberOfTaxonomyCategories(),
 						taxonomyVocabulary2.getNumberOfTaxonomyCategories())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("permissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taxonomyVocabulary1.getPermissions(),
+						taxonomyVocabulary2.getPermissions())) {
 
 					return false;
 				}
@@ -3455,6 +3474,11 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 					taxonomyVocabulary.getNumberOfTaxonomyCategories()));
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("permissions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("siteExternalReferenceCode")) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -62,6 +62,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -982,14 +983,15 @@ public class TaxonomyCategoryResourceTest
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		Permission permission = new Permission() {
-			{
-				actionIds = new String[] {ActionKeys.DELETE};
-				roleName = role.getName();
-			}
-		};
-
-		randomTaxonomyCategory.setPermissions(new Permission[] {permission});
+		randomTaxonomyCategory.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						actionIds = new String[] {ActionKeys.DELETE};
+						roleName = role.getName();
+					}
+				}
+			});
 
 		TaxonomyCategory postTaxonomyCategory =
 			testPostTaxonomyCategoryTaxonomyCategory_addTaxonomyCategory(
@@ -1001,15 +1003,23 @@ public class TaxonomyCategoryResourceTest
 		Assert.assertEquals(
 			Arrays.toString(permissions), 2, permissions.length);
 
-		_assertPermissions(
-			new String[] {
-				ActionKeys.ADD_CATEGORY, ActionKeys.DELETE,
-				ActionKeys.PERMISSIONS, ActionKeys.UPDATE, ActionKeys.VIEW
-			},
-			permissions[0], RoleConstants.OWNER);
+		for (Permission permission : permissions) {
+			if (Objects.equals(permission.getRoleName(), role.getName())) {
+				Assert.assertArrayEquals(
+					new String[] {ActionKeys.DELETE},
+					permission.getActionIds());
+			}
 
-		_assertPermissions(
-			new String[] {ActionKeys.DELETE}, permissions[1], role.getName());
+			if (Objects.equals(permission.getRoleName(), RoleConstants.OWNER)) {
+				Assert.assertArrayEquals(
+					new String[] {
+						ActionKeys.ADD_CATEGORY, ActionKeys.DELETE,
+						ActionKeys.PERMISSIONS, ActionKeys.UPDATE,
+						ActionKeys.VIEW
+					},
+					permission.getActionIds());
+			}
+		}
 	}
 
 	private void _testPutTaxonomyCategoryWithPermissions() throws Exception {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -42,7 +42,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -447,21 +446,6 @@ public class TaxonomyCategoryResourceTest
 
 		return taxonomyCategoryResource.postTaxonomyCategoryTaxonomyCategory(
 			parentTaxonomyCategoryId, taxonomyCategory);
-	}
-
-	private void _assertPermissions(
-		String[] expectedActionIds, Permission permission, String role) {
-
-		Assert.assertEquals(
-			expectedActionIds.length, permission.getActionIds().length);
-
-		Object[] actionIds = permission.getActionIds();
-
-		for (String expectedActionId : expectedActionIds) {
-			Assert.assertTrue(ArrayUtil.contains(actionIds, expectedActionId));
-		}
-
-		Assert.assertEquals(role, permission.getRoleName());
 	}
 
 	private void _assertTaxonomyCategoriesPageOrder(
@@ -1030,14 +1014,15 @@ public class TaxonomyCategoryResourceTest
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		Permission permission = new Permission() {
-			{
-				actionIds = new String[] {ActionKeys.VIEW};
-				roleName = role.getName();
-			}
-		};
-
-		randomTaxonomyCategory.setPermissions(new Permission[] {permission});
+		randomTaxonomyCategory.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						actionIds = new String[] {ActionKeys.VIEW};
+						roleName = role.getName();
+					}
+				}
+			});
 
 		TaxonomyCategory putTaxonomyCategory =
 			taxonomyCategoryResource.putTaxonomyCategory(
@@ -1049,8 +1034,12 @@ public class TaxonomyCategoryResourceTest
 		Assert.assertEquals(
 			Arrays.toString(permissions), 1, permissions.length);
 
-		_assertPermissions(
-			new String[] {ActionKeys.VIEW}, permissions[0], role.getName());
+		Permission permission = permissions[0];
+
+		Assert.assertArrayEquals(
+			new String[] {ActionKeys.VIEW}, permission.getActionIds());
+
+		Assert.assertEquals(role.getName(), permission.getRoleName());
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -1013,8 +1013,8 @@ public class TaxonomyCategoryResourceTest
 			if (Objects.equals(permission.getRoleName(), RoleConstants.OWNER)) {
 				Assert.assertArrayEquals(
 					new String[] {
-						ActionKeys.ADD_CATEGORY, ActionKeys.DELETE,
-						ActionKeys.PERMISSIONS, ActionKeys.UPDATE,
+						ActionKeys.DELETE, ActionKeys.PERMISSIONS,
+						ActionKeys.ADD_CATEGORY, ActionKeys.UPDATE,
 						ActionKeys.VIEW
 					},
 					permission.getActionIds());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -6,10 +6,12 @@
 package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyVocabulary;
 import com.liferay.headless.admin.taxonomy.client.pagination.Page;
 import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
+import com.liferay.headless.admin.taxonomy.client.permission.Permission;
 import com.liferay.headless.admin.taxonomy.client.problem.Problem;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyVocabularySerDes;
@@ -17,10 +19,19 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Arrays;
@@ -264,61 +275,15 @@ public class TaxonomyVocabularyResourceTest
 			).build());
 	}
 
+	@FeatureFlags("LPD-41304")
 	@Override
 	@Test
 	public void testGetTaxonomyVocabulary() throws Exception {
 		super.testGetTaxonomyVocabulary();
 
-		TaxonomyVocabulary postTaxonomyVocabulary =
-			testGetTaxonomyVocabulary_addTaxonomyVocabulary();
+		_testGetTaxonomyVocabularyActions();
 
-		TaxonomyVocabulary getTaxonomyVocabulary =
-			taxonomyVocabularyResource.getTaxonomyVocabulary(
-				postTaxonomyVocabulary.getId());
-
-		assertValid(
-			getTaxonomyVocabulary.getActions(),
-			HashMapBuilder.<String, Map<String, String>>put(
-				"delete",
-				HashMapBuilder.put(
-					"href",
-					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
-						"/taxonomy-vocabularies/" +
-							getTaxonomyVocabulary.getId()
-				).put(
-					"method", "DELETE"
-				).build()
-			).put(
-				"get",
-				HashMapBuilder.put(
-					"href",
-					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
-						"/taxonomy-vocabularies/" +
-							getTaxonomyVocabulary.getId()
-				).put(
-					"method", "GET"
-				).build()
-			).put(
-				"replace",
-				HashMapBuilder.put(
-					"href",
-					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
-						"/taxonomy-vocabularies/" +
-							getTaxonomyVocabulary.getId()
-				).put(
-					"method", "PUT"
-				).build()
-			).put(
-				"update",
-				HashMapBuilder.put(
-					"href",
-					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
-						"/taxonomy-vocabularies/" +
-							getTaxonomyVocabulary.getId()
-				).put(
-					"method", "PATCH"
-				).build()
-			).build());
+		_testGetTaxonomyVocabularyWithPermissions();
 	}
 
 	@Override
@@ -514,5 +479,96 @@ public class TaxonomyVocabularyResourceTest
 
 		return testDepotEntry.getDepotEntryId();
 	}
+
+	private void _testGetTaxonomyVocabularyActions() throws Exception {
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testGetTaxonomyVocabulary_addTaxonomyVocabulary();
+
+		TaxonomyVocabulary getTaxonomyVocabulary =
+			taxonomyVocabularyResource.getTaxonomyVocabulary(
+				postTaxonomyVocabulary.getId());
+
+		assertValid(
+			getTaxonomyVocabulary.getActions(),
+			HashMapBuilder.<String, Map<String, String>>put(
+				"delete",
+				HashMapBuilder.put(
+					"href",
+					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
+						"/taxonomy-vocabularies/" +
+							getTaxonomyVocabulary.getId()
+				).put(
+					"method", "DELETE"
+				).build()
+			).put(
+				"get",
+				HashMapBuilder.put(
+					"href",
+					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
+						"/taxonomy-vocabularies/" +
+							getTaxonomyVocabulary.getId()
+				).put(
+					"method", "GET"
+				).build()
+			).put(
+				"replace",
+				HashMapBuilder.put(
+					"href",
+					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
+						"/taxonomy-vocabularies/" +
+							getTaxonomyVocabulary.getId()
+				).put(
+					"method", "PUT"
+				).build()
+			).put(
+				"update",
+				HashMapBuilder.put(
+					"href",
+					"http://localhost:8080/o/headless-admin-taxonomy/v1.0" +
+						"/taxonomy-vocabularies/" +
+							getTaxonomyVocabulary.getId()
+				).put(
+					"method", "PATCH"
+				).build()
+			).build());
+	}
+
+	private void _testGetTaxonomyVocabularyWithPermissions() throws Exception {
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testGetTaxonomyVocabulary_addTaxonomyVocabulary();
+
+		_resourcePermissionLocalService.deleteResourcePermissions(
+			testCompany.getCompanyId(), AssetVocabulary.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, postTaxonomyVocabulary.getId());
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), AssetVocabulary.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(postTaxonomyVocabulary.getId()), role.getRoleId(),
+			new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS});
+
+		TaxonomyVocabulary getTaxonomyVocabulary =
+			taxonomyVocabularyResource.getTaxonomyVocabulary(
+				postTaxonomyVocabulary.getId());
+
+		Assert.assertNotNull(getTaxonomyVocabulary.getPermissions());
+
+		Permission[] permissions = getTaxonomyVocabulary.getPermissions();
+
+		Assert.assertEquals(
+			Arrays.toString(permissions), 1, permissions.length);
+
+		Permission permission = permissions[0];
+
+		Assert.assertEquals(role.getName(), permission.getRoleName());
+		Assert.assertEquals(
+			new Object[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
+			permission.getActionIds());
+	}
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.util.PropsValues;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -368,6 +369,24 @@ public class TaxonomyVocabularyResourceTest
 					taxonomyVocabulariesJSONObject.getString("items"))));
 	}
 
+	@FeatureFlags("LPD-41304")
+	@Override
+	@Test
+	public void testPostAssetLibraryTaxonomyVocabulary() throws Exception {
+		super.testPostAssetLibraryTaxonomyVocabulary();
+
+		_testPostAssetLibraryTaxonomyVocabularyWithPermissions();
+	}
+
+	@FeatureFlags("LPD-41304")
+	@Override
+	@Test
+	public void testPostSiteTaxonomyVocabulary() throws Exception {
+		super.testPostSiteTaxonomyVocabulary();
+
+		_testPostSiteTaxonomyVocabularyWithPermissions();
+	}
+
 	@Override
 	@Test
 	public void testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode()
@@ -607,6 +626,98 @@ public class TaxonomyVocabularyResourceTest
 		Assert.assertArrayEquals(
 			new Object[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
 			permission.getActionIds());
+	}
+
+	private void _testPostAssetLibraryTaxonomyVocabularyWithPermissions()
+		throws Exception {
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		randomTaxonomyVocabulary.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						actionIds = new String[] {ActionKeys.DELETE};
+						roleName = role.getName();
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testPostAssetLibraryTaxonomyVocabulary_addTaxonomyVocabulary(
+				randomTaxonomyVocabulary);
+
+		Permission[] permissions = postTaxonomyVocabulary.getPermissions();
+
+		Assert.assertNotNull(permissions);
+		Assert.assertEquals(
+			Arrays.toString(permissions), 2, permissions.length);
+
+		for (Permission permission : permissions) {
+			if (Objects.equals(permission.getRoleName(), role.getName())) {
+				Assert.assertArrayEquals(
+					new String[] {ActionKeys.DELETE},
+					permission.getActionIds());
+			}
+
+			if (Objects.equals(permission.getRoleName(), RoleConstants.OWNER)) {
+				Assert.assertArrayEquals(
+					new String[] {
+						ActionKeys.DELETE, ActionKeys.PERMISSIONS,
+						ActionKeys.UPDATE, ActionKeys.VIEW
+					},
+					permission.getActionIds());
+			}
+		}
+	}
+
+	private void _testPostSiteTaxonomyVocabularyWithPermissions()
+		throws Exception {
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		randomTaxonomyVocabulary.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						actionIds = new String[] {ActionKeys.DELETE};
+						roleName = role.getName();
+					}
+				}
+			});
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			testPostSiteTaxonomyVocabulary_addTaxonomyVocabulary(
+				randomTaxonomyVocabulary);
+
+		Permission[] permissions = postTaxonomyVocabulary.getPermissions();
+
+		Assert.assertNotNull(permissions);
+		Assert.assertEquals(
+			Arrays.toString(permissions), 2, permissions.length);
+
+		for (Permission permission : permissions) {
+			if (Objects.equals(permission.getRoleName(), role.getName())) {
+				Assert.assertArrayEquals(
+					new String[] {ActionKeys.DELETE},
+					permission.getActionIds());
+			}
+
+			if (Objects.equals(permission.getRoleName(), RoleConstants.OWNER)) {
+				Assert.assertArrayEquals(
+					new String[] {
+						ActionKeys.DELETE, ActionKeys.PERMISSIONS,
+						ActionKeys.UPDATE, ActionKeys.VIEW
+					},
+					permission.getActionIds());
+			}
+		}
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -387,6 +387,7 @@ public class TaxonomyVocabularyResourceTest
 		_testPostSiteTaxonomyVocabularyWithPermissions();
 	}
 
+	@FeatureFlags("LPD-41304")
 	@Override
 	@Test
 	public void testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode()
@@ -394,22 +395,28 @@ public class TaxonomyVocabularyResourceTest
 
 		super.testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode();
 
-		String externalReferenceCode = StringUtil.toLowerCase(
-			RandomTestUtil.randomString());
+		_testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithExternalReferenceCode();
+		_testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithPermissions();
+	}
 
-		TaxonomyVocabulary taxonomyVocabulary =
-			testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_createTaxonomyVocabulary();
+	@FeatureFlags("LPD-41304")
+	@Override
+	@Test
+	public void testPutSiteTaxonomyVocabularyByExternalReferenceCode()
+		throws Exception {
 
-		TaxonomyVocabulary putTaxonomyVocabulary =
-			taxonomyVocabularyResource.
-				putAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
-					testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
-					externalReferenceCode, taxonomyVocabulary);
+		super.testPutSiteTaxonomyVocabularyByExternalReferenceCode();
 
-		Assert.assertEquals(
-			externalReferenceCode,
-			putTaxonomyVocabulary.getExternalReferenceCode());
-		assertValid(putTaxonomyVocabulary);
+		_testPutSiteTaxonomyVocabularyByExternalReferenceCodeWithPermissions();
+	}
+
+	@FeatureFlags("LPD-41304")
+	@Override
+	@Test
+	public void testPutTaxonomyVocabulary() throws Exception {
+		super.testPutTaxonomyVocabulary();
+
+		_testPutTaxonomyVocabularyWithPermissions();
 	}
 
 	@Override
@@ -718,6 +725,150 @@ public class TaxonomyVocabularyResourceTest
 					permission.getActionIds());
 			}
 		}
+	}
+
+	private void _testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithExternalReferenceCode()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		TaxonomyVocabulary taxonomyVocabulary =
+			testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.
+				putAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+					testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
+					externalReferenceCode, taxonomyVocabulary);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			putTaxonomyVocabulary.getExternalReferenceCode());
+		assertValid(putTaxonomyVocabulary);
+	}
+
+	private void _testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCodeWithPermissions()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		TaxonomyVocabulary taxonomyVocabulary =
+			testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_createTaxonomyVocabulary();
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.
+				putAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+					testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
+					externalReferenceCode, taxonomyVocabulary);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		Permission permission = new Permission() {
+			{
+				actionIds = new String[] {ActionKeys.VIEW};
+				roleName = role.getName();
+			}
+		};
+
+		putTaxonomyVocabulary.setPermissions(new Permission[] {permission});
+
+		putTaxonomyVocabulary =
+			taxonomyVocabularyResource.
+				putAssetLibraryTaxonomyVocabularyByExternalReferenceCode(
+					testPutAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),
+					putTaxonomyVocabulary.getExternalReferenceCode(),
+					putTaxonomyVocabulary);
+
+		Permission[] permissions = putTaxonomyVocabulary.getPermissions();
+
+		Assert.assertNotNull(permissions);
+		Assert.assertEquals(
+			Arrays.toString(permissions), 1, permissions.length);
+
+		Assert.assertEquals(permission.getRoleName(), role.getName());
+		Assert.assertArrayEquals(
+			new String[] {ActionKeys.VIEW}, permission.getActionIds());
+	}
+
+	private void _testPutSiteTaxonomyVocabularyByExternalReferenceCodeWithPermissions()
+		throws Exception {
+
+		String externalReferenceCode = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		TaxonomyVocabulary taxonomyVocabulary =
+			testPutSiteTaxonomyVocabularyByExternalReferenceCode_createTaxonomyVocabulary();
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.
+				putSiteTaxonomyVocabularyByExternalReferenceCode(
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						taxonomyVocabulary),
+					externalReferenceCode, taxonomyVocabulary);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		Permission permission = new Permission() {
+			{
+				actionIds = new String[] {ActionKeys.VIEW};
+				roleName = role.getName();
+			}
+		};
+
+		putTaxonomyVocabulary.setPermissions(new Permission[] {permission});
+
+		putTaxonomyVocabulary =
+			taxonomyVocabularyResource.
+				putSiteTaxonomyVocabularyByExternalReferenceCode(
+					testPutSiteTaxonomyVocabularyByExternalReferenceCode_getSiteId(
+						putTaxonomyVocabulary),
+					putTaxonomyVocabulary.getExternalReferenceCode(),
+					putTaxonomyVocabulary);
+
+		Permission[] permissions = putTaxonomyVocabulary.getPermissions();
+
+		Assert.assertNotNull(permissions);
+		Assert.assertEquals(
+			Arrays.toString(permissions), 1, permissions.length);
+
+		Assert.assertEquals(permission.getRoleName(), role.getName());
+		Assert.assertArrayEquals(
+			new String[] {ActionKeys.VIEW}, permission.getActionIds());
+	}
+
+	private void _testPutTaxonomyVocabularyWithPermissions() throws Exception {
+		TaxonomyVocabulary taxonomyVocabulary =
+			testPutTaxonomyVocabulary_addTaxonomyVocabulary();
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		Permission permission = new Permission() {
+			{
+				actionIds = new String[] {ActionKeys.VIEW};
+				roleName = role.getName();
+			}
+		};
+
+		randomTaxonomyVocabulary.setPermissions(new Permission[] {permission});
+
+		TaxonomyVocabulary putTaxonomyVocabulary =
+			taxonomyVocabularyResource.putTaxonomyVocabulary(
+				taxonomyVocabulary.getId(), randomTaxonomyVocabulary);
+
+		Permission[] permissions = putTaxonomyVocabulary.getPermissions();
+
+		Assert.assertNotNull(permissions);
+		Assert.assertEquals(
+			Arrays.toString(permissions), 1, permissions.length);
+
+		Assert.assertEquals(permission.getRoleName(), role.getName());
+		Assert.assertArrayEquals(
+			new String[] {ActionKeys.VIEW}, permission.getActionIds());
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -21,12 +21,15 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -282,7 +285,7 @@ public class TaxonomyVocabularyResourceTest
 		super.testGetTaxonomyVocabulary();
 
 		_testGetTaxonomyVocabularyActions();
-
+		_testGetTaxonomyVocabularyWithoutPermissionsAction();
 		_testGetTaxonomyVocabularyWithPermissions();
 	}
 
@@ -533,6 +536,44 @@ public class TaxonomyVocabularyResourceTest
 			).build());
 	}
 
+	private void _testGetTaxonomyVocabularyWithoutPermissionsAction()
+		throws Exception {
+
+		TaxonomyVocabulary randomTaxonomyVocabulary =
+			randomTaxonomyVocabulary();
+
+		randomTaxonomyVocabulary.setViewableBy(
+			TaxonomyVocabulary.ViewableBy.MEMBERS);
+
+		TaxonomyVocabulary postTaxonomyVocabulary =
+			taxonomyVocabularyResource.postSiteTaxonomyVocabulary(
+				testGroup.getGroupId(), randomTaxonomyVocabulary);
+
+		User siteMemberUser = UserTestUtil.addGroupUser(
+			testGroup, RoleConstants.SITE_MEMBER);
+
+		String password = RandomTestUtil.randomString();
+
+		_userLocalService.updatePassword(
+			siteMemberUser.getUserId(), password, password, false, true);
+
+		TaxonomyVocabularyResource siteMemberTaxonomyVocabularyResource =
+			TaxonomyVocabularyResource.builder(
+			).authentication(
+				siteMemberUser.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		TaxonomyVocabulary getTaxonomyVocabulary =
+			siteMemberTaxonomyVocabularyResource.getTaxonomyVocabulary(
+				postTaxonomyVocabulary.getId());
+
+		Assert.assertNull(getTaxonomyVocabulary.getPermissions());
+	}
+
 	private void _testGetTaxonomyVocabularyWithPermissions() throws Exception {
 		TaxonomyVocabulary postTaxonomyVocabulary =
 			testGetTaxonomyVocabulary_addTaxonomyVocabulary();
@@ -563,12 +604,15 @@ public class TaxonomyVocabularyResourceTest
 		Permission permission = permissions[0];
 
 		Assert.assertEquals(role.getName(), permission.getRoleName());
-		Assert.assertEquals(
+		Assert.assertArrayEquals(
 			new Object[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
 			permission.getActionIds());
 	}
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
LPD-45800 Embed the Vocabulary permissions property for GET, POST and PUT requests


Note: this PR should be send after the changes on https://github.com/liferay-content-management/liferay-portal/pull/6299 are merged

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47085
https://liferay.atlassian.net/browse/LPD-47633
https://liferay.atlassian.net/browse/LPD-47634

For batch import/export we also want to include the permissions of Vocabularies. For this reason we add a new property to TaxonomyVocabulary with the permissions that we have. 
We adapt the code for GET, POST and PUT calls

# How am I fixing it?

Just add the new property and adapt the code to take it into account


# How can you verify that it works?

Run the included automated tests.

Or manual testing: 

1. Enable FF for LPD-41304 (very important)
2. Create a new Vocabulary
3. Go to http://localhost:8080/o/api?endpoint=http://localhost:8080/o/headless-admin-taxonomy/v1.0/openapi.json (notice that we want another application)
4. Find /v1.0/taxonomy-vocabularies/{taxonomyVocabularyId} with GET method and expand the section
5. Specify the vocabularyId that was created
6. Press execute
	
	Results will contain the permissions of the category

Note : 
 For post and put you would have to call the corresponding endpoints

# Commits


- **LPD-47085 adds permissions property to TaxonomyVocabulary**
- **LPD-47085 buildRest**
- **LPD-47085 Embed new property as part of GET request taking into account that the user can have permission to see the vocabulary but not to see the permissions of the vocabulary**
- **LPD-47085 add test to check that under the FF if user has the permissions you can see them**
- **LPD-47085 add test to check that without permissions permission you can not see the permission field**
- **LPD-47633 take into account the permissions when creating a vocabulary**
- **LPD-47633 add test to check that the post, with the FF active, is returning the permissions**
- **LPD-47634 take into account the permissions when updating a vocabulary if FF is active**
- **LPD-47634 take into account the viewableBy when updating the Vocabulary**
- **LPD-47634 add test to check that when updating, with the FF active, is returning the permissions**
