### PR TITLE
LPD-47985 Keep Creator data for vocabularies and categories during import for Batch engine

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Headless Admin Taxonomy Implementation
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.impl
 Bundle-Version: 5.0.94
+-dsannotations-options: inherit

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/BaseImportTaskPostAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/BaseImportTaskPostAction.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPostAction;
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.context.ImportTaskContext;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+/**
+ * @author Jürgen Kappler
+ */
+public abstract class BaseImportTaskPostAction<T>
+	implements ImportTaskPostAction {
+
+	@Override
+	public void run(
+			BatchEngineImportTask batchEngineImportTask,
+			ImportTaskContext importTaskContext, Object item,
+			Object persistedItem)
+		throws Exception {
+
+		if (!Objects.equals(item.getClass(), getItemClass()) ||
+			!StringUtil.equals(
+				batchEngineImportTask.getParameterValue(
+					"importCreatorStrategy"),
+				BatchEngineImportTaskConstants.
+					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
+
+			return;
+		}
+
+		String originalUserId = importTaskContext.getOriginalUserId();
+
+		if (Validator.isNotNull(originalUserId)) {
+			PrincipalThreadLocal.setName(originalUserId);
+
+			importTaskContext.setOriginalUserId(null);
+		}
+	}
+
+	protected abstract Class<T> getItemClass();
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/BaseImportTaskPreAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/BaseImportTaskPreAction.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPreAction;
+import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
+import com.liferay.batch.engine.context.ImportTaskContext;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jürgen Kappler
+ */
+public abstract class BaseImportTaskPreAction<T>
+	implements ImportTaskPreAction {
+
+	@Override
+	public void run(
+			BatchEngineImportTask batchEngineImportTask,
+			ImportTaskContext importTaskContext, Object item)
+		throws Exception {
+
+		if (!Objects.equals(item.getClass(), getItemClass()) ||
+			!StringUtil.equals(
+				batchEngineImportTask.getParameterValue(
+					"importCreatorStrategy"),
+				BatchEngineImportTaskConstants.
+					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
+
+			return;
+		}
+
+		User user = _getCreatorUser(getCreator(item));
+
+		if (user == null) {
+			return;
+		}
+
+		String name = PrincipalThreadLocal.getName();
+
+		if (GetterUtil.getLong(name) == user.getUserId()) {
+			return;
+		}
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		importTaskContext.setOriginalUserId(name);
+	}
+
+	protected abstract Creator getCreator(Object item);
+
+	protected abstract Class<T> getItemClass();
+
+	@Reference
+	protected UserLocalService userLocalService;
+
+	private User _getCreatorUser(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		User user = null;
+
+		if (Validator.isNotNull(creator.getExternalReferenceCode())) {
+			user = userLocalService.fetchUserByExternalReferenceCode(
+				creator.getExternalReferenceCode(),
+				CompanyThreadLocal.getCompanyId());
+		}
+
+		if ((user == null) && Validator.isNotNull(creator.getId())) {
+			user = userLocalService.fetchUser(creator.getId());
+		}
+
+		return user;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPostAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPostAction.java
@@ -6,13 +6,7 @@
 package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
 
 import com.liferay.batch.engine.action.ImportTaskPostAction;
-import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
-import com.liferay.batch.engine.context.ImportTaskContext;
-import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -20,32 +14,11 @@ import org.osgi.service.component.annotations.Component;
  * @author Jürgen Kappler
  */
 @Component(service = ImportTaskPostAction.class)
-public class KeywordImportTaskPostAction implements ImportTaskPostAction {
+public class KeywordImportTaskPostAction extends BaseImportTaskPostAction {
 
 	@Override
-	public void run(
-			BatchEngineImportTask batchEngineImportTask,
-			ImportTaskContext importTaskContext, Object item,
-			Object persistedItem)
-		throws Exception {
-
-		if (!(item instanceof Keyword) ||
-			!StringUtil.equals(
-				batchEngineImportTask.getParameterValue(
-					"importCreatorStrategy"),
-				BatchEngineImportTaskConstants.
-					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
-
-			return;
-		}
-
-		String originalUserId = importTaskContext.getOriginalUserId();
-
-		if (Validator.isNotNull(originalUserId)) {
-			PrincipalThreadLocal.setName(originalUserId);
-
-			importTaskContext.setOriginalUserId(null);
-		}
+	protected Class getItemClass() {
+		return Keyword.class;
 	}
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPreAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/KeywordImportTaskPreAction.java
@@ -6,90 +6,31 @@
 package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
 
 import com.liferay.batch.engine.action.ImportTaskPreAction;
-import com.liferay.batch.engine.constants.BatchEngineImportTaskConstants;
-import com.liferay.batch.engine.context.ImportTaskContext;
-import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
 import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
  */
 @Component(service = ImportTaskPreAction.class)
-public class KeywordImportTaskPreAction implements ImportTaskPreAction {
+public class KeywordImportTaskPreAction extends BaseImportTaskPreAction {
 
 	@Override
-	public void run(
-			BatchEngineImportTask batchEngineImportTask,
-			ImportTaskContext importTaskContext, Object item)
-		throws Exception {
-
-		if (!(item instanceof Keyword) ||
-			!StringUtil.equals(
-				batchEngineImportTask.getParameterValue(
-					"importCreatorStrategy"),
-				BatchEngineImportTaskConstants.
-					IMPORT_CREATOR_STRATEGY_KEEP_CREATOR)) {
-
-			return;
+	protected Creator getCreator(Object item) {
+		if (!(item instanceof Keyword)) {
+			return null;
 		}
 
 		Keyword keyword = (Keyword)item;
 
-		User user = _getCreatorUser(keyword);
-
-		if (user == null) {
-			return;
-		}
-
-		String name = PrincipalThreadLocal.getName();
-
-		if (GetterUtil.getLong(name) == user.getUserId()) {
-			return;
-		}
-
-		PrincipalThreadLocal.setName(user.getUserId());
-
-		importTaskContext.setOriginalUserId(name);
+		return keyword.getCreator();
 	}
 
-	private User _getCreatorUser(Keyword keyword) {
-		if (keyword == null) {
-			return null;
-		}
-
-		Creator creator = keyword.getCreator();
-
-		if (creator == null) {
-			return null;
-		}
-
-		User user = null;
-
-		if (Validator.isNotNull(creator.getExternalReferenceCode())) {
-			user = _userLocalService.fetchUserByExternalReferenceCode(
-				creator.getExternalReferenceCode(),
-				CompanyThreadLocal.getCompanyId());
-		}
-
-		if ((user == null) && Validator.isNotNull(creator.getId())) {
-			user = _userLocalService.fetchUser(creator.getId());
-		}
-
-		return user;
+	@Override
+	protected Class<Keyword> getItemClass() {
+		return Keyword.class;
 	}
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyCategoryImportTaskPostAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyCategoryImportTaskPostAction.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPostAction;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPostAction.class)
+public class TaxonomyCategoryImportTaskPostAction
+	extends BaseImportTaskPostAction {
+
+	@Override
+	protected Class getItemClass() {
+		return TaxonomyCategory.class;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyCategoryImportTaskPreAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyCategoryImportTaskPreAction.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPreAction;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPreAction.class)
+public class TaxonomyCategoryImportTaskPreAction
+	extends BaseImportTaskPreAction {
+
+	@Override
+	protected Creator getCreator(Object item) {
+		if (!(item instanceof TaxonomyCategory)) {
+			return null;
+		}
+
+		TaxonomyCategory taxonomyCategory = (TaxonomyCategory)item;
+
+		return taxonomyCategory.getCreator();
+	}
+
+	@Override
+	protected Class<TaxonomyCategory> getItemClass() {
+		return TaxonomyCategory.class;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyVocabularyImportTaskPostAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyVocabularyImportTaskPostAction.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPostAction;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPostAction.class)
+public class TaxonomyVocabularyImportTaskPostAction
+	extends BaseImportTaskPostAction {
+
+	@Override
+	protected Class getItemClass() {
+		return TaxonomyVocabulary.class;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyVocabularyImportTaskPreAction.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/TaxonomyVocabularyImportTaskPreAction.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action;
+
+import com.liferay.batch.engine.action.ImportTaskPreAction;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Creator;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ImportTaskPreAction.class)
+public class TaxonomyVocabularyImportTaskPreAction
+	extends BaseImportTaskPreAction {
+
+	@Override
+	protected Creator getCreator(Object item) {
+		if (!(item instanceof TaxonomyVocabulary)) {
+			return null;
+		}
+
+		TaxonomyVocabulary taxonomyVocabulary = (TaxonomyVocabulary)item;
+
+		return taxonomyVocabulary.getCreator();
+	}
+
+	@Override
+	protected Class<TaxonomyVocabulary> getItemClass() {
+		return TaxonomyVocabulary.class;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/KeywordImportTaskPreActionTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/KeywordImportTaskPreActionTest.java
@@ -56,10 +56,10 @@ public class KeywordImportTaskPreActionTest {
 		AssetTag assetTag = _getAssetTag(_user.getUserId());
 
 		String json = ExportImportTaskResourceTestUtil.executeExportTask(
-			Keyword.class.getName(), _localGroup.getGroupId());
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
 
 		ExportImportTaskResourceTestUtil.executeImportTask(
-			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
 			"KEEP_CREATOR", json);
 
 		_assertAssetTag(
@@ -74,12 +74,12 @@ public class KeywordImportTaskPreActionTest {
 		AssetTag assetTag = _getAssetTag(_user.getUserId());
 
 		String json = ExportImportTaskResourceTestUtil.executeExportTask(
-			Keyword.class.getName(), _localGroup.getGroupId());
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
 
 		_userLocalService.deleteUser(_user);
 
 		ExportImportTaskResourceTestUtil.executeImportTask(
-			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
 			"KEEP_CREATOR", json);
 
 		_assertAssetTag(
@@ -92,10 +92,10 @@ public class KeywordImportTaskPreActionTest {
 		AssetTag assetTag = _getAssetTag(_user.getUserId());
 
 		String json = ExportImportTaskResourceTestUtil.executeExportTask(
-			Keyword.class.getName(), _localGroup.getGroupId());
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
 
 		ExportImportTaskResourceTestUtil.executeImportTask(
-			Keyword.class.getName(), "INSERT", _targetGroup.getGroupId(),
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
 			"OVERWRITE_CREATOR", json);
 
 		_assertAssetTag(
@@ -108,12 +108,12 @@ public class KeywordImportTaskPreActionTest {
 		AssetTag assetTag = _getAssetTag(_user.getUserId());
 
 		String json = ExportImportTaskResourceTestUtil.executeExportTask(
-			Keyword.class.getName(), _localGroup.getGroupId());
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
 
 		_assetTagLocalService.deleteTag(assetTag);
 
 		ExportImportTaskResourceTestUtil.executeImportTask(
-			Keyword.class.getName(), "UPSERT", _localGroup.getGroupId(),
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
 			"KEEP_CREATOR", json);
 
 		_assertAssetTag(
@@ -126,14 +126,14 @@ public class KeywordImportTaskPreActionTest {
 		AssetTag assetTag = _getAssetTag(_user.getUserId());
 
 		String json = ExportImportTaskResourceTestUtil.executeExportTask(
-			Keyword.class.getName(), _localGroup.getGroupId());
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
 
 		_assetTagLocalService.deleteTag(assetTag);
 
 		_userLocalService.deleteUser(_user);
 
 		ExportImportTaskResourceTestUtil.executeImportTask(
-			Keyword.class.getName(), "UPSERT", _localGroup.getGroupId(),
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
 			"OVERWRITE_CREATOR", json);
 
 		_assertAssetTag(
@@ -158,6 +158,8 @@ public class KeywordImportTaskPreActionTest {
 			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext(_localGroup.getGroupId()));
 	}
+
+	private static final String _ITEM_CLASS_NAME = Keyword.class.getName();
 
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/TaxonomyCategoryImportTaskPreActionTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/TaxonomyCategoryImportTaskPreActionTest.java
@@ -1,0 +1,244 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
+import com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test.util.ExportImportTaskResourceTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class TaxonomyCategoryImportTaskPreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_localGroup = GroupTestUtil.addGroup();
+		_targetGroup = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.addUser();
+
+		_localAssetVocabulary = _assetVocabularyLocalService.addVocabulary(
+			_user.getUserId(), _localGroup.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+		_targetAssetVocabulary = _assetVocabularyLocalService.addVocabulary(
+			_user.getUserId(), _targetGroup.getGroupId(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreator() throws Exception {
+		AssetCategory assetCategory = _getAssetCategory(_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId(),
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", json,
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_targetAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assertAssetCategory(
+			assetCategory.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			_user.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreatorUserDoesNotExist()
+		throws Exception {
+
+		AssetCategory assetCategory = _getAssetCategory(_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId(),
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", json,
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_targetAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assertAssetCategory(
+			assetCategory.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndOverwriteCreator() throws Exception {
+		AssetCategory assetCategory = _getAssetCategory(_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId(),
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"OVERWRITE_CREATOR", json,
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_targetAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assertAssetCategory(
+			assetCategory.getExternalReferenceCode(), _targetGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndKeepCreator() throws Exception {
+		AssetCategory assetCategory = _getAssetCategory(_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId(),
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assetCategoryLocalService.deleteVocabularyCategories(
+			_localAssetVocabulary.getVocabularyId());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
+			"KEEP_CREATOR", json,
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assertAssetCategory(
+			assetCategory.getExternalReferenceCode(), _localGroup.getGroupId(),
+			_user.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndOverwriteCreator() throws Exception {
+		AssetCategory assetCategory = _getAssetCategory(_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId(),
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assetCategoryLocalService.deleteVocabularyCategories(
+			_localAssetVocabulary.getVocabularyId());
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
+			"OVERWRITE_CREATOR", json,
+			HashMapBuilder.put(
+				"taxonomyVocabularyId",
+				String.valueOf(_localAssetVocabulary.getVocabularyId())
+			).build());
+
+		_assertAssetCategory(
+			assetCategory.getExternalReferenceCode(), _localGroup.getGroupId(),
+			TestPropsValues.getUserId());
+	}
+
+	private void _assertAssetCategory(
+			String externalReferenceCode, long groupId, long userId)
+		throws Exception {
+
+		AssetCategory assetCategory =
+			_assetCategoryLocalService.getAssetCategoryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		Assert.assertEquals(userId, assetCategory.getUserId());
+
+		_assetCategoryLocalService.deleteCategory(assetCategory);
+	}
+
+	private AssetCategory _getAssetCategory(long userId) throws Exception {
+		return _assetCategoryLocalService.addCategory(
+			userId, _localGroup.getGroupId(), RandomTestUtil.randomString(),
+			_localAssetVocabulary.getVocabularyId(),
+			ServiceContextTestUtil.getServiceContext(_localGroup.getGroupId()));
+	}
+
+	private static final String _ITEM_CLASS_NAME =
+		TaxonomyCategory.class.getName();
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private AssetVocabulary _localAssetVocabulary;
+
+	@DeleteAfterTestRun
+	private Group _localGroup;
+
+	private AssetVocabulary _targetAssetVocabulary;
+
+	@DeleteAfterTestRun
+	private Group _targetGroup;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/TaxonomyVocabularyImportTaskPreActionTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/TaxonomyVocabularyImportTaskPreActionTest.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
+import com.liferay.headless.admin.taxonomy.internal.batch.engine.action.test.util.ExportImportTaskResourceTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class TaxonomyVocabularyImportTaskPreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_localGroup = GroupTestUtil.addGroup();
+		_targetGroup = GroupTestUtil.addGroup();
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreator() throws Exception {
+		AssetVocabulary assetVocabulary = _getAssetVocabulary(
+			_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", json);
+
+		_assertAssetVocabulary(
+			assetVocabulary.getExternalReferenceCode(),
+			_targetGroup.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndKeepCreatorUserDoesNotExist()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = _getAssetVocabulary(
+			_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"KEEP_CREATOR", json);
+
+		_assertAssetVocabulary(
+			assetVocabulary.getExternalReferenceCode(),
+			_targetGroup.getGroupId(), TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithInsertAndOverwriteCreator() throws Exception {
+		AssetVocabulary assetVocabulary = _getAssetVocabulary(
+			_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "INSERT", _targetGroup.getGroupId(),
+			"OVERWRITE_CREATOR", json);
+
+		_assertAssetVocabulary(
+			assetVocabulary.getExternalReferenceCode(),
+			_targetGroup.getGroupId(), TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndKeepCreator() throws Exception {
+		AssetVocabulary assetVocabulary = _getAssetVocabulary(
+			_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
+
+		_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
+			"KEEP_CREATOR", json);
+
+		_assertAssetVocabulary(
+			assetVocabulary.getExternalReferenceCode(),
+			_localGroup.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testImportWithUpsertAndOverwriteCreator() throws Exception {
+		AssetVocabulary assetVocabulary = _getAssetVocabulary(
+			_user.getUserId());
+
+		String json = ExportImportTaskResourceTestUtil.executeExportTask(
+			_ITEM_CLASS_NAME, _localGroup.getGroupId());
+
+		_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+
+		_userLocalService.deleteUser(_user);
+
+		ExportImportTaskResourceTestUtil.executeImportTask(
+			_ITEM_CLASS_NAME, "UPSERT", _localGroup.getGroupId(),
+			"OVERWRITE_CREATOR", json);
+
+		_assertAssetVocabulary(
+			assetVocabulary.getExternalReferenceCode(),
+			_localGroup.getGroupId(), TestPropsValues.getUserId());
+	}
+
+	private void _assertAssetVocabulary(
+			String externalReferenceCode, long groupId, long userId)
+		throws Exception {
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.
+				getAssetVocabularyByExternalReferenceCode(
+					externalReferenceCode, groupId);
+
+		Assert.assertEquals(userId, assetVocabulary.getUserId());
+	}
+
+	private AssetVocabulary _getAssetVocabulary(long userId) throws Exception {
+		return _assetVocabularyLocalService.addVocabulary(
+			userId, _localGroup.getGroupId(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(_localGroup.getGroupId()));
+	}
+
+	private static final String _ITEM_CLASS_NAME =
+		TaxonomyVocabulary.class.getName();
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _localGroup;
+
+	@DeleteAfterTestRun
+	private Group _targetGroup;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
@@ -12,13 +12,16 @@ import com.liferay.headless.batch.engine.client.serdes.v1_0.ExportTaskSerDes;
 import com.liferay.headless.batch.engine.client.serdes.v1_0.ImportTaskSerDes;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.InputStream;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.zip.ZipInputStream;
 
@@ -32,14 +35,32 @@ public class ExportImportTaskResourceTestUtil {
 	public static String executeExportTask(String className, long groupId)
 		throws Exception {
 
+		return executeExportTask(className, groupId, null);
+	}
+
+	public static String executeExportTask(
+			String className, long groupId, Map<String, String> parameters)
+		throws Exception {
+
 		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
 		httpInvoker.header(HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON);
 		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-		httpInvoker.path(
-			StringBundler.concat(
-				"http://localhost:8080/o/headless-batch-engine/v1.0",
-				"/export-task/", className, "/JSON?siteId=", groupId));
+
+		String path = StringBundler.concat(
+			"http://localhost:8080/o/headless-batch-engine/v1.0/export-task/",
+			className, "/JSON?siteId=", groupId);
+
+		if (MapUtil.isNotEmpty(parameters)) {
+			for (Map.Entry<String, String> entry : parameters.entrySet()) {
+				path = StringBundler.concat(
+					path, StringPool.AMPERSAND, entry.getKey(),
+					StringPool.EQUAL, entry.getValue());
+			}
+		}
+
+		httpInvoker.path(path);
+
 		httpInvoker.userNameAndPassword(
 			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
 
@@ -97,19 +118,40 @@ public class ExportImportTaskResourceTestUtil {
 
 	public static void executeImportTask(
 			String className, String createStrategy, long groupId,
-			String importCreatorStrategy, String jsonString)
+			String importCreatorStrategy, String json)
+		throws Exception {
+
+		executeImportTask(
+			className, createStrategy, groupId, importCreatorStrategy, json,
+			null);
+	}
+
+	public static void executeImportTask(
+			String className, String createStrategy, long groupId,
+			String importCreatorStrategy, String json,
+			Map<String, String> parameters)
 		throws Exception {
 
 		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
-		httpInvoker.body(jsonString, "application/json");
+		httpInvoker.body(json, "application/json");
 		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
-		httpInvoker.path(
-			StringBundler.concat(
-				"http://localhost:8080/o/headless-batch-engine/v1.0",
-				"/import-task/", className, "?createStrategy=", createStrategy,
-				"&importCreatorStrategy=", importCreatorStrategy, "&siteId=",
-				groupId));
+
+		String path = StringBundler.concat(
+			"http://localhost:8080/o/headless-batch-engine/v1.0/import-task/",
+			className, "?createStrategy=", createStrategy,
+			"&importCreatorStrategy=", importCreatorStrategy, "&siteId=",
+			groupId);
+
+		if (MapUtil.isNotEmpty(parameters)) {
+			for (Map.Entry<String, String> entry : parameters.entrySet()) {
+				path = StringBundler.concat(
+					path, StringPool.AMPERSAND, entry.getKey(),
+					StringPool.EQUAL, entry.getValue());
+			}
+		}
+
+		httpInvoker.path(path);
 		httpInvoker.userNameAndPassword(
 			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
 


### PR DESCRIPTION
Keep Creator data for categories and vocabularies during import for Batch engine

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-47985)

Currently Staging can be configured to keep or not the Creator related information during import for content. With this story, we want to allow users to do the same thing but using Batch engine with categories and vocabularies and a new query parameter. 

# How am I fixing it?

Adding ImportTaskPostAction and ImportTaskPreAction so as to select the user based on the importCreatorStrategy

# How can you verify that it works?

Run the provided integration tests

If you want to test manually, you can follow the guide located here: https://liferay.atlassian.net/wiki/spaces/~5570586e267afec60c4fe3a33934eaf1110faf/pages/3553493093/How+to+test+creatorStrategy. Instead of Keyword as classname, you would need to use TaxonomyCategory and TaxonomyVocabulary as classnames