### PR TITLE
LPD-48503 - Get existing name from DDMStructure

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -69,10 +69,11 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			DataDefinition dataDefinition = DataDefinition.toDTO(
 				FileUtil.read(uploadPortletRequest.getFile("jsonFile")));
 
-			DataDefinitionUtil.validateDefinitionFields(dataDefinition);
-
 			DDMStructure ddmStructure =
 				_ddmStructureLocalService.getDDMStructure(dataDefinitionId);
+
+			DataDefinitionUtil.validateDefinitionFields(
+				dataDefinition, ddmStructure);
 
 			dataDefinition.setExternalReferenceCode(
 				ddmStructure::getExternalReferenceCode);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -72,7 +72,7 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			DDMStructure ddmStructure =
 				_ddmStructureLocalService.getDDMStructure(dataDefinitionId);
 
-			DataDefinitionUtil.validateDefinitionFields(
+			DataDefinitionUtil.validateAndUpdateDataDefinitionFields(
 				dataDefinition, ddmStructure);
 
 			dataDefinition.setExternalReferenceCode(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
@@ -62,7 +62,7 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 					ParamUtil.getString(actionRequest, "name")
 				).build());
 
-			DataDefinitionUtil.validateDefinitionFields(dataDefinition);
+			DataDefinitionUtil.validateDefinitionFields(dataDefinition, null);
 
 			DataDefinitionResource.Builder dataDefinitionResourcedBuilder =
 				_dataDefinitionResourceFactory.create();

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
@@ -62,7 +62,8 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 					ParamUtil.getString(actionRequest, "name")
 				).build());
 
-			DataDefinitionUtil.validateDefinitionFields(dataDefinition, null);
+			DataDefinitionUtil.validateAndUpdateDataDefinitionFields(
+				dataDefinition, null);
 
 			DataDefinitionResource.Builder dataDefinitionResourcedBuilder =
 				_dataDefinitionResourceFactory.create();

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
@@ -11,22 +11,41 @@ import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
 import com.liferay.data.engine.rest.dto.v2_0.DataLayoutColumn;
 import com.liferay.data.engine.rest.dto.v2_0.DataLayoutPage;
 import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.util.DDMFormFieldUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
 
 /**
  * @author Attila Bakay
  */
 public class DataDefinitionUtil {
 
-	public static void validateDefinitionFields(DataDefinition dataDefinition) {
+	public static boolean isValidFieldName(String fieldName) {
+		int index = fieldName.length() - 8;
+
+		if ((index >= 0) && Validator.isNumber(fieldName.substring(index))) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static void validateDefinitionFields(
+		DataDefinition dataDefinition, DDMStructure ddmStructure) {
+
 		for (DataDefinitionField dataDefinitionField :
 				dataDefinition.getDataDefinitionFields()) {
 
 			String oldFieldName = dataDefinitionField.getName();
 
-			String newFieldName = _getFieldName(oldFieldName);
+			String newFieldName = _getFieldName(
+				dataDefinitionField, ddmStructure, oldFieldName);
 
 			if (StringUtil.equals(newFieldName, oldFieldName)) {
 				continue;
@@ -40,11 +59,53 @@ public class DataDefinitionUtil {
 		}
 	}
 
-	private static String _getFieldName(String fieldName) {
-		int index = fieldName.length() - 8;
+	private static String _getExistingFieldName(
+		DataDefinitionField dataDefinitionField, DDMStructure ddmStructure) {
 
-		if ((index >= 0) && Validator.isNumber(fieldName.substring(index))) {
+		Map<String, Object> customProperties =
+			dataDefinitionField.getCustomProperties();
+
+		if ((customProperties != null) &&
+			customProperties.containsKey("fieldReference")) {
+
+			String fieldReference = GetterUtil.getString(
+				customProperties.get("fieldReference"));
+
+			DDMForm ddmForm = ddmStructure.getDDMForm();
+
+			Map<String, DDMFormField> ddmFormFieldsReferencesMap =
+				ddmForm.getDDMFormFieldsReferencesMap(true);
+
+			if (ddmFormFieldsReferencesMap.containsKey(fieldReference)) {
+				DDMFormField ddmFormField = ddmFormFieldsReferencesMap.get(
+					fieldReference);
+
+				return ddmFormField.getName();
+			}
+		}
+
+		return null;
+	}
+
+	private static String _getFieldName(
+		DataDefinitionField dataDefinitionField, DDMStructure ddmStructure,
+		String fieldName) {
+
+		if (isValidFieldName(fieldName)) {
 			return fieldName;
+		}
+
+		if (ddmStructure != null) {
+			String existingFieldName = _getExistingFieldName(
+				dataDefinitionField, ddmStructure);
+
+			if (existingFieldName != null) {
+				if (isValidFieldName(existingFieldName)) {
+					return existingFieldName;
+				}
+
+				fieldName = existingFieldName;
+			}
 		}
 
 		return DDMFormFieldUtil.getDDMFormFieldName(fieldName);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
@@ -15,7 +15,7 @@ import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.util.DDMFormFieldUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -65,23 +65,27 @@ public class DataDefinitionUtil {
 		Map<String, Object> customProperties =
 			dataDefinitionField.getCustomProperties();
 
-		if ((customProperties != null) &&
-			customProperties.containsKey("fieldReference")) {
+		if (customProperties == null) {
+			return null;
+		}
 
-			String fieldReference = GetterUtil.getString(
-				customProperties.get("fieldReference"));
+		String fieldReference = MapUtil.getString(
+			customProperties, "fieldReference");
 
-			DDMForm ddmForm = ddmStructure.getDDMForm();
+		if (Validator.isNull(fieldReference)) {
+			return null;
+		}
 
-			Map<String, DDMFormField> ddmFormFieldsReferencesMap =
-				ddmForm.getDDMFormFieldsReferencesMap(true);
+		DDMForm ddmForm = ddmStructure.getDDMForm();
 
-			if (ddmFormFieldsReferencesMap.containsKey(fieldReference)) {
-				DDMFormField ddmFormField = ddmFormFieldsReferencesMap.get(
-					fieldReference);
+		Map<String, DDMFormField> ddmFormFieldsReferencesMap =
+			ddmForm.getDDMFormFieldsReferencesMap(true);
 
-				return ddmFormField.getName();
-			}
+		if (ddmFormFieldsReferencesMap.containsKey(fieldReference)) {
+			DDMFormField ddmFormField = ddmFormFieldsReferencesMap.get(
+				fieldReference);
+
+			return ddmFormField.getName();
 		}
 
 		return null;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
@@ -36,7 +36,7 @@ public class DataDefinitionUtil {
 		return false;
 	}
 
-	public static void validateDefinitionFields(
+	public static void validateAndUpdateDataDefinitionFields(
 		DataDefinition dataDefinition, DDMStructure ddmStructure) {
 
 		for (DataDefinitionField dataDefinitionField :

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.util;
+
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutColumn;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutPage;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.util.DDMFormFieldUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Gergely Szalay
+ */
+public class DataDefinitionUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_fieldName = RandomTestUtil.randomString(8);
+		_fieldReference = RandomTestUtil.randomString();
+	}
+
+	@Test
+	public void testValidateDefinitionFields() {
+		_testValidateDefinitionFieldsWithExistingDataDefinition();
+		_testValidateDefinitionFieldsWithExistingInvalidName();
+		_testValidateDefinitionFieldsWithNewDataDefinition();
+	}
+
+	private DataDefinition _getDataDefinition() {
+		DataDefinition dataDefinition = new DataDefinition();
+
+		dataDefinition.setDefaultDataLayout(_getDataLayout(_fieldName));
+
+		DataDefinitionField dataDefinitionField = new DataDefinitionField();
+
+		dataDefinitionField.setCustomProperties(
+			HashMapBuilder.<String, Object>put(
+				"fieldReference", _fieldReference
+			).build());
+
+		dataDefinitionField.setName(_fieldName);
+
+		dataDefinition.setDataDefinitionFields(
+			new DataDefinitionField[] {dataDefinitionField});
+
+		return dataDefinition;
+	}
+
+	private String _getDataDefinitionFieldName(DataDefinition dataDefinition) {
+		DataDefinitionField dataDefinitionField =
+			dataDefinition.getDataDefinitionFields()[0];
+
+		return dataDefinitionField.getName();
+	}
+
+	private DataLayout _getDataLayout(String fieldName) {
+		DataLayout dataLayout = new DataLayout();
+
+		dataLayout.setDataLayoutPages(
+			new DataLayoutPage[] {
+				new DataLayoutPage() {
+					{
+						dataLayoutRows = new DataLayoutRow[] {
+							new DataLayoutRow() {
+								{
+									dataLayoutColumns = new DataLayoutColumn[] {
+										new DataLayoutColumn() {
+											{
+												fieldNames = new String[] {
+													fieldName
+												};
+											}
+										}
+									};
+								}
+							}
+						};
+						description = HashMapBuilder.<String, Object>put(
+							"en_US", "Description"
+						).build();
+						title = HashMapBuilder.<String, Object>put(
+							"en_US", "Title"
+						).build();
+					}
+				}
+			});
+
+		return dataLayout;
+	}
+
+	private DDMStructure _getDDMStructure(String existingFieldName) {
+		DDMStructure ddmStructure = Mockito.mock(DDMStructure.class);
+
+		DDMForm ddmForm = Mockito.mock(DDMForm.class);
+
+		DDMFormField ddmFormField = new DDMFormField(existingFieldName, "text");
+
+		ddmFormField.setFieldReference(_fieldReference);
+
+		Mockito.when(
+			ddmForm.getDDMFormFieldsReferencesMap(true)
+		).thenReturn(
+			Map.of(_fieldReference, ddmFormField)
+		);
+
+		Mockito.when(
+			ddmStructure.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		return ddmStructure;
+	}
+
+	private void _testValidateDefinitionFieldsWithExistingDataDefinition() {
+		DataDefinition dataDefinition = _getDataDefinition();
+
+		String existingFieldName = DDMFormFieldUtil.getDDMFormFieldName(
+			_fieldName);
+
+		DataDefinitionUtil.validateDefinitionFields(
+			dataDefinition, _getDDMStructure(existingFieldName));
+
+		String newFieldName = _getDataDefinitionFieldName(dataDefinition);
+
+		Assert.assertTrue(DataDefinitionUtil.isValidFieldName(newFieldName));
+
+		Assert.assertEquals(existingFieldName, newFieldName);
+	}
+
+	private void _testValidateDefinitionFieldsWithExistingInvalidName() {
+		DataDefinition dataDefinition = _getDataDefinition();
+
+		DataDefinitionUtil.validateDefinitionFields(
+			dataDefinition, _getDDMStructure(_fieldName));
+
+		String newFieldName = _getDataDefinitionFieldName(dataDefinition);
+
+		Assert.assertTrue(DataDefinitionUtil.isValidFieldName(newFieldName));
+	}
+
+	private void _testValidateDefinitionFieldsWithNewDataDefinition() {
+		DataDefinition dataDefinition = _getDataDefinition();
+
+		DataDefinitionUtil.validateDefinitionFields(dataDefinition, null);
+
+		Assert.assertTrue(
+			DataDefinitionUtil.isValidFieldName(
+				_getDataDefinitionFieldName(dataDefinition)));
+	}
+
+	private String _fieldName;
+	private String _fieldReference;
+
+}

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
@@ -46,10 +46,10 @@ public class DataDefinitionUtilTest {
 	}
 
 	@Test
-	public void testValidateDefinitionFields() {
-		_testValidateDefinitionFieldsWithExistingDataDefinition();
-		_testValidateDefinitionFieldsWithExistingInvalidName();
-		_testValidateDefinitionFieldsWithNewDataDefinition();
+	public void testValidateAndUpdateDataDefinitionFields() {
+		_testValidateAndUpdateDataDefinitionFieldsWithExistingDataAndUpdateDefinition();
+		_testValidateAndUpdateDataDefinitionFieldsWithExistingInvalidName();
+		_testValidateAndUpdateDataDefinitionFieldsWithNewDataAndUpdateDefinition();
 	}
 
 	private DataDefinition _getDataDefinition() {
@@ -138,13 +138,13 @@ public class DataDefinitionUtilTest {
 		return ddmStructure;
 	}
 
-	private void _testValidateDefinitionFieldsWithExistingDataDefinition() {
+	private void _testValidateAndUpdateDataDefinitionFieldsWithExistingDataAndUpdateDefinition() {
 		DataDefinition dataDefinition = _getDataDefinition();
 
 		String existingFieldName = DDMFormFieldUtil.getDDMFormFieldName(
 			_fieldName);
 
-		DataDefinitionUtil.validateDefinitionFields(
+		DataDefinitionUtil.validateAndUpdateDataDefinitionFields(
 			dataDefinition, _getDDMStructure(existingFieldName));
 
 		String newFieldName = _getDataDefinitionFieldName(dataDefinition);
@@ -154,10 +154,10 @@ public class DataDefinitionUtilTest {
 		Assert.assertEquals(existingFieldName, newFieldName);
 	}
 
-	private void _testValidateDefinitionFieldsWithExistingInvalidName() {
+	private void _testValidateAndUpdateDataDefinitionFieldsWithExistingInvalidName() {
 		DataDefinition dataDefinition = _getDataDefinition();
 
-		DataDefinitionUtil.validateDefinitionFields(
+		DataDefinitionUtil.validateAndUpdateDataDefinitionFields(
 			dataDefinition, _getDDMStructure(_fieldName));
 
 		String newFieldName = _getDataDefinitionFieldName(dataDefinition);
@@ -165,10 +165,11 @@ public class DataDefinitionUtilTest {
 		Assert.assertTrue(DataDefinitionUtil.isValidFieldName(newFieldName));
 	}
 
-	private void _testValidateDefinitionFieldsWithNewDataDefinition() {
+	private void _testValidateAndUpdateDataDefinitionFieldsWithNewDataAndUpdateDefinition() {
 		DataDefinition dataDefinition = _getDataDefinition();
 
-		DataDefinitionUtil.validateDefinitionFields(dataDefinition, null);
+		DataDefinitionUtil.validateAndUpdateDataDefinitionFields(
+			dataDefinition, null);
 
 		Assert.assertTrue(
 			DataDefinitionUtil.isValidFieldName(


### PR DESCRIPTION
"**What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-48503

When import and overriding a structure with a structure that has old naming format, repatable fields are disappearing.

**How am I fixing it?**

When generating a new name for the field, first I check if the structure already existing and hast the same fieldreference. If it does, use the name of the already existing fields, if those are valid and update the datalayout with that.

**How can you verify that it works?**
run DataDefinitionUtilTest.testValidateDefinitionFields 

Included changes requested in https://github.com/brianchandotcom/liferay-portal/pull/158884#issuecomment-2666814611