### PR TITLE
LPD-48867 Technical Task | Add headless API for folders : For an Object entry folder

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 50.0.1
+Bundle-Version: 50.1.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ObjectEntryFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ObjectEntryFolder.java
@@ -113,6 +113,51 @@ public class ObjectEntryFolder implements Serializable {
 	private Supplier<Map<String, Map<String, String>>> _actionsSupplier;
 
 	@Schema(
+		description = "The ID of the asset library to which this object entry folder is scoped."
+	)
+	public Long getAssetLibraryId() {
+		if (_assetLibraryIdSupplier != null) {
+			assetLibraryId = _assetLibraryIdSupplier.get();
+
+			_assetLibraryIdSupplier = null;
+		}
+
+		return assetLibraryId;
+	}
+
+	public void setAssetLibraryId(Long assetLibraryId) {
+		this.assetLibraryId = assetLibraryId;
+
+		_assetLibraryIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAssetLibraryId(
+		UnsafeSupplier<Long, Exception> assetLibraryIdUnsafeSupplier) {
+
+		_assetLibraryIdSupplier = () -> {
+			try {
+				return assetLibraryIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The ID of the asset library to which this object entry folder is scoped."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long assetLibraryId;
+
+	@JsonIgnore
+	private Supplier<Long> _assetLibraryIdSupplier;
+
+	@Schema(
 		description = "The key of the asset library to which the object entry folder is scoped."
 	)
 	public String getAssetLibraryKey() {
@@ -727,6 +772,18 @@ public class ObjectEntryFolder implements Serializable {
 			sb.append("\"actions\": ");
 
 			sb.append(_toJSON(actions));
+		}
+
+		Long assetLibraryId = getAssetLibraryId();
+
+		if (assetLibraryId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetLibraryId\": ");
+
+			sb.append(assetLibraryId);
 		}
 
 		String assetLibraryKey = getAssetLibraryKey();

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ObjectEntryFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ObjectEntryFolderResource.java
@@ -69,6 +69,27 @@ public interface ObjectEntryFolderResource {
 			Long assetLibraryId, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception;
+
+	public Response deleteObjectEntryFolderBatch(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public ObjectEntryFolder getObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception;
+
+	public ObjectEntryFolder patchObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public ObjectEntryFolder putObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public Response putObjectEntryFolderBatch(String callbackURL, Object object)
+		throws Exception;
+
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 32.0.0
+version 32.1.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 18.11.0
+version 18.12.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ObjectEntryFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ObjectEntryFolder.java
@@ -49,6 +49,27 @@ public class ObjectEntryFolder implements Cloneable, Serializable {
 
 	protected Map<String, Map<String, String>> actions;
 
+	public Long getAssetLibraryId() {
+		return assetLibraryId;
+	}
+
+	public void setAssetLibraryId(Long assetLibraryId) {
+		this.assetLibraryId = assetLibraryId;
+	}
+
+	public void setAssetLibraryId(
+		UnsafeSupplier<Long, Exception> assetLibraryIdUnsafeSupplier) {
+
+		try {
+			assetLibraryId = assetLibraryIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long assetLibraryId;
+
 	public String getAssetLibraryKey() {
 		return assetLibraryKey;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ObjectEntryFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ObjectEntryFolderResource.java
@@ -79,6 +79,50 @@ public interface ObjectEntryFolderResource {
 				Long assetLibraryId, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteObjectEntryFolderHttpResponse(
+			Long objectEntryFolderId)
+		throws Exception;
+
+	public void deleteObjectEntryFolderBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteObjectEntryFolderBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public ObjectEntryFolder getObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getObjectEntryFolderHttpResponse(
+			Long objectEntryFolderId)
+		throws Exception;
+
+	public ObjectEntryFolder patchObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse patchObjectEntryFolderHttpResponse(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public ObjectEntryFolder putObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse putObjectEntryFolderHttpResponse(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception;
+
+	public void putObjectEntryFolderBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse putObjectEntryFolderBatchHttpResponse(
+			String callbackURL, Object object)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -659,6 +703,634 @@ public interface ObjectEntryFolderResource {
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/object-entry-folders/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteObjectEntryFolder(Long objectEntryFolderId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectEntryFolderHttpResponse(objectEntryFolderId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteObjectEntryFolderHttpResponse(
+				Long objectEntryFolderId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteObjectEntryFolderBatch(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectEntryFolderBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteObjectEntryFolderBatchHttpResponse(
+					String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public ObjectEntryFolder getObjectEntryFolder(Long objectEntryFolderId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectEntryFolderHttpResponse(objectEntryFolderId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ObjectEntryFolderSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getObjectEntryFolderHttpResponse(
+				Long objectEntryFolderId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public ObjectEntryFolder patchObjectEntryFolder(
+				Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				patchObjectEntryFolderHttpResponse(
+					objectEntryFolderId, objectEntryFolder);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ObjectEntryFolderSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse patchObjectEntryFolderHttpResponse(
+				Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(objectEntryFolder.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PATCH);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public ObjectEntryFolder putObjectEntryFolder(
+				Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putObjectEntryFolderHttpResponse(
+					objectEntryFolderId, objectEntryFolder);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ObjectEntryFolderSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse putObjectEntryFolderHttpResponse(
+				Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(objectEntryFolder.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void putObjectEntryFolderBatch(String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putObjectEntryFolderBatchHttpResponse(callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse putObjectEntryFolderBatchHttpResponse(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/object-entry-folders/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ObjectEntryFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ObjectEntryFolderSerDes.java
@@ -62,6 +62,16 @@ public class ObjectEntryFolderSerDes {
 			sb.append(_toJSON(objectEntryFolder.getActions()));
 		}
 
+		if (objectEntryFolder.getAssetLibraryId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetLibraryId\": ");
+
+			sb.append(objectEntryFolder.getAssetLibraryId());
+		}
+
 		if (objectEntryFolder.getAssetLibraryKey() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -255,6 +265,15 @@ public class ObjectEntryFolderSerDes {
 			map.put("actions", String.valueOf(objectEntryFolder.getActions()));
 		}
 
+		if (objectEntryFolder.getAssetLibraryId() == null) {
+			map.put("assetLibraryId", null);
+		}
+		else {
+			map.put(
+				"assetLibraryId",
+				String.valueOf(objectEntryFolder.getAssetLibraryId()));
+		}
+
 		if (objectEntryFolder.getAssetLibraryKey() == null) {
 			map.put("assetLibraryKey", null);
 		}
@@ -389,6 +408,9 @@ public class ObjectEntryFolderSerDes {
 			if (Objects.equals(jsonParserFieldName, "actions")) {
 				return true;
 			}
+			else if (Objects.equals(jsonParserFieldName, "assetLibraryId")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "assetLibraryKey")) {
 				return false;
 			}
@@ -449,6 +471,12 @@ public class ObjectEntryFolderSerDes {
 				if (jsonParserFieldValue != null) {
 					objectEntryFolder.setActions(
 						(Map<String, Map<String, String>>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetLibraryId")) {
+				if (jsonParserFieldValue != null) {
+					objectEntryFolder.setAssetLibraryId(
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "assetLibraryKey")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -3675,6 +3675,12 @@ components:
                         Block of actions allowed by the user making the request.
                     readOnly: true
                     type: object
+                assetLibraryId:
+                    # @review
+                    description:
+                        The ID of the asset library to which this object entry folder is scoped.
+                    format: int64
+                    type: integer
                 assetLibraryKey:
                     # @review
                     description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -12368,6 +12368,116 @@ paths:
                         application/json: {}
                         application/xml: {}
             tags: ["NavigationMenu"]
+    "/object-entry-folders/{objectEntryFolderId}":
+        delete:
+            description:
+                Deletes the object entry folder and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryFolder
+            parameters:
+                - in: path
+                  name: objectEntryFolderId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ObjectEntryFolder"]
+        get:
+            description:
+                Retrieves the object entry folder.
+            operationId: getObjectEntryFolder
+            parameters:
+                - in: path
+                  name: objectEntryFolderId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: fields
+                  schema:
+                      type: string
+                - in: query
+                  name: nestedFields
+                  schema:
+                      type: string
+                - in: query
+                  name: restrictFields
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+            tags: ["ObjectEntryFolder"]
+        patch:
+            description:
+                Updates only the fields received in the request body, leaving any other fields untouched.
+            operationId: patchObjectEntryFolder
+            parameters:
+                - in: path
+                  name: objectEntryFolderId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntryFolder"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntryFolder"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+            tags: ["ObjectEntryFolder"]
+        put:
+            description:
+                Replaces the object entry folder with the information sent in the request body. Any missing fields are
+                deleted, unless they are required.
+            operationId: putObjectEntryFolder
+            parameters:
+                - in: path
+                  name: objectEntryFolderId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntryFolder"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ObjectEntryFolder"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntryFolder"
+            tags: ["ObjectEntryFolder"]
     "/sites/{siteId}/blog-posting-images":
         get:
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6268,7 +6268,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.91'."
+        'com.liferay.headless.delivery.client', and version '4.0.93'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
@@ -5,12 +5,13 @@
 
 package com.liferay.headless.delivery.internal.dto.v1_0.converter;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryService;
 import com.liferay.headless.delivery.dto.v1_0.ObjectEntryFolder;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -45,12 +46,15 @@ public class ObjectEntryFolderDTOConverter
 			_objectEntryFolderLocalService.getObjectEntryFolder(
 				(Long)dtoConverterContext.getId());
 
-		Group group = _groupLocalService.getGroup(
+		DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
 			objectEntryFolder.getGroupId());
+
+		Group group = depotEntry.getGroup();
 
 		return new ObjectEntryFolder() {
 			{
 				setActions(dtoConverterContext::getActions);
+				setAssetLibraryId(depotEntry::getDepotEntryId);
 				setAssetLibraryKey(() -> GroupUtil.getAssetLibraryKey(group));
 				setCreator(
 					() -> CreatorUtil.toCreator(
@@ -98,7 +102,7 @@ public class ObjectEntryFolderDTOConverter
 	}
 
 	@Reference
-	private GroupLocalService _groupLocalService;
+	private DepotEntryService _depotEntryService;
 
 	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -4830,6 +4830,85 @@ public class Mutation {
 						Long.valueOf(assetLibraryId), callbackURL, object));
 	}
 
+	@GraphQLField(
+		description = "Deletes the object entry folder and returns a 204 if the operation succeeds."
+	)
+	public boolean deleteObjectEntryFolder(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.deleteObjectEntryFolder(
+					objectEntryFolderId));
+
+		return true;
+	}
+
+	@GraphQLField
+	public Response deleteObjectEntryFolderBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.deleteObjectEntryFolderBatch(
+					callbackURL, object));
+	}
+
+	@GraphQLField(
+		description = "Updates only the fields received in the request body, leaving any other fields untouched."
+	)
+	public ObjectEntryFolder patchObjectEntryFolder(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("objectEntryFolder") ObjectEntryFolder
+				objectEntryFolder)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.patchObjectEntryFolder(
+					objectEntryFolderId, objectEntryFolder));
+	}
+
+	@GraphQLField(
+		description = "Replaces the object entry folder with the information sent in the request body. Any missing fields are deleted, unless they are required."
+	)
+	public ObjectEntryFolder updateObjectEntryFolder(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("objectEntryFolder") ObjectEntryFolder
+				objectEntryFolder)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.putObjectEntryFolder(
+					objectEntryFolderId, objectEntryFolder));
+	}
+
+	@GraphQLField
+	public Response updateObjectEntryFolderBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.putObjectEntryFolderBatch(
+					callbackURL, object));
+	}
+
 	@GraphQLField
 	public Response createSiteSitePagesPageExportBatch(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -3289,6 +3289,24 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolder(objectEntryFolderId: ___){actions, assetLibraryId, assetLibraryKey, creator, dateCreated, dateModified, externalReferenceCode, id, label, label_i18n, name, numberOfObjectEntries, numberOfObjectEntryFolders, parentObjectEntryFolderId, viewableBy}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(description = "Retrieves the object entry folder.")
+	public ObjectEntryFolder objectEntryFolder(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectEntryFolderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectEntryFolderResource ->
+				objectEntryFolderResource.getObjectEntryFolder(
+					objectEntryFolderId));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePages(aggregation: ___, filter: ___, page: ___, pageSize: ___, search: ___, siteKey: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the public pages of the site")
@@ -7080,6 +7098,33 @@ public class Query {
 		}
 
 		private NavigationMenuItem _navigationMenuItem;
+
+	}
+
+	@GraphQLTypeExtension(ObjectEntryFolder.class)
+	public class ParentObjectEntryFolderObjectEntryFolderIdTypeExtension {
+
+		public ParentObjectEntryFolderObjectEntryFolderIdTypeExtension(
+			ObjectEntryFolder objectEntryFolder) {
+
+			_objectEntryFolder = objectEntryFolder;
+		}
+
+		@GraphQLField(description = "Retrieves the object entry folder.")
+		public ObjectEntryFolder parentObjectEntryFolder() throws Exception {
+			if (_objectEntryFolder.getParentObjectEntryFolderId() == null) {
+				return null;
+			}
+
+			return _applyComponentServiceObjects(
+				_objectEntryFolderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				objectEntryFolderResource ->
+					objectEntryFolderResource.getObjectEntryFolder(
+						_objectEntryFolder.getParentObjectEntryFolderId()));
+		}
+
+		private ObjectEntryFolder _objectEntryFolder;
 
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -1481,6 +1481,31 @@ public class ServletDataImpl implements ServletData {
 							ObjectEntryFolderResourceImpl.class,
 							"postAssetLibraryObjectEntryFolderBatch"));
 					put(
+						"mutation#deleteObjectEntryFolder",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"deleteObjectEntryFolder"));
+					put(
+						"mutation#deleteObjectEntryFolderBatch",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"deleteObjectEntryFolderBatch"));
+					put(
+						"mutation#patchObjectEntryFolder",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"patchObjectEntryFolder"));
+					put(
+						"mutation#updateObjectEntryFolder",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"putObjectEntryFolder"));
+					put(
+						"mutation#updateObjectEntryFolderBatch",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"putObjectEntryFolderBatch"));
+					put(
 						"mutation#createSiteSitePagesPageExportBatch",
 						new ObjectValuePair<>(
 							SitePageResourceImpl.class,
@@ -2508,6 +2533,11 @@ public class ServletDataImpl implements ServletData {
 							ObjectEntryFolderResourceImpl.class,
 							"getAssetLibraryObjectEntryFoldersPage"));
 					put(
+						"query#objectEntryFolder",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"getObjectEntryFolder"));
+					put(
 						"query#sitePages",
 						new ObjectValuePair<>(
 							SitePageResourceImpl.class,
@@ -3008,6 +3038,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							NavigationMenuResourceImpl.class,
 							"getNavigationMenu"));
+					put(
+						"query#ObjectEntryFolder.parentObjectEntryFolder",
+						new ObjectValuePair<>(
+							ObjectEntryFolderResourceImpl.class,
+							"getObjectEntryFolder"));
 					put(
 						"query#StructuredContentFolder.parentStructuredContentFolder",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/NoSuchObjectEntryFolderExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/NoSuchObjectEntryFolderExceptionMapper.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.NoSuchObjectEntryFolderException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code NoSuchObjectEntryFolderException} to a {@code 404} error.
+ *
+ * @author Alicia García
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Delivery.NoSuchObjectEntryFolderExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class NoSuchObjectEntryFolderExceptionMapper
+	extends BaseExceptionMapper<NoSuchObjectEntryFolderException> {
+
+	@Override
+	protected Problem getProblem(
+		NoSuchObjectEntryFolderException noSuchObjectEntryFolderException) {
+
+		return new Problem(
+			Response.Status.NOT_FOUND,
+			noSuchObjectEntryFolderException.getMessage());
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/ObjectEntryFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/ObjectEntryFolderNameExceptionMapper.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectEntryFolderNameException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code ObjectEntryFolderNameException} to a {@code 400} or
+ * {@code 409} error.
+ *
+ * @author Alicia García
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Delivery.ObjectEntryFolderNameExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectEntryFolderNameExceptionMapper
+	extends BaseExceptionMapper<ObjectEntryFolderNameException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectEntryFolderNameException objectEntryFolderNameException) {
+
+		if (objectEntryFolderNameException instanceof
+				ObjectEntryFolderNameException.MustNotBeDuplicate) {
+
+			return new Problem(
+				Response.Status.CONFLICT,
+				"A object entry folder already exists with the name " +
+					objectEntryFolderNameException.getMessage());
+		}
+
+		if (objectEntryFolderNameException instanceof
+				ObjectEntryFolderNameException.MustNotBeNull) {
+
+			return new Problem(
+				Response.Status.BAD_REQUEST,
+				"A object entry folder name must not be null" +
+					objectEntryFolderNameException.getMessage());
+		}
+
+		return new Problem(objectEntryFolderNameException);
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/ObjectEntryFolderScopeExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/ObjectEntryFolderScopeExceptionMapper.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectEntryFolderScopeException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code ObjectEntryFolderScopeException} to a {@code 409} error.
+ *
+ * @author Alicia García
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Delivery.ObjectEntryFolderScopeExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectEntryFolderScopeExceptionMapper
+	extends BaseExceptionMapper<ObjectEntryFolderScopeException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectEntryFolderScopeException objectEntryFolderScopeException) {
+
+		return new Problem(
+			Response.Status.CONFLICT,
+			"Group ID does not match with parent folder group ID " +
+				objectEntryFolderScopeException.getMessage());
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseObjectEntryFolderResourceImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
@@ -69,7 +70,8 @@ import javax.ws.rs.core.UriInfo;
 @javax.ws.rs.Path("/v1.0")
 public abstract class BaseObjectEntryFolderResourceImpl
 	implements EntityModelResource, ObjectEntryFolderResource,
-			   VulcanBatchEngineTaskItemDelegate<ObjectEntryFolder> {
+			   VulcanBatchEngineTaskItemDelegate<ObjectEntryFolder>,
+			   VulcanCRUDItemDelegate<ObjectEntryFolder> {
 
 	/**
 	 * Invoke this method with the command line:
@@ -247,7 +249,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/object-entry-folders' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/object-entry-folders' -d $'{"assetLibraryId": ___, "externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -334,6 +336,291 @@ public abstract class BaseObjectEntryFolderResourceImpl
 		).build();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the object entry folder and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path("/object-entry-folders/{objectEntryFolderId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteObjectEntryFolder(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path("/object-entry-folders/batch")
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response deleteObjectEntryFolderBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.deleteImportTask(
+				ObjectEntryFolder.class.getName(), callbackURL, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the object entry folder."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/object-entry-folders/{objectEntryFolderId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ObjectEntryFolder getObjectEntryFolder(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId)
+		throws Exception {
+
+		return new ObjectEntryFolder();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}' -d $'{"assetLibraryId": ___, "externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Updates only the fields received in the request body, leaving any other fields untouched."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.PATCH
+	@javax.ws.rs.Path("/object-entry-folders/{objectEntryFolderId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ObjectEntryFolder patchObjectEntryFolder(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		ObjectEntryFolder existingObjectEntryFolder = getObjectEntryFolder(
+			objectEntryFolderId);
+
+		if (objectEntryFolder.getAssetLibraryId() != null) {
+			existingObjectEntryFolder.setAssetLibraryId(
+				objectEntryFolder.getAssetLibraryId());
+		}
+
+		if (objectEntryFolder.getExternalReferenceCode() != null) {
+			existingObjectEntryFolder.setExternalReferenceCode(
+				objectEntryFolder.getExternalReferenceCode());
+		}
+
+		if (objectEntryFolder.getLabel() != null) {
+			existingObjectEntryFolder.setLabel(objectEntryFolder.getLabel());
+		}
+
+		if (objectEntryFolder.getLabel_i18n() != null) {
+			existingObjectEntryFolder.setLabel_i18n(
+				objectEntryFolder.getLabel_i18n());
+		}
+
+		if (objectEntryFolder.getName() != null) {
+			existingObjectEntryFolder.setName(objectEntryFolder.getName());
+		}
+
+		if (objectEntryFolder.getParentObjectEntryFolderId() != null) {
+			existingObjectEntryFolder.setParentObjectEntryFolderId(
+				objectEntryFolder.getParentObjectEntryFolderId());
+		}
+
+		if (objectEntryFolder.getViewableBy() != null) {
+			existingObjectEntryFolder.setViewableBy(
+				objectEntryFolder.getViewableBy());
+		}
+
+		preparePatch(objectEntryFolder, existingObjectEntryFolder);
+
+		return putObjectEntryFolder(
+			objectEntryFolderId, existingObjectEntryFolder);
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/{objectEntryFolderId}' -d $'{"assetLibraryId": ___, "externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Replaces the object entry folder with the information sent in the request body. Any missing fields are deleted, unless they are required."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/object-entry-folders/{objectEntryFolderId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public ObjectEntryFolder putObjectEntryFolder(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return new ObjectEntryFolder();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/object-entry-folders/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntryFolder")
+		}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/object-entry-folders/batch")
+	@javax.ws.rs.Produces("application/json")
+	@javax.ws.rs.PUT
+	@Override
+	public Response putObjectEntryFolderBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.putImportTask(
+				ObjectEntryFolder.class.getName(), callbackURL, object)
+		).build();
+	}
+
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
@@ -387,8 +674,26 @@ public abstract class BaseObjectEntryFolderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<ObjectEntryFolder, ObjectEntryFolder, Exception>
+			objectEntryFolderUnsafeFunction = objectEntryFolder -> {
+				deleteObjectEntryFolder(objectEntryFolder.getId());
+
+				return objectEntryFolder;
+			};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				objectEntryFolders, objectEntryFolderUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectEntryFolders, objectEntryFolderUnsafeFunction::apply);
+		}
+		else {
+			for (ObjectEntryFolder objectEntryFolder : objectEntryFolders) {
+				objectEntryFolderUnsafeFunction.apply(objectEntryFolder);
+			}
+		}
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
@@ -396,7 +701,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("PARTIAL_UPDATE", "UPDATE");
 	}
 
 	@Override
@@ -468,8 +773,51 @@ public abstract class BaseObjectEntryFolderResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<ObjectEntryFolder, ObjectEntryFolder, Exception>
+			objectEntryFolderUnsafeFunction = null;
+
+		String updateStrategy = (String)parameters.getOrDefault(
+			"updateStrategy", "UPDATE");
+
+		if (StringUtil.equalsIgnoreCase(updateStrategy, "PARTIAL_UPDATE")) {
+			objectEntryFolderUnsafeFunction =
+				objectEntryFolder -> patchObjectEntryFolder(
+					objectEntryFolder.getId() != null ?
+						objectEntryFolder.getId() :
+							_parseLong(
+								(String)parameters.get("objectEntryFolderId")),
+					objectEntryFolder);
+		}
+
+		if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+			objectEntryFolderUnsafeFunction =
+				objectEntryFolder -> putObjectEntryFolder(
+					objectEntryFolder.getId() != null ?
+						objectEntryFolder.getId() :
+							_parseLong(
+								(String)parameters.get("objectEntryFolderId")),
+					objectEntryFolder);
+		}
+
+		if (objectEntryFolderUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Update strategy \"" + updateStrategy +
+					"\" is not supported for ObjectEntryFolder");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				objectEntryFolders, objectEntryFolderUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				objectEntryFolders, objectEntryFolderUnsafeFunction::apply);
+		}
+		else {
+			for (ObjectEntryFolder objectEntryFolder : objectEntryFolders) {
+				objectEntryFolderUnsafeFunction.apply(objectEntryFolder);
+			}
+		}
 	}
 
 	private Boolean _parseBoolean(String value) {
@@ -478,6 +826,19 @@ public abstract class BaseObjectEntryFolderResourceImpl
 		}
 
 		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
+	}
+
+	@Override
+	public ObjectEntryFolder getItem(Long id) throws Exception {
+		return getObjectEntryFolder(id);
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -686,6 +1047,11 @@ public abstract class BaseObjectEntryFolderResourceImpl
 
 		return addAction(
 			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected void preparePatch(
+		ObjectEntryFolder objectEntryFolder,
+		ObjectEntryFolder existingObjectEntryFolder) {
 	}
 
 	protected <T, R, E extends Throwable> List<R> transform(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -5,11 +5,17 @@
 
 package com.liferay.headless.delivery.internal.resource.v1_0;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.delivery.dto.v1_0.ObjectEntryFolder;
 import com.liferay.headless.delivery.resource.v1_0.ObjectEntryFolderResource;
+import com.liferay.object.exception.NoSuchObjectEntryFolderException;
 import com.liferay.object.service.ObjectEntryFolderService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -40,6 +46,17 @@ public class ObjectEntryFolderResourceImpl
 	extends BaseObjectEntryFolderResourceImpl {
 
 	@Override
+	public void deleteObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_objectEntryFolderService.deleteObjectEntryFolder(objectEntryFolderId);
+	}
+
+	@Override
 	public Page<ObjectEntryFolder> getAssetLibraryObjectEntryFoldersPage(
 			Long assetLibraryId, Boolean flatten, String search,
 			Aggregation aggregation, Filter filter, Pagination pagination,
@@ -52,6 +69,11 @@ public class ObjectEntryFolderResourceImpl
 
 		return _getAssetLibraryObjectEntryFoldersPage(
 			HashMapBuilder.put(
+				"create",
+				addAction(
+					ActionKeys.UPDATE, "postAssetLibraryObjectEntryFolder",
+					_CLASS_NAME, assetLibraryId)
+			).put(
 				"createBatch",
 				addAction(
 					ActionKeys.UPDATE, "postAssetLibraryObjectEntryFolderBatch",
@@ -66,6 +88,67 @@ public class ObjectEntryFolderResourceImpl
 	}
 
 	@Override
+	public ObjectEntryFolder getObjectEntryFolder(Long objectEntryFolderId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _toObjectEntryFolder(
+			_objectEntryFolderService.getObjectEntryFolder(
+				objectEntryFolderId));
+	}
+
+	@Override
+	public ObjectEntryFolder patchObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		com.liferay.object.model.ObjectEntryFolder persistedObjectEntryFolder =
+			_objectEntryFolderService.getObjectEntryFolder(objectEntryFolderId);
+
+		Long parentObjectEntryFolderId =
+			objectEntryFolder.getParentObjectEntryFolderId();
+
+		if (parentObjectEntryFolderId == null) {
+			parentObjectEntryFolderId =
+				persistedObjectEntryFolder.getParentObjectEntryFolderId();
+		}
+
+		String name = objectEntryFolder.getName();
+
+		if (name == null) {
+			name = persistedObjectEntryFolder.getName();
+		}
+
+		String label = objectEntryFolder.getLabel();
+
+		if (label == null) {
+			label = persistedObjectEntryFolder.getLabel();
+		}
+
+		Map<String, String> labelMap = objectEntryFolder.getLabel_i18n();
+
+		if (labelMap == null) {
+			labelMap = LocalizedMapUtil.getI18nMap(
+				persistedObjectEntryFolder.getLabelMap());
+		}
+
+		return _toObjectEntryFolder(
+			_objectEntryFolderService.updateObjectEntryFolder(
+				objectEntryFolderId, parentObjectEntryFolderId,
+				LocalizedMapUtil.getLocalizedMap(
+					contextAcceptLanguage.getPreferredLocale(), label,
+					labelMap),
+				name));
+	}
+
+	@Override
 	public ObjectEntryFolder postAssetLibraryObjectEntryFolder(
 			Long assetLibraryId, ObjectEntryFolder objectEntryFolder)
 		throws Exception {
@@ -74,7 +157,52 @@ public class ObjectEntryFolderResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		return _addObjectEntryFolder(assetLibraryId, null, objectEntryFolder);
+		Long parentObjectEntryFolderId =
+			objectEntryFolder.getParentObjectEntryFolderId();
+
+		if (parentObjectEntryFolderId == null) {
+			parentObjectEntryFolderId = 0L;
+		}
+
+		return _addObjectEntryFolder(
+			assetLibraryId, parentObjectEntryFolderId, objectEntryFolder);
+	}
+
+	@Override
+	public ObjectEntryFolder putObjectEntryFolder(
+			Long objectEntryFolderId, ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Long parentObjectEntryFolderId =
+			objectEntryFolder.getParentObjectEntryFolderId();
+
+		if (parentObjectEntryFolderId == null) {
+			throw new NoSuchObjectEntryFolderException();
+		}
+
+		try {
+			_objectEntryFolderService.getObjectEntryFolder(objectEntryFolderId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return _putObjectEntryFolder(objectEntryFolder);
+		}
+
+		return _toObjectEntryFolder(
+			_objectEntryFolderService.updateObjectEntryFolder(
+				objectEntryFolderId, parentObjectEntryFolderId,
+				LocalizedMapUtil.getLocalizedMap(
+					contextAcceptLanguage.getPreferredLocale(),
+					objectEntryFolder.getLabel(),
+					objectEntryFolder.getLabel_i18n()),
+				objectEntryFolder.getName()));
 	}
 
 	private ObjectEntryFolder _addObjectEntryFolder(
@@ -120,6 +248,27 @@ public class ObjectEntryFolderResourceImpl
 				groupId, group.getCompanyId(), 0L));
 	}
 
+	private ObjectEntryFolder _putObjectEntryFolder(
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		Long assetLibraryId = objectEntryFolder.getAssetLibraryId();
+
+		if (assetLibraryId == null) {
+			throw new NoSuchObjectEntryFolderException();
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchDepotEntry(
+			assetLibraryId);
+
+		if (depotEntry == null) {
+			throw new NoSuchObjectEntryFolderException();
+		}
+
+		return postAssetLibraryObjectEntryFolder(
+			depotEntry.getGroupId(), objectEntryFolder);
+	}
+
 	private ObjectEntryFolder _toObjectEntryFolder(
 			com.liferay.object.model.ObjectEntryFolder objectEntryFolder)
 		throws Exception {
@@ -128,16 +277,25 @@ public class ObjectEntryFolderResourceImpl
 			new DefaultDTOConverterContext(
 				contextAcceptLanguage.isAcceptAllLanguages(),
 				HashMapBuilder.put(
-					"create",
+					"delete",
 					addAction(
-						ActionKeys.UPDATE, "postAssetLibraryObjectEntryFolder",
-						_CLASS_NAME, objectEntryFolder.getGroupId())
+						ActionKeys.DELETE, objectEntryFolder,
+						"deleteObjectEntryFolder")
 				).put(
 					"get",
 					addAction(
-						ActionKeys.VIEW,
-						"getAssetLibraryObjectEntryFoldersPage", _CLASS_NAME,
-						objectEntryFolder.getGroupId())
+						ActionKeys.VIEW, objectEntryFolder,
+						"getObjectEntryFolder")
+				).put(
+					"replace",
+					addAction(
+						ActionKeys.UPDATE, objectEntryFolder,
+						"putObjectEntryFolder")
+				).put(
+					"update",
+					addAction(
+						ActionKeys.UPDATE, objectEntryFolder,
+						"patchObjectEntryFolder")
 				).build(),
 				_dtoConverterRegistry,
 				objectEntryFolder.getObjectEntryFolderId(),
@@ -147,6 +305,12 @@ public class ObjectEntryFolderResourceImpl
 
 	private static final String _CLASS_NAME =
 		com.liferay.object.model.ObjectEntryFolder.class.getName();
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryFolderResourceImpl.class);
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.91'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.93'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry-folder.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/object-entry-folder.properties
@@ -7,6 +7,8 @@ batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ObjectEntr
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=true
 batch.planner.import.enabled=true
+crud.entity.class.name=com.liferay.headless.delivery.dto.v1_0.ObjectEntryFolder
+crud.item.delegate=true
 entity.class.name=com.liferay.headless.delivery.dto.v1_0.ObjectEntryFolder
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -262,6 +263,12 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 			page,
 			testGetAssetLibraryObjectEntryFoldersPage_getExpectedActions(
 				assetLibraryId));
+
+		objectEntryFolderResource.deleteObjectEntryFolder(
+			objectEntryFolder1.getId());
+
+		objectEntryFolderResource.deleteObjectEntryFolder(
+			objectEntryFolder2.getId());
 	}
 
 	protected Map<String, Map<String, String>>
@@ -692,6 +699,306 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 			objectEntryFolder);
 	}
 
+	@Test
+	public void testDeleteObjectEntryFolder() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ObjectEntryFolder objectEntryFolder =
+			testDeleteObjectEntryFolder_addObjectEntryFolder();
+
+		assertHttpResponseStatusCode(
+			204,
+			objectEntryFolderResource.deleteObjectEntryFolderHttpResponse(
+				objectEntryFolder.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			objectEntryFolderResource.getObjectEntryFolderHttpResponse(
+				objectEntryFolder.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			objectEntryFolderResource.getObjectEntryFolderHttpResponse(0L));
+	}
+
+	protected ObjectEntryFolder
+			testDeleteObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteObjectEntryFolder() throws Exception {
+
+		// No namespace
+
+		ObjectEntryFolder objectEntryFolder1 =
+			testGraphQLDeleteObjectEntryFolder_addObjectEntryFolder();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"deleteObjectEntryFolder",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectEntryFolderId",
+									objectEntryFolder1.getId());
+							}
+						})),
+				"JSONObject/data", "Object/deleteObjectEntryFolder"));
+
+		JSONArray errorsJSONArray1 = JSONUtil.getValueAsJSONArray(
+			invokeGraphQLQuery(
+				new GraphQLField(
+					"objectEntryFolder",
+					new HashMap<String, Object>() {
+						{
+							put(
+								"objectEntryFolderId",
+								objectEntryFolder1.getId());
+						}
+					},
+					new GraphQLField("id"))),
+			"JSONArray/errors");
+
+		Assert.assertTrue(errorsJSONArray1.length() > 0);
+
+		// Using the namespace headlessDelivery_v1_0
+
+		ObjectEntryFolder objectEntryFolder2 =
+			testGraphQLDeleteObjectEntryFolder_addObjectEntryFolder();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"headlessDelivery_v1_0",
+						new GraphQLField(
+							"deleteObjectEntryFolder",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"objectEntryFolderId",
+										objectEntryFolder2.getId());
+								}
+							}))),
+				"JSONObject/data", "JSONObject/headlessDelivery_v1_0",
+				"Object/deleteObjectEntryFolder"));
+
+		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
+			invokeGraphQLQuery(
+				new GraphQLField(
+					"headlessDelivery_v1_0",
+					new GraphQLField(
+						"objectEntryFolder",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectEntryFolderId",
+									objectEntryFolder2.getId());
+							}
+						},
+						new GraphQLField("id")))),
+			"JSONArray/errors");
+
+		Assert.assertTrue(errorsJSONArray2.length() > 0);
+	}
+
+	protected ObjectEntryFolder
+			testGraphQLDeleteObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return testGraphQLObjectEntryFolder_addObjectEntryFolder();
+	}
+
+	@Test
+	public void testGetObjectEntryFolder() throws Exception {
+		ObjectEntryFolder postObjectEntryFolder =
+			testGetObjectEntryFolder_addObjectEntryFolder();
+
+		ObjectEntryFolder getObjectEntryFolder =
+			objectEntryFolderResource.getObjectEntryFolder(
+				postObjectEntryFolder.getId());
+
+		assertEquals(postObjectEntryFolder, getObjectEntryFolder);
+		assertValid(getObjectEntryFolder);
+	}
+
+	protected ObjectEntryFolder testGetObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolder() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			testGraphQLGetObjectEntryFolder_addObjectEntryFolder();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				objectEntryFolder,
+				ObjectEntryFolderSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"objectEntryFolder",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"objectEntryFolderId",
+											objectEntryFolder.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data", "Object/objectEntryFolder"))));
+
+		// Using the namespace headlessDelivery_v1_0
+
+		Assert.assertTrue(
+			equals(
+				objectEntryFolder,
+				ObjectEntryFolderSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessDelivery_v1_0",
+								new GraphQLField(
+									"objectEntryFolder",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"objectEntryFolderId",
+												objectEntryFolder.getId());
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessDelivery_v1_0",
+						"Object/objectEntryFolder"))));
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolderNotFound() throws Exception {
+		Long irrelevantObjectEntryFolderId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectEntryFolder",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectEntryFolderId",
+									irrelevantObjectEntryFolderId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessDelivery_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessDelivery_v1_0",
+						new GraphQLField(
+							"objectEntryFolder",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"objectEntryFolderId",
+										irrelevantObjectEntryFolderId);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected ObjectEntryFolder
+			testGraphQLGetObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return testGraphQLObjectEntryFolder_addObjectEntryFolder();
+	}
+
+	@Test
+	public void testPatchObjectEntryFolder() throws Exception {
+		ObjectEntryFolder postObjectEntryFolder =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		ObjectEntryFolder randomPatchObjectEntryFolder =
+			randomPatchObjectEntryFolder();
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ObjectEntryFolder patchObjectEntryFolder =
+			objectEntryFolderResource.patchObjectEntryFolder(
+				postObjectEntryFolder.getId(), randomPatchObjectEntryFolder);
+
+		ObjectEntryFolder expectedPatchObjectEntryFolder =
+			postObjectEntryFolder.clone();
+
+		BeanTestUtil.copyProperties(
+			randomPatchObjectEntryFolder, expectedPatchObjectEntryFolder);
+
+		ObjectEntryFolder getObjectEntryFolder =
+			objectEntryFolderResource.getObjectEntryFolder(
+				patchObjectEntryFolder.getId());
+
+		assertEquals(expectedPatchObjectEntryFolder, getObjectEntryFolder);
+		assertValid(getObjectEntryFolder);
+	}
+
+	protected ObjectEntryFolder
+			testPatchObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPutObjectEntryFolder() throws Exception {
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutObjectEntryFolder_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder putObjectEntryFolder =
+			objectEntryFolderResource.putObjectEntryFolder(
+				postObjectEntryFolder.getId(), randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, putObjectEntryFolder);
+		assertValid(putObjectEntryFolder);
+
+		ObjectEntryFolder getObjectEntryFolder =
+			objectEntryFolderResource.getObjectEntryFolder(
+				putObjectEntryFolder.getId());
+
+		assertEquals(randomObjectEntryFolder, getObjectEntryFolder);
+		assertValid(getObjectEntryFolder);
+	}
+
+	protected ObjectEntryFolder testPutObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
@@ -800,6 +1107,14 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 
 			if (Objects.equals("actions", additionalAssertFieldName)) {
 				if (objectEntryFolder.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetLibraryId", additionalAssertFieldName)) {
+				if (objectEntryFolder.getAssetLibraryId() == null) {
 					valid = false;
 				}
 
@@ -1019,6 +1334,17 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				if (!equals(
 						(Map)objectEntryFolder1.getActions(),
 						(Map)objectEntryFolder2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetLibraryId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectEntryFolder1.getAssetLibraryId(),
+						objectEntryFolder2.getAssetLibraryId())) {
 
 					return false;
 				}
@@ -1275,6 +1601,11 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 		sb.append(" ");
 
 		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("assetLibraryId")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}
@@ -1612,6 +1943,7 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 	protected ObjectEntryFolder randomObjectEntryFolder() throws Exception {
 		return new ObjectEntryFolder() {
 			{
+				assetLibraryId = RandomTestUtil.randomLong();
 				assetLibraryKey = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				dateCreated = RandomTestUtil.nextDate();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -6,15 +6,87 @@
 package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.delivery.client.dto.v1_0.ObjectEntryFolder;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 /**
- * @author Javier Gamarra
+ * @author Alicia García
  */
-@Ignore
+@FeatureFlags("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryFolderResourceTest
 	extends BaseObjectEntryFolderResourceTestCase {
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"label", "name"};
+	}
+
+	@Override
+	protected ObjectEntryFolder randomObjectEntryFolder() throws Exception {
+		return new ObjectEntryFolder() {
+			{
+				assetLibraryId = testDepotEntry.getDepotEntryId();
+				assetLibraryKey = testGroup.getGroupKey();
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
+				label = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				numberOfObjectEntries = RandomTestUtil.randomInt();
+				numberOfObjectEntryFolders = RandomTestUtil.randomInt();
+				parentObjectEntryFolderId = 0L;
+			}
+		};
+	}
+
+	@Override
+	protected ObjectEntryFolder
+			testDeleteObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return objectEntryFolderResource.postAssetLibraryObjectEntryFolder(
+			testDepotEntry.getDepotEntryId(), randomObjectEntryFolder());
+	}
+
+	@Override
+	protected ObjectEntryFolder testGetObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return objectEntryFolderResource.postAssetLibraryObjectEntryFolder(
+			testDepotEntry.getDepotEntryId(), randomObjectEntryFolder());
+	}
+
+	@Override
+	protected ObjectEntryFolder
+			testGraphQLObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return objectEntryFolderResource.postAssetLibraryObjectEntryFolder(
+			testDepotEntry.getDepotEntryId(), randomObjectEntryFolder());
+	}
+
+	@Override
+	protected ObjectEntryFolder
+			testPatchObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return objectEntryFolderResource.postAssetLibraryObjectEntryFolder(
+			testDepotEntry.getDepotEntryId(), randomObjectEntryFolder());
+	}
+
+	@Override
+	protected ObjectEntryFolder testPutObjectEntryFolder_addObjectEntryFolder()
+		throws Exception {
+
+		return objectEntryFolderResource.postAssetLibraryObjectEntryFolder(
+			testDepotEntry.getDepotEntryId(), randomObjectEntryFolder());
+	}
+
 }


### PR DESCRIPTION
LPD-48867 Technical Task | Add headless API for folders - : For an Object entry folder

This PR depends on ~https://liferay.atlassian.net/browse/LPD-48988~ ~(https://github.com/liferay-headless/liferay-portal/pull/2561)~, ~https://liferay.atlassian.net/browse/LPD-48254 ( )~ and ~https://liferay.atlassian.net/browse/LPD-43166 (https://github.com/liferay-content-management/liferay-portal/pull/6367)~ so



# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-42982

As an Content Creator, I want to be able to create and manage folders in objects so that I can classify and group assets by different criteria.

# How am I fixing it?

Adding API Rest endpoints and methods to obtain the CRUD functionality for the ObjectEntryFolder object.


<img width="1415" alt="image" src="https://github.com/user-attachments/assets/e26c59e9-2294-4e1c-91b7-bd94ee592304" />




# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-48867 add endpoints to obtain the DELETE GET PATCH and PUT of the Object Entry Folder**
- **LPD-48867 add asset library id to the ObjectEntryFolder model**
- **LPD-48867 add new parameters to the converter and to the yaml**
- **LPD-48867 buildRest**
- **LPD-48867 implement CRUD for ObjectEntryFolder**
- **LPD-48867 fix test**
- **LPD-48867 generate the exception mapper to give the user more context**
