### PR TITLE
LPD-49103 Cannot preview a Web Content with a DPT when autosave is enabled

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/PreviewButton.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/PreviewButton.js
@@ -22,10 +22,12 @@ export default function PreviewButton({
 			disabled={disabled}
 			displayType="secondary"
 			onClick={() => {
+				const futureDate = new Date(new Date().getTime() + 1000);
+
 				updateJournalInput({
 					name: 'formDate',
 					namespace,
-					value: Date.now().toString(),
+					value: futureDate.getTime(),
 				});
 
 				const form = document.getElementById(`${namespace}fm1`);

--- a/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticleAutosave.spec.ts
@@ -694,7 +694,7 @@ autosaveWithoutPermissionsTest(
 
 		const articleTitle = 'Web Content Title';
 
-		journalEditArticlePage.createWCWithBasicPublishButton(articleTitle);
+		journalEditArticlePage.createAndPublishBasicArticle(articleTitle);
 
 		await expect(page.getByTitle(articleTitle)).toBeVisible();
 	}

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -228,15 +228,6 @@ export class JournalEditArticlePage {
 		await expect(this.page.getByTitle(title, {exact: true})).toBeVisible();
 	}
 
-	async createWCWithBasicPublishButton(articleTitle: string) {
-		await this.titleInput.fill(articleTitle);
-		this.publishArticle();
-
-		await waitForAlert(
-			this.page,
-			`Success:${articleTitle} was created successfully.`
-		);
-	}
 	async createArticleWithDuplicatedField(
 		structureName: string,
 		site?: Site,


### PR DESCRIPTION

[Link to issue](https://liferay.atlassian.net/browse/LPD-49103)

### Motivation
When autosave is enabled (LPD-11228) the preview button was launching an exception due to the modified date was not in future. So I have added a 1sec delay to it. 

### How to test it

1. Assure that FF LPD-11228: Autosave draft in Web Content editor is enabled from Instance Settings
2. Create a Display Page Template (for Web Content > Basic Web Content) with Content Display widget for example 
3. Make previous DPT as default 
4. Go to Content & Data > Create a Basic Web Content and fill title 
5. On the right side “Display page” click the button Preview

Test` DisplayPageTemplatesForWebContentArticle#PreviewWebContentThroughTheDisplayPageOfCurrentSite` already covers this case. This bug was resolved while removing the FF, so current test is enough and should pass once the FF is removed. 