### PR TITLE
LPD-48258 Modified Date for Web Content articles in Table view doesn't show user

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -306,8 +306,9 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 						</c:if>
 
 						<liferay-ui:search-container-column-date
-							cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
+							cssClass="table-cell-expand-smallest"
 							name="modified-date"
+							userName="<%= curArticle.getStatusByUserName() %>"
 							value="<%= curArticle.getModifiedDate() %>"
 						/>
 

--- a/modules/test/playwright/tests/journal-web/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalPage.spec.ts
@@ -142,3 +142,26 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Validate Modified Date format in Table View',
+	{
+		tag: '@LPD-48258',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'First Web content'},
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		expect(
+			page.getByRole('row', {name: /\d+ .* ago by .*/i})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-48258
Modified Date for Web Content articles in Table view doesn't show user

### **How am I fixing it?**
Using key "modified-x-ago-by-x" inside liferay-ui:search-container-column-text tag

### **How can you verify that it works?**

1. Start Liferay
2. Open Web Content
3. Select display type as "Table"
4. View Modified Date