### PR TITLE
LPD-47103 Cannot filter content elements by 'contentType' with headless-delivery API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
@@ -51,7 +52,7 @@ public class ContentElementEntityModel implements EntityModel {
 				locale -> Field.ENTRY_CLASS_NAME,
 				locale -> Field.ENTRY_CLASS_NAME,
 				object -> _getFilterableFieldFunction(
-					dtoConverterRegistry, object)),
+					dtoConverterRegistry, String.valueOf(object))),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),
 			new StringEntityField(
 				"title",
@@ -72,18 +73,20 @@ public class ContentElementEntityModel implements EntityModel {
 	}
 
 	private String _getFilterableFieldFunction(
-		DTOConverterRegistry dtoConverterRegistry, Object object) {
+		DTOConverterRegistry dtoConverterRegistry, String value) {
 
 		for (String dtoClassName : dtoConverterRegistry.getDTOClassNames()) {
 			DTOConverter<?, ?> dtoConverter =
 				dtoConverterRegistry.getDTOConverter(dtoClassName);
 
-			if (object.equals(dtoConverter.getContentType())) {
+			if (StringUtil.equalsIgnoreCase(
+					value, dtoConverter.getContentType())) {
+
 				return dtoConverter.getDTOClassName();
 			}
 		}
 
-		return String.valueOf(object);
+		return value;
 	}
 
 	private final Map<String, EntityField> _entityFieldsMap;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentElementResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentElementResourceTest.java
@@ -8,26 +8,31 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentElement;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.resource.v1_0.ContentElementResource;
 import com.liferay.headless.delivery.client.serdes.v1_0.ContentElementSerDes;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -90,6 +95,28 @@ public class ContentElementResourceTest
 
 		testGetAssetLibraryContentElementsPageWithSort(
 			EntityField.Type.DOUBLE, _getUnsafeTriConsumer());
+	}
+
+	@Override
+	@Test
+	public void testGetSiteContentElementsPageWithFilterStringEquals()
+		throws Exception {
+
+		super.testGetSiteContentElementsPageWithFilterStringEquals();
+
+		Long siteId = testGetSiteContentElementsPage_getSiteId();
+
+		ContentElement contentElement = _toContentElement(
+			DLAppTestUtil.addFileEntry(siteId));
+
+		Page<ContentElement> page =
+			contentElementResource.getSiteContentElementsPage(
+				siteId, null, null, "(contentType eq 'Document')",
+				Pagination.of(1, 2), null);
+
+		assertEquals(
+			Collections.singletonList(contentElement),
+			(List<ContentElement>)page.getItems());
 	}
 
 	@Override
@@ -220,9 +247,20 @@ public class ContentElementResourceTest
 		);
 	}
 
+	private ContentElement _toContentElement(FileEntry fileEntry) {
+		return new ContentElement() {
+			{
+				contentType = "Document";
+				id = fileEntry.getFileEntryId();
+				title = fileEntry.getTitle();
+			}
+		};
+	}
+
 	private ContentElement _toContentElement(JournalArticle journalArticle) {
 		return new ContentElement() {
 			{
+				contentType = "StructuredContent";
 				id = journalArticle.getId();
 				title = journalArticle.getTitle();
 			}
@@ -231,5 +269,8 @@ public class ContentElementResourceTest
 
 	private final Map<ContentElement, Map<String, Object>> _fieldValueMaps =
 		new IdentityHashMap<>();
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
 
 }


### PR DESCRIPTION
Comment

I am sending again a PR because of this [brian's comment](https://github.com/brianchandotcom/liferay-portal/pull/158278#issuecomment-2628860448), so, I have changed the method name to testGetSiteContentElementsPageWithFilterStringEquals, and only I add a file because there is already a content added from super method, so, also I have changed the filter string to document because I created one document in the method and there is another type of content element (Journal article) created from the super call. 

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47103

Cannot filter content elements by 'contentType' with headless-delivery API

# How am I fixing it?

Find the dto converter using a ignore case comparison in order to find the class name to build the filter.

# How can you verify that it works?

Run included integration test