### PR TITLE
LPD-42896 | Create a Skeleton for Card View

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class AllSectionDisplayContext {
 
 	public String getAPIURL() {
-		return "/o/search/v1.0/search?emptySearch=true";
+		return "/o/search/v1.0/search?emptySearch=true&nestedFields=embedded";
 	}
 
 	public List<DropdownItem> getBulkActionDropdownItems() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/cards/AllSectionCardsFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/cards/AllSectionCardsFDSView.java
@@ -27,7 +27,7 @@ public class AllSectionCardsFDSView extends BaseCardsFDSView {
 
 	@Override
 	public String getImage() {
-		return "image";
+		return "embedded.contentUrl";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/cards/AllSectionCardsFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/cards/AllSectionCardsFDSView.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.view.cards;
+
+import com.liferay.frontend.data.set.view.FDSView;
+import com.liferay.frontend.data.set.view.cards.BaseCardsFDSView;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@Component(
+	property = "frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_SECTION,
+	service = FDSView.class
+)
+public class AllSectionCardsFDSView extends BaseCardsFDSView {
+
+	@Override
+	public String getDescription() {
+		return "description";
+	}
+
+	@Override
+	public String getImage() {
+		return "image";
+	}
+
+	@Override
+	public String getTitle() {
+		return "title";
+	}
+
+}


### PR DESCRIPTION
Rebased https://github.com/liferay-content-management/liferay-portal/pull/6312 to follow the DisplayContext pattern from https://liferay.atlassian.net/browse/LPD-47851

Original pull request comment:
Story https://liferay.atlassian.net/browse/LPD-42752
Technical Task https://liferay.atlassian.net/browse/LPD-42896

Requirements
An option to select the Card view is added to the View icon in the management toolbar
Once clicked, the Card view for the content section is loaded