### PR TITLE
LPD-48888 Fix legacy structures import and override

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseImportDataDefinitionMVCActionCommandTestCase.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseImportDataDefinitionMVCActionCommandTestCase.java
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.File;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.impl.LayoutImpl;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public abstract class BaseImportDataDefinitionMVCActionCommandTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		group = GroupTestUtil.addGroup();
+	}
+
+	protected MockLiferayPortletActionRequest
+			createMockLiferayPortletActionRequest(String fileName, String name)
+		throws Exception {
+
+		return createMockLiferayPortletActionRequest(fileName, name, null);
+	}
+
+	protected MockLiferayPortletActionRequest
+			createMockLiferayPortletActionRequest(
+				String fileName, String name, Long dataDefinitionId)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest(
+				_createMockMultipartHttpServletRequest(fileName));
+
+		mockLiferayPortletActionRequest.addParameter("name", name);
+		mockLiferayPortletActionRequest.addParameter("redirect", "fakeURL");
+
+		if (dataDefinitionId != null) {
+			mockLiferayPortletActionRequest.addParameter(
+				"dataDefinitionId", String.valueOf(dataDefinitionId));
+		}
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	protected DataDefinition getImportedDataDefinition() throws Exception {
+		DataDefinitionResource.Builder builder =
+			dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource = builder.user(
+			TestPropsValues.getUser()
+		).build();
+
+		Page<DataDefinition> page =
+			dataDefinitionResource.
+				getSiteDataDefinitionByContentTypeContentTypePage(
+					group.getGroupId(), "journal", "Imported Structure",
+					Pagination.of(1, 1), null);
+
+		List<DataDefinition> items = (List<DataDefinition>)page.getItems();
+
+		return items.get(0);
+	}
+
+	protected abstract MVCActionCommand getMVCActionCommand();
+
+	protected void setUpUploadPortletRequest(
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
+
+		ReflectionTestUtil.setFieldValue(
+			getMVCActionCommand(), "_portal",
+			ProxyUtil.newProxyInstance(
+				BaseImportDataDefinitionMVCActionCommandTestCase.class.
+					getClassLoader(),
+				new Class<?>[] {Portal.class},
+				(proxy, method, args) -> {
+					if (Objects.equals(
+							method.getName(), "getUploadPortletRequest")) {
+
+						LiferayPortletRequest liferayPortletRequest =
+							portal.getLiferayPortletRequest(
+								mockLiferayPortletActionRequest);
+
+						return UploadTestUtil.createUploadPortletRequest(
+							portal.getUploadServletRequest(
+								liferayPortletRequest.getHttpServletRequest()),
+							liferayPortletRequest,
+							portal.getPortletNamespace(
+								liferayPortletRequest.getPortletName()));
+					}
+
+					return method.invoke(portal, args);
+				}));
+	}
+
+	@Inject
+	protected DataDefinitionResource.Factory dataDefinitionResourceFactory;
+
+	@DeleteAfterTestRun
+	protected Group group;
+
+	@Inject
+	protected Portal portal;
+
+	private MockMultipartHttpServletRequest
+			_createMockMultipartHttpServletRequest(String fileName)
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		Class<?> clazz = getClass();
+
+		byte[] bytes = _file.getBytes(
+			clazz.getResourceAsStream("dependencies/" + fileName));
+
+		mockMultipartHttpServletRequest.addFile(
+			new MockMultipartFile(fileName, bytes));
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+
+		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
+
+		mockMultipartHttpServletRequest.setContent(
+			_getContent(boundary, bytes, fileName));
+		mockMultipartHttpServletRequest.setContentType(
+			MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + boundary);
+
+		return mockMultipartHttpServletRequest;
+	}
+
+	private byte[] _getContent(String boundary, byte[] bytes, String fileName) {
+		String start = StringBundler.concat(
+			StringPool.DOUBLE_DASH, boundary,
+			"\r\nContent-Disposition:form-data;name=\"jsonFile\";filename=\"",
+			fileName, "\";\r\nContent-type:application/json\r\n\r\n");
+
+		String end = StringBundler.concat(
+			"\r\n--", boundary, StringPool.DOUBLE_DASH);
+
+		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		Layout layout = new LayoutImpl();
+
+		layout.setType(LayoutConstants.TYPE_CONTROL_PANEL);
+
+		themeDisplay.setLayout(layout);
+
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private File _file;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportAndOverrideDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportAndOverrideDataDefinitionMVCActionCommandTest.java
@@ -8,67 +8,29 @@ package com.liferay.journal.web.internal.portlet.action.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
-import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.data.engine.rest.test.util.DataDefinitionTestUtil;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutConstants;
-import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.upload.test.util.UploadTestUtil;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
-
-import java.util.List;
-import java.util.Objects;
 
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 /**
  * @author Mariano Álvaro Sáiz
  */
 @RunWith(Arquillian.class)
-public class ImportAndOverrideDataDefinitionMVCActionCommandTest {
+public class ImportAndOverrideDataDefinitionMVCActionCommandTest
+	extends BaseImportDataDefinitionMVCActionCommandTestCase {
 
-	@ClassRule
-	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
-
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+	public MVCActionCommand getMVCActionCommand() {
+		return _mvcActionCommand;
 	}
 
 	@Test
@@ -77,16 +39,16 @@ public class ImportAndOverrideDataDefinitionMVCActionCommandTest {
 
 		DataDefinition dataDefinition =
 			DataDefinitionTestUtil.addDataDefinition(
-				"journal", _dataDefinitionResourceFactory, _group.getGroupId(),
+				"journal", dataDefinitionResourceFactory, group.getGroupId(),
 				_read("previous_version_valid_data_definition.json"),
 				TestPropsValues.getUser());
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_createMockLiferayPortletActionRequest(
+			createMockLiferayPortletActionRequest(
 				"previous_version_valid_data_definition.json",
 				"Imported Structure", dataDefinition.getId());
 
-		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+		setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 		_mvcActionCommand.processAction(
 			mockLiferayPortletActionRequest,
@@ -95,14 +57,14 @@ public class ImportAndOverrideDataDefinitionMVCActionCommandTest {
 		Assert.assertNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
-				_portal.getPortletId(mockLiferayPortletActionRequest) +
+				portal.getPortletId(mockLiferayPortletActionRequest) +
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE));
 		Assert.assertNull(
 			SessionErrors.get(
 				mockLiferayPortletActionRequest,
 				"importDataDefinitionErrorMessage"));
 
-		dataDefinition = _getImportedDataDefinition();
+		dataDefinition = getImportedDataDefinition();
 
 		DataDefinitionField[] dataDefinitionFields =
 			dataDefinition.getDataDefinitionFields();
@@ -113,147 +75,14 @@ public class ImportAndOverrideDataDefinitionMVCActionCommandTest {
 			previousTextFieldName, dataDefinitionFields[0].getName());
 	}
 
-	private MockLiferayPortletActionRequest
-			_createMockLiferayPortletActionRequest(
-				String fileName, String name, long dataDefinitionId)
-		throws Exception {
-
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			new MockLiferayPortletActionRequest(
-				_createMockMultipartHttpServletRequest(fileName));
-
-		mockLiferayPortletActionRequest.addParameter("name", name);
-		mockLiferayPortletActionRequest.addParameter("redirect", "fakeURL");
-		mockLiferayPortletActionRequest.addParameter(
-			"dataDefinitionId", String.valueOf(dataDefinitionId));
-		mockLiferayPortletActionRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _getThemeDisplay());
-
-		return mockLiferayPortletActionRequest;
-	}
-
-	private MockMultipartHttpServletRequest
-			_createMockMultipartHttpServletRequest(String fileName)
-		throws Exception {
-
-		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
-			new MockMultipartHttpServletRequest();
-
-		Class<?> clazz = getClass();
-
-		byte[] bytes = _file.getBytes(
-			clazz.getResourceAsStream("dependencies/" + fileName));
-
-		mockMultipartHttpServletRequest.addFile(
-			new MockMultipartFile(fileName, bytes));
-
-		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
-
-		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
-
-		mockMultipartHttpServletRequest.setContent(
-			_getContent(boundary, bytes, fileName));
-		mockMultipartHttpServletRequest.setContentType(
-			MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + boundary);
-
-		return mockMultipartHttpServletRequest;
-	}
-
-	private byte[] _getContent(String boundary, byte[] bytes, String fileName) {
-		String start = StringBundler.concat(
-			StringPool.DOUBLE_DASH, boundary,
-			"\r\nContent-Disposition:form-data;name=\"jsonFile\";filename=\"",
-			fileName, "\";\r\nContent-type:application/json\r\n\r\n");
-
-		String end = StringBundler.concat(
-			"\r\n--", boundary, StringPool.DOUBLE_DASH);
-
-		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
-	}
-
-	private DataDefinition _getImportedDataDefinition() throws Exception {
-		DataDefinitionResource.Builder builder =
-			_dataDefinitionResourceFactory.create();
-
-		DataDefinitionResource dataDefinitionResource = builder.user(
-			TestPropsValues.getUser()
-		).build();
-
-		Page<DataDefinition> page =
-			dataDefinitionResource.
-				getSiteDataDefinitionByContentTypeContentTypePage(
-					_group.getGroupId(), "journal", "Imported Structure",
-					Pagination.of(1, 1), null);
-
-		List<DataDefinition> items = (List<DataDefinition>)page.getItems();
-
-		return items.get(0);
-	}
-
-	private ThemeDisplay _getThemeDisplay() throws Exception {
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		Layout layout = new LayoutImpl();
-
-		layout.setType(LayoutConstants.TYPE_CONTROL_PANEL);
-
-		themeDisplay.setLayout(layout);
-
-		themeDisplay.setScopeGroupId(_group.getGroupId());
-		themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
-		themeDisplay.setUser(TestPropsValues.getUser());
-
-		return themeDisplay;
-	}
-
 	private String _read(String fileName) throws Exception {
 		return new String(
 			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
 	}
 
-	private void _setUpUploadPortletRequest(
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
-
-		ReflectionTestUtil.setFieldValue(
-			_mvcActionCommand, "_portal",
-			ProxyUtil.newProxyInstance(
-				ImportDataDefinitionMVCActionCommandTest.class.getClassLoader(),
-				new Class<?>[] {Portal.class},
-				(proxy, method, args) -> {
-					if (Objects.equals(
-							method.getName(), "getUploadPortletRequest")) {
-
-						LiferayPortletRequest liferayPortletRequest =
-							_portal.getLiferayPortletRequest(
-								mockLiferayPortletActionRequest);
-
-						return UploadTestUtil.createUploadPortletRequest(
-							_portal.getUploadServletRequest(
-								liferayPortletRequest.getHttpServletRequest()),
-							liferayPortletRequest,
-							_portal.getPortletNamespace(
-								liferayPortletRequest.getPortletName()));
-					}
-
-					return method.invoke(_portal, args);
-				}));
-	}
-
-	@Inject
-	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
-
-	@Inject
-	private File _file;
-
-	@DeleteAfterTestRun
-	private Group _group;
-
 	@Inject(
 		filter = "mvc.command.name=/journal/import_and_override_data_definition"
 	)
 	private MVCActionCommand _mvcActionCommand;
-
-	@Inject
-	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportAndOverrideDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportAndOverrideDataDefinitionMVCActionCommandTest.java
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.data.engine.rest.test.util.DataDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.File;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.impl.LayoutImpl;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upload.test.util.UploadTestUtil;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+@RunWith(Arquillian.class)
+public class ImportAndOverrideDataDefinitionMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testProcessActionWithDataDefinitionFromPreviousVersion()
+		throws Exception {
+
+		DataDefinition dataDefinition =
+			DataDefinitionTestUtil.addDataDefinition(
+				"journal", _dataDefinitionResourceFactory, _group.getGroupId(),
+				_read("previous_version_valid_data_definition.json"),
+				TestPropsValues.getUser());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_createMockLiferayPortletActionRequest(
+				"previous_version_valid_data_definition.json",
+				"Imported Structure", dataDefinition.getId());
+
+		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Assert.assertNull(
+			SessionMessages.get(
+				mockLiferayPortletActionRequest,
+				_portal.getPortletId(mockLiferayPortletActionRequest) +
+					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE));
+		Assert.assertNull(
+			SessionErrors.get(
+				mockLiferayPortletActionRequest,
+				"importDataDefinitionErrorMessage"));
+
+		dataDefinition = _getImportedDataDefinition();
+
+		DataDefinitionField[] dataDefinitionFields =
+			dataDefinition.getDataDefinitionFields();
+
+		String previousTextFieldName = "Text1";
+
+		Assert.assertEquals(
+			previousTextFieldName, dataDefinitionFields[0].getName());
+	}
+
+	private MockLiferayPortletActionRequest
+			_createMockLiferayPortletActionRequest(
+				String fileName, String name, long dataDefinitionId)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest(
+				_createMockMultipartHttpServletRequest(fileName));
+
+		mockLiferayPortletActionRequest.addParameter("name", name);
+		mockLiferayPortletActionRequest.addParameter("redirect", "fakeURL");
+		mockLiferayPortletActionRequest.addParameter(
+			"dataDefinitionId", String.valueOf(dataDefinitionId));
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private MockMultipartHttpServletRequest
+			_createMockMultipartHttpServletRequest(String fileName)
+		throws Exception {
+
+		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
+			new MockMultipartHttpServletRequest();
+
+		Class<?> clazz = getClass();
+
+		byte[] bytes = _file.getBytes(
+			clazz.getResourceAsStream("dependencies/" + fileName));
+
+		mockMultipartHttpServletRequest.addFile(
+			new MockMultipartFile(fileName, bytes));
+
+		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
+
+		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
+
+		mockMultipartHttpServletRequest.setContent(
+			_getContent(boundary, bytes, fileName));
+		mockMultipartHttpServletRequest.setContentType(
+			MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + boundary);
+
+		return mockMultipartHttpServletRequest;
+	}
+
+	private byte[] _getContent(String boundary, byte[] bytes, String fileName) {
+		String start = StringBundler.concat(
+			StringPool.DOUBLE_DASH, boundary,
+			"\r\nContent-Disposition:form-data;name=\"jsonFile\";filename=\"",
+			fileName, "\";\r\nContent-type:application/json\r\n\r\n");
+
+		String end = StringBundler.concat(
+			"\r\n--", boundary, StringPool.DOUBLE_DASH);
+
+		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
+	}
+
+	private DataDefinition _getImportedDataDefinition() throws Exception {
+		DataDefinitionResource.Builder builder =
+			_dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource = builder.user(
+			TestPropsValues.getUser()
+		).build();
+
+		Page<DataDefinition> page =
+			dataDefinitionResource.
+				getSiteDataDefinitionByContentTypeContentTypePage(
+					_group.getGroupId(), "journal", "Imported Structure",
+					Pagination.of(1, 1), null);
+
+		List<DataDefinition> items = (List<DataDefinition>)page.getItems();
+
+		return items.get(0);
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		Layout layout = new LayoutImpl();
+
+		layout.setType(LayoutConstants.TYPE_CONTROL_PANEL);
+
+		themeDisplay.setLayout(layout);
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private String _read(String fileName) throws Exception {
+		return new String(
+			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
+	}
+
+	private void _setUpUploadPortletRequest(
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
+
+		ReflectionTestUtil.setFieldValue(
+			_mvcActionCommand, "_portal",
+			ProxyUtil.newProxyInstance(
+				ImportDataDefinitionMVCActionCommandTest.class.getClassLoader(),
+				new Class<?>[] {Portal.class},
+				(proxy, method, args) -> {
+					if (Objects.equals(
+							method.getName(), "getUploadPortletRequest")) {
+
+						LiferayPortletRequest liferayPortletRequest =
+							_portal.getLiferayPortletRequest(
+								mockLiferayPortletActionRequest);
+
+						return UploadTestUtil.createUploadPortletRequest(
+							_portal.getUploadServletRequest(
+								liferayPortletRequest.getHttpServletRequest()),
+							liferayPortletRequest,
+							_portal.getPortletNamespace(
+								liferayPortletRequest.getPortletName()));
+					}
+
+					return method.invoke(_portal, args);
+				}));
+	}
+
+	@Inject
+	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	@Inject
+	private File _file;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "mvc.command.name=/journal/import_and_override_data_definition"
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/ImportDataDefinitionMVCActionCommandTest.java
@@ -8,68 +8,32 @@ package com.liferay.journal.web.internal.portlet.action.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
-import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutConstants;
-import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.File;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.upload.test.util.UploadTestUtil;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 /**
  * @author Rodrigo Paulino
  */
 @RunWith(Arquillian.class)
-public class ImportDataDefinitionMVCActionCommandTest {
+public class ImportDataDefinitionMVCActionCommandTest
+	extends BaseImportDataDefinitionMVCActionCommandTestCase {
 
-	@ClassRule
-	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
-
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
+	public MVCActionCommand getMVCActionCommand() {
+		return _mvcActionCommand;
 	}
 
 	@Test
@@ -77,11 +41,11 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_createMockLiferayPortletActionRequest(
+			createMockLiferayPortletActionRequest(
 				"previous_version_valid_data_definition.json",
 				"Imported Structure");
 
-		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+		setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 		_mvcActionCommand.processAction(
 			mockLiferayPortletActionRequest,
@@ -90,14 +54,14 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		Assert.assertNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
-				_portal.getPortletId(mockLiferayPortletActionRequest) +
+				portal.getPortletId(mockLiferayPortletActionRequest) +
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE));
 		Assert.assertNull(
 			SessionErrors.get(
 				mockLiferayPortletActionRequest,
 				"importDataDefinitionErrorMessage"));
 
-		DataDefinition dataDefinition = _getImportedDataDefinition();
+		DataDefinition dataDefinition = getImportedDataDefinition();
 
 		DataDefinitionField[] dataDefinitionFields =
 			dataDefinition.getDataDefinitionFields();
@@ -113,12 +77,12 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_createMockLiferayPortletActionRequest(
+			createMockLiferayPortletActionRequest(
 				"valid_data_definition_with_field_names_without_random_" +
 					"digits.json",
 				"Imported Structure");
 
-		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+		setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 		_mvcActionCommand.processAction(
 			mockLiferayPortletActionRequest,
@@ -127,7 +91,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		Assert.assertNotNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
-				_portal.getPortletId(mockLiferayPortletActionRequest) +
+				portal.getPortletId(mockLiferayPortletActionRequest) +
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE));
 		Assert.assertNotNull(
 			SessionMessages.get(
@@ -138,7 +102,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 	@Test
 	public void testProcessActionWithInvalidDataDefinition() throws Exception {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_createMockLiferayPortletActionRequest(
+			createMockLiferayPortletActionRequest(
 				"invalid_data_definition.json", "Imported Structure");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -146,7 +110,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 					"ImportDataDefinitionMVCActionCommand",
 				LoggerTestUtil.ERROR)) {
 
-			_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+			setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 			_mvcActionCommand.processAction(
 				mockLiferayPortletActionRequest,
@@ -179,10 +143,10 @@ public class ImportDataDefinitionMVCActionCommandTest {
 				LoggerTestUtil.ERROR)) {
 
 			MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-				_createMockLiferayPortletActionRequest(
+				createMockLiferayPortletActionRequest(
 					"valid_data_definition.json", null);
 
-			_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+			setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 			_mvcActionCommand.processAction(
 				mockLiferayPortletActionRequest,
@@ -211,10 +175,10 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_createMockLiferayPortletActionRequest(
+			createMockLiferayPortletActionRequest(
 				"valid_data_definition.json", "Imported Structure");
 
-		_setUpUploadPortletRequest(mockLiferayPortletActionRequest);
+		setUpUploadPortletRequest(mockLiferayPortletActionRequest);
 
 		_mvcActionCommand.processAction(
 			mockLiferayPortletActionRequest,
@@ -223,14 +187,14 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		Assert.assertNotNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
-				_portal.getPortletId(mockLiferayPortletActionRequest) +
+				portal.getPortletId(mockLiferayPortletActionRequest) +
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE));
 		Assert.assertNotNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
 				"importDataDefinitionSuccessMessage"));
 
-		DataDefinition dataDefinition = _getImportedDataDefinition();
+		DataDefinition dataDefinition = getImportedDataDefinition();
 
 		DataDefinitionField[] dataDefinitionFields =
 			dataDefinition.getDataDefinitionFields();
@@ -244,7 +208,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 		Assert.assertNotNull(
 			SessionMessages.get(
 				mockLiferayPortletActionRequest,
-				_portal.getPortletId(mockLiferayPortletActionRequest) +
+				portal.getPortletId(mockLiferayPortletActionRequest) +
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE));
 		Assert.assertNotNull(
 			SessionErrors.get(
@@ -252,137 +216,7 @@ public class ImportDataDefinitionMVCActionCommandTest {
 				"importDataDefinitionErrorMessage"));
 	}
 
-	private MockLiferayPortletActionRequest
-			_createMockLiferayPortletActionRequest(String fileName, String name)
-		throws Exception {
-
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			new MockLiferayPortletActionRequest(
-				_createMockMultipartHttpServletRequest(fileName));
-
-		mockLiferayPortletActionRequest.addParameter("name", name);
-		mockLiferayPortletActionRequest.addParameter("redirect", "fakeURL");
-		mockLiferayPortletActionRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _getThemeDisplay());
-
-		return mockLiferayPortletActionRequest;
-	}
-
-	private MockMultipartHttpServletRequest
-			_createMockMultipartHttpServletRequest(String fileName)
-		throws Exception {
-
-		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
-			new MockMultipartHttpServletRequest();
-
-		Class<?> clazz = getClass();
-
-		byte[] bytes = _file.getBytes(
-			clazz.getResourceAsStream("dependencies/" + fileName));
-
-		mockMultipartHttpServletRequest.addFile(
-			new MockMultipartFile(fileName, bytes));
-
-		mockMultipartHttpServletRequest.setCharacterEncoding(StringPool.UTF8);
-
-		String boundary = "WebKitFormBoundary" + StringUtil.randomString();
-
-		mockMultipartHttpServletRequest.setContent(
-			_getContent(boundary, bytes, fileName));
-		mockMultipartHttpServletRequest.setContentType(
-			MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + boundary);
-
-		return mockMultipartHttpServletRequest;
-	}
-
-	private byte[] _getContent(String boundary, byte[] bytes, String fileName) {
-		String start = StringBundler.concat(
-			StringPool.DOUBLE_DASH, boundary,
-			"\r\nContent-Disposition:form-data;name=\"jsonFile\";filename=\"",
-			fileName, "\";\r\nContent-type:application/json\r\n\r\n");
-
-		String end = StringBundler.concat(
-			"\r\n--", boundary, StringPool.DOUBLE_DASH);
-
-		return ArrayUtil.append(start.getBytes(), bytes, end.getBytes());
-	}
-
-	private DataDefinition _getImportedDataDefinition() throws Exception {
-		DataDefinitionResource.Builder builder =
-			_dataDefinitionResourceFactory.create();
-
-		DataDefinitionResource dataDefinitionResource = builder.user(
-			TestPropsValues.getUser()
-		).build();
-
-		Page<DataDefinition> page =
-			dataDefinitionResource.
-				getSiteDataDefinitionByContentTypeContentTypePage(
-					_group.getGroupId(), "journal", "Imported Structure",
-					Pagination.of(1, 1), null);
-
-		List<DataDefinition> items = (List<DataDefinition>)page.getItems();
-
-		return items.get(0);
-	}
-
-	private ThemeDisplay _getThemeDisplay() throws Exception {
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		Layout layout = new LayoutImpl();
-
-		layout.setType(LayoutConstants.TYPE_CONTROL_PANEL);
-
-		themeDisplay.setLayout(layout);
-
-		themeDisplay.setScopeGroupId(_group.getGroupId());
-		themeDisplay.setSiteDefaultLocale(LocaleUtil.US);
-		themeDisplay.setUser(TestPropsValues.getUser());
-
-		return themeDisplay;
-	}
-
-	private void _setUpUploadPortletRequest(
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest) {
-
-		ReflectionTestUtil.setFieldValue(
-			_mvcActionCommand, "_portal",
-			ProxyUtil.newProxyInstance(
-				ImportDataDefinitionMVCActionCommandTest.class.getClassLoader(),
-				new Class<?>[] {Portal.class},
-				(proxy, method, args) -> {
-					if (Objects.equals(
-							method.getName(), "getUploadPortletRequest")) {
-
-						LiferayPortletRequest liferayPortletRequest =
-							_portal.getLiferayPortletRequest(
-								mockLiferayPortletActionRequest);
-
-						return UploadTestUtil.createUploadPortletRequest(
-							_portal.getUploadServletRequest(
-								liferayPortletRequest.getHttpServletRequest()),
-							liferayPortletRequest,
-							_portal.getPortletNamespace(
-								liferayPortletRequest.getPortletName()));
-					}
-
-					return method.invoke(_portal, args);
-				}));
-	}
-
-	@Inject
-	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
-
-	@Inject
-	private File _file;
-
-	@DeleteAfterTestRun
-	private Group _group;
-
 	@Inject(filter = "mvc.command.name=/journal/import_data_definition")
 	private MVCActionCommand _mvcActionCommand;
-
-	@Inject
-	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -10,7 +10,6 @@ import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.journal.constants.JournalPortletKeys;
-import com.liferay.journal.web.internal.util.DataDefinitionUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -68,8 +67,6 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 
 			DataDefinition dataDefinition = DataDefinition.toDTO(
 				FileUtil.read(uploadPortletRequest.getFile("jsonFile")));
-
-			DataDefinitionUtil.validateDefinitionFields(dataDefinition);
 
 			DDMStructure ddmStructure =
 				_ddmStructureLocalService.getDDMStructure(dataDefinitionId);


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-48888](https://liferay.atlassian.net/browse/LPD-488888)}

Import and overriding old legacy structures can made web contents lose its values.

# How am I fixing it?

Not modifying structure fields name on import an override.

# How can you verify that it works?

Run the included automated tests. Execute [LPD-48888](https://liferay.atlassian.net/browse/LPD-488888) and [LPD-33587](https://liferay.atlassian.net/browse/LPD-33587) steps.

**LPD-48888 Create test to expose issue with legacy structures.**
**LPD-48888 Override should respect names to avoid losing current web content values.**
**LPD-48888 Create test to expose issue with legacy structures.**