### PR TITLE
LPD-38768 Generic error page when url title ends in a slash

### DIFF
--- a/modules/apps/blogs/blogs-web-test/build.gradle
+++ b/modules/apps/blogs/blogs-web-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
+	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")

--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/portlet/action/test/EditEntryMVCActionCommandTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/portlet/action/test/EditEntryMVCActionCommandTest.java
@@ -9,12 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryService;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.friendly.url.exception.FriendlyURLLocalizationUrlTitleException;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
@@ -22,15 +26,24 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.trash.model.TrashEntry;
 import com.liferay.trash.service.TrashEntryLocalService;
 
+import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,7 +76,7 @@ public class EditEntryMVCActionCommandTest {
 	}
 
 	@Test(expected = NoSuchEntryException.class)
-	public void testDeleteEntries() throws PortalException {
+	public void testDeleteEntries() throws Exception {
 		BlogsEntry blogsEntry = _addBlogEntry(RandomTestUtil.randomString());
 
 		_deleteEntries(
@@ -74,7 +87,7 @@ public class EditEntryMVCActionCommandTest {
 	}
 
 	@Test
-	public void testDeleteEntriesToTrash() throws PortalException {
+	public void testDeleteEntriesToTrash() throws Exception {
 		BlogsEntry blogsEntry = _addBlogEntry(RandomTestUtil.randomString());
 
 		_deleteEntries(
@@ -91,7 +104,58 @@ public class EditEntryMVCActionCommandTest {
 			trashEntries.isEmpty());
 	}
 
-	private BlogsEntry _addBlogEntry(String title) throws PortalException {
+	@Test
+	public void testUpdateEntry() throws Exception {
+		BlogsEntry blogsEntry = _addBlogEntry(RandomTestUtil.randomString());
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.setTime(blogsEntry.getDisplayDate());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				HashMapBuilder.put(
+					Constants.CMD, Constants.UPDATE
+				).put(
+					"content", blogsEntry.getContent()
+				).put(
+					"displayDateAmPm",
+					String.valueOf(calendar.get(Calendar.AM_PM))
+				).put(
+					"displayDateDay",
+					String.valueOf(calendar.get(Calendar.DAY_OF_MONTH))
+				).put(
+					"displayDateHour",
+					String.valueOf(calendar.get(Calendar.HOUR))
+				).put(
+					"displayDateMinute",
+					String.valueOf(calendar.get(Calendar.MINUTE))
+				).put(
+					"displayDateMonth",
+					String.valueOf(calendar.get(Calendar.MONTH))
+				).put(
+					"displayDateYear",
+					String.valueOf(calendar.get(Calendar.YEAR))
+				).put(
+					"entryId", String.valueOf(blogsEntry.getEntryId())
+				).put(
+					"urlTitle", StringUtil.randomString() + StringPool.SLASH
+				).build());
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doProcessAction",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Assert.assertNotNull(
+			SessionErrors.get(
+				mockLiferayPortletActionRequest,
+				FriendlyURLLocalizationUrlTitleException.
+					MustNotHaveTrailingSlash.class));
+	}
+
+	private BlogsEntry _addBlogEntry(String title) throws Exception {
 		return _blogsEntryService.addEntry(
 			title, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), 1, 1, 1990, 1, 1, true, false,
@@ -109,19 +173,48 @@ public class EditEntryMVCActionCommandTest {
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
-		long entryId) {
+			long entryId)
+		throws Exception {
+
+		return _getMockLiferayPortletActionRequest(
+			HashMapBuilder.put(
+				"entryId", String.valueOf(entryId)
+			).build());
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+			Map<String, String> parameters)
+		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
-		mockLiferayPortletActionRequest.addParameter(
-			"entryId", new String[] {String.valueOf(entryId)});
+		for (Map.Entry<String, String> entry : parameters.entrySet()) {
+			mockLiferayPortletActionRequest.addParameter(
+				entry.getKey(), new String[] {entry.getValue()});
+		}
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.fetchCompany(TestPropsValues.getCompanyId()));
+
+		themeDisplay.setRequest(
+			mockLiferayPortletActionRequest.getHttpServletRequest());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		return mockLiferayPortletActionRequest;
 	}
 
 	@Inject
 	private BlogsEntryService _blogsEntryService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -27,6 +27,7 @@ import com.liferay.bulk.selection.BulkSelectionFactory;
 import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.friendly.url.exception.DuplicateFriendlyURLEntryException;
 import com.liferay.friendly.url.exception.FriendlyURLCategoryException;
+import com.liferay.friendly.url.exception.FriendlyURLLocalizationUrlTitleException;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTTransactionException;
@@ -242,9 +243,10 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 			   EntryDisplayDateException | EntrySmallImageNameException |
 			   EntrySmallImageScaleException | EntryTitleException |
 			   EntryUrlTitleException | FileSizeException |
-			   FriendlyURLCategoryException | ImageResolutionException |
-			   LiferayFileItemException | SanitizerException |
-			   UploadRequestSizeException exception) {
+			   FriendlyURLCategoryException |
+			   FriendlyURLLocalizationUrlTitleException |
+			   ImageResolutionException | LiferayFileItemException |
+			   SanitizerException | UploadRequestSizeException exception) {
 
 			SessionErrors.add(actionRequest, exception.getClass());
 

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -41,6 +41,7 @@ renderResponse.setTitle(blogsEditEntryDisplayContext.getPageTitle(resourceBundle
 			<liferay-ui:error exception="<%= EntryTitleException.class %>" message="please-enter-a-valid-title" />
 			<liferay-ui:error exception="<%= EntryUrlTitleException.class %>" message="please-enter-a-valid-url-title" />
 			<liferay-ui:error exception="<%= FriendlyURLCategoryException.class %>" message="the-url-title-cannot-contain-slashes-and-categories" />
+			<liferay-ui:error exception="<%= FriendlyURLLocalizationUrlTitleException.MustNotHaveTrailingSlash.class %>" message="the-url-title-cannot-have-a-trailing-slash" />
 
 			<liferay-ui:error exception="<%= LiferayFileItemException.class %>">
 				<liferay-ui:message arguments="<%= LanguageUtil.formatStorageSize(FileItem.THRESHOLD_SIZE, locale) %>" key="please-enter-valid-content-with-valid-content-size-no-larger-than-x" translateArguments="<%= false %>" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/init.jsp
@@ -75,6 +75,7 @@ page import="com.liferay.blogs.web.internal.util.BlogsPortletInstanceConfigurati
 page import="com.liferay.blogs.web.internal.util.BlogsUtil" %><%@
 page import="com.liferay.document.library.kernel.exception.FileSizeException" %><%@
 page import="com.liferay.friendly.url.exception.DuplicateFriendlyURLEntryException" %><%@
+page import="com.liferay.friendly.url.exception.FriendlyURLLocalizationUrlTitleException" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -19312,6 +19312,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page.
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title.
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=يمكن تغيير عنوان URL 
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=رابط الصفحة التي تقارن بين محتوى هذه الصفحة والنسخة السابقة منها
 the-url-prefix-might-change-based-on-the-selected-display-page=قد تتغير بادئة عنوان URL استنادًا إلى صفحة العرض المحددة.
 the-url-title-cannot-contain-slashes-and-categories=لا يمكن أن يحتوي عنوان URL على فاصلات وفئات.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=عنوان URL قيد الاستخدام بالفعل. يُرجى إدخال عنوان URL فريد.
 the-url-to-unsubscribe-the-user=عنوان URL لإلغاء اشتراك المستخدم
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=عنوان URL المستخدم في {0} موجود بالفعل في مواقع أخرى أو مكتبات أصول.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL адресът на страницата, сравняваща съдържанието на тази страница с предишната версия (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Заглавието на URL адреса вече се използва. Въведете уникално име на URL адреса. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL адресът за отписване на потребителя (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=L'URL es pot modificar per garantir
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=La URL de la pàgina que compara aquest contingut de la pàgina amb la versió anterior
 the-url-prefix-might-change-based-on-the-selected-display-page=El prefix de l'URL pot canviar en funció de la pàgina de visualització seleccionada.
 the-url-title-cannot-contain-slashes-and-categories=El títol de l'URL no pot contenir ni barres ni categories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=El títol d'URL ja està en ús. Introduïu un títol d'URL únic.
 the-url-to-unsubscribe-the-user=L'URL per donar de baixa l'usuari
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilitzat a {0} ja existeix en altres llocs web o biblioteques de continguts.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL stránky, jejíž obsah bude porovnán s předchozí verzí
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL-titlen er allerede i brug. Angiv en entydig URL-titel. (Automatic Translation)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=Die URL kann angepasst werden, um d
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL der Seite, die diesen Seiteninhalt mit der vorhergehenden Version vergleicht
 the-url-prefix-might-change-based-on-the-selected-display-page=Das URL-Präfix kann sich je nach ausgewählter Anzeigeseite ändern.
 the-url-title-cannot-contain-slashes-and-categories=Der URL-Titel darf keine Schrägstriche und Kategorien enthalten.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Der URL-Titel wird bereits verwendet. Bitte geben Sie einen einzigartigen URL-Titel ein.
 the-url-to-unsubscribe-the-user=Die URL zum Abmelden des Benutzers
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Die in {0} verwendete URL existiert bereits in anderen Sites oder Asset-Bibliotheken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=Die URL kann angepasst werden, um d
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL der Seite, die diesen Seiteninhalt mit der vorhergehenden Version vergleicht
 the-url-prefix-might-change-based-on-the-selected-display-page=Das URL-Präfix kann sich je nach ausgewählter Anzeigeseite ändern.
 the-url-title-cannot-contain-slashes-and-categories=Der URL-Titel darf keine Schrägstriche und Kategorien enthalten.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Der URL-Titel wird bereits verwendet. Bitte geben Sie einen einzigartigen URL-Titel ein.
 the-url-to-unsubscribe-the-user=Die URL zum Abmelden des Benutzers
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Die in {0} verwendete URL existiert bereits in anderen Sites oder Asset-Bibliotheken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=Die URL kann angepasst werden, um d
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL der Seite, die diesen Seiteninhalt mit der vorhergehenden Version vergleicht
 the-url-prefix-might-change-based-on-the-selected-display-page=Das URL-Präfix kann sich je nach ausgewählter Anzeigeseite ändern.
 the-url-title-cannot-contain-slashes-and-categories=Der URL-Titel darf keine Schrägstriche und Kategorien enthalten.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Der URL-Titel wird bereits verwendet. Bitte geben Sie einen einzigartigen URL-Titel ein.
 the-url-to-unsubscribe-the-user=Die URL zum Abmelden des Benutzers
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Die in {0} verwendete URL existiert bereits in anderen Sites oder Asset-Bibliotheken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Το URL της σελίδας που εμφανίζει το περιεχόμενο αυτής της σελίδας συγκριτικά με την προηγούμενη έκδοση
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Ο τίτλος URL χρησιμοποιείται ήδη. Πληκτρολογήστε έναν μοναδικό τίτλο URL. (Automatic Translation)
 the-url-to-unsubscribe-the-user=Η διεύθυνση URL για την κατάργηση της εγγραφής του χρήστη (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -19312,6 +19312,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page.
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title.
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=La URL se puede modificar para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL de la página que compara este contenido de la página con la versión previa del mismo
 the-url-prefix-might-change-based-on-the-selected-display-page=El prefijo de la URL puede cambiar según la página de visualización seleccionada.
 the-url-title-cannot-contain-slashes-and-categories=El título de la URL no puede contener barras ni categorías.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=La URL del título ya está en uso. Escriba una URL única para el título.
 the-url-to-unsubscribe-the-user=La dirección URL para cancelar la suscripción del usuario
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} ya existe en otros repositorios o sitios.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=La URL se puede modificar para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL de la página que compara este contenido de la página con la versión previa del mismo
 the-url-prefix-might-change-based-on-the-selected-display-page=El prefijo de la URL puede cambiar según la página de visualización seleccionada.
 the-url-title-cannot-contain-slashes-and-categories=El título de la URL no puede contener barras ni categorías.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=La URL del título ya está en uso. Escriba una URL única para el título.
 the-url-to-unsubscribe-the-user=La dirección URL para cancelar la suscripción del usuario
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} ya existe en otros repositorios o sitios.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=La URL se puede modificar para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL de la página que compara este contenido de la página con la versión previa del mismo
 the-url-prefix-might-change-based-on-the-selected-display-page=El prefijo de la URL puede cambiar según la página de visualización seleccionada.
 the-url-title-cannot-contain-slashes-and-categories=El título de la URL no puede contener barras ni categorías.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=La URL del título ya está en uso. Escriba una URL única para el título.
 the-url-to-unsubscribe-the-user=La dirección URL para cancelar la suscripción del usuario
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} ya existe en otros repositorios o sitios.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=La URL se puede modificar para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL de la página que compara este contenido de la página con la versión previa del mismo
 the-url-prefix-might-change-based-on-the-selected-display-page=El prefijo de la URL puede cambiar según la página de visualización seleccionada.
 the-url-title-cannot-contain-slashes-and-categories=El título de la URL no puede contener barras ni categorías.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=La URL del título ya está en uso. Escriba una URL única para el título.
 the-url-to-unsubscribe-the-user=La dirección URL para cancelar la suscripción del usuario
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=La URL utilizada en {0} ya existe en otros repositorios o sitios.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Lehe URL, mis võrdleb selle lehe sisu eelmise versiooniga (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL-i tiitel on juba kasutusel. Sisestage kordumatu URL-i tiitel. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL kasutaja tellimuse tühistamiseks (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Orriaren URLa orriaren edukia aurreko bertsioarekin konparatuz
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Hizkuntza honetan erabilitako URLa dagoeneko existitzen da beste liburutegi edo gune batzuetan: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=آدرس صفحه‌ای که محتوای صفحه را با نسخه‌های قبل مقایسه می‌کند.
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=عنوان آدرس قبلا استفاده شده است. لطفا یک عنوان آدرس منحصر به فرد وارد کنید.
 the-url-to-unsubscribe-the-user=آدرس برای لغو اشتراک کاربر (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -19304,6 +19304,7 @@ the-url-can-be-modified-to-ensure-uniqueness=URL:ää voidaan muuttaa varmistama
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Tämän sivun URL-osoiteella verrataan sivun sisältöä edelliseen versioon.
 the-url-prefix-might-change-based-on-the-selected-display-page=URL-etuliite saattaa muuttua valitun näyttösivun mukaan.
 the-url-title-cannot-contain-slashes-and-categories=URL-otiskko ei voi sisältää vinoviivoja ja luokkia.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL-otsikko on jo käytössä. Kirjoita yksikäsitteinen URL-otsikko.
 the-url-to-unsubscribe-the-user=URL käyttäjän tilauksen peruuttamiseksi
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=Kohteessa {0} käytetty URL on jo olemassa muilla sivustoilla tai resurssikirjastoissa.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=L'URL peut être modifiée pour gar
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=L'URL de la page comparant ce contenu de page à la version préalable
 the-url-prefix-might-change-based-on-the-selected-display-page=Le préfixe de l'URL peut changer en fonction de la page d'affichage sélectionnée.
 the-url-title-cannot-contain-slashes-and-categories=Le titre de l'URL ne peut pas contenir de barres obliques ni de catégories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Le titre de l'URL est déjà en cours d'utilisation. Veuillez indiquer un titre URL unique.
 the-url-to-unsubscribe-the-user=L'URL pour désabonner l'utilisateur
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} existe déjà dans d'autres sites ou dépôts.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=L'URL peut être modifiée pour gar
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=L'URL de la page comparant ce contenu de page à la version préalable
 the-url-prefix-might-change-based-on-the-selected-display-page=Le préfixe de l'URL peut changer en fonction de la page d'affichage sélectionnée.
 the-url-title-cannot-contain-slashes-and-categories=Le titre de l'URL ne peut pas contenir de barres obliques ni de catégories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Le titre de l'URL est déjà en cours d'utilisation. Veuillez indiquer un titre URL unique.
 the-url-to-unsubscribe-the-user=L'URL pour désabonner l'utilisateur
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} existe déjà dans d'autres sites ou dépôts.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=L'URL de la page comparant ce contenu de page à la version préalable
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Le titre de l'URL est déjà en cours d'utilisation. Veuillez indiquer un titre URL unique.
 the-url-to-unsubscribe-the-user=L'URL pour désabonner l'utilisateur
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=L'URL peut être modifiée pour gar
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=L'URL de la page comparant ce contenu de page à la version préalable
 the-url-prefix-might-change-based-on-the-selected-display-page=Le préfixe de l'URL peut changer en fonction de la page d'affichage sélectionnée.
 the-url-title-cannot-contain-slashes-and-categories=Le titre de l'URL ne peut pas contenir de barres obliques ni de catégories.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Le titre de l'URL est déjà en cours d'utilisation. Veuillez indiquer un titre URL unique.
 the-url-to-unsubscribe-the-user=L'URL pour désabonner l'utilisateur
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=L'URL utilisée dans {0} existe déjà dans d'autres sites ou dépôts.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=O URL da pázina comparando este contido da páxina coa versión anterior
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=पिछले संस्करण के साथ इस पृष्ठ सामग्री की तुलना पृष्ठ का URL (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL शीर्षक पहले से उपयोग में है। कृपया एक अद्वितीय URL शीर्षक दर्ज करें।
 the-url-to-unsubscribe-the-user=यूआरएल उपयोगकर्ता को सदस्यता समाप्त करने के लिए (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL stranice uspoređujući ovu stranicu sadržaja s prethodnom verzijom
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -19309,6 +19309,7 @@ the-url-can-be-modified-to-ensure-uniqueness=Az URL cím megváltoztatható az e
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Az oldal URL címe összehasonlítva az oldal tartalmának előző változatához
 the-url-prefix-might-change-based-on-the-selected-display-page=Az URL-előtag a kiválasztott megjelenítési oldal alapján változhat.
 the-url-title-cannot-contain-slashes-and-categories=Az URL-cím nem tartalmazhat perjeleket és kategóriákat.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Az URL-cím már használatban van. Adjon meg egy egyedi URL-címet.
 the-url-to-unsubscribe-the-user=URL-cím a felhasználó leiratkozásához
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=A {0} által használt URL-cím már létezik más webhelyeken vagy adattárakban.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL halaman ini membandingkan isi halaman dengan versi sebelumnya
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Judul URL sudah digunakan. Masukkan judul URL unik. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL untuk berhenti berlangganan pengguna (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -19307,6 +19307,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL della pagina che confronta questo contenuto con la versione precedente
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Il titolo di URL è già in uso. Inserisci un titolo URL univoco.
 the-url-to-unsubscribe-the-user=L'URL da utilizzare per annullare la sottoscrizione utente
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL della pagina che confronta questo contenuto con la versione precedente
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Il titolo di URL è già in uso. Inserisci un titolo URL univoco.
 the-url-to-unsubscribe-the-user=L'URL da utilizzare per annullare la sottoscrizione utente
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=כתובת ה-URL של הדף המשווה תוכן דף זה עם הגירסה הקודמת שלו
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=כותרת כתובת ה-URL כבר נמצאת בשימוש. אנא הזן כותרת כתובת URL ייחודית.
 the-url-to-unsubscribe-the-user=כתובת ה-URL כדי לבטל את מנוי המשתמש
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=URL は一意性を確保するた�
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=前のバージョンとこのページの内容を比較するページのURL
 the-url-prefix-might-change-based-on-the-selected-display-page=URL 接頭辞は選択した表示ページに応じて変わる場合があります。
 the-url-title-cannot-contain-slashes-and-categories=URL のタイトルにスラッシュとカテゴリを含めることはできません。
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL のタイトルはすでに使用中です。重複しない URL のタイトルを入力してください。
 the-url-to-unsubscribe-the-user=ユーザー登録を解除する URL
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries={0} で使用されている URL はすでに他のサイトまたはアセットライブラリに存在します。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -19312,6 +19312,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title.
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -19305,6 +19305,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=이전 버전과 이 페이지 내용을 비교하는 페이지의 URL
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL 제목이 이미 사용 중입니다. 고유한 URL 제목을 입력하세요.
 the-url-to-unsubscribe-the-user=사용자를 구독 취소할 URL
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Puslapio, kuriame šio puslapio turinys lyginamas su ankstesne versija, URL (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL pavadinimas jau naudojamas. Įveskite unikalų URL pavadinimą. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL, kurio reikia atsisakyti vartotojui (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL halaman membandingkan kandungan halaman ini dengan versi terdahulu (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Tajuk URL sedang digunakan. Sila masukkan tajuk URL yang unik. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL untuk berhenti melanggan pengguna (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URLen til siden som sammenligner denne siden med en tidligere versjon
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Denne URL-tittelen er allerede i bruk. Vennligst angi en unik URL-tittel.
 the-url-to-unsubscribe-the-user=URL-adressen for å avslutte abonnementet på brukeren (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -19309,6 +19309,7 @@ the-url-can-be-modified-to-ensure-uniqueness=De URL kan worden gewijzigd om deze
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=De URL van de pagina die deze paginainhoud vergelijkt met de vorige versie
 the-url-prefix-might-change-based-on-the-selected-display-page=Het prefix van de URL kan veranderen op basis van de geselecteerde weergavepagina.
 the-url-title-cannot-contain-slashes-and-categories=De URL-titel mag geen slashes en categorieën bevatten.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=De titel van de URL is al in gebruik. Voer een unieke URL titel in.
 the-url-to-unsubscribe-the-user=De URL om het abonnement van de gebruiker stop te zetten
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=De URL gebruikt in {0} bestaat al in andere sites of assetbibliotheken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -19309,6 +19309,7 @@ the-url-can-be-modified-to-ensure-uniqueness=De URL kan worden gewijzigd om deze
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=De URL van de pagina die deze pagina-inhoud vergelijkt met de vorige versie
 the-url-prefix-might-change-based-on-the-selected-display-page=Het prefix van de URL kan veranderen op basis van de geselecteerde weergavepagina.
 the-url-title-cannot-contain-slashes-and-categories=De URL-titel mag geen slashes en categorieën bevatten.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=De titel van de URL is al in gebruik. Voer een unieke URL titel in.
 the-url-to-unsubscribe-the-user=De URL om het abonnement van de gebruiker stop te zetten
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=De URL gebruikt in {0} bestaat al in andere sites of assetbibliotheken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URLen til siden som sammenligner denne siden med en tidligere versjon
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Denne URL-tittelen er allerede i bruk. Vennligst angi en unik URL-tittel.
 the-url-to-unsubscribe-the-user=URL-adressen for å avslutte abonnementet på brukeren (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL strony porównującej zawartość tej strony z poprzednią wersją
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Tytuł adresu URL jest już używany. Podaj unikatowy tytuł adresu URL. (Automatic Translation)
 the-url-to-unsubscribe-the-user=Adres URL, aby anulować subskrypcję użytkownika (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=O URL pode ser modificado para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=A URL da página que compara o conteúdo desta página com a versão anterior
 the-url-prefix-might-change-based-on-the-selected-display-page=O prefixo do URL pode mudar com base na página de exibição selecionada.
 the-url-title-cannot-contain-slashes-and-categories=O título do URL não pode conter barras e categorias.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=O título de URL já está em uso. Por favor, digite um título de URL único.
 the-url-to-unsubscribe-the-user=O URL para cancelar inscrição do usuário
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=O URL utilizado em {0} já existe em outros sites ou bibliotecas de conteúdo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=O URL pode ser modificado para gara
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=O URL da página que compara o conteúdo desta página com a versão anterior
 the-url-prefix-might-change-based-on-the-selected-display-page=O prefixo do URL pode mudar com base na página de exibição selecionada.
 the-url-title-cannot-contain-slashes-and-categories=O título do URL não pode conter barras e categorias.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=O título de URL já está a ser utilizado. Por favor, indique um título de URL unico.
 the-url-to-unsubscribe-the-user=O URL para cancelar inscrição do usuário
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=O URL utilizado em {0} já existe em outros sites ou bibliotecas de conteúdo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL-ul compararii continutului pagini cu versiunea precedenta the-user-could-not-be-found=The user could not be found.
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Titlul URL-ului este deja în uz. Introduceți un titlu URL unic. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL-ul pentru dezabonare a utilizatorului (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL страницы, содержащей сравнение контента этой страницы с предыдущей версией
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Название URL уже используется. Пожалуйста, введите уникальное название URL. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL-адрес для подписки на пользователя (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL stránky, ktorej obsah bude porovnaný s predchádzajúcou verziou.
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Názov adresy URL sa už používa. Zadajte jedinečný názov adresy URL. (Automatic Translation)
 the-url-to-unsubscribe-the-user=Adresa URL na zrušenie odberu používateľa (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL strani, ki primerja to vsebino strani s prejšnjo različico (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Naslov URL-ja je že v uporabi. Vnesite edinstven naslov URL-ja. (Automatic Translation)
 the-url-to-unsubscribe-the-user=Spletni naslov za odjava uporabnika (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=УРЛ странице пореди садржај ове странице са претходном верзијом
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL stranice poredi sadržaj ove stranice sa prethodnom verzijom
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=The URL title is already in use. Please enter a unique URL title. (Automatic Copy)
 the-url-to-unsubscribe-the-user=The URL to unsubscribe the user (Automatic Copy)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=URL:en kan ändras för att garante
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL till sidan som jämför den här sidans innehåll med den tidigare versionen
 the-url-prefix-might-change-based-on-the-selected-display-page=URL-prefixet kan ändras baserat på den valda visningssidan.
 the-url-title-cannot-contain-slashes-and-categories=URL-titel får inte innehålla snedstreck och kategorier.
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL-titeln används redan. Ange en unik URL-titel.
 the-url-to-unsubscribe-the-user=URL för att avsluta användarens prenumeration
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=URL som används i {0} finns redan på andra webbplatser eller tillgångsbibliotek.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=The URL of the page comparing this page content with the previous version (Automatic Copy)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=இந்த URL தலைப்பு ஏற்கனவே இருக்கிறது. புதிய தலைப்பை கொடுக்கவும்.
 the-url-to-unsubscribe-the-user=பயனர் குழுவிலகுவதற்கான URL
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL ของหน้าเว็บที่เปรียบเทียบเนื้อหาของหน้านี้กับเวอร์ชันก่อนหน้า
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=มีการใช้งานชื่อ URL แล้ว โปรดป้อนชื่อ URL ที่ไม่ซ้ำกัน
 the-url-to-unsubscribe-the-user=URL ที่จะยกเลิกการสมัครสมาชิกของผู้ใช้
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Bu sayfa içeriğini önceki sürümle karşılaştıran sayfanın URL'si (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=URL başlığı zaten kullanılıyor. Lütfen benzersiz bir URL başlığı girin. (Automatic Translation)
 the-url-to-unsubscribe-the-user=Kullanıcının aboneliğini iptal etmek için URL (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=URL-адреса сторінки, що порівнює вміст цієї сторінки з попередньою версією (Automatic Translation)
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Заголовок URL-адреси вже використовується. Введіть унікальну URL-адресу. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL-адреса для скасування підписки на користувача (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -19306,6 +19306,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=Liên kết của trang kết quả so sánh nội dung trang này và phiên bản trước
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=Tiêu đề URL đã được sử dụng. Vui lòng nhập tiêu đề URL duy nhất. (Automatic Translation)
 the-url-to-unsubscribe-the-user=URL để hủy đăng ký người dùng (Automatic Translation)
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -19308,6 +19308,7 @@ the-url-can-be-modified-to-ensure-uniqueness=可对 URL 进行修改，以确保
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=页面的URL与这个页面内容的先前的版本比较
 the-url-prefix-might-change-based-on-the-selected-display-page=URL 前缀可能会根据所选显示页面进行更改。
 the-url-title-cannot-contain-slashes-and-categories=URL 标题不能包含斜线和类别。
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=此URL标题已被使用，请输入一个唯一的URL标题。
 the-url-to-unsubscribe-the-user=取消订阅用户的 URL
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries={0} 中使用的 URL 在其他站点或资产库中已存在。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -19307,6 +19307,7 @@ the-url-can-be-modified-to-ensure-uniqueness=The URL can be modified to ensure u
 the-url-of-the-page-comparing-this-page-content-with-the-previous-version=頁面網址相較於之前版本的頁面內容
 the-url-prefix-might-change-based-on-the-selected-display-page=The URL prefix might change based on the selected display page. (Automatic Copy)
 the-url-title-cannot-contain-slashes-and-categories=The URL title cannot contain slashes and categories. (Automatic Copy)
+the-url-title-cannot-have-a-trailing-slash=The URL title cannot have a trailing slash (Automatic Copy)
 the-url-title-is-already-in-use-please-enter-a-unique-url-title=此 URL 標題已被使用，請輸入唯一不重複的 URL 標題。
 the-url-to-unsubscribe-the-user=取消訂閱用戶的 URL
 the-url-used-in-x-already-exists-in-other-sites-or-asset-libraries=The URL used in {0} already exists in other sites or asset libraries. (Automatic Copy)


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38768

One of the possible exceptions thrown by the service was not properly handled, so instead of a validation error the user got redirected to the fatal error page.

# How am I fixing it?

Handle the specific exception as an additional case in the mvc action.

# How can you verify that it works?

Run the included integration test.