### PR TITLE
LPD-49047 Web Content Folder should include a configuration permission

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -897,64 +898,9 @@ public class JournalFolderLocalServiceImpl
 				serviceContext);
 		}
 
-		List<ObjectValuePair<Long, String>> workflowDefinitionOVPs =
-			new ArrayList<>();
-
-		if (restrictionType ==
-				JournalFolderConstants.
-					RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {
-
-			workflowDefinitionOVPs.add(
-				new ObjectValuePair<Long, String>(
-					JournalArticleConstants.DDM_STRUCTURE_ID_ALL,
-					StringPool.BLANK));
-
-			for (long ddmStructureId : ddmStructureIds) {
-				String workflowDefinition = ParamUtil.getString(
-					serviceContext, "workflowDefinition" + ddmStructureId);
-
-				workflowDefinitionOVPs.add(
-					new ObjectValuePair<Long, String>(
-						ddmStructureId, workflowDefinition));
-			}
-		}
-		else if (restrictionType ==
-					JournalFolderConstants.RESTRICTION_TYPE_INHERIT) {
-
-			if (originalDDMStructureIds.isEmpty()) {
-				originalDDMStructureIds.add(
-					JournalArticleConstants.DDM_STRUCTURE_ID_ALL);
-			}
-
-			for (long originalDDMStructureId : originalDDMStructureIds) {
-				workflowDefinitionOVPs.add(
-					new ObjectValuePair<Long, String>(
-						originalDDMStructureId, StringPool.BLANK));
-			}
-		}
-		else if (restrictionType ==
-					JournalFolderConstants.RESTRICTION_TYPE_WORKFLOW) {
-
-			String workflowDefinition = ParamUtil.getString(
-				serviceContext,
-				"workflowDefinition" +
-					JournalArticleConstants.DDM_STRUCTURE_ID_ALL);
-
-			workflowDefinitionOVPs.add(
-				new ObjectValuePair<Long, String>(
-					JournalArticleConstants.DDM_STRUCTURE_ID_ALL,
-					workflowDefinition));
-
-			for (long originalDDMStructureId : originalDDMStructureIds) {
-				workflowDefinitionOVPs.add(
-					new ObjectValuePair<Long, String>(
-						originalDDMStructureId, StringPool.BLANK));
-			}
-		}
-
-		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLinks(
-			userId, serviceContext.getCompanyId(), groupId,
-			JournalFolder.class.getName(), folderId, workflowDefinitionOVPs);
+		_updateWorkflowDefinitionLinks(
+			userId, groupId, folderId, ddmStructureIds, restrictionType,
+			serviceContext, originalDDMStructureIds);
 
 		return folder;
 	}
@@ -1483,6 +1429,79 @@ public class JournalFolderLocalServiceImpl
 		}
 
 		return folder;
+	}
+
+	private void _updateWorkflowDefinitionLinks(
+			long userId, long groupId, long folderId, long[] ddmStructureIds,
+			int restrictionType, ServiceContext serviceContext,
+			Set<Long> originalDDMStructureIds)
+		throws PortalException {
+
+		if (!GetterUtil.getBoolean(
+				serviceContext.getAttribute("updateWorkflowDefinitionLinks"),
+				true)) {
+
+			return;
+		}
+
+		List<ObjectValuePair<Long, String>> workflowDefinitionOVPs =
+			new ArrayList<>();
+
+		if (restrictionType ==
+				JournalFolderConstants.
+					RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {
+
+			workflowDefinitionOVPs.add(
+				new ObjectValuePair<Long, String>(
+					JournalArticleConstants.DDM_STRUCTURE_ID_ALL,
+					StringPool.BLANK));
+
+			for (long ddmStructureId : ddmStructureIds) {
+				String workflowDefinition = ParamUtil.getString(
+					serviceContext, "workflowDefinition" + ddmStructureId);
+
+				workflowDefinitionOVPs.add(
+					new ObjectValuePair<Long, String>(
+						ddmStructureId, workflowDefinition));
+			}
+		}
+		else if (restrictionType ==
+					JournalFolderConstants.RESTRICTION_TYPE_INHERIT) {
+
+			if (originalDDMStructureIds.isEmpty()) {
+				originalDDMStructureIds.add(
+					JournalArticleConstants.DDM_STRUCTURE_ID_ALL);
+			}
+
+			for (long originalDDMStructureId : originalDDMStructureIds) {
+				workflowDefinitionOVPs.add(
+					new ObjectValuePair<Long, String>(
+						originalDDMStructureId, StringPool.BLANK));
+			}
+		}
+		else if (restrictionType ==
+					JournalFolderConstants.RESTRICTION_TYPE_WORKFLOW) {
+
+			String workflowDefinition = ParamUtil.getString(
+				serviceContext,
+				"workflowDefinition" +
+					JournalArticleConstants.DDM_STRUCTURE_ID_ALL);
+
+			workflowDefinitionOVPs.add(
+				new ObjectValuePair<Long, String>(
+					JournalArticleConstants.DDM_STRUCTURE_ID_ALL,
+					workflowDefinition));
+
+			for (long originalDDMStructureId : originalDDMStructureIds) {
+				workflowDefinitionOVPs.add(
+					new ObjectValuePair<Long, String>(
+						originalDDMStructureId, StringPool.BLANK));
+			}
+		}
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLinks(
+			userId, serviceContext.getCompanyId(), groupId,
+			JournalFolder.class.getName(), folderId, workflowDefinitionOVPs);
 	}
 
 	private void _validateArticleDDMStructures(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.journal.service.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureLink;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLinkService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.util.comparator.StructureLinkStructureModifiedDateComparator;
@@ -538,23 +539,16 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		PermissionChecker permissionChecker = getPermissionChecker();
+		JournalFolder folder = getFolder(folderId);
 
-		if (ModelResourcePermissionUtil.contains(
-				_journalFolderModelResourcePermission, permissionChecker,
-				groupId, folderId, ActionKeys.ADVANCED_UPDATE) ||
-			ModelResourcePermissionUtil.contains(
-				_journalFolderModelResourcePermission, permissionChecker,
-				groupId, folderId, ActionKeys.UPDATE)) {
-
-			return journalFolderLocalService.updateFolder(
-				getUserId(), groupId, folderId, parentFolderId, name,
-				description, mergeWithParentFolder, serviceContext);
-		}
-
-		throw new PrincipalException.MustHavePermission(
-			permissionChecker, JournalFolder.class.getName(), folderId,
-			ActionKeys.ADVANCED_UPDATE, ActionKeys.UPDATE);
+		return updateFolder(
+			groupId, folderId, parentFolderId, name, description,
+			TransformUtil.transformToLongArray(
+				_ddmStructureLinkLocalService.getStructureLinks(
+					_classNameLocalService.getClassNameId(JournalFolder.class),
+					folderId),
+				ddmStructureLink -> ddmStructureLink.getStructureId()),
+			folder.getRestrictionType(), mergeWithParentFolder, serviceContext);
 	}
 
 	@Override
@@ -632,6 +626,9 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
 
 	@Reference
 	private DDMStructureLinkService _ddmStructureLinkService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -537,13 +538,22 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		_journalFolderModelResourcePermission.check(
-			getPermissionChecker(),
-			journalFolderLocalService.getFolder(folderId), ActionKeys.UPDATE);
+		PermissionChecker permissionChecker = getPermissionChecker();
+		JournalFolder folder = journalFolderLocalService.getFolder(folderId);
 
-		return journalFolderLocalService.updateFolder(
-			getUserId(), groupId, folderId, parentFolderId, name, description,
-			mergeWithParentFolder, serviceContext);
+		if (_journalFolderModelResourcePermission.contains(
+				permissionChecker, folder, ActionKeys.ADVANCED_UPDATE) ||
+			_journalFolderModelResourcePermission.contains(
+				permissionChecker, folder, ActionKeys.UPDATE)) {
+
+			return journalFolderLocalService.updateFolder(
+				getUserId(), groupId, folderId, parentFolderId, name,
+				description, mergeWithParentFolder, serviceContext);
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			permissionChecker, JournalFolder.class.getName(), folderId,
+			ActionKeys.ADVANCED_UPDATE, ActionKeys.UPDATE);
 	}
 
 	@Override
@@ -553,14 +563,24 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 			boolean mergeWithParentFolder, ServiceContext serviceContext)
 		throws PortalException {
 
-		ModelResourcePermissionUtil.check(
-			_journalFolderModelResourcePermission, getPermissionChecker(),
-			groupId, folderId, ActionKeys.UPDATE);
+		PermissionChecker permissionChecker = getPermissionChecker();
 
-		return journalFolderLocalService.updateFolder(
-			getUserId(), groupId, folderId, parentFolderId, name, description,
-			ddmStructureIds, restrictionType, mergeWithParentFolder,
-			serviceContext);
+		if (ModelResourcePermissionUtil.contains(
+				_journalFolderModelResourcePermission, permissionChecker,
+				groupId, folderId, ActionKeys.ADVANCED_UPDATE) ||
+			ModelResourcePermissionUtil.contains(
+				_journalFolderModelResourcePermission, permissionChecker,
+				groupId, folderId, ActionKeys.UPDATE)) {
+
+			return journalFolderLocalService.updateFolder(
+				getUserId(), groupId, folderId, parentFolderId, name,
+				description, ddmStructureIds, restrictionType,
+				mergeWithParentFolder, serviceContext);
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			permissionChecker, JournalFolder.class.getName(), folderId,
+			ActionKeys.ADVANCED_UPDATE, ActionKeys.UPDATE);
 	}
 
 	private List<DDMStructure> _filterStructures(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -539,12 +539,13 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 		throws PortalException {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
-		JournalFolder folder = journalFolderLocalService.getFolder(folderId);
 
-		if (_journalFolderModelResourcePermission.contains(
-				permissionChecker, folder, ActionKeys.ADVANCED_UPDATE) ||
-			_journalFolderModelResourcePermission.contains(
-				permissionChecker, folder, ActionKeys.UPDATE)) {
+		if (ModelResourcePermissionUtil.contains(
+				_journalFolderModelResourcePermission, permissionChecker,
+				groupId, folderId, ActionKeys.ADVANCED_UPDATE) ||
+			ModelResourcePermissionUtil.contains(
+				_journalFolderModelResourcePermission, permissionChecker,
+				groupId, folderId, ActionKeys.UPDATE)) {
 
 			return journalFolderLocalService.updateFolder(
 				getUserId(), groupId, folderId, parentFolderId, name,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -566,6 +567,39 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 			ModelResourcePermissionUtil.contains(
 				_journalFolderModelResourcePermission, permissionChecker,
 				groupId, folderId, ActionKeys.UPDATE)) {
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					serviceContext.getCompanyId(), "LPD-42452")) {
+
+				JournalFolder folder = getFolder(folderId);
+
+				if (!ModelResourcePermissionUtil.contains(
+						_journalFolderModelResourcePermission,
+						permissionChecker, groupId, folderId,
+						ActionKeys.ADVANCED_UPDATE)) {
+
+					ddmStructureIds = TransformUtil.transformToLongArray(
+						_ddmStructureLinkLocalService.getStructureLinks(
+							_classNameLocalService.getClassNameId(
+								JournalFolder.class),
+							folderId),
+						ddmStructureLink -> ddmStructureLink.getStructureId());
+
+					restrictionType = folder.getRestrictionType();
+
+					serviceContext.setAttribute(
+						"updateWorkflowDefinitionLinks", Boolean.FALSE);
+				}
+
+				if (!ModelResourcePermissionUtil.contains(
+						_journalFolderModelResourcePermission,
+						permissionChecker, groupId, folderId,
+						ActionKeys.UPDATE)) {
+
+					name = folder.getName();
+					description = folder.getDescription();
+				}
+			}
 
 			return journalFolderLocalService.updateFolder(
 				getUserId(), groupId, folderId, parentFolderId, name,

--- a/modules/apps/journal/journal-service/src/main/resources/resource-actions/journal.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/resource-actions/journal.xml
@@ -107,6 +107,7 @@
 				<action-key>ACCESS</action-key>
 				<action-key>ADD_ARTICLE</action-key>
 				<action-key>ADD_SUBFOLDER</action-key>
+				<action-key>ADVANCED_UPDATE</action-key>
 				<action-key>DELETE</action-key>
 				<action-key>PERMISSIONS</action-key>
 				<action-key>SUBSCRIBE</action-key>
@@ -124,6 +125,7 @@
 			<guest-unsupported>
 				<action-key>ADD_ARTICLE</action-key>
 				<action-key>ADD_SUBFOLDER</action-key>
+				<action-key>ADVANCE_UPDATE</action-key>
 				<action-key>SUBSCRIBE</action-key>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.dao.search.ResultRowSplitter;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -1173,6 +1174,27 @@ public class JournalDisplayContext {
 		).build();
 	}
 
+	public boolean hasAdvancedUpdateDLFolderPermission()
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-42452")) {
+
+			return hasUpdateDLFolderPermission();
+		}
+
+		if (_advancedUpdateDLFolderPermission != null) {
+			return _advancedUpdateDLFolderPermission;
+		}
+
+		_advancedUpdateDLFolderPermission = JournalFolderPermission.contains(
+			_themeDisplay.getPermissionChecker(),
+			_themeDisplay.getScopeGroupId(), getFolderId(),
+			ActionKeys.ADVANCED_UPDATE);
+
+		return _advancedUpdateDLFolderPermission;
+	}
+
 	public boolean hasAssetFilter() {
 		if (ArrayUtil.isEmpty(_getAssetCategoryIds()) &&
 			ArrayUtil.isEmpty(_getAssetTagNames())) {
@@ -1217,6 +1239,18 @@ public class JournalDisplayContext {
 		}
 
 		return false;
+	}
+
+	public boolean hasUpdateDLFolderPermission() throws PortalException {
+		if (_updateJournalFolderPermission != null) {
+			return _updateJournalFolderPermission;
+		}
+
+		_updateJournalFolderPermission = JournalFolderPermission.contains(
+			_themeDisplay.getPermissionChecker(),
+			_themeDisplay.getScopeGroupId(), getFolderId(), ActionKeys.UPDATE);
+
+		return _updateJournalFolderPermission;
 	}
 
 	public boolean hasVersionsResults() throws PortalException {
@@ -2117,6 +2151,7 @@ public class JournalDisplayContext {
 		JournalDisplayContext.class);
 
 	private long[] _addMenuFavItems;
+	private Boolean _advancedUpdateDLFolderPermission;
 	private JournalArticle _article;
 	private JournalArticleDisplay _articleDisplay;
 	private SearchContainer<?> _articleSearchContainer;
@@ -2159,5 +2194,6 @@ public class JournalDisplayContext {
 	private final ThemeDisplay _themeDisplay;
 	private final TrashHelper _trashHelper;
 	private String _type;
+	private Boolean _updateJournalFolderPermission;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalFolderActionDropdownItems.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalFolderActionDropdownItems.java
@@ -17,6 +17,7 @@ import com.liferay.journal.web.internal.security.permission.resource.JournalPerm
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -72,7 +73,13 @@ public class JournalFolderActionDropdownItems {
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> hasUpdatePermission,
+						() ->
+							hasUpdatePermission ||
+							(FeatureFlagManagerUtil.isEnabled(
+								_folder.getCompanyId(), "LPD-42452") &&
+							 JournalFolderPermission.contains(
+								 _themeDisplay.getPermissionChecker(), _folder,
+								 ActionKeys.ADVANCED_UPDATE)),
 						_getEditFolderActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -114,6 +114,7 @@ renderResponse.setTitle(title);
 			<liferay-frontend:fieldset
 				collapsed="<%= false %>"
 				collapsible="<%= true %>"
+				disabled="<%= !journalDisplayContext.hasUpdateDLFolderPermission() %>"
 				label="details"
 			>
 				<aui:input name="name" />
@@ -127,6 +128,7 @@ renderResponse.setTitle(title);
 				<liferay-frontend:fieldset
 					collapsed="<%= true %>"
 					collapsible="<%= true %>"
+					disabled="<%= !journalDisplayContext.hasUpdateDLFolderPermission() %>"
 					label="custom-fields"
 				>
 					<liferay-expando:custom-attribute-list
@@ -143,6 +145,7 @@ renderResponse.setTitle(title);
 			<liferay-frontend:fieldset
 				collapsed="<%= true %>"
 				collapsible="<%= true %>"
+				disabled="<%= !journalDisplayContext.hasUpdateDLFolderPermission() %>"
 				label="parent-folder"
 			>
 
@@ -181,7 +184,7 @@ renderResponse.setTitle(title);
 			</liferay-frontend:fieldset>
 		</c:if>
 
-		<c:if test="<%= rootFolder || (folder != null) %>">
+		<c:if test="<%= (rootFolder || (folder != null)) && journalDisplayContext.hasAdvancedUpdateDLFolderPermission() %>">
 
 			<%
 			List<DDMStructure> ddmStructures = journalDisplayContext.getDDMStructures(JournalFolderConstants.RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW);


### PR DESCRIPTION
**What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-49047

As a content creator, I want to update a folder without modifying the workflow defined for it, so that this ensure there are not security issues.

**How can you verify that it works?**

* Start the portal with the admin user
* Enable FF for LPD-42452
* Create a new site role with the following permissions: 


* Create a new user, and assign it the default site and the role previously created
* Create a new web content folder
* Log in another browser with the new user
* Go to Web content admin and click edit action on the folder

Only workflow will be changable

* With the admin user, go to the role, and remove advanced update and set only update
* Log in another browser with the new user
* Go to Web content admin and click edit action on the folder

Only name and description are changable, workflow is not visible in the UI


**Tests**

PR does not included tests since it's behind FF, the tests will be addressed in subsequent PRs

@gergelyszalay 