### PR TITLE
LPD-45257 Technical Task | ST-38 Fix fileEntry.spec.ts > Show icon in the DL item selector

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
@@ -62,7 +62,7 @@ export class DocumentLibraryEditDocumentTypesPage {
 	) {
 		await this.goto(siteUrl);
 		await this.addField('Upload', siteUrl);
-		await this.titleSelector.fill(title);
+		await fillAndClickOutside(this.page, this.titleSelector, title);
 		await this.saveButton.click();
 	}
 }

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -116,14 +116,6 @@ export class DocumentLibraryPage {
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 	}
 
-	async deleteFileEntry(name: string) {
-		await this.goto();
-		await this.changeView('list');
-		await this.page.getByLabel(name).check();
-		await this.page.getByRole('button', {name: 'Delete'}).click();
-		await this.changeView('cards');
-	}
-
 	async deleteDocumentType(name: string) {
 		await this.goto();
 		await this.changeTab('Document Types');

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -58,14 +58,12 @@ export class DocumentLibraryPage {
 		);
 	}
 
-	async assertPrivateFileIcon(frameLocator?: FrameLocator) {
-		const privateFileIcon = await (frameLocator ?? this.page)
-			.getByLabel('Not Visible to Guest Users')
-			.last();
-
-		await privateFileIcon.waitFor();
-
-		await expect(privateFileIcon).toBeVisible();
+	async assertPrivateFileIcon(parent: Page | FrameLocator = this.page) {
+		await expect(async () => {
+			await expect(
+				await parent.getByLabel('Not Visible to Guest Users').last()
+			).toBeVisible();
+		}).toPass();
 	}
 
 	async openInfoPanel(entryTitle: string, tabName: 'Details' | 'Versions') {

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -282,14 +282,12 @@ test(
 		documentLibraryEditDocumentTypesPage,
 		documentLibraryEditFilePage,
 		documentLibraryPage,
-		site,
 	}) => {
 		const dTypeTitle = getRandomString();
 		const title = getRandomString();
 
 		await documentLibraryEditDocumentTypesPage.createNewDLTypeWithUploadField(
-			dTypeTitle,
-			site.friendlyUrlPath
+			dTypeTitle
 		);
 
 		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -281,20 +281,25 @@ test(
 	async ({
 		documentLibraryEditDocumentTypesPage,
 		documentLibraryEditFilePage,
-		documentLibraryPage,
+		site,
 	}) => {
 		const dTypeTitle = getRandomString();
 		const title = getRandomString();
 
 		await documentLibraryEditDocumentTypesPage.createNewDLTypeWithUploadField(
-			dTypeTitle
+			dTypeTitle,
+			site.friendlyUrlPath
 		);
 
 		await documentLibraryEditFilePage.publishNewFileWithoutGuestViewPermission(
-			title
+			title,
+			site.friendlyUrlPath
 		);
 
-		await documentLibraryEditFilePage.goToNewFileDifferentType(dTypeTitle);
+		await documentLibraryEditFilePage.goToNewFileDifferentType(
+			dTypeTitle,
+			site.friendlyUrlPath
+		);
 
 		await documentLibraryEditFilePage.selectForUpdateButton.click();
 
@@ -319,10 +324,6 @@ test(
 		await documentLibraryEditFilePage.assertPrivateFileIconInSelectPopUp(
 			'Document'
 		);
-
-		await documentLibraryPage.deleteFileEntry(title);
-
-		await documentLibraryPage.deleteDocumentType(dTypeTitle);
 	}
 );
 


### PR DESCRIPTION
[LPD-45257](https://liferay.atlassian.net/browse/LPD-45257)

I fixed the test by not creating the new DLType on a new site, as none of the other parts were run on a new site and the cleanup methods did not support new sites either. This was the approach that required the least amount of modification.

I also modified `createNewDLTypeWithUploadField` to use `fillAndClickOutside` to make it more robust.


To test run:
`npm run playwright -- test -g 'Show icon in the DL item selector'`

<img width="907" alt="Screenshot 2025-02-03 at 16 05 06" src="https://github.com/user-attachments/assets/24e78477-1179-4e2e-9389-025e02075653" />

Please review the change