### PR TITLE
LPD-48157 Wait for AssetDisplayPage to start the mutationObserver

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -600,21 +600,23 @@ function attachFormChangeListener(
 		}
 	});
 
-	mutationObserver.observe(form, {
-		attributeFilter: ['value'],
-		attributeOldValue: true,
-		attributes: true,
-		childList: true,
-		subtree: true,
-	});
-
 	const handleFormChange = (event) => {
 		if (accentChangeEvent(event)) {
 			handleChange();
 		}
 	};
 
-	form.addEventListener('change', handleFormChange);
+	Liferay.componentReady(`${namespace}SelectAssetDisplayPage`).then(() => {
+		mutationObserver.observe(form, {
+			attributeFilter: ['value'],
+			attributeOldValue: true,
+			attributes: true,
+			childList: true,
+			subtree: true,
+		});
+
+		form.addEventListener('change', handleFormChange);
+	});
 
 	return {
 		detach() {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
@@ -4,7 +4,7 @@
  */
 
 import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import AssetDisplayPageSelector from './AssetDisplayPageSelector';
 import PreviewButton from './PreviewButton';
@@ -70,6 +70,18 @@ export default function SelectAssetDisplayPage({
 			value: DISPLAY_PAGE_TYPE.none,
 		},
 	];
+
+	useEffect(() => {
+		Liferay.component(
+			`${namespace}SelectAssetDisplayPage`,
+			{},
+			{destroyOnNavigate: true}
+		);
+
+		return () => {
+			Liferay.destroyComponent(`${namespace}SelectAssetDisplayPage`);
+		};
+	}, [namespace]);
 
 	return (
 		<>


### PR DESCRIPTION
[LPD-48157](https://liferay.atlassian.net/browse/LPD-48157)

The issue is caused by the [SelectAssetDisplayPage](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js#L92-L108) React component, that is rendered later in the form [triggering the autosave thru the mutationObserver](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js#L576-L601).

As it's rendering the following hidden inputFields:
<img width="892" alt="Screenshot 2025-02-06 at 15 06 11" src="https://github.com/user-attachments/assets/1986856a-ae00-4842-a127-186c2185c1b5" />

I resolved the issue by registering the react component as a Liferay component and used componentReady's promise to start the mutationObserver. This will ensure the form is already rendered fully when we start the observer.
The caveat of this fix, that we have to include future react components in componentReady, however there were no generic solution to wait for the form to fully render.

Please review the change.