### PR TITLE
LPD-48633 KnowledgeBase + Staging - Attachment is not deleted upon Publishing

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -28,7 +28,10 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -454,6 +457,24 @@ public class KBArticleStagedModelDataHandler
 			KBArticle importedKBArticle)
 		throws Exception {
 
+		Repository repository = _portletFileRepository.fetchPortletRepository(
+			portletDataContext.getGroupId(),
+			KBPortletKeys.KNOWLEDGE_BASE_ADMIN);
+
+		if (repository != null) {
+			LocalRepository localRepository =
+				_repositoryProvider.getLocalRepository(
+					repository.getRepositoryId());
+
+			List<FileEntry> fileEntries = localRepository.getFileEntries(
+				importedKBArticle.getAttachmentsFolderId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+			for (FileEntry fileEntry : fileEntries) {
+				localRepository.deleteFileEntry(fileEntry.getFileEntryId());
+			}
+		}
+
 		List<Element> dlFileEntryElements =
 			portletDataContext.getReferenceDataElements(
 				kbArticle, DLFileEntry.class);
@@ -558,5 +579,8 @@ public class KBArticleStagedModelDataHandler
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;
+
+	@Reference
+	private RepositoryProvider _repositoryProvider;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
@@ -15,16 +15,24 @@ import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -48,6 +56,69 @@ public class KBArticleStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testExportImportKBArticleWithAttachments() throws Exception {
+		initExport();
+
+		KBArticle kbArticle = _addKBArticle(
+			new Date(System.currentTimeMillis() + Time.DAY),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			ClassNameLocalServiceUtil.getClassNameId(
+				KBFolderConstants.getClassName()),
+			_createServiceContext(stagingGroup));
+
+		InputStream inputStream = new ByteArrayInputStream(
+			TestDataConstants.TEST_BYTE_ARRAY);
+
+		FileEntry fileEntry1 = _kbArticleLocalService.addAttachment(
+			TestPropsValues.getUserId(), kbArticle.getResourcePrimKey(),
+			RandomTestUtil.randomString(), inputStream,
+			ContentTypes.TEXT_PLAIN);
+		FileEntry fileEntry2 = _kbArticleLocalService.addAttachment(
+			TestPropsValues.getUserId(), kbArticle.getResourcePrimKey(),
+			RandomTestUtil.randomString(), inputStream,
+			ContentTypes.TEXT_PLAIN);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, kbArticle);
+
+		initImport();
+
+		KBArticle exportedKBArticle = (KBArticle)readExportedStagedModel(
+			kbArticle);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedKBArticle);
+
+		KBArticle importedKBArticle = (KBArticle)getStagedModel(
+			kbArticle.getUuid(), liveGroup);
+
+		_assertKBArticleAttachments(
+			new String[] {fileEntry1.getFileName(), fileEntry2.getFileName()},
+			importedKBArticle);
+
+		_portletFileRepository.deletePortletFileEntry(
+			fileEntry2.getFileEntryId());
+
+		initExport();
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, kbArticle);
+
+		initImport();
+
+		exportedKBArticle = (KBArticle)readExportedStagedModel(kbArticle);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedKBArticle);
+
+		importedKBArticle = (KBArticle)getStagedModel(
+			kbArticle.getUuid(), liveGroup);
+
+		_assertKBArticleAttachments(
+			new String[] {fileEntry1.getFileName()}, importedKBArticle);
+	}
 
 	@Test
 	public void testExportImportScheduledKBArticleCanBePublished()
@@ -208,11 +279,32 @@ public class KBArticleStagedModelDataHandlerTest
 			parentResourceClassNameId, serviceContext);
 	}
 
+	private void _assertKBArticleAttachments(
+			String[] expectedFileNames, KBArticle importedKBArticle)
+		throws Exception {
+
+		List<FileEntry> attachmentsFileEntries =
+			importedKBArticle.getAttachmentsFileEntries();
+
+		Assert.assertEquals(
+			attachmentsFileEntries.toString(), attachmentsFileEntries.size(),
+			expectedFileNames.length);
+
+		for (FileEntry attachmentFileEntry : attachmentsFileEntries) {
+			Assert.assertTrue(
+				ArrayUtil.contains(
+					expectedFileNames, attachmentFileEntry.getFileName()));
+		}
+	}
+
 	private ServiceContext _createServiceContext(Group group) throws Exception {
 		return ServiceContextTestUtil.getServiceContext(group.getGroupId());
 	}
 
 	@Inject
 	private KBArticleLocalService _kbArticleLocalService;
+
+	@Inject
+	private PortletFileRepository _portletFileRepository;
 
 }


### PR DESCRIPTION
KnowledgeBase + Staging - Attachment is not deleted upon Publishing

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-48633)

Attachments for KB Articles are not deleted when publishing to staging

# How am I fixing it?

Deleting the existing attachments and recreate based on the files that come with the KB Article

# How can you verify that it works?

Run the provided integration test, or follow the steps in the ticket