### PR TITLE
LPD-48450 AssetRenderer is null in TaskExecutor

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -292,12 +292,18 @@ public class DepotAssetRendererFactoryWrapper<T>
 	}
 
 	private Group _getGroup(Group fallbackGroup) {
-		ServiceContext serviceContext = ServiceContextThreadLocal.getServiceContext();
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
 
 		if (serviceContext == null) {
-			Group group = _groupLocalService.fetchGroup(GroupThreadLocal.getGroupId());
+			Group group = _groupLocalService.fetchGroup(
+				GroupThreadLocal.getGroupId());
 
-			return (group != null) ? group : fallbackGroup;
+			if (group != null) {
+				return group;
+			}
+
+			return fallbackGroup;
 		}
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -95,7 +95,7 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return assetRenderer;
 		}
 
-		Group group = _getGroup();
+		Group group = _getGroup(assetRendererGroup);
 
 		if (group == null) {
 			return null;
@@ -264,7 +264,7 @@ public class DepotAssetRendererFactoryWrapper<T>
 
 	@Override
 	public boolean isSelectable() {
-		Group group = _getGroup();
+		Group group = _getGroup(null);
 
 		if ((group != null) && group.isDepot() &&
 			!_depotApplicationController.isClassNameEnabled(
@@ -291,12 +291,13 @@ public class DepotAssetRendererFactoryWrapper<T>
 		_assetRendererFactory.setPortletId(portletId);
 	}
 
-	private Group _getGroup() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
+	private Group _getGroup(Group fallbackGroup) {
+		ServiceContext serviceContext = ServiceContextThreadLocal.getServiceContext();
 
 		if (serviceContext == null) {
-			return _groupLocalService.fetchGroup(GroupThreadLocal.getGroupId());
+			Group group = _groupLocalService.fetchGroup(GroupThreadLocal.getGroupId());
+
+			return (group != null) ? group : fallbackGroup;
 		}
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -14,13 +14,15 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.function.Consumer;
+
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import java.util.function.Consumer;
+import org.mockito.Mockito;
 
 /**
  * @author Adolfo Pérez
@@ -31,6 +33,50 @@ public class DepotAssetRendererFactoryWrapperTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAssetRendererReturnsFallbackGroupWhenNoContext()
+		throws Exception {
+
+		AssetRenderer<Object> assetRenderer = Mockito.mock(AssetRenderer.class);
+
+		Mockito.when(
+			_assetRendererFactory.getAssetRenderer(Mockito.anyLong())
+		).thenReturn(
+			assetRenderer
+		);
+
+		long depotGroupId = _setUpDepotGroup();
+
+		Mockito.when(
+			assetRenderer.getGroupId()
+		).thenReturn(
+			depotGroupId
+		);
+
+		long groupId = _setUpGroup();
+
+		Mockito.when(
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(Mockito.anyLong())
+		).thenReturn(
+			new long[] {depotGroupId, groupId}
+		);
+
+		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
+			new DepotAssetRendererFactoryWrapper(
+				_assetRendererFactory, null, null, _groupLocalService, null,
+				null, _siteConnectedGroupGroupProvider);
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(-1)) {
+
+			Assert.assertSame(
+				assetRenderer,
+				depotAssetRendererFactoryWrapper.getAssetRenderer(
+					RandomTestUtil.randomLong()));
+		}
+	}
 
 	@Test
 	public void testAssetRenderIsNotReturnedForUnconnectedGroup()
@@ -63,48 +109,6 @@ public class DepotAssetRendererFactoryWrapperTest {
 				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
 
 			Assert.assertNull(
-				depotAssetRendererFactoryWrapper.getAssetRenderer(
-					RandomTestUtil.randomLong()));
-		}
-	}
-
-	@Test
-	public void testAssetRendererReturnsFallbackGroupWhenNoContext() throws Exception {
-		AssetRenderer<Object> assetRenderer = Mockito.mock(AssetRenderer.class);
-
-		Mockito.when(
-			_assetRendererFactory.getAssetRenderer(Mockito.anyLong())
-		).thenReturn(
-			assetRenderer
-		);
-
-		long depotGroupId = _setUpDepotGroup();
-
-		Mockito.when(
-			assetRenderer.getGroupId()
-		).thenReturn(
-			depotGroupId
-		);
-
-		long groupId = _setUpGroup();
-
-		Mockito.when(
-			_siteConnectedGroupGroupProvider.
-				getCurrentAndAncestorSiteAndDepotGroupIds(Mockito.anyLong())
-		).thenReturn(
-			new long[] {depotGroupId, groupId}
-		);
-
-		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
-			new DepotAssetRendererFactoryWrapper(
-				_assetRendererFactory, null, null, _groupLocalService, null,
-				null, _siteConnectedGroupGroupProvider);
-
-		try (SafeCloseable safeCloseable =
-				 GroupThreadLocal.setGroupIdWithSafeCloseable(-1)) {
-
-			Assert.assertSame(
-				assetRenderer,
 				depotAssetRendererFactoryWrapper.getAssetRenderer(
 					RandomTestUtil.randomLong()));
 		}

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -14,15 +14,13 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-
-import java.util.function.Consumer;
-
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.mockito.Mockito;
+
+import java.util.function.Consumer;
 
 /**
  * @author Adolfo Pérez
@@ -65,6 +63,48 @@ public class DepotAssetRendererFactoryWrapperTest {
 				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
 
 			Assert.assertNull(
+				depotAssetRendererFactoryWrapper.getAssetRenderer(
+					RandomTestUtil.randomLong()));
+		}
+	}
+
+	@Test
+	public void testAssetRendererReturnsFallbackGroupWhenNoContext() throws Exception {
+		AssetRenderer<Object> assetRenderer = Mockito.mock(AssetRenderer.class);
+
+		Mockito.when(
+			_assetRendererFactory.getAssetRenderer(Mockito.anyLong())
+		).thenReturn(
+			assetRenderer
+		);
+
+		long depotGroupId = _setUpDepotGroup();
+
+		Mockito.when(
+			assetRenderer.getGroupId()
+		).thenReturn(
+			depotGroupId
+		);
+
+		long groupId = _setUpGroup();
+
+		Mockito.when(
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(Mockito.anyLong())
+		).thenReturn(
+			new long[] {depotGroupId, groupId}
+		);
+
+		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
+			new DepotAssetRendererFactoryWrapper(
+				_assetRendererFactory, null, null, _groupLocalService, null,
+				null, _siteConnectedGroupGroupProvider);
+
+		try (SafeCloseable safeCloseable =
+				 GroupThreadLocal.setGroupIdWithSafeCloseable(-1)) {
+
+			Assert.assertSame(
+				assetRenderer,
 				depotAssetRendererFactoryWrapper.getAssetRenderer(
 					RandomTestUtil.randomLong()));
 		}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-57579

When **TaskExecutor** attempting to retrieve the **AssetRenderer** object, it returns null.

# How am I fixing it?

added fallback value, since this data is not filled by the process/task

# How can you verify that it works?

Added unit test in `modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java`
