### PR TITLE
LPD-48425 CSP Adaptive Media / Akismet

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/com/liferay/adaptive/media/web/internal/background/task/display/dependencies/optimize_images_background_task_progress.ftl
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/com/liferay/adaptive/media/web/internal/background/task/display/dependencies/optimize_images_background_task_progress.ftl
@@ -2,8 +2,10 @@
 
 <div class="background-task-status-in-progress">
 	<div class="active progress progress-striped reindex-progress">
-		<div class="progress-bar" style="width:${percentage}%">
-			<span class="progress-percentage">${percentage}%</span>
-		</div>
+		<@liferay_ui.csp>
+			<div class="progress-bar" style="width:${percentage}%">
+				<span class="progress-percentage">${percentage}%</span>
+			</div>
+		</@liferay_ui.csp>
 	</div>
 </div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/abstract.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/abstract.jsp
@@ -19,7 +19,9 @@ AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute(WebKeys.
 	%>
 
 	<c:if test="<%= Validator.isNotNull(imagePreviewURL) %>">
-		<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= imagePreviewURL %>);"></div>
+		<liferay-ui:csp>
+			<div class="aspect-ratio aspect-ratio-8-to-3 aspect-ratio-bg-cover cover-image mb-4" style="background-image: url(<%= imagePreviewURL %>);"></div>
+		</liferay-ui:csp>
 	</c:if>
 
 	<%

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/display/template/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/display/template/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -65,6 +65,4 @@
 			</#if>
 		</#list>
 	</ul>
-
-	<br style="clear: both;" />
 </#if>

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/dynamic_include/spam_header.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/dynamic_include/spam_header.jsp
@@ -12,7 +12,7 @@ MBCategory category = (MBCategory)request.getAttribute("edit_message.jsp-categor
 %>
 
 <c:if test="<%= MBResourcePermission.contains(permissionChecker, scopeGroupId, ActionKeys.BAN_USER) %>">
-	<div class="spam" style="margin: 10px;">
+	<div class="mt-8 spam">
 		<c:choose>
 			<c:when test="<%= spam %>">
 				<portlet:actionURL name="/message_boards/edit_message" var="notSpamURL">

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
@@ -24,7 +24,7 @@ if (messageId > 0) {
 <a id="<portlet:namespace />message_<%= message.getMessageId() %>"></a>
 
 <clay:container-fluid>
-	<div class="spam" style="margin: 10px;">
+	<div class="mt-8 spam">
 		<portlet:actionURL name="markNotSpamMBMessages" var="markAsHamURL" windowState="<%= WindowState.MAXIMIZED.toString() %>">
 			<portlet:param name="redirect" value="<%= portletURL.toString() %>" />
 			<portlet:param name="notSpamMBMessageIds" value="<%= String.valueOf(message.getMessageId()) %>" />


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48425

Clean inline styles to support style-src '[NONCE]' in Adaptive Media / Akismet / Asset Display

# How am I fixing it?

Trying to move all cases of inline style to css classes wraping with `<liferay-ui:csp>` or `<@liferay_ui.csp>` when is needed

 # How can you verify that it works?
I don't know ¯\_(ツ)_/¯ 

I was only able to check the render of 17440958ac181e37516faa569c909d5ae34fa677

> [!CAUTION]
> I'm not able to review the render of: 
> - asset_display/abstract.jsp 3133974b339363709a78966777da5a787b289417
> - Akismet c582fcd8b53e56f47c6a9f662904646469f1fddd
> - adaptive-media/.../display/dependencies/optimize_images_background_task_progress.ftl bdf5b127a59b8cea039c281c934e62fc97f40d8f

