### PR TITLE
LPD-45037 Fix tests of auto tagging in Asset Library (documents)

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-test/src/testFunctional/macros/GoogleCloudAutoTagging.macro
+++ b/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-test/src/testFunctional/macros/GoogleCloudAutoTagging.macro
@@ -50,7 +50,9 @@ definition {
 
 		Click(locator1 = "Dropdown#TRIGGER");
 
-		DropdownMenuItem.click(menuItem = ${assetType});
+		Click.javaScriptClick(
+			key_menuItem = ${assetType},
+			locator1 = "MenuItem#DROPDOWN_MENU_ITEM");
 
 		if (IsElementPresent(locator1 = "Button#UPDATE")) {
 			PortletEntry.update();

--- a/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-test/src/testFunctional/tests/GoogleCloudAutoTagging.testcase
+++ b/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-test/src/testFunctional/tests/GoogleCloudAutoTagging.testcase
@@ -52,6 +52,7 @@ definition {
 			dmDocumentTitle = "DM Document Title",
 			groupName = "Test Depot Name",
 			mimeType = "application/msword",
+			site = "false",
 			sourceFileName = "Document_1.doc");
 
 		DepotNavigator.openToDMEntryInDepot(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45037

The last element of a dropdown selector wasn't being selected.

# How am I fixing it?

I used the `Click.javaScriptClick` function instead of the regular `Click` function.

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=GoogleCloudAutoTagging#CanAutoTagDocumentInDepot`
`ant -f build-test.xml run-selenium-test -Dtest.class=GoogleCloudAutoTagging#CanViewDocumentAutoTagsAfterPublishing`