### PR TITLE
LPD-49074 Part 2 of Update AMDLStoreConvertProcess to use common pattern from other DLStoreConvertProcess implementors

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
@@ -8,7 +8,7 @@ package com.liferay.adaptive.media.image.internal.convert.document.library;
 import com.liferay.adaptive.media.image.internal.storage.AMStoreUtil;
 import com.liferay.adaptive.media.image.model.AMImageEntry;
 import com.liferay.adaptive.media.image.service.AMImageEntryLocalService;
-import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -60,7 +60,7 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 				FileVersion fileVersion = null;
 
 				try {
-					fileVersion = _dlAppService.getFileVersion(
+					fileVersion = _dlAppLocalService.getFileVersion(
 						amImageEntry.getFileVersionId());
 				}
 				catch (PortalException portalException) {
@@ -136,6 +136,6 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 	private CompanyLocalService _companyLocalService;
 
 	@Reference
-	private DLAppService _dlAppService;
+	private DLAppLocalService _dlAppLocalService;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
@@ -15,12 +15,11 @@ import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.util.MaintenanceUtil;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -67,25 +66,16 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 							amImageEntry.getCompanyId(),
 							CompanyConstants.SYSTEM, fileVersionPath)) {
 
-					try (InputStream inputStream = sourceStore.getFileAsStream(
+					try {
+						transferFile(
+							sourceStore, targetStore,
 							amImageEntry.getCompanyId(),
 							CompanyConstants.SYSTEM, fileVersionPath,
-							versionLabel)) {
-
-						targetStore.addFile(
-							amImageEntry.getCompanyId(),
-							CompanyConstants.SYSTEM, fileVersionPath,
-							versionLabel, inputStream);
-
-						if (delete) {
-							sourceStore.deleteFile(
-								amImageEntry.getCompanyId(),
-								CompanyConstants.SYSTEM, fileVersionPath,
-								versionLabel);
-						}
+							versionLabel, delete);
 					}
-					catch (IOException ioException) {
-						throw new PortalException(ioException);
+					catch (Exception exception) {
+						_log.error(
+							"Unable to migrate " + fileVersionPath, exception);
 					}
 				}
 			});
@@ -119,6 +109,9 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 				actionableDynamicQuery.performActions();
 			});
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AMDLStoreConvertProcess.class);
 
 	@Reference
 	private AMImageEntryLocalService _amImageEntryLocalService;

--- a/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-service/src/main/java/com/liferay/adaptive/media/image/internal/convert/document/library/AMDLStoreConvertProcess.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.util.MaintenanceUtil;
 
@@ -56,10 +57,25 @@ public class AMDLStoreConvertProcess implements DLStoreConvertProcess {
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(AMImageEntry amImageEntry) -> {
+				FileVersion fileVersion = null;
+
+				try {
+					fileVersion = _dlAppService.getFileVersion(
+						amImageEntry.getFileVersionId());
+				}
+				catch (PortalException portalException) {
+					_log.error(
+						"Unable to migrate file version id: " +
+							amImageEntry.getFileVersionId(),
+						portalException);
+				}
+
+				if (fileVersion == null) {
+					return;
+				}
+
 				String fileVersionPath = AMStoreUtil.getFileVersionPath(
-					_dlAppService.getFileVersion(
-						amImageEntry.getFileVersionId()),
-					amImageEntry.getConfigurationUuid());
+					fileVersion, amImageEntry.getConfigurationUuid());
 
 				for (String versionLabel :
 						sourceStore.getFileVersions(


### PR DESCRIPTION
What is this trying to solve?
Task [LPD-48990](https://liferay.atlassian.net/browse/LPD-48990)
Technical Task [LPD-49074](https://liferay.atlassian.net/browse/LPD-49074)

AMDLStoreConvertProcess can fail on IOException if an Adaptive Media file is not present

How am I fixing it?
By using the common pattern of other DLStoreConvertProcess implementor's, we only log the Exception. A missing file can't be recovered and thus should not stop other files from being transferred.

Why doesn't this include any test?
Reusing common pattern.