### PR TITLE
LPD-48633 KnowledgeBase + Staging - Attachment is not deleted upon Publishing

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -8,6 +8,7 @@ package com.liferay.knowledge.base.internal.exportimport.data.handler;
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
@@ -45,6 +46,7 @@ import com.liferay.portlet.documentlibrary.lar.FileEntryUtil;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -463,11 +465,46 @@ public class KBArticleStagedModelDataHandler
 		serviceContext.setCompanyId(portletDataContext.getCompanyId());
 		serviceContext.setScopeGroupId(portletDataContext.getScopeGroupId());
 
+		Map<String, FileEntry> attachments = new HashMap<>();
+
+		for (FileEntry attachment :
+				importedKBArticle.getAttachmentsFileEntries()) {
+
+			attachments.put(attachment.getUuid(), attachment);
+		}
+
 		for (Element dlFileEntryElement : dlFileEntryElements) {
 			String path = dlFileEntryElement.attributeValue("path");
 
 			FileEntry fileEntry =
 				(FileEntry)portletDataContext.getZipEntryAsObject(path);
+
+			if (attachments.get(fileEntry.getUuid()) != null) {
+				attachments.remove(fileEntry.getUuid());
+
+				continue;
+			}
+
+			DLFileEntry importedFileEntry =
+				_dlFileEntryLocalService.getFileEntryByUuidAndGroupId(
+					fileEntry.getUuid(), portletDataContext.getScopeGroupId());
+
+			if (importedFileEntry != null) {
+				if (importedFileEntry.getFolderId() !=
+						importedKBArticle.getAttachmentsFolderId()) {
+
+					importedFileEntry.setClassName(KBArticle.class.getName());
+					importedFileEntry.setClassPK(
+						importedKBArticle.getClassPK());
+					importedFileEntry.setFolderId(
+						importedKBArticle.getAttachmentsFolderId());
+
+					_dlFileEntryLocalService.updateDLFileEntry(
+						importedFileEntry);
+				}
+
+				continue;
+			}
 
 			String binPath = dlFileEntryElement.attributeValue("bin-path");
 
@@ -501,6 +538,11 @@ public class KBArticleStagedModelDataHandler
 					_log.debug(duplicateFileEntryException);
 				}
 			}
+		}
+
+		for (FileEntry unreferencedAttachment : attachments.values()) {
+			_portletFileRepository.deletePortletFileEntry(
+				unreferencedAttachment.getFileEntryId());
 		}
 	}
 
@@ -540,6 +582,9 @@ public class KBArticleStagedModelDataHandler
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.knowledge.base.model.KBArticle)"

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -486,7 +486,7 @@ public class KBArticleStagedModelDataHandler
 			}
 
 			DLFileEntry importedFileEntry =
-				_dlFileEntryLocalService.getFileEntryByUuidAndGroupId(
+				_dlFileEntryLocalService.fetchFileEntry(
 					fileEntry.getUuid(), portletDataContext.getScopeGroupId());
 
 			if (importedFileEntry != null) {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/exportimport/data/handler/test/KBArticleStagedModelDataHandlerTest.java
@@ -15,16 +15,24 @@ import com.liferay.knowledge.base.service.KBArticleLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -48,6 +56,75 @@ public class KBArticleStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testExportImportKBArticleWithAttachments() throws Exception {
+		initExport();
+
+		KBArticle kbArticle = _addKBArticle(
+			new Date(System.currentTimeMillis() + Time.DAY),
+			KBFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			ClassNameLocalServiceUtil.getClassNameId(
+				KBFolderConstants.getClassName()),
+			_createServiceContext(stagingGroup));
+
+		InputStream inputStream = new ByteArrayInputStream(
+			TestDataConstants.TEST_BYTE_ARRAY);
+
+		FileEntry fileEntry1 = _kbArticleLocalService.addAttachment(
+			TestPropsValues.getUserId(), kbArticle.getResourcePrimKey(),
+			RandomTestUtil.randomString(), inputStream,
+			ContentTypes.TEXT_PLAIN);
+		FileEntry fileEntry2 = _kbArticleLocalService.addAttachment(
+			TestPropsValues.getUserId(), kbArticle.getResourcePrimKey(),
+			RandomTestUtil.randomString(), inputStream,
+			ContentTypes.TEXT_PLAIN);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, kbArticle);
+
+		initImport();
+
+		KBArticle exportedKBArticle = (KBArticle)readExportedStagedModel(
+			kbArticle);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedKBArticle);
+
+		KBArticle importedKBArticle = (KBArticle)getStagedModel(
+			kbArticle.getUuid(), liveGroup);
+
+		_assertKBArticleAttachments(
+			new String[] {fileEntry1.getFileName(), fileEntry2.getFileName()},
+			importedKBArticle);
+
+		initExport();
+
+		kbArticle = _kbArticleLocalService.updateKBArticle(
+			kbArticle.getUserId(), kbArticle.getResourcePrimKey(),
+			kbArticle.getTitle(), kbArticle.getContent(),
+			kbArticle.getDescription(), null, kbArticle.getSourceURL(),
+			kbArticle.getDisplayDate(), kbArticle.getExpirationDate(),
+			kbArticle.getReviewDate(), null,
+			new long[] {fileEntry2.getFileEntryId()},
+			_createServiceContext(stagingGroup));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, kbArticle);
+
+		initImport();
+
+		exportedKBArticle = (KBArticle)readExportedStagedModel(kbArticle);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedKBArticle);
+
+		importedKBArticle = (KBArticle)getStagedModel(
+			kbArticle.getUuid(), liveGroup);
+
+		_assertKBArticleAttachments(
+			new String[] {fileEntry1.getFileName()}, importedKBArticle);
+	}
 
 	@Test
 	public void testExportImportScheduledKBArticleCanBePublished()
@@ -208,11 +285,32 @@ public class KBArticleStagedModelDataHandlerTest
 			parentResourceClassNameId, serviceContext);
 	}
 
+	private void _assertKBArticleAttachments(
+			String[] expectedFileNames, KBArticle importedKBArticle)
+		throws Exception {
+
+		List<FileEntry> attachmentsFileEntries =
+			importedKBArticle.getAttachmentsFileEntries();
+
+		Assert.assertEquals(
+			attachmentsFileEntries.toString(), attachmentsFileEntries.size(),
+			expectedFileNames.length);
+
+		for (FileEntry attachmentFileEntry : attachmentsFileEntries) {
+			Assert.assertTrue(
+				ArrayUtil.contains(
+					expectedFileNames, attachmentFileEntry.getFileName()));
+		}
+	}
+
 	private ServiceContext _createServiceContext(Group group) throws Exception {
 		return ServiceContextTestUtil.getServiceContext(group.getGroupId());
 	}
 
 	@Inject
 	private KBArticleLocalService _kbArticleLocalService;
+
+	@Inject
+	private PortletFileRepository _portletFileRepository;
 
 }


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-48633

### How am I fixing it?
I'm avoiding double importing files and removing attachment files that are not referenced in the KBA in export.


### How can you verify that it works?

To test run:
`gw testIntegration --tests KBArticleStagedModelDataHandlerTest.testExportImportKBArticleWithAttachments`


---
```

com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testCleanAssetCategoriesAndTags STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testCleanAssetCategoriesAndTags PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testCleanStagedModelDataHandler STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testCleanStagedModelDataHandler PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportKBArticleWithAttachments STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportKBArticleWithAttachments PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportScheduledKBArticleCanBePublished STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportScheduledKBArticleCanBePublished PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportWithDefaultData STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testExportImportWithDefaultData PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testMovingKBArticleUpdatesParentResourcePrimKey STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testMovingKBArticleUpdatesParentResourcePrimKey PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testStagedModelDataHandler STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testStagedModelDataHandler PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioning STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioning PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioning2 STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioning2 PASSED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioningExportImportTwice STARTED
com.liferay.knowledge.base.internal.exportimport.data.handler.test.KBArticleStagedModelDataHandlerTest > testVersioningExportImportTwice PASSED
```