### PR TITLE
LPD-48315 Fix POSHI tests MSBUpgrade#ViewMSBAndAddContentPageAfterUpgrade*

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/contentpage/ContentPages.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/contentpage/ContentPages.macro
@@ -126,7 +126,7 @@ definition {
 				locator1 = "Breadcrumb#BREADCRUMB_ENTRY",
 				value1 = "Pages");
 
-			LexiconEntry.gotoAddMenuItem(menuItem = "Public Page");
+			Button.click(button = "New");
 		}
 
 		ContentPages._selectCard(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/modernsitebuilding/MSBUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/modernsitebuilding/MSBUpgrade.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-site-management"
 definition {
 
 	property ci.retries.disabled = "true";
@@ -6,7 +6,7 @@ definition {
 	property portal.upstream = "true";
 	property test.liferay.virtual.instance = "false";
 	property test.run.type = "single";
-	property testray.main.component.name = "Upgrades Content Management";
+	property testray.main.component.name = "Upgrades Site Management";
 
 	setUp {
 		SignIn.signIn();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48315

Failing tests:

* LocalFile.MSBUpgrade#ViewMSBAndAddContentPageAfterUpgrade71102
* LocalFile.MSBUpgrade#ViewMSBAndAddContentPageAfterUpgrade713

I'm also changing ownership of testcase file to Site Management team

# How am I fixing it?

I'm applying the same fix already created in https://github.com/liferay-site-management/liferay-portal/pull/1706

# How can you verify that it works?

`ant -f build-test.xml run-selenium-test -Dtest.class=MSBUpgrade#ViewMSBAndAddContentPageAfterUpgrade71102`
`ant -f build-test.xml run-selenium-test -Dtest.class=MSBUpgrade#ViewMSBAndAddContentPageAfterUpgrade713`