### PR TITLE
LPD-47853 fix poshi auto tagging in asset library images (again)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/document-libary/JSONDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/document-libary/JSONDocument.macro
@@ -185,7 +185,7 @@ definition {
 			var userPassword = PropsUtil.get("default.admin.password");
 		}
 
-		if (isSet(site) && (${site} == "true")) {
+		if (isSet(site)) {
 			var serviceContext = JSONDocumentSetter.setServiceContext(
 				addGroupPermissions = ${groupPermissions},
 				addGuestPermissions = ${guestPermissions},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
@@ -931,7 +931,6 @@ definition {
 			dmDocumentTitle = "DM Document Title",
 			groupName = "Site Name-staging",
 			mimeType = "image/jpeg",
-			site = "false",
 			sourceFileName = "Document_1.jpeg");
 
 		DMNavigator.openToEditEntryInSite(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/CategoriesWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/CategoriesWithStaging.testcase
@@ -55,7 +55,6 @@ definition {
 				dmDocumentTitle = "Document Title",
 				groupName = "Test Site Name-staging",
 				mimeType = "image/jpeg",
-				site = "false",
 				sourceFileName = "Document_1.jpg");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesWithStagingForFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPageTemplatesWithStagingForFileEntry.testcase
@@ -75,7 +75,6 @@ definition {
 				dmDocumentTitle = "Document Title",
 				groupName = "Test Site Name-staging",
 				mimeType = "image/jpeg",
-				site = "false",
 				sourceFileName = "Document_1.jpg");
 		}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47853

Fix tests:

LocalFile.DepotAutoTagging#ImageCanBeAutoTagged
LocalFile.GoogleCloudAutoTagging#CanAutoTagImageInDepot

# How am I fixing it?

I fixed once in #6202, but the fix broke these tests, that were fixed in #6245 :

* CategoriesWithStaging#ViewUsages
* DisplayPageTemplatesWithStagingForFileEntry#AccessToAssociatedDisplayPageTemplateInLiveSite
* LocalFile.DMLocalStaging#CanPublishRelatedAsset

However #6245 broke again the autotagging tests, so:

* I reverted the fix in #6245
* Fixed the other failing tests in a different way
