### PR TITLE
LPD-48973 - Content Structure Headless getSiteContentStructuresPage search does not consider Structure name or description

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMStructureTestHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMStructureTestHelper.java
@@ -132,6 +132,19 @@ public class DDMStructureTestHelper {
 
 	public DDMStructure addStructure(
 			long classNameId, String structureKey, String name,
+			String description, DDMForm ddmForm, String storageType, int type)
+		throws Exception {
+
+		DDMFormLayout ddmFormLayout = DDMUtil.getDefaultDDMFormLayout(ddmForm);
+
+		return addStructure(
+			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID, classNameId,
+			structureKey, name, description, ddmForm, ddmFormLayout,
+			storageType, type);
+	}
+
+	public DDMStructure addStructure(
+			long classNameId, String structureKey, String name,
 			String definition, String storageType)
 		throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentStructureResourceImpl.java
@@ -83,6 +83,8 @@ public class ContentStructureResourceImpl
 				Field.ENTRY_CLASS_PK),
 			searchContext -> {
 				searchContext.addVulcanAggregation(aggregation);
+				searchContext.setAttribute(Field.DESCRIPTION, search);
+				searchContext.setAttribute(Field.NAME, search);
 				searchContext.setAttribute(
 					"searchPermissionContext", StringPool.BLANK);
 				searchContext.setCompanyId(contextCompany.getCompanyId());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentStructureResourceTest.java
@@ -15,6 +15,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentStructure;
+import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -26,6 +27,8 @@ import com.liferay.portal.test.rule.Inject;
 
 import java.io.InputStream;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -34,6 +37,25 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ContentStructureResourceTest
 	extends BaseContentStructureResourceTestCase {
+
+	@Test
+	public void testGetSiteContentStructuresPageSearch() throws Exception {
+		DDMStructure structure = _addDDMStructure(
+			testGroup, RandomTestUtil.randomString());
+
+		Page<ContentStructure> structuresPage =
+			contentStructureResource.getSiteContentStructuresPage(
+				testGroup.getGroupId(), structure.getName("en_US"), null, null,
+				null, null);
+
+		Assert.assertEquals(1, structuresPage.getTotalCount());
+
+		structuresPage = contentStructureResource.getSiteContentStructuresPage(
+			testGroup.getGroupId(), structure.getDescription("en_US"), null,
+			null, null, null);
+
+		Assert.assertEquals(1, structuresPage.getTotalCount());
+	}
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
@@ -135,7 +157,7 @@ public class ContentStructureResourceTest
 
 		return ddmStructureTestHelper.addStructure(
 			PortalUtil.getClassNameId(JournalArticle.class),
-			RandomTestUtil.randomString(), name,
+			RandomTestUtil.randomString(), name, RandomTestUtil.randomString(),
 			_deserialize(_read("test-ddm-structure.json")),
 			StorageType.DEFAULT.getValue(), DDMStructureConstants.TYPE_DEFAULT);
 	}


### PR DESCRIPTION
# What is this trying to solve?
[LPD-48973](https://liferay.atlassian.net/browse/LPD-48973)

Content Structure Headless getSiteContentStructuresPage does not consider Structure name or description when used as keywords for search.

# How am I fixing it?
By setting name and description in the searchContext of the call.

# How can you verify that it works?
```
cd modules/apps/headless/headless-delivery/headless-delivery-test
gw testIntegration --tests ContentStructureResourceTest.testGetSiteContentStructuresPageSearch
```

Cheers,
Balázs