### PR TITLE
LPD-47849 Fix PW test journalArticle.spec.ts › LPD-6813: Make prefix URLs configurable

### DIFF
--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -26,15 +26,24 @@ export class FriendlyUrlInstanceSettingsPage {
 		);
 	}
 
-	async modifySeparator(testId: string, value: string) {
-		await this.page.locator(`[data-testid='${testId}']`).click();
-		await this.page.locator(`[data-testid='${testId}']`).fill(value);
+	async modifySeparator(label: string, value: string) {
+		const separatorInput = this.page.getByLabel(label);
+		await separatorInput.click();
+		await separatorInput.fill(value);
+
 		await this.saveButton.click();
 		await waitForAlert(this.page);
 	}
 
-	async resetSeparator(testId: string) {
-		await this.page.locator(`[data-testid='${testId}']`).click();
+	async resetSeparator(label: string) {
+		const separatorResetButton = this.page
+			.locator('.input-group', {has: this.page.getByLabel(label)})
+			.getByLabel('Reset to Default Value');
+		await clickAndExpectToBeHidden({
+			target: separatorResetButton,
+			trigger: separatorResetButton,
+		});
+
 		await this.saveButton.click();
 		await waitForAlert(this.page);
 	}

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -706,7 +706,7 @@ prefixUrlTest(
 
 		await friendlyUrlInstanceSettingsPage.goto();
 
-		const urlSeparator = 'content';
+		const urlSeparator = 'web-content';
 
 		await friendlyUrlInstanceSettingsPage.modifySeparator(
 			'Web Content URL Separator',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47849

Fix PW test journalArticle.spec.ts › LPD-6813: Make prefix URLs configurable

# How am I fixing it?

Reverting this a7c53497815489678f972091156a396b936bad07 because I think it was pushed by mistake on this PR https://github.com/liferay-content-management/liferay-portal/pull/6136.
This fix a7c53497815489678f972091156a396b936bad07 is made before we change it here https://github.com/liferay-content-management/liferay-portal/pull/5653

>[!NOTE]
> I am adding a more uncommon separator 31c97eafb02136eb91758115f04e7c313b0900ae because `content` fails locally before the fix
>
> ![image](https://github.com/user-attachments/assets/837a5396-ddfc-41e1-9fea-62635d98bbd6)


# How can you verify that it works?

Run the test 

```sh
npm run playwright -- test -g "LPD-6813"
```

## Tested locally
![image](https://github.com/user-attachments/assets/64dacd4f-347f-4901-8eb3-0afe365da227)

## No CI failures
[![image](https://github.com/user-attachments/assets/06001f27-907f-4c83-b52b-cf0391592b3d)](https://github.com/liferay-content-management/liferay-portal/pull/6316#issuecomment-2630671842)

