### PR TITLE
LPD-49332 Fix Translations Unit Test

### DIFF
--- a/modules/apps/translation/translation-web/src/test/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContextTest.java
+++ b/modules/apps/translation/translation-web/src/test/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContextTest.java
@@ -10,6 +10,7 @@ import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.portal.bean.BeanPropertiesImpl;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.redirect.RedirectURLSettingsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
@@ -58,6 +59,7 @@ public class TranslateDisplayContextTest {
 	@AfterClass
 	public static void tearDownClass() {
 		_classNameLocalServiceUtilMockedStatic.close();
+		_redirectURLSettingsUtilMockedStatic.close();
 		_translationEntryLocalServiceUtilMockedStatic.close();
 		_workflowDefinitionLinkLocalServiceUtilMockedStatic.close();
 	}
@@ -67,6 +69,7 @@ public class TranslateDisplayContextTest {
 		_setUpBeanPropertiesUtil();
 		_setUpLanguageUtil();
 		_setUpPortalUtil();
+		_setUpRedirectURLSettingsUtil();
 	}
 
 	@Test
@@ -161,9 +164,20 @@ public class TranslateDisplayContextTest {
 		portalUtil.setPortal(new PortalImpl());
 	}
 
+	private void _setUpRedirectURLSettingsUtil() {
+		_redirectURLSettingsUtilMockedStatic.when(
+			() -> RedirectURLSettingsUtil.getAllowedProtocols(Mockito.anyLong())
+		).thenReturn(
+			new String[] {"http", "https"}
+		);
+	}
+
 	private static final MockedStatic<ClassNameLocalServiceUtil>
 		_classNameLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			ClassNameLocalServiceUtil.class);
+	private static final MockedStatic<RedirectURLSettingsUtil>
+		_redirectURLSettingsUtilMockedStatic = Mockito.mockStatic(
+			RedirectURLSettingsUtil.class);
 	private static final MockedStatic<TranslationEntryLocalServiceUtil>
 		_translationEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			TranslationEntryLocalServiceUtil.class);


### PR DESCRIPTION
Fix Translations Unit Test

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-49332)

Redirect now checks for protocol, and it's not mocked

# How am I fixing it?

Adds mock static so that the test won't fail

# How can you verify that it works?

Run com.liferay.translation.web.internal.display.context.TranslateDisplayContextTest unit test
