### PR TITLE
LPD-29489 Edit Default Values of a Structure: a repeatable field should not be replicable

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article_content.jspf
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article_content.jspf
@@ -17,6 +17,7 @@
 	languageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>"
 	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	persisted="<%= article != null %>"
+	readOnly="<%= JournalUtil.isEditDefaultValues(article) %>"
 	submittable="<%= false %>"
 />
 

--- a/modules/test/playwright/tests/journal-web/journalStructure.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalStructure.spec.ts
@@ -95,3 +95,32 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Can not duplicate a repeatable field in the "Edit Default Values" form',
+	{
+		tag: '@LPD-29489',
+	},
+	async ({apiHelpers, journalStructuresPage, page, site}) => {
+		const structureName = 'Structure Test';
+		const fieldName = 'TextFieldTest';
+
+		await apiHelpers.dataEngine.createStructure(
+			site.id,
+			getDataStructureDefinition({
+				defaultLanguageId: 'en_US',
+				fields: [{name: fieldName, repeatable: true}],
+				name: structureName,
+			})
+		);
+		await journalStructuresPage.goto(site.friendlyUrlPath);
+		await journalStructuresPage.goToJournalStructureAction(
+			'Edit Default Values',
+			structureName
+		);
+
+		await expect(
+			page.getByLabel(`Add Duplicate Field ${fieldName}`)
+		).toBeDisabled();
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-29489

Edit Default Values of a Structure: a repeatable field should not be replicable.

# How am I fixing it?

Pass the `readOnly` attribute to `<liferay-data-engine:data-layout-renderer` to true when editing the default values.

# How can you verify that it works?

Run the test

```sh
npm run test -- -g LPD-29489
```

# Tested locally
## Before the PR
![image](https://github.com/user-attachments/assets/9d8d2932-3008-4e35-9670-d1de98266aa0)

## After the PR
![image](https://github.com/user-attachments/assets/7eec7e80-f85f-4601-805f-2e4da16a917f)
