### PR TITLE
LPD-48450 AssetRenderer is null in TaskExecutor

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -95,7 +95,7 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return assetRenderer;
 		}
 
-		Group group = _getGroup();
+		Group group = _getGroup(assetRendererGroup);
 
 		if (group == null) {
 			return null;
@@ -264,7 +264,7 @@ public class DepotAssetRendererFactoryWrapper<T>
 
 	@Override
 	public boolean isSelectable() {
-		Group group = _getGroup();
+		Group group = _getGroup(null);
 
 		if ((group != null) && group.isDepot() &&
 			!_depotApplicationController.isClassNameEnabled(
@@ -291,12 +291,19 @@ public class DepotAssetRendererFactoryWrapper<T>
 		_assetRendererFactory.setPortletId(portletId);
 	}
 
-	private Group _getGroup() {
+	private Group _getGroup(Group fallbackGroup) {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
 		if (serviceContext == null) {
-			return _groupLocalService.fetchGroup(GroupThreadLocal.getGroupId());
+			Group group = _groupLocalService.fetchGroup(
+				GroupThreadLocal.getGroupId());
+
+			if (group != null) {
+				return group;
+			}
+
+			return fallbackGroup;
 		}
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -35,6 +35,50 @@ public class DepotAssetRendererFactoryWrapperTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testAssetRendererReturnsFallbackGroupWhenNoContext()
+		throws Exception {
+
+		AssetRenderer<Object> assetRenderer = Mockito.mock(AssetRenderer.class);
+
+		Mockito.when(
+			_assetRendererFactory.getAssetRenderer(Mockito.anyLong())
+		).thenReturn(
+			assetRenderer
+		);
+
+		long depotGroupId = _setUpDepotGroup();
+
+		Mockito.when(
+			assetRenderer.getGroupId()
+		).thenReturn(
+			depotGroupId
+		);
+
+		long groupId = _setUpGroup();
+
+		Mockito.when(
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(Mockito.anyLong())
+		).thenReturn(
+			new long[] {depotGroupId, groupId}
+		);
+
+		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
+			new DepotAssetRendererFactoryWrapper(
+				_assetRendererFactory, null, null, _groupLocalService, null,
+				null, _siteConnectedGroupGroupProvider);
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(-1)) {
+
+			Assert.assertSame(
+				assetRenderer,
+				depotAssetRendererFactoryWrapper.getAssetRenderer(
+					RandomTestUtil.randomLong()));
+		}
+	}
+
+	@Test
 	public void testAssetRenderIsNotReturnedForUnconnectedGroup()
 		throws Exception {
 


### PR DESCRIPTION

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-57579

When TaskExecutor attempting to retrieve the AssetRenderer object, it returns null.

# How am I fixing it?

added fallback value, since this data is not filled by the process/task

# How can you verify that it works?

Added unit test in `modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java`
