### PR TITLE
LPD-47915 Keep Creator data for keywords during import for Batch engine

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-category-property-api")
+	compileOnly project(":apps:batch-engine:batch-engine-api")
 	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	compileOnly project(":apps:headless:headless-common-spi")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPostAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPostAction.java
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPostAction;
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.context.ImportTaskContext;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPostAction.class)
+public class KeywordImportTaskPostAction implements ImportTaskPostAction {
+
+	@Override
+	public void run(
+			BatchEngineImportTask batchEngineImportTask,
+			ImportTaskContext importTaskContext, Object item,
+			Object persistedItem)
+		throws Exception {
+
+		if (!(item instanceof Keyword) ||
+			!StringUtil.equals(
+				batchEngineImportTask.getParameterValue(
+					"importCreatorStrategy"),
+				BatchEngineImportTaskConstants.
+					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
+
+			return;
+		}
+
+		String originalUserId = importTaskContext.getOriginalUserId();
+
+		if (Validator.isNotNull(originalUserId)) {
+			PrincipalThreadLocal.setName(originalUserId);
+
+			importTaskContext.setOriginalUserId(null);
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPreAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPreAction.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPreAction;
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.context.ImportTaskContext;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPreAction.class)
+public class KeywordImportTaskPreAction implements ImportTaskPreAction {
+
+	@Override
+	public void run(
+			BatchEngineImportTask batchEngineImportTask,
+			ImportTaskContext importTaskContext, Object item)
+		throws Exception {
+
+		if (!(item instanceof Keyword) ||
+			!StringUtil.equals(
+				batchEngineImportTask.getParameterValue(
+					"importCreatorStrategy"),
+				BatchEngineImportTaskConstants.
+					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
+
+			return;
+		}
+
+		Keyword keyword = (Keyword)item;
+
+		User user = _getCreatorUser(keyword);
+
+		if (user == null) {
+			return;
+		}
+
+		String name = PrincipalThreadLocal.getName();
+
+		if (GetterUtil.getLong(name) == user.getUserId()) {
+			return;
+		}
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		importTaskContext.setOriginalUserId(name);
+	}
+
+	private User _getCreatorUser(Keyword keyword) {
+		if (keyword == null) {
+			return null;
+		}
+
+		Creator creator = keyword.getCreator();
+
+		if (creator == null) {
+			return null;
+		}
+
+		User user = null;
+
+		if (Validator.isNotNull(creator.getExternalReferenceCode())) {
+			user = _userLocalService.fetchUserByExternalReferenceCode(
+				creator.getExternalReferenceCode(),
+				CompanyThreadLocal.getCompanyId());
+		}
+
+		if ((user == null) && Validator.isNotNull(creator.getId())) {
+			user = _userLocalService.fetchUser(creator.getId());
+		}
+
+		return user;
+	}
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/bnd.bnd
@@ -3,4 +3,5 @@ Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.test
 Bundle-Version: 1.0.0
 -includeresource: :\
 	com.liferay.headless.admin.taxonomy.client.jar=com.liferay.headless.admin.taxonomy.client-*.jar;lib:=true,\
+	com.liferay.headless.batch.engine.client.jar=com.liferay.headless.batch.engine.client-*.jar;lib:=true,\
 	@jsonassert-[0-9.]*.jar

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")
+	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/KeywordImportTaskPreActionTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/KeywordImportTaskPreActionTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
+import com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test.util.ExportImportTaskResourceTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class KeywordImportTaskPreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_localGroup = GroupTestUtil.addGroup();
+
+		_targetGroup = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreator() throws Exception {
+		AssetTag assetTag = _getAssetTag(_user.getUserId());
+
+		String jsonString = ExportImportTaskResourceTestUtil.executeExportTask(
+			Keyword.class.getName(), _localGroup.getGroupId());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", jsonString);
+
+		_assertAssetTag(
+			assetTag.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			_user.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreatorUserDoesNotExist()
+		throws Exception {
+
+		AssetTag assetTag = _getAssetTag(_user.getUserId());
+
+		String jsonString = ExportImportTaskResourceTestUtil.executeExportTask(
+			Keyword.class.getName(), _localGroup.getGroupId());
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", jsonString);
+
+		_assertAssetTag(
+			assetTag.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndOverwriteCreator() throws Exception {
+		AssetTag assetTag = _getAssetTag(_user.getUserId());
+
+		String jsonString = ExportImportTaskResourceTestUtil.executeExportTask(
+			Keyword.class.getName(), _localGroup.getGroupId());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			"OVERWRITE_CREATOR", jsonString);
+
+		_assertAssetTag(
+			assetTag.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndKeepCreator() throws Exception {
+		AssetTag assetTag = _getAssetTag(_user.getUserId());
+
+		String jsonString = ExportImportTaskResourceTestUtil.executeExportTask(
+			Keyword.class.getName(), _localGroup.getGroupId());
+
+		_assetTagLocalService.deleteTag(assetTag);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			Keyword.class.getName(), "UPSERT", _localGroup.getGroupId(),
+			"KEEP_CREATOR", jsonString);
+
+		_assertAssetTag(
+			assetTag.getExternalReferenceCode(), _localGroup.getGroupId(),
+			_user.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndOverwriteCreator() throws Exception {
+		AssetTag assetTag = _getAssetTag(_user.getUserId());
+
+		String jsonString = ExportImportTaskResourceTestUtil.executeExportTask(
+			Keyword.class.getName(), _localGroup.getGroupId());
+
+		_assetTagLocalService.deleteTag(assetTag);
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			Keyword.class.getName(), "UPSERT", _localGroup.getGroupId(),
+			"OVERWRITE_CREATOR", jsonString);
+
+		_assertAssetTag(
+			assetTag.getExternalReferenceCode(), _localGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	private void _assertAssetTag(
+			String externalReferenceCode, long groupId, long userId)
+		throws Exception {
+
+		AssetTag assetTag =
+			_assetTagLocalService.getAssetTagByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		Assert.assertEquals(userId, assetTag.getUserId());
+	}
+
+	private AssetTag _getAssetTag(long userId) throws Exception {
+		return _assetTagLocalService.addTag(
+			null, userId, _localGroup.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_localGroup.getGroupId()));
+	}
+
+	@Inject
+	private AssetTagLocalService _assetTagLocalService;
+
+	@DeleteAfterTestRun
+	private Group _localGroup;
+
+	@DeleteAfterTestRun
+	private Group _targetGroup;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test.util;
+
+import com.liferay.headless.admin.taxonomy.client.http.HttpInvoker;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ExportTask;
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.serdes.v1_0.ExportTaskSerDes;
+import com.liferay.headless.batch.engine.client.serdes.v1_0.ImportTaskSerDes;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.InputStream;
+
+import java.util.Objects;
+import java.util.zip.ZipInputStream;
+
+import org.junit.Assert;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ExportImportTaskResourceTestUtil {
+
+	public static String executeExportTask(String className, long groupId)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.header(HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON);
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			StringBundler.concat(
+				"http://localhost:8080/o/headless-batch-engine/v1.0",
+				"/export-task/", className, "/JSON?siteId=", groupId));
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		ExportTask exportTask = ExportTaskSerDes.toDTO(
+			httpResponse.getContent());
+
+		String externalReferenceCode = exportTask.getExternalReferenceCode();
+
+		while (true) {
+			exportTask = ExportTaskSerDes.toDTO(
+				_invoke(
+					"http://localhost:8080/o/headless-batch-engine/v1.0" +
+						"/export-task/by-external-reference-code/" +
+							externalReferenceCode));
+
+			if (Objects.equals(
+					exportTask.getExecuteStatusAsString(), "COMPLETED")) {
+
+				break;
+			}
+			else if (Objects.equals(
+						exportTask.getExecuteStatusAsString(), "FAILED")) {
+
+				throw new AssertionError(exportTask.getErrorMessage());
+			}
+		}
+
+		httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.header(
+			HttpHeaders.ACCEPT, ContentTypes.APPLICATION_OCTET_STREAM);
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+		httpInvoker.path(
+			StringBundler.concat(
+				"http://localhost:8080/o/headless-batch-engine/v1.0",
+				"/export-task/by-external-reference-code/",
+				externalReferenceCode, "/content"));
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		httpResponse = httpInvoker.invoke();
+
+		try (InputStream inputStream = new UnsyncByteArrayInputStream(
+				httpResponse.getBinaryContent())) {
+
+			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+
+			zipInputStream.getNextEntry();
+
+			return StringUtil.read(zipInputStream);
+		}
+	}
+
+	public static void executeImportTask(
+			String className, String createStrategy, long groupId,
+			String importCreatorStrategy, String jsonString)
+		throws Exception {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(jsonString, "application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+		httpInvoker.path(
+			StringBundler.concat(
+				"http://localhost:8080/o/headless-batch-engine/v1.0",
+				"/import-task/", className, "?createStrategy=", createStrategy,
+				"&importCreatorStrategy=", importCreatorStrategy, "&siteId=",
+				groupId));
+
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		ImportTask importTask = ImportTaskSerDes.toDTO(
+			httpResponse.getContent());
+
+		String externalReferenceCode = importTask.getExternalReferenceCode();
+
+		while (true) {
+			importTask = ImportTaskSerDes.toDTO(
+				_invoke(
+					"http://localhost:8080/o/headless-batch-engine/v1.0" +
+						"/import-task/by-external-reference-code/" +
+							externalReferenceCode));
+
+			if (Objects.equals(
+					importTask.getExecuteStatusAsString(), "COMPLETED")) {
+
+				break;
+			}
+			else if (Objects.equals(
+						importTask.getExecuteStatusAsString(), "FAILED")) {
+
+				throw new AssertionError(importTask.getErrorMessage());
+			}
+		}
+	}
+
+	private static String _invoke(String url) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+		httpInvoker.path(url);
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		Assert.assertEquals(200, httpResponse.getStatusCode());
+
+		return httpResponse.getContent();
+	}
+
+}


### PR DESCRIPTION
Keep Creator data for keywords during import for Batch engine

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-47915)

Currently Staging can be configured to keep or not the Creator related information during import for content. With this story, we want to allow users to do the same thing but using Batch engine with keywords and a new query parameter. 

# How am I fixing it?

Adding ImportTaskPostAction and ImportTaskPreAction so as to select the user based on the importCreatorStrategy

# How can you verify that it works?

Run the provided integration tests
