### PR TITLE
LPD-49324 Fix integration test in content dashboard

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-test/src/testIntegration/java/com/liferay/content/dashboard/document/library/internal/item/item/test/FileEntryContentDashboardItemTest.java
@@ -55,6 +55,8 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -343,13 +345,20 @@ public class FileEntryContentDashboardItemTest {
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
 
-		ContentDashboardItemAction contentDashboardItemAction =
-			versionableContentDashboardItem.
-				getDefaultContentDashboardItemAction(mockHttpServletRequest);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.content.dashboard.document.library.internal." +
+					"item.FileEntryContentDashboardItem",
+				LoggerTestUtil.ERROR)) {
 
-		Assert.assertEquals(
-			ContentDashboardItemAction.Type.VIEW,
-			contentDashboardItemAction.getType());
+			ContentDashboardItemAction contentDashboardItemAction =
+				versionableContentDashboardItem.
+					getDefaultContentDashboardItemAction(
+						mockHttpServletRequest);
+
+			Assert.assertEquals(
+				ContentDashboardItemAction.Type.VIEW,
+				contentDashboardItemAction.getType());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Fix Content Dashboard Integration Test

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-49324)

An error appears in the logs, such as: PortalLogAssertorTest#testScanXMLLog: User 51807 must have VIEW permission for com.liferay.portal.kernel.repository.model.FileEntry 51786 

# How am I fixing it?

Just capture the log, the error should be thrown

# How can you verify that it works?

There are several tests that already cover this:

Run testGetDefaultContentDashboardItemActionWithFileEntryWithoutPermissions integration test and check that there are no errors in the logs