### PR TITLE
LPD-47867 Error translating deleted user content

### DIFF
--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
@@ -29,6 +29,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -159,7 +160,11 @@ public class JournalArticleInfoItemFieldValuesUpdater
 				fields, ddmStructure, importedLocaleContentMap, targetLocale);
 		}
 
-		User user = _userLocalService.getUser(latestArticle.getUserId());
+		User user = _userLocalService.fetchUser(journalArticle.getUserId());
+
+		if (user == null) {
+			user = _userLocalService.getUser(GuestOrUserUtil.getUserId());
+		}
 
 		int[] displayDateArray = _getDateArray(
 			user, latestArticle.getDisplayDate());
@@ -171,7 +176,7 @@ public class JournalArticleInfoItemFieldValuesUpdater
 		ServiceContext serviceContext = _getServiceContext(latestArticle);
 
 		return _journalArticleLocalService.updateArticle(
-			latestArticle.getUserId(), latestArticle.getGroupId(),
+			user.getUserId(), latestArticle.getGroupId(),
 			latestArticle.getFolderId(), latestArticle.getArticleId(),
 			latestArticle.getVersion(), titleMap, descriptionMap,
 			latestArticle.getFriendlyURLMap(),

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
@@ -160,7 +160,7 @@ public class JournalArticleInfoItemFieldValuesUpdater
 				fields, ddmStructure, importedLocaleContentMap, targetLocale);
 		}
 
-		User user = _userLocalService.fetchUser(journalArticle.getUserId());
+		User user = _userLocalService.fetchUser(latestArticle.getUserId());
 
 		if (user == null) {
 			user = _userLocalService.getUser(GuestOrUserUtil.getUserId());

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -21,16 +21,21 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -41,19 +46,20 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.translation.importer.TranslationInfoItemFieldValuesImporter;
 import com.liferay.translation.service.TranslationEntryLocalService;
 import com.liferay.translation.test.util.TranslationTestUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * @author Alicia García
@@ -67,11 +73,21 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 		new LiferayIntegrationTestRule(),
 		PermissionCheckerMethodTestRule.INSTANCE);
 
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalName = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
 		User user = TestPropsValues.getUser();
+		long companyId = TestPropsValues.getCompanyId();
+
+		_company = _companyLocalService.getCompany(companyId);
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group, user.getUserId());
@@ -82,6 +98,11 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	@After
 	public void tearDown() throws Exception {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		PrincipalThreadLocal.setName(_originalName);
 	}
 
 	@Test
@@ -249,6 +270,50 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 			StringPool.BLANK,
 			_getContent(
 				journalArticle, "name", LocaleUtil.US, LocaleUtil.SPAIN));
+	}
+
+	@Test
+	public void testUpdateJournalArticleAfterUserDeletion() throws Exception {
+		User user = UserTestUtil.addCompanyAdminUser(_company);
+
+		ServiceContext userServiceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), user.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(userServiceContext);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "<p>This is the content</p>"
+			).build(),
+			LocaleUtil.getSiteDefault(), false, true, userServiceContext);
+
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemReference(JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"test-journal-article-122.xlf"));
+
+		_userLocalService.deleteUser(user);
+
+		journalArticle =
+			_journalArticleInfoItemFieldValuesUpdater.updateFromInfoItemFieldValues(
+				journalArticle, infoItemFieldValues);
+
+		Assert.assertEquals(
+			TestPropsValues.getUserId(), journalArticle.getStatusByUserId());
+
+		Assert.assertEquals(
+			"Este es el titulo", journalArticle.getTitle(LocaleUtil.SPAIN));
 	}
 
 	@Test
@@ -423,5 +488,15 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	@Inject(filter = "content.type=application/xliff+xml")
 	private TranslationInfoItemFieldValuesImporter
 		_xliffTranslationInfoItemFieldValuesImporter;
+
+	private Company _company;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private static String _originalName;
 
 }

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/info/item/updater/test/JournalArticleInfoItemFieldValuesUpdaterTest.java
@@ -46,6 +46,12 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.translation.importer.TranslationInfoItemFieldValuesImporter;
 import com.liferay.translation.service.TranslationEntryLocalService;
 import com.liferay.translation.test.util.TranslationTestUtil;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -55,11 +61,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Alicia García
@@ -80,14 +81,19 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
 	}
 
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		PrincipalThreadLocal.setName(_originalName);
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
 		User user = TestPropsValues.getUser();
-		long companyId = TestPropsValues.getCompanyId();
 
-		_company = _companyLocalService.getCompany(companyId);
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group, user.getUserId());
@@ -100,9 +106,50 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		PrincipalThreadLocal.setName(_originalName);
+	@Test
+	public void testUpdateJournalArticleAfterUserDeletion() throws Exception {
+		User user = UserTestUtil.addCompanyAdminUser(_company);
+
+		ServiceContext userServiceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), user.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(userServiceContext);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "<p>This is the content</p>"
+			).build(),
+			LocaleUtil.getSiteDefault(), false, true, userServiceContext);
+
+		InfoItemFieldValues infoItemFieldValues =
+			_xliffTranslationInfoItemFieldValuesImporter.
+				importInfoItemFieldValues(
+					_group.getGroupId(),
+					new InfoItemReference(JournalArticle.class.getName(), 122),
+					TranslationTestUtil.readFileToInputStream(
+						"test-journal-article-122.xlf"));
+
+		_userLocalService.deleteUser(user);
+
+		journalArticle =
+			_journalArticleInfoItemFieldValuesUpdater.
+				updateFromInfoItemFieldValues(
+					journalArticle, infoItemFieldValues);
+
+		Assert.assertEquals(
+			TestPropsValues.getUserId(), journalArticle.getStatusByUserId());
+
+		Assert.assertEquals(
+			"Este es el titulo", journalArticle.getTitle(LocaleUtil.SPAIN));
 	}
 
 	@Test
@@ -273,50 +320,6 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	}
 
 	@Test
-	public void testUpdateJournalArticleAfterUserDeletion() throws Exception {
-		User user = UserTestUtil.addCompanyAdminUser(_company);
-
-		ServiceContext userServiceContext = ServiceContextTestUtil.getServiceContext(
-			_group.getGroupId(), user.getUserId());
-
-		ServiceContextThreadLocal.pushServiceContext(userServiceContext);
-
-		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			_group.getGroupId(), 0,
-			PortalUtil.getClassNameId(JournalArticle.class),
-			HashMapBuilder.put(
-				LocaleUtil.US, RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.US, RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.US, "<p>This is the content</p>"
-			).build(),
-			LocaleUtil.getSiteDefault(), false, true, userServiceContext);
-
-		InfoItemFieldValues infoItemFieldValues =
-			_xliffTranslationInfoItemFieldValuesImporter.
-				importInfoItemFieldValues(
-					_group.getGroupId(),
-					new InfoItemReference(JournalArticle.class.getName(), 122),
-					TranslationTestUtil.readFileToInputStream(
-						"test-journal-article-122.xlf"));
-
-		_userLocalService.deleteUser(user);
-
-		journalArticle =
-			_journalArticleInfoItemFieldValuesUpdater.updateFromInfoItemFieldValues(
-				journalArticle, infoItemFieldValues);
-
-		Assert.assertEquals(
-			TestPropsValues.getUserId(), journalArticle.getStatusByUserId());
-
-		Assert.assertEquals(
-			"Este es el titulo", journalArticle.getTitle(LocaleUtil.SPAIN));
-	}
-
-	@Test
 	public void testUpdateJournalArticleFromInfoItemFieldValuesUpdatesTranslations()
 		throws Exception {
 
@@ -467,6 +470,13 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 			ddmStructure.getStructureKey(), null);
 	}
 
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private static String _originalName;
+
+	private Company _company;
+
 	@Inject(filter = "ddm.form.deserializer.type=json")
 	private DDMFormDeserializer _ddmFormDeserializer;
 
@@ -485,18 +495,11 @@ public class JournalArticleInfoItemFieldValuesUpdaterTest {
 	@Inject
 	private TranslationEntryLocalService _translationEntryLocalService;
 
-	@Inject(filter = "content.type=application/xliff+xml")
-	private TranslationInfoItemFieldValuesImporter
-		_xliffTranslationInfoItemFieldValuesImporter;
-
-	private Company _company;
-
 	@Inject
 	private UserLocalService _userLocalService;
 
-	@Inject
-	private static CompanyLocalService _companyLocalService;
-
-	private static String _originalName;
+	@Inject(filter = "content.type=application/xliff+xml")
+	private TranslationInfoItemFieldValuesImporter
+		_xliffTranslationInfoItemFieldValuesImporter;
 
 }


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-47867

The web content created by user who is deleted is not translatable by other user

# How am I fixing it?

Added a check to handle cases where the user is null (i.e., deleted user). If the user has been deleted, the system will now assign the current user as the new updater.

# How can you verify that it works?

Run the included automated test, `module/apps/translation/translation-test/JournalArticleInfoItemFieldValuesUpdaterTest.testUpdateJournalArticleAfterUserDeletion`





