### PR TITLE
LPD-48254 Add object definition folders and object entry folders

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
@@ -124,6 +124,10 @@ public interface ObjectEntryFolderLocalService
 			ObjectEntryFolder objectEntryFolder)
 		throws PortalException;
 
+	public ObjectEntryFolder deleteObjectEntryFolder(
+			String externalReferenceCode, long companyId, long groupId)
+		throws PortalException;
+
 	/**
 	 * @throws PortalException
 	 */
@@ -265,6 +269,11 @@ public interface ObjectEntryFolderLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntryFolder> getObjectEntryFolders(int start, int end);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntryFolder> getObjectEntryFolders(
+		long groupId, long companyId, long parentObjectEntryFolderId, int start,
+		int end);
+
 	/**
 	 * Returns all the object entry folders matching the UUID and company.
 	 *
@@ -298,6 +307,10 @@ public interface ObjectEntryFolderLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getObjectEntryFoldersCount();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntryFoldersCount(
+		long groupId, long companyId, long parentObjectEntryFolderId);
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
@@ -124,6 +124,14 @@ public class ObjectEntryFolderLocalServiceUtil {
 		return getService().deleteObjectEntryFolder(objectEntryFolder);
 	}
 
+	public static ObjectEntryFolder deleteObjectEntryFolder(
+			String externalReferenceCode, long companyId, long groupId)
+		throws PortalException {
+
+		return getService().deleteObjectEntryFolder(
+			externalReferenceCode, companyId, groupId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -306,6 +314,14 @@ public class ObjectEntryFolderLocalServiceUtil {
 		return getService().getObjectEntryFolders(start, end);
 	}
 
+	public static List<ObjectEntryFolder> getObjectEntryFolders(
+		long groupId, long companyId, long parentObjectEntryFolderId, int start,
+		int end) {
+
+		return getService().getObjectEntryFolders(
+			groupId, companyId, parentObjectEntryFolderId, start, end);
+	}
+
 	/**
 	 * Returns all the object entry folders matching the UUID and company.
 	 *
@@ -346,6 +362,13 @@ public class ObjectEntryFolderLocalServiceUtil {
 	 */
 	public static int getObjectEntryFoldersCount() {
 		return getService().getObjectEntryFoldersCount();
+	}
+
+	public static int getObjectEntryFoldersCount(
+		long groupId, long companyId, long parentObjectEntryFolderId) {
+
+		return getService().getObjectEntryFoldersCount(
+			groupId, companyId, parentObjectEntryFolderId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
@@ -126,6 +126,15 @@ public class ObjectEntryFolderLocalServiceWrapper
 			objectEntryFolder);
 	}
 
+	@Override
+	public com.liferay.object.model.ObjectEntryFolder deleteObjectEntryFolder(
+			String externalReferenceCode, long companyId, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryFolderLocalService.deleteObjectEntryFolder(
+			externalReferenceCode, companyId, groupId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -340,6 +349,16 @@ public class ObjectEntryFolderLocalServiceWrapper
 		return _objectEntryFolderLocalService.getObjectEntryFolders(start, end);
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntryFolder>
+		getObjectEntryFolders(
+			long groupId, long companyId, long parentObjectEntryFolderId,
+			int start, int end) {
+
+		return _objectEntryFolderLocalService.getObjectEntryFolders(
+			groupId, companyId, parentObjectEntryFolderId, start, end);
+	}
+
 	/**
 	 * Returns all the object entry folders matching the UUID and company.
 	 *
@@ -386,6 +405,14 @@ public class ObjectEntryFolderLocalServiceWrapper
 	@Override
 	public int getObjectEntryFoldersCount() {
 		return _objectEntryFolderLocalService.getObjectEntryFoldersCount();
+	}
+
+	@Override
+	public int getObjectEntryFoldersCount(
+		long groupId, long companyId, long parentObjectEntryFolderId) {
+
+		return _objectEntryFolderLocalService.getObjectEntryFoldersCount(
+			groupId, companyId, parentObjectEntryFolderId);
 	}
 
 	/**

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -175,6 +175,19 @@ public class ObjectEntryFolderLocalServiceImpl
 	}
 
 	@Override
+	public ObjectEntryFolder deleteObjectEntryFolder(
+			String externalReferenceCode, long companyId, long groupId)
+		throws PortalException {
+
+		ObjectEntryFolder objectEntryFolder =
+			objectEntryFolderPersistence.findByERC_G_C(
+				externalReferenceCode, groupId, companyId);
+
+		return objectEntryFolderLocalService.deleteObjectEntryFolder(
+			objectEntryFolder);
+	}
+
+	@Override
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -185,6 +186,23 @@ public class ObjectEntryFolderLocalServiceImpl
 
 		return objectEntryFolderLocalService.deleteObjectEntryFolder(
 			objectEntryFolder);
+	}
+
+	@Override
+	public List<ObjectEntryFolder> getObjectEntryFolders(
+		long groupId, long companyId, long parentObjectEntryFolderId, int start,
+		int end) {
+
+		return objectEntryFolderPersistence.findByG_C_P(
+			groupId, companyId, parentObjectEntryFolderId, start, end);
+	}
+
+	@Override
+	public int getObjectEntryFoldersCount(
+		long groupId, long companyId, long parentObjectEntryFolderId) {
+
+		return objectEntryFolderPersistence.countByG_C_P(
+			groupId, companyId, parentObjectEntryFolderId);
 	}
 
 	@Override

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-definitions/basic-document.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-definitions/basic-document.json
@@ -1,0 +1,254 @@
+{
+	"accountEntryRestricted": false,
+	"accountEntryRestrictedObjectFieldName": "",
+	"actions": {
+		"delete": {
+		},
+		"exportObjectDefinition": {
+		},
+		"get": {
+		},
+		"permissions": {
+		},
+		"update": {
+		}
+	},
+	"active": true,
+	"className": "com.liferay.object.model.ObjectDefinition#P9T4",
+	"defaultLanguageId": "en_US",
+	"enableCategorization": true,
+	"enableComments": true,
+	"enableIndexSearch": true,
+	"enableLocalization": true,
+	"enableObjectEntryDraft": true,
+	"enableObjectEntryHistory": true,
+	"externalReferenceCode": "6f996152-4147-b444-7284-2ae839234de1",
+	"label": {
+		"en_US": "Basic Document"
+	},
+	"modifiable": true,
+	"name": "BasicDocument",
+	"objectActions": [
+	],
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "d54e04c7-5605-f870-11d5-d60dde33d93f",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Author"
+			},
+			"localized": false,
+			"name": "creator",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "String",
+			"unique": false
+		},
+		{
+			"DBType": "Date",
+			"businessType": "Date",
+			"defaultValue": "null",
+			"externalReferenceCode": "765fa757-c0b3-65d7-85f6-ac4baa3b303d",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Create Date"
+			},
+			"localized": false,
+			"name": "createDate",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Date",
+			"unique": false
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "4cdcc028-4cbe-4ac9-eb4c-bf450443b185",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "External Reference Code"
+			},
+			"localized": false,
+			"name": "externalReferenceCode",
+			"objectFieldSettings": [
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "String",
+			"unique": false
+		},
+		{
+			"DBType": "Date",
+			"businessType": "Date",
+			"defaultValue": "null",
+			"externalReferenceCode": "8b398437-b02b-df91-0d75-00008ffcc73c",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Modified Date"
+			},
+			"localized": false,
+			"name": "modifiedDate",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Date",
+			"unique": false
+		},
+		{
+			"DBType": "Long",
+			"businessType": "LongInteger",
+			"defaultValue": "null",
+			"externalReferenceCode": "e7cb827a-adab-c07e-d8f1-f80395326a1e",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "ID"
+			},
+			"localized": false,
+			"name": "id",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Long",
+			"unique": false
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "c1e1fe8c-93d5-c04a-f8a7-a5d35f76916b",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Status"
+			},
+			"localized": false,
+			"name": "status",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Integer",
+			"unique": false
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"defaultValue": "null",
+			"externalReferenceCode": "b2de6856-5bc1-bb6d-f500-7e550459ef60",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "File"
+			},
+			"localized": false,
+			"name": "file",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": 100
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": false
+				}
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": true,
+			"state": false,
+			"system": false,
+			"type": "Long",
+			"unique": false
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "fb339363-ad0d-b456-1833-dbee3fe2252a",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Title"
+			},
+			"localized": true,
+			"name": "title",
+			"objectFieldSettings": [
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "String",
+			"unique": false
+		}
+	],
+	"objectFolderExternalReferenceCode": "8a5269c6-79b0-b741-ed1a-4cf13c4560e0",
+	"objectLayouts": [
+	],
+	"objectRelationships": [
+	],
+	"objectValidationRules": [
+	],
+	"objectViews": [
+	],
+	"panelCategoryKey": "",
+	"parameterRequired": false,
+	"pluralLabel": {
+		"en_US": "BasicDocuments"
+	},
+	"portlet": false,
+	"restContextPath": "/o/c/basicdocuments",
+	"scope": "site",
+	"system": false,
+	"titleObjectFieldName": "title"
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-definitions/basic-web-content.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-definitions/basic-web-content.json
@@ -1,0 +1,238 @@
+{
+	"accountEntryRestricted": false,
+	"accountEntryRestrictedObjectFieldName": "",
+	"actions": {
+		"delete": {
+		},
+		"exportObjectDefinition": {
+		},
+		"get": {
+		},
+		"permissions": {
+		},
+		"update": {
+		}
+	},
+	"active": true,
+	"className": "com.liferay.object.model.ObjectDefinition#K4I6",
+	"defaultLanguageId": "en_US",
+	"enableCategorization": true,
+	"enableComments": true,
+	"enableIndexSearch": true,
+	"enableLocalization": true,
+	"enableObjectEntryDraft": true,
+	"enableObjectEntryHistory": true,
+	"externalReferenceCode": "e42820e4-28f7-fcc5-cd40-07f6717174d2",
+	"label": {
+		"en_US": "Basic Web Content"
+	},
+	"modifiable": true,
+	"name": "BasicWebContent",
+	"objectActions": [
+	],
+	"objectFields": [
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "493dbe64-fda6-ad94-a910-f6a095666b74",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Author"
+			},
+			"localized": false,
+			"name": "creator",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "String",
+			"unique": false
+		},
+		{
+			"DBType": "Date",
+			"businessType": "Date",
+			"defaultValue": "null",
+			"externalReferenceCode": "ed834529-3dcb-681b-3289-69f812af5e98",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Create Date"
+			},
+			"localized": false,
+			"name": "createDate",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Date",
+			"unique": false
+		},
+		{
+			"DBType": "Long",
+			"businessType": "LongInteger",
+			"defaultValue": "null",
+			"externalReferenceCode": "2209cada-9614-a935-1766-ae99c02f89a5",
+			"indexed": true,
+			"indexedAsKeyword": true,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "ID"
+			},
+			"localized": false,
+			"name": "id",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Long",
+			"unique": false
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "f9c0f11b-4054-c3f0-f3ad-cfc52704eeae",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "External Reference Code"
+			},
+			"localized": false,
+			"name": "externalReferenceCode",
+			"objectFieldSettings": [
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "String",
+			"unique": false
+		},
+		{
+			"DBType": "Date",
+			"businessType": "Date",
+			"defaultValue": "null",
+			"externalReferenceCode": "aa26877b-9e9a-bae2-354b-cec7d8db0e61",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Modified Date"
+			},
+			"localized": false,
+			"name": "modifiedDate",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Date",
+			"unique": false
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "16fb5971-5e36-0853-25e6-4399c63d43e9",
+			"indexed": false,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "",
+			"label": {
+				"en_US": "Status"
+			},
+			"localized": false,
+			"name": "status",
+			"objectFieldSettings": [
+			],
+			"readOnly": "true",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": true,
+			"type": "Integer",
+			"unique": false
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"defaultValue": "null",
+			"externalReferenceCode": "1a7dd531-5915-24df-0bf7-e095a5ca07b7",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Title"
+			},
+			"localized": true,
+			"name": "title",
+			"objectFieldSettings": [
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "String",
+			"unique": false
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "RichText",
+			"defaultValue": "null",
+			"externalReferenceCode": "24ef2a53-617e-776e-d714-cba9e680bbaa",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Content"
+			},
+			"localized": true,
+			"name": "content",
+			"objectFieldSettings": [
+			],
+			"readOnly": "false",
+			"readOnlyConditionExpression": "",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "Clob",
+			"unique": false
+		}
+	],
+	"objectFolderExternalReferenceCode": "a0166c3c-6c8a-74a4-2d43-dba2e5577c40",
+	"objectLayouts": [
+	],
+	"objectRelationships": [
+	],
+	"objectValidationRules": [
+	],
+	"objectViews": [
+	],
+	"panelCategoryKey": "",
+	"parameterRequired": false,
+	"pluralLabel": {
+		"en_US": "BasicWebContents"
+	},
+	"portlet": true,
+	"restContextPath": "/o/c/basicwebcontents",
+	"scope": "site",
+	"system": false,
+	"titleObjectFieldName": "id"
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-folders/cms-content.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-folders/cms-content.json
@@ -1,0 +1,19 @@
+{
+	"actions": {
+		"delete": {
+		},
+		"get": {
+		},
+		"permissions": {
+		},
+		"update": {
+		}
+	},
+	"externalReferenceCode": "a0166c3c-6c8a-74a4-2d43-dba2e5577c40",
+	"label": {
+		"en_US": "CMS Content"
+	},
+	"name": "CMSContent",
+	"objectFolderItems": [
+	]
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-folders/cms-files.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/object-folders/cms-files.json
@@ -1,0 +1,19 @@
+{
+	"actions": {
+		"delete": {
+		},
+		"get": {
+		},
+		"permissions": {
+		},
+		"update": {
+		}
+	},
+	"externalReferenceCode": "8a5269c6-79b0-b741-ed1a-4cf13c4560e0",
+	"label": {
+		"en_US": "CMS Files"
+	},
+	"name": "CMSFiles",
+	"objectFolderItems": [
+	]
+}

--- a/modules/apps/site/site-cms-site-initializer-test/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Site CMS Site Initializer Test
+Bundle-SymbolicName: com.liferay.site.cms.site.initializer.test
+Bundle-Version: 1.0.0

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class GroupModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@FeatureFlags("LPD-17809")
+	@Test
+	public void testAddDepotEntry() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			2,
+			_objectEntryFolderLocalService.getObjectEntryFoldersCount(
+				_depotEntry.getGroupId(), _depotEntry.getCompanyId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
+
+		AssertUtils.assertEquals(
+			Arrays.asList("Content", "Files"),
+			ListUtil.sort(
+				ListUtil.toList(
+					_objectEntryFolderLocalService.getObjectEntryFolders(
+						_depotEntry.getGroupId(), _depotEntry.getCompanyId(),
+						ObjectEntryFolderConstants.
+							PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					ObjectEntryFolder::getName)));
+	}
+
+	@FeatureFlags("LPD-17809")
+	@Test
+	public void testDeleteDepotEntry() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
+
+		Assert.assertEquals(
+			0,
+			_objectEntryFolderLocalService.getObjectEntryFoldersCount(
+				depotEntry.getGroupId(), depotEntry.getCompanyId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
+	}
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/constants/CMSSiteInitializerConstants.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/constants/CMSSiteInitializerConstants.java
@@ -13,4 +13,12 @@ public class CMSSiteInitializerConstants {
 	public static final String BUNDLE_SYMBOLIC_NAME =
 		"com.liferay.site.cms.site.initializer";
 
+	public static final String
+		CONTENT_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE =
+			"ea251ac8-e3c4-11ef-8b1b-7070fc01ae5e";
+
+	public static final String
+		FILES_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE =
+			"07b8bbe4-e3c5-11ef-ad6a-7070fc01ae5e";
+
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -9,6 +9,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
@@ -31,7 +32,10 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		try {
 			super.onAfterCreate(group);
 
-			if (!group.isDepot()) {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					group.getCompanyId(), "LPD-17809") ||
+				!group.isDepot()) {
+
 				return;
 			}
 
@@ -66,7 +70,10 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		try {
 			super.onBeforeRemove(group);
 
-			if (!group.isDepot()) {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					group.getCompanyId(), "LPD-17809") ||
+				!group.isDepot()) {
+
 				return;
 			}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener;
+
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerConstants;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(service = ModelListener.class)
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onAfterCreate(Group group) throws ModelListenerException {
+		try {
+			super.onAfterCreate(group);
+
+			if (!group.isDepot()) {
+				return;
+			}
+
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				CMSSiteInitializerConstants.
+					CONTENT_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE,
+				group.getCreatorUserId(), group.getGroupId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, "Content"
+				).build(),
+				"Content", ServiceContextThreadLocal.getServiceContext());
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				CMSSiteInitializerConstants.
+					FILES_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE,
+				group.getCreatorUserId(), group.getGroupId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, "Files"
+				).build(),
+				"Files", ServiceContextThreadLocal.getServiceContext());
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Override
+	public void onBeforeRemove(Group group) throws ModelListenerException {
+		try {
+			super.onBeforeRemove(group);
+
+			if (!group.isDepot()) {
+				return;
+			}
+
+			_objectEntryFolderLocalService.deleteObjectEntryFolder(
+				CMSSiteInitializerConstants.
+					CONTENT_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE,
+				group.getCompanyId(), group.getGroupId());
+			_objectEntryFolderLocalService.deleteObjectEntryFolder(
+				CMSSiteInitializerConstants.
+					FILES_OBJECT_ENTRY_FOLDER_EXTERNAL_REFERENCE_CODE,
+				group.getCompanyId(), group.getGroupId());
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48254

Object definition folders will be used to namespace CMS structures, so that they are clearly separated from other object definitions not related to the CMS.

Object entry folders in asset libraries (aka "spaces" in the CMS) will be used as a filter criteria when displaying content in the files and content sections.