### PR TITLE
LPD-48029 Hide new configuration from the ui

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/configuration/CMSSiteInitializerConfiguration.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/configuration/CMSSiteInitializerConfiguration.java
@@ -12,7 +12,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 /**
  * @author Sam Ziemer
  */
-@ExtendedObjectClassDefinition(category = "assets")
+@ExtendedObjectClassDefinition(category = "assets", generateUI = false)
 @Meta.OCD(
 	id = "com.liferay.site.cms.site.initializer.internal.configuration.CMSSiteInitializerConfiguration",
 	localization = "content/Language",


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-43626

# How am I fixing it?

Hide configuration from the ui to do not show it for the moment until we decide how to set classnames for the  sections

# How can you verify that it works?

There is not test needed here
