### PR TITLE
LPD-49078 Improve GetContentDashboardItemsXlsMVCResourceCommand performance

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -739,11 +739,13 @@ public class FileEntryContentDashboardItem
 	}
 
 	private String _getStringValue(String infoFieldName) {
-		InfoItemFieldValues infoItemFieldValues =
-			_infoItemFieldValuesProvider.getInfoItemFieldValues(_fileEntry);
+		if (_infoItemFieldValuesProvider != null) {
+			_infoItemFieldValues =
+				_infoItemFieldValuesProvider.getInfoItemFieldValues(_fileEntry);
+		}
 
 		InfoFieldValue<Object> infoFieldValue =
-			infoItemFieldValues.getInfoFieldValue(infoFieldName);
+			_infoItemFieldValues.getInfoFieldValue(infoFieldName);
 
 		if (infoFieldValue == null) {
 			return StringPool.BLANK;
@@ -837,6 +839,7 @@ public class FileEntryContentDashboardItem
 	private final DLURLHelper _dlURLHelper;
 	private final FileEntry _fileEntry;
 	private final Group _group;
+	private InfoItemFieldValues _infoItemFieldValues;
 	private final InfoItemFieldValuesProvider<FileEntry>
 		_infoItemFieldValuesProvider;
 	private final Language _language;

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItem.java
@@ -26,11 +26,8 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.model.DDMField;
 import com.liferay.dynamic.data.mapping.model.DDMFieldAttribute;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
-import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemClassDetails;
-import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemReference;
-import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -94,7 +91,6 @@ public class FileEntryContentDashboardItem
 		DLDisplayContextProvider dlDisplayContextProvider,
 		DLFileEntryMetadataLocalService dlFileEntryMetadataLocalService,
 		DLURLHelper dlURLHelper, FileEntry fileEntry, Group group,
-		InfoItemFieldValuesProvider<FileEntry> infoItemFieldValuesProvider,
 		Language language, Portal portal) {
 
 		if (ListUtil.isEmpty(assetCategories)) {
@@ -122,7 +118,6 @@ public class FileEntryContentDashboardItem
 		_dlURLHelper = dlURLHelper;
 		_fileEntry = fileEntry;
 		_group = group;
-		_infoItemFieldValuesProvider = infoItemFieldValuesProvider;
 		_language = language;
 		_portal = portal;
 	}
@@ -300,7 +295,7 @@ public class FileEntryContentDashboardItem
 
 	@Override
 	public String getDescription(Locale locale) {
-		return _getStringValue("description");
+		return _fileEntry.getDescription();
 	}
 
 	@Override
@@ -655,7 +650,7 @@ public class FileEntryContentDashboardItem
 	}
 
 	private String _getFileName() {
-		return _getStringValue("fileName");
+		return _fileEntry.getFileName();
 	}
 
 	private ContentDashboardItemVersion _getLastContentDashboardItemVersion(
@@ -738,28 +733,6 @@ public class FileEntryContentDashboardItem
 		return LanguageUtil.formatStorageSize(_fileEntry.getSize(), locale);
 	}
 
-	private String _getStringValue(String infoFieldName) {
-		if (_infoItemFieldValuesProvider != null) {
-			_infoItemFieldValues =
-				_infoItemFieldValuesProvider.getInfoItemFieldValues(_fileEntry);
-		}
-
-		InfoFieldValue<Object> infoFieldValue =
-			_infoItemFieldValues.getInfoFieldValue(infoFieldName);
-
-		if (infoFieldValue == null) {
-			return StringPool.BLANK;
-		}
-
-		Object value = infoFieldValue.getValue();
-
-		if (value == null) {
-			return StringPool.BLANK;
-		}
-
-		return value.toString();
-	}
-
 	private URL _getWebDAVURL() {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
@@ -839,9 +812,6 @@ public class FileEntryContentDashboardItem
 	private final DLURLHelper _dlURLHelper;
 	private final FileEntry _fileEntry;
 	private final Group _group;
-	private InfoItemFieldValues _infoItemFieldValues;
-	private final InfoItemFieldValuesProvider<FileEntry>
-		_infoItemFieldValuesProvider;
 	private final Language _language;
 	private final Portal _portal;
 

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/FileEntryContentDashboardItemFactory.java
@@ -21,7 +21,6 @@ import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalServi
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.info.item.InfoItemServiceRegistry;
-import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -61,10 +60,6 @@ public class FileEntryContentDashboardItemFactory
 			throw new NoSuchModelException();
 		}
 
-		InfoItemFieldValuesProvider<FileEntry> infoItemFieldValuesProvider =
-			infoItemServiceRegistry.getFirstInfoItemService(
-				InfoItemFieldValuesProvider.class, FileEntry.class.getName());
-
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
 		return new FileEntryContentDashboardItem(
@@ -75,8 +70,8 @@ public class FileEntryContentDashboardItemFactory
 				dlFileEntry.getFileEntryTypeId(), dlFileEntry.getFileEntryId()),
 			_ddmFieldLocalService, _dlDisplayContextProvider,
 			_dlFileEntryMetadataLocalService, _dlURLHelper, fileEntry,
-			_groupLocalService.fetchGroup(fileEntry.getGroupId()),
-			infoItemFieldValuesProvider, _language, _portal);
+			_groupLocalService.fetchGroup(fileEntry.getGroupId()), _language,
+			_portal);
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-49078](https://liferay.atlassian.net/browse/LPD-49078)}

Improve the XLS download performance. Right now when trying to retrieve the fileName or the description there are useless operations involved as analyzing the files:

```
at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.storage.StorageImpl.listBlobs(StorageImpl.java:452)
	at com.google.cloud.storage.StorageImpl.list(StorageImpl.java:408)
	at com.liferay.portal.store.gcs.GCSStore.hasFile(GCSStore.java:246)
	at com.liferay.change.tracking.store.internal.CTStore.hasFile(CTStore.java:308)
	at com.liferay.document.library.preview.pdf.internal.PDFPreviewableDLProcessor.hasPreview(PDFPreviewableDLProcessor.java:366)
	at com.liferay.document.library.preview.pdf.internal.PDFPreviewableDLProcessor.hasPreview(PDFPreviewableDLProcessor.java:359)
	at com.liferay.document.library.preview.pdf.internal.PDFPreviewableDLProcessor._hasImages(PDFPreviewableDLProcessor.java:1001)
	at com.liferay.document.library.preview.pdf.internal.PDFPreviewableDLProcessor.hasImages(PDFPreviewableDLProcessor.java:186)
	at com.liferay.document.library.kernel.processor.PDFProcessorUtil.hasImages(PDFProcessorUtil.java:102)
	at com.liferay.document.library.internal.helper.DLURLHelperImpl.getImagePreviewURL(DLURLHelperImpl.java:176)
	at com.liferay.document.library.internal.helper.DLURLHelperImpl.getImagePreviewURL(DLURLHelperImpl.java:138)
	at com.liferay.document.library.internal.helper.DLURLHelperImpl.getImagePreviewURL(DLURLHelperImpl.java:196)
	at com.liferay.document.library.web.internal.info.item.provider.FileEntryInfoItemFieldValuesProvider._getFileEntryInfoFieldValues(FileEntryInfoItemFieldValuesProvider.java:304)
	at com.liferay.document.library.web.internal.info.item.provider.FileEntryInfoItemFieldValuesProvider.getInfoItemFieldValues(FileEntryInfoItemFieldValuesProvider.java:68)
	at com.liferay.document.library.web.internal.info.item.provider.FileEntryInfoItemFieldValuesProvider.getInfoItemFieldValues(FileEntryInfoItemFieldValuesProvider.java:56)
	at com.liferay.content.dashboard.document.library.internal.item.FileEntryContentDashboardItem._getStringValue(FileEntryContentDashboardItem.java:613)
	at com.liferay.content.dashboard.document.library.internal.item.FileEntryContentDashboardItem.getDescription(FileEntryContentDashboardItem.java:293)
	at com.liferay.content.dashboard.web.internal.portlet.action.GetContentDashboardItemsXlsMVCResourceCommand._addWorkbookCell(GetContentDashboardItemsXlsMVCResourceCommand.java:185)
	at com.liferay.content.dashboard.web.internal.portlet.action.GetContentDashboardItemsXlsMVCResourceCommand._addWorkbookRows(GetContentDashboardItemsXlsMVCResourceCommand.java:276)
	at com.liferay.content.dashboard.web.internal.portlet.action.GetContentDashboardItemsXlsMVCResourceCommand.doServeResource(GetContentDashboardItemsXlsMVCResourceCommand.java:113)
```
This should be simplify, even if it impacts a bit the extensibility.


# How am I fixing it?

Retrieve directly the information from the file entry as it is done with other fields like title.

# How can you verify that it works?

Run GetContentDashboardItemsXlsMVCResourceCommandTest

**LPD-49078 Do not calculate each time.**
**LPD-49078 Use fileEntry fileName/description directly as with title.**