### PR TITLE
LPD-49327 content management part of LPD-47718

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/package.json
+++ b/modules/apps/adaptive-media/adaptive-media-web/package.json
@@ -8,6 +8,7 @@
 		"@clayui/progress-bar": "3.111.0",
 		"@liferay/frontend-js-react-web": "*",
 		"formik": "2.1.4",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/js/EditAdaptiveMedia.js
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/js/EditAdaptiveMedia.js
@@ -8,12 +8,12 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayCheckbox, ClayRadio, ClayRadioGroup} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import {useFormik} from 'formik';
+import {openToast} from 'frontend-js-components-web';
 import {
 	fetch,
 	navigate,
 	normalizeFriendlyURL,
 	objectToFormData,
-	openToast,
 } from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "34b8542f25d2516167b2e3f1f30651d6eb379b0d",
+	"@generated": "aa54981f785ab39d6de6b9b4d9142efdcaabb828",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/announcements/announcements-web/package.json
+++ b/modules/apps/announcements/announcements-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/js/announcements_admin/AnnouncementsManagementToolbarPropsTransformer.js
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/js/announcements_admin/AnnouncementsManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesURL, inputId, inputValue},

--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "398337f4411177c966f03104ec114d2c3ce1c31a",
+	"@generated": "37a49bbfec053059a9b71e7dfc18f24d66d890b0",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/asset/asset-categories-admin-web/package.json
+++ b/modules/apps/asset/asset-categories-admin-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"asset-taglib": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	fetch,
-	navigate,
-	objectToFormData,
-	openSelectionModal,
-	openToast,
-} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
+import {fetch, navigate, objectToFormData} from 'frontend-js-web';
 
 import openDeleteVocabularyModal from './openDeleteVocabularyModal';
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {addParams, navigate, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {addParams, navigate} from 'frontend-js-web';
 
 import openDeleteCategoryModal from './openDeleteCategoryModal';
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/CategoryActionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/CategoryActionDropdownPropsTransformer.js
@@ -7,9 +7,8 @@ import {
 	openModal,
 	openSelectionModal,
 	openToast,
-	setFormValues,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {setFormValues, sub} from 'frontend-js-web';
 
 import openDeleteCategoryModal from './openDeleteCategoryModal';
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/VocabularyActionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/VocabularyActionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 import openDeleteVocabularyModal from './openDeleteVocabularyModal';
 

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteCategoryModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteCategoryModal({
 	message,

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/openDeleteVocabularyModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteVocabularyModal({
 	multiple = false,

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b51b18608b8df43b864ebbb2db7117782c739d12",
+	"@generated": "2b1c82afd9cc8c074e035e0f82238c79206d68d6",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"asset-taglib": [
 				"../../../../../../asset-taglib/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../asset-taglib/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/asset/asset-publisher-web/package.json
+++ b/modules/apps/asset/asset-publisher-web/package.json
@@ -4,6 +4,7 @@
 		"@clayui/form": "3.125.0",
 		"@clayui/icon": "3.111.0",
 		"asset-taglib": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntryActionButtonPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntryActionButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({additionalProps, ...props}) {
 	return {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntryActionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntryActionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	assetEntryAction: ({assetEntryActionTitle, assetEntryActionURL}) => {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntrySelectionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/AssetEntrySelectionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	actions,

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({additionalProps, ...props}) {
 	return {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/ScopeActionDropdownPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/ScopeActionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	addScope: ({url}) => {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/SelectCollection.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/SelectCollection.js
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 export default function SelectCollection({

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {openSelectionModal} from 'frontend-js-components-web';
 import {
 	addParams,
 	delegate,
-	openSelectionModal,
 	sub,
 	toggleDisabled,
 	toggleSelectBox,

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5ff1d41ce9655f2cd93ea08a13814c216999fc63",
+	"@generated": "862246fbaf106654ee3f7fac57ad559b3554eff7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"asset-taglib": [
 				"../../../../../../asset-taglib/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../asset-taglib/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	actions,

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -10,12 +10,8 @@ import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {
-	createPortletURL,
-	fetch,
-	openSelectionModal,
-	sub,
-} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {createPortletURL, fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 

--- a/modules/apps/asset/asset-tags-admin-web/package.json
+++ b/modules/apps/asset/asset-tags-admin-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/openDeleteTagModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteTagModal({multiple = false, onDelete}) {
 	openModal({

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "36af3a4b38dd31901b812a5dc6e708c9179ec54e",
+	"@generated": "e67b67ff3d0bcf81269736c215c300076309275d",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogEntriesManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesCmd, deleteEntriesURL, trashEnabled},

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsDefaultEventHandler.es.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	DefaultEventHandler,
-	openConfirmModal,
-	openWindow,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {DefaultEventHandler, openWindow} from 'frontend-js-web';
 
 class ElementsDefaultEventHandler extends DefaultEventHandler {
 	created(props) {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/ElementsPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openWindow} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {openWindow} from 'frontend-js-web';
 
 const ACTIONS = {
 	delete(itemData, trashEnabled) {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs/blogs.js
@@ -4,10 +4,10 @@
  */
 
 import {State} from '@liferay/frontend-js-state-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import {
 	fetch,
 	normalizeFriendlyURL,
-	openConfirmModal,
 	toggleBoxes,
 	toggleDisabled,
 } from 'frontend-js-web';

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/BlogEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/BlogEntriesManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesCmd, deleteEntriesURL, trashEnabled},

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/ElementsDefaultEventHandler.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/ElementsDefaultEventHandler.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	DefaultEventHandler,
-	openConfirmModal,
-	openWindow,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {DefaultEventHandler, openWindow} from 'frontend-js-web';
 
 class ElementsDefaultEventHandler extends DefaultEventHandler {
 	created(props) {

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/ElementsPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/js/blogs_admin/ElementsPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openWindow} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {openWindow} from 'frontend-js-web';
 
 const ACTIONS = {
 	delete(itemData, trashEnabled) {

--- a/modules/apps/bookmarks/bookmarks-web/package.json
+++ b/modules/apps/bookmarks/bookmarks-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/js/bookmarks/BookmarksManagementToolbarPropsTransformer.js
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/js/bookmarks/BookmarksManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesURL, inputId, inputValue, trashEnabled},

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "bda97a8f68e7426daa9089bdf32010f80c418fe7",
+	"@generated": "ec33e78aa08c3c185c30a4b750671f2748205789",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/comment/comment-taglib/package.json
+++ b/modules/apps/comment/comment-taglib/package.json
@@ -5,6 +5,7 @@
 		"@clayui/popover": "3.119.0",
 		"@clayui/sticker": "3.125.0",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {openToast} from 'frontend-js-components-web';
 import {
 	fetch,
 	getFormElement,
 	objectToFormData,
-	openToast,
 	openWindow,
 	runScriptsInElement,
 	setFormValues,

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "379240886fcff4279b4420f289b4974341cfc466",
+	"@generated": "cf496dcf1f71c994b82b6e2febd5856f5e4ff4c2",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ConfigurationButtonPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ConfigurationButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function ({additionalProps, ...props}) {
 	return {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -4,12 +4,11 @@
  */
 
 import {
-	addParams,
-	navigate,
 	openCategorySelectionModal,
 	openSelectionModal,
 	openTagSelectionModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, navigate} from 'frontend-js-web';
 
 import openCustomDateModal from './utils/openCustomDateModal';
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/FileUrlCopyButton.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/FileUrlCopyButton.js
@@ -5,7 +5,8 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Subscribe.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Subscribe.tsx
@@ -4,7 +4,7 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {useContext} from 'react';
 
 // @ts-ignore
@@ -20,6 +20,8 @@ const Subscribe = ({disabled, icon, label, url}: IProps) => {
 		}
 
 		try {
+
+			// eslint-disable-next-line @liferay/portal/no-global-fetch
 			const {ok}: Response = await fetch(url);
 
 			if (!ok) {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Subscribe.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Subscribe.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 // @ts-ignore

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
@@ -8,7 +8,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 
 import Sidebar from '../../../../src/main/resources/META-INF/resources/js/components/Sidebar';
 import SidebarPanelInfoView from '../../../../src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView';
@@ -33,12 +34,14 @@ import {
 	mockedVideoShortcutDocumentProps,
 } from '../../mocks/props';
 
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
+
 jest.mock('frontend-js-web', () => ({
 	fetch: jest.fn().mockReturnValue({
 		ok: true,
 	}),
-
-	openToast: jest.fn(),
 	sub: jest.fn((str) => str),
 }));
 

--- a/modules/apps/depot/depot-web/package.json
+++ b/modules/apps/depot/depot-web/package.json
@@ -11,6 +11,7 @@
 		"@clayui/table": "3.111.0",
 		"@liferay/document-library-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/AddConnectedSitesButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps,

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/ConnectedSiteDropdownPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/ConnectedSiteDropdownPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {navigate, openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {navigate} from 'frontend-js-web';
 
 const ACTIONS = {
 	disconnect({url: disconnectSiteActionURL}) {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotAdminManagementToolbarPropsTransformer.js
@@ -4,11 +4,10 @@
  */
 
 import {
-	getCheckedCheckboxes,
 	openConfirmModal,
 	openSimpleInputModal,
-	postForm,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteDepotEntriesURL},

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownDefaultEventHandler.es.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	DefaultEventHandler,
-	openConfirmModal,
-	openWindow,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {DefaultEventHandler, openWindow} from 'frontend-js-web';
 
 class DepotEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 	deleteDepotEntry(itemData) {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownPropsTransformer.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotEntryDropdownPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openWindow} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {openWindow} from 'frontend-js-web';
 
 const ACTIONS = {
 	deleteDepotEntry(itemData) {

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/DepotRoles.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {delegate, escapeHTML, openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {delegate, escapeHTML, sub} from 'frontend-js-web';
 
 export default function ({
 	portletNamespace,

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/StagingIndicator.js
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/js/StagingIndicator.js
@@ -5,7 +5,7 @@
 
 import {Align, ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/depot/depot-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "2d8187cb1c09bbe8ca2fa3bd951717c180e542c2",
+	"@generated": "fc29e33bd175a66a1ca1a08294bdeb35324f38cd",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/document-library-web": [
 				"../../../../../../../document-library/document-library-web/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../document-library/document-library-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/document-library/document-library-taglib/package.json
+++ b/modules/apps/document-library/document-library-taglib/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 
 export default function RepositoryBrowserComponent({
 	namespace,

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserDropdownActions.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserDropdownActions.js
@@ -4,11 +4,11 @@
  */
 
 import {
-	fetch,
 	openConfirmModal,
 	openSimpleInputModal,
 	openToast,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 
 function deleteEntry(deleteURL) {
 	openConfirmModal({

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserManagementToolbarPropsTransformer.js
@@ -4,12 +4,11 @@
  */
 
 import {
-	fetch,
-	getCheckedCheckboxes,
 	openConfirmModal,
 	openSimpleInputModal,
 	openToast,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {fetch, getCheckedCheckboxes} from 'frontend-js-web';
 
 function handleCreationMenuClick(
 	event,

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b039498dd4e4975f68e381b896fe3861c0110003",
+	"@generated": "1ffa7622f996fce5566dd0bbdef5c2119fe3a76c",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/document-library/document-library-web/package.json
+++ b/modules/apps/document-library/document-library-web/package.json
@@ -12,6 +12,7 @@
 		"asset-taglib": "*",
 		"classnames": "2.3.1",
 		"clipboard": "2.0.4",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"item-selector-taglib": "*",
 		"prop-types": "15.7.2",

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/session_messages.jspf
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/session_messages.jspf
@@ -23,7 +23,7 @@
 					"type", "warning"
 				).build()
 			%>'
-			module="{openToast} from frontend-js-web"
+			module="{openToast} from frontend-js-components-web"
 		/>
 	</c:if>
 
@@ -36,7 +36,7 @@
 					"message", scheduledDocumentMessage
 				).build()
 			%>'
-			module="{openToast} from frontend-js-web"
+			module="{openToast} from frontend-js-components-web"
 		/>
 	</c:if>
 </c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DDMStructuresManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DDMStructuresManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFileEntryDropdownPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFileEntryDropdownPropsTransformer.js
@@ -4,12 +4,11 @@
  */
 
 import {
-	addParams,
-	navigate,
 	openConfirmModal,
 	openModal,
 	openSelectionModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, navigate} from 'frontend-js-web';
 
 const ACTIONS = {
 	checkin({checkinURL}, portletNamespace) {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFolderDropdownPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFolderDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const _webDAVHTML = (
 	learnMessage,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFolderSelector.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLFolderSelector.js
@@ -6,14 +6,8 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {
-	fetch,
-	navigate,
-	objectToFormData,
-	openSelectionModal,
-	openToast,
-	sub,
-} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
+import {fetch, navigate, objectToFormData, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 const TPL_ERROR_MESSAGES = `<span>{0}</span><ul class="mb-0 mt-2 pl-3">{1}</ul>`;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLManagementToolbarPropsTransformer.js
@@ -4,16 +4,13 @@
  */
 
 import {
-	addParams,
-	createPortletURL,
-	navigate,
 	openCategorySelectionModal,
 	openConfirmModal,
 	openSelectionModal,
 	openTagSelectionModal,
 	openToast,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, createPortletURL, navigate, sub} from 'frontend-js-web';
 
 import {collectDigitalSignature} from './digital-signature/DigitalSignatureUtil';
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DocumentLibrary.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DocumentLibrary.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {buildFragment, openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {buildFragment, sub} from 'frontend-js-web';
 
 const HTML5_UPLOAD =
 	window && window.File && window.FormData && window.XMLHttpRequest;

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/InfoPanel.es.js
@@ -4,7 +4,8 @@
  */
 
 import ClipboardJS from 'clipboard';
-import {PortletBase, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {PortletBase} from 'frontend-js-web';
 
 /**
  * @class InfoPanel

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/bulk/BulkStatus.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/bulk/BulkStatus.es.js
@@ -5,7 +5,8 @@
 
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useTimeout} from '@liferay/frontend-js-react-web';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useReducer} from 'react';
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/data-engine/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/data-engine/DataEngineLayoutBuilderHandler.es.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast, postForm, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {postForm, sub} from 'frontend-js-web';
 
 import {
 	getDataEngineStructure,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/digital-signature/DigitalSignatureUtil.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/digital-signature/DigitalSignatureUtil.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {openModal} from 'frontend-js-components-web';
 import {
 	createPortletURL,
 	createResourceURL,
 	fetch,
 	navigate,
 	objectToFormData,
-	openModal,
 	sub,
 } from 'frontend-js-web';
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "af36f646dc8f3dee6ea48b3a97ba25e1d21ddaac",
+	"@generated": "266d5e20f2cd6468a79bb5a8e7effc675aa6c071",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -17,6 +17,9 @@
 			],
 			"asset-taglib": [
 				"../../../../../../../asset/asset-taglib/src/main/resources/META-INF/resources/js/index.js"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -46,6 +49,9 @@
 		},
 		{
 			"path": "../../../../../../../asset/asset-taglib/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/item-selector/item-selector-taglib/package.json
+++ b/modules/apps/item-selector/item-selector-taglib/package.json
@@ -13,6 +13,7 @@
 		"@liferay/frontend-js-state-web": "*",
 		"classnames": "2.3.1",
 		"cropperjs": "1.5.11",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/image_selector/ImageSelector.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/image_selector/ImageSelector.js
@@ -6,12 +6,8 @@
 import ClayIcon from '@clayui/icon';
 import {State} from '@liferay/frontend-js-state-web';
 import classNames from 'classnames';
-import {
-	STATUS_CODE,
-	formatStorage,
-	openSelectionModal,
-	sub,
-} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {STATUS_CODE, formatStorage, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/repository_entry_browser/ItemSelectorRepositoryEntryBrowserManagementToolbarPropsTransformer.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/repository_entry_browser/ItemSelectorRepositoryEntryBrowserManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {createPortletURL, navigate, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {createPortletURL, navigate} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "07019c90db76bc8c1600f88d18136aea2e4d4e2a",
+	"@generated": "27a23186bbc7a096ce5b93a590528a4b9285d719",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -17,6 +17,9 @@
 			],
 			"@liferay/frontend-js-state-web": [
 				"../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -43,6 +46,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-state-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/item-selector/item-selector-web/package.json
+++ b/modules/apps/item-selector/item-selector-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.ts",

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/openItemSelectorModal.ts
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/js/openItemSelectorModal.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {createPortletURL, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {createPortletURL} from 'frontend-js-web';
 
 const openItemSelectorModal = ({multiple, params, url, ...props}: any) => {
 	openSelectionModal({

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ee83ef58544852d8df0b589b29aaca5a7d3b5f45",
+	"@generated": "f2971525c1906b6ddf012e6bbaace9042a6b670b",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/package.json
@@ -3,6 +3,7 @@
 		"@clayui/button": "3.116.0",
 		"@clayui/form": "3.125.0",
 		"dynamic-data-mapping-form-field-type": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/index.js
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import {ReactFieldBase} from 'dynamic-data-mapping-form-field-type';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 function parseInputValue(inputValue) {

--- a/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/journal/journal-article-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0803236e389fc7703366809799903860c25decb8",
+	"@generated": "d09d7274d1b53e465863490ed382e1d22306a7df",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"dynamic-data-mapping-form-field-type": [
 				"../../../../../../../dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/journal/journal-content-web/package.json
+++ b/modules/apps/journal/journal-content-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/JournalTemplate.js
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/JournalTemplate.js
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	delegate,
-	fetch,
-	openSelectionModal,
-	openToast,
-	toggleRadio,
-} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
+import {delegate, fetch, toggleRadio} from 'frontend-js-web';
 
 export default function ({actionURL, namespace, portletNamespace, portletURL}) {
 	const form = document.getElementById(`${namespace}fm`);

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/PortletHeaderDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/PortletHeaderDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	permissions(itemData) {

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "6f3ff84a33476938b0fee9cfdb3471688be00582",
+	"@generated": "286944c70de8fdfbab161d1aad3d06153938636f",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ArticleHistoryManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ArticleHistoryManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteArticles = (itemData) => {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructrureElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructrureElementsDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	deleteDDMStructure(itemData) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMStructuresManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	deleteDDMTemplate(itemData) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplatesManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplatesManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast, postForm, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {postForm, sub} from 'frontend-js-web';
 
 import openStructureKeyChangesModal from './modals/openStructureKeyChangesModal';
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -4,11 +4,11 @@
  */
 
 import {
-	addParams,
 	openConfirmModal,
 	openModal,
 	openSelectionModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams} from 'frontend-js-web';
 
 import openDeleteArticleModal from './modals/openDeleteArticleModal';
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/FeedElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/FeedElementsDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	deleteJournalFeed(itemData) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/FeedsManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/FeedsManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	debounce,
-	fetch,
-	navigate,
-	openConfirmModal,
-	sub,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {debounce, fetch, navigate, sub} from 'frontend-js-web';
 
 import {LocaleChangedHandler} from './LocaleChangedHandler.es';
 import removeAlert from './removeAlert';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -4,15 +4,12 @@
  */
 
 import {
-	addParams,
-	createPortletURL,
-	navigate,
 	openCategorySelectionModal,
 	openModal,
 	openSelectionModal,
 	openTagSelectionModal,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, createPortletURL, navigate, sub} from 'frontend-js-web';
 
 import openDeleteArticleModal from './modals/openDeleteArticleModal';
 import openPublishArticlesModal from './modals/openPublishArticlesModal';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryButtonPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButton.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButton.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export default function ({
 	namespace,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButtonPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openSelectionModal} from 'frontend-js-web';
+import {openConfirmModal, openSelectionModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps: {description, selectDDMStructurePropsTransformerURL},

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SmallImage.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SmallImage.js
@@ -6,7 +6,8 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
 const SMALL_IMAGE_SOURCES = {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SuccessMessageWithLink.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SuccessMessageWithLink.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function ({alertMessage, namespace}) {
 	const componentId = `${namespace}successMessageWithLink`;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPagePreview.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPagePreview.js
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import {openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useMemo, useState} from 'react';
 
 import AssetDisplayPageSelector from './AssetDisplayPageSelector';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPageSelector.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/AssetDisplayPageSelector.js
@@ -6,7 +6,8 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
-import {getPortletNamespace, openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {getPortletNamespace, sub} from 'frontend-js-web';
 import React from 'react';
 
 export default function AssetDisplayPageSelector({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/PreviewButton.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/PreviewButton.js
@@ -4,7 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import React from 'react';
 
 export default function PreviewButton({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/Template.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/Template.js
@@ -3,13 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	addParams,
-	navigate,
-	openConfirmModal,
-	openSelectionModal,
-	setFormValues,
-} from 'frontend-js-web';
+import {openConfirmModal, openSelectionModal} from 'frontend-js-components-web';
+import {addParams, navigate, setFormValues} from 'frontend-js-web';
 
 export default function ({
 	availableLocales,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function ({namespace}) {
 	const fileInput = document.getElementById(`${namespace}importScriptInput`);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration_browse/HighlightedDDMStructuresConfiguration.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration_browse/HighlightedDDMStructuresConfiguration.tsx
@@ -4,7 +4,8 @@
  */
 
 import ClayButton from '@clayui/button';
-import {openSelectionModal, sub} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {StructureList} from './StructureList';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteArticleModal({onDelete}) {
 	openModal({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openPublishArticlesModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openPublishArticlesModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openPublishArticlesModal({onPublish}) {
 	openModal({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openStructureKeyChangesModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openStructureKeyChangesModal.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function openStructureKeyChangesModal({onSave}) {
 	openModal({

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/showAlert.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/showAlert.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 import removeAlert from './removeAlert';
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/showWarningAlert.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/showWarningAlert.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function showWarningAlert({message}: {message: string}) {
 	openToast({

--- a/modules/apps/journal/journal-web/test/js/configuration_browse/HighlightedDDMStructuresConfiguration.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/configuration_browse/HighlightedDDMStructuresConfiguration.test.tsx
@@ -6,7 +6,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React from 'react';
 
 import HighlightedDDMStructuresConfiguration, {
@@ -14,8 +14,11 @@ import HighlightedDDMStructuresConfiguration, {
 	removeDuplicates,
 } from '../../../src/main/resources/META-INF/resources/js/configuration_browse/HighlightedDDMStructuresConfiguration';
 
-jest.mock('frontend-js-web', () => ({
+jest.mock('frontend-js-components-web', () => ({
 	openSelectionModal: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
 	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
 }));
 

--- a/modules/apps/knowledge-base/knowledge-base-web/package.json
+++ b/modules/apps/knowledge-base/knowledge-base-web/package.json
@@ -13,6 +13,7 @@
 		"@clayui/loading-indicator": "3.111.0",
 		"@clayui/modal": "3.122.0",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/KBDropdownPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/KBDropdownPropsTransformer.js
@@ -4,15 +4,12 @@
  */
 
 import {
-	addParams,
-	fetch,
-	objectToFormData,
 	openConfirmModal,
 	openModal,
 	openSelectionModal,
 	openToast,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, fetch, objectToFormData, sub} from 'frontend-js-web';
 
 import showSuccessMessage from './utils/showSuccessMessage';
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/ManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps: {trashEnabled},

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/MoveKBObject.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/MoveKBObject.js
@@ -3,14 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	addParams,
-	fetch,
-	objectToFormData,
-	openSelectionModal,
-	openToast,
-	sub,
-} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
+import {addParams, fetch, objectToFormData, sub} from 'frontend-js-web';
 
 import showSuccessMessage from './utils/showSuccessMessage';
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/SuggestionsManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/SuggestionsManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/TemplatesManagementToolbarPropsTransformer.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/TemplatesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {getCheckedCheckboxes, openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteKBTemplatesURL},

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/NavigationPanel.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/NavigationPanel.js
@@ -6,7 +6,8 @@
 import {TreeView as ClayTreeView} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import classnames from 'classnames';
-import {fetch, navigate, objectToFormData, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, navigate, objectToFormData} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/utils/openToast.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/utils/openToast.js
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export {openToast as default} from 'frontend-js-web';
+export {openToast as default} from 'frontend-js-components-web';

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/utils/showSuccessMessage.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/utils/showSuccessMessage.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function showSuccessMessage(portletNamespace) {
 	const openToastSuccessProps = {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0129bfa71b63dc68ecbd732a05eaf7af373453c9",
+	"@generated": "454cbcf1372d607a1a13d3700811ea9462ad70a8",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/package.json
@@ -3,6 +3,7 @@
 		"@clayui/button": "3.116.0",
 		"@clayui/form": "3.125.0",
 		"dynamic-data-mapping-form-field-type": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/index.js
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import {ReactFieldBase} from 'dynamic-data-mapping-form-field-type';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 function getInputValue(value, predefinedValue) {

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "1283a85058085af32bf7d68b2afc0eecf9d0f3ce",
+	"@generated": "0a3ddb96b360f7a32b45173107c98c6830195a5d",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"dynamic-data-mapping-form-field-type": [
 				"../../../../../../../dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/message-boards/message-boards-web/package.json
+++ b/modules/apps/message-boards/message-boards-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards/MBPortlet.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, openConfirmModal, openModal, sub} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
+import {fetch, sub} from 'frontend-js-web';
 
 const RECENTLY_REMOVED_ATTACHMENTS = {
 	multiple: Liferay.Language.get('x-recently-removed-attachments'),

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards_admin/MBEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/js/message_boards_admin/MBEntriesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, postForm} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/MBEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/js/MBEntriesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, postForm} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "0aff6251bbfb22ab6a71b320ae9512eafb334923",
+	"@generated": "b740b176ab3fb7b6a490fc0309758b6ae517a0f5",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/questions/questions-web/package.json
+++ b/modules/apps/questions/questions-web/package.json
@@ -24,6 +24,7 @@
 		"asset-taglib": "*",
 		"classnames": "2.3.1",
 		"frontend-editor-ckeditor-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"graphql-hooks": "4.4.0",
 		"graphql-hooks-memcache": "^2.1.1",

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/hooks/useActivityQuestionKebabOptions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/hooks/useActivityQuestionKebabOptions.es.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import {useMutation} from 'graphql-hooks';
 import {useCallback, useMemo, useState} from 'react';
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {cancelDebounce, debounce, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {cancelDebounce, debounce} from 'frontend-js-web';
 import {useRef} from 'react';
 
 import {client} from './client.es';

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "743ee51fe7ace282da6c5b183f94a64e3f4dd0c4",
+	"@generated": "78b9754af51881074d972967f22d44f7a06fc5b3",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -23,6 +23,9 @@
 			],
 			"frontend-editor-ckeditor-web": [
 				"../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -55,6 +58,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/ratings/ratings-taglib/package.json
+++ b/modules/apps/ratings/ratings-taglib/package.json
@@ -6,6 +6,7 @@
 		"@clayui/layout": "3.111.0",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/utils/toast.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/utils/toast.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export function errorToast(
 	message = Liferay.Language.get('an-unexpected-error-occurred'),

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5c090d9bfaa4c5d4cc98823b40a1090d04c392cf",
+	"@generated": "53726b3a10589137e6323d640d98100fc28ef1ed",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/saved-content/saved-content-taglib/package.json
+++ b/modules/apps/saved-content/saved-content-taglib/package.json
@@ -4,6 +4,7 @@
 		"@clayui/icon": "3.111.0",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/saved-content/saved-content-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/saved-content/saved-content-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -4,7 +4,8 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import {fetch, objectToFormData, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 

--- a/modules/apps/saved-content/saved-content-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/saved-content/saved-content-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "8c33c670ed36e57e06e66c06a1e802b117f7080b",
+	"@generated": "c81e2f0d709803267689284c809a98f5e7c636e7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/saved-content/saved-content-taglib/test/SavedContentEntry.js
+++ b/modules/apps/saved-content/saved-content-taglib/test/SavedContentEntry.js
@@ -8,17 +8,19 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
-import {
-	fetch as mockedFetch,
-	openToast as mockedOpenToast,
-} from 'frontend-js-web';
+import {openToast as mockedOpenToast} from 'frontend-js-components-web';
+import {fetch as mockedFetch} from 'frontend-js-web';
 
 import {SavedContentEntry} from '../src/main/resources/META-INF/resources/js/index';
+
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
+	openToast: jest.fn(),
+}));
 
 jest.mock('frontend-js-web', () => ({
 	...jest.requireActual('frontend-js-web'),
 	fetch: jest.fn(),
-	openToast: jest.fn(),
 	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
 }));
 

--- a/modules/apps/sharing/sharing-web/package.json
+++ b/modules/apps/sharing/sharing-web/package.json
@@ -12,6 +12,7 @@
 		"@clayui/sticker": "3.125.0",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/shared_assets/SharedAssetsManagementToolbarPropsTransformer.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/shared_assets/SharedAssetsManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {addParams, navigate, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {addParams, navigate} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {selectAssetTypeURL, viewAssetTypeURL},

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5781ecc9e3b3e394b2f8cf7e386d9576df6749c8",
+	"@generated": "0793b4b4b836105d45eb2ef967c2d68e239c72ba",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/translation/translation-web/package.json
+++ b/modules/apps/translation/translation-web/package.json
@@ -14,6 +14,7 @@
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
 		"frontend-editor-ckeditor-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	delete(itemData) {

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/TranslationManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -6,7 +6,8 @@
 import ClayAlert from '@clayui/alert';
 import ClayLayout from '@clayui/layout';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
-import {fetch, navigate, openConfirmModal, unescapeHTML} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {fetch, navigate, unescapeHTML} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useMemo, useReducer, useState} from 'react';
 

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5eb93fe61df5937b02b0417d1e4cc78689be8d72",
+	"@generated": "ffab942bc7736631474c58b15a5622c875c266c7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -17,6 +17,9 @@
 			],
 			"frontend-editor-ckeditor-web": [
 				"../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -43,6 +46,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/trash/trash-taglib/package.json
+++ b/modules/apps/trash/trash-taglib/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export function undo({alertMessage, namespace}) {
 	const componentId = `${namespace}recycleBinAlert`;

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "5102641f4db818d3f71735adeef558d28935587b",
+	"@generated": "77bbce6faa889e207563c5226720b054ad27b437",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/trash/trash-web/package.json
+++ b/modules/apps/trash/trash-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesPropsTransformer.js
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/EntriesPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 import openDeleteEntryModal from './openDeleteEntryModal';
 

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/openDeleteEntryModal.js
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/js/openDeleteEntryModal.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function openDeleteEntryModal({onDelete}) {
 	openModal({

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "f73ab748d742717554a9a0b0d5bf0ba8a418addd",
+	"@generated": "73c2e788118464653f2fd15da1ee233d106502ea",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/wiki/wiki-web/package.json
+++ b/modules/apps/wiki/wiki-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki-admin/WikiNodesManagementToolbarPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki-admin/WikiNodesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, postForm} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteNodesCmd, deleteNodesURL, trashEnabled},

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki-admin/WikiPagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki-admin/WikiPagesManagementToolbarPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, postForm} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {postForm} from 'frontend-js-web';
 
 export default function propsTransformer({
 	additionalProps: {deletePagesCmd, deletePagesURL, trashEnabled},

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPageDeleteButtonPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPageDeleteButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({additionalProps, ...props}) {
 	return {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPageDropdownPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPageDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openModal} from 'frontend-js-web';
+import {openConfirmModal, openModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	delete({deleteURL, trashEnabled}) {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPagePermissionsButtonPropsTransformer.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPagePermissionsButtonPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({additionalProps, ...props}) {
 	return {

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPortlet.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/js/wiki/WikiPortlet.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, openConfirmModal, sub} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {fetch, sub} from 'frontend-js-web';
 
 const CONFIRM_DISCARD_IMAGES = Liferay.Language.get(
 	'uploads-are-in-progress-confirmation'

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "66525a5a112565bd803c22645cf493a9aef99749",
+	"@generated": "e554b171ebf2b724994d8676bf02be51074c8d85",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/package.json
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@liferay/frontend-icons-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
@@ -4,14 +4,8 @@
  */
 
 import {getSpritemap} from '@liferay/frontend-icons-web';
-import {
-	fetch,
-	getWindow,
-	navigate,
-	openSimpleInputModal,
-	openToast,
-	openWindow,
-} from 'frontend-js-web';
+import {openSimpleInputModal, openToast} from 'frontend-js-components-web';
+import {fetch, getWindow, navigate, openWindow} from 'frontend-js-web';
 
 const TIME_POLLING = 500;
 const TIME_SHOW_MSG = 2000;

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "43717aaa3f3a04aa69ec24c10eb6c5df06b4f1ac",
+	"@generated": "90fd421dbf2452aabf9cb887f1f5aa63794b9a47",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-icons-web": [
 				"../../../../../../../../../apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../../../apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../../../apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../../../apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../../../apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../../../apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
@@ -9,6 +9,10 @@ import {DocumentLibraryOpener} from '../../src/main/resources/META-INF/resources
 
 const realSetTimeout = setTimeout;
 
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
+
 jest.mock('frontend-js-web', () => ({
 	...jest.requireActual('frontend-js-web'),
 	getWindow: jest.fn(() => ({hide: jest.fn()})),


### PR DESCRIPTION
Hi team :wave: 

This PR is part of [LPD-47718](https://liferay.atlassian.net/browse/LPD-47718).

It refactors your code to import `openModal`, `openToast`, etc. from `frontend-js-components-web` instead of `frontend-js-web`.

The final goal is to remove those methods from `frontend-js-web` so that whenever that module is imported the browser doesn't need to pull React and Clay simply because those methods existed there. This will enhance the performance of sites that don't need React or Clay.

Internally, for now, we are only [re-exporting those methods](https://github.com/brianchandotcom/liferay-portal/pull/159020/commits/3c4231e573b72d8775583af87224810fe42de532) from `frontend-js-components-web`, but once all PRs like this one sent to teams are merged, we (Frontend Infra) will send another final PR to move the methods and remove them completely from `frontend-js-web`.

The code in this PR (as well as the one we will send to other teams) has been thoroughly tested in [this PR](https://github.com/liferay-frontend/liferay-portal/pull/4720#) but we want to make sure that it doesn't break anything and that's why we send it to you for review.

The expectations are that you run the tests suites you think apply and if nothing breaks you just simply forward the PR to Brian. 

Also, it would be great if any new code you write that uses those methods imports them from `frontend-js-components-web` instead of `frontend-js-web` so that we don't have to repeat this process again :grimacing: .

For reference, here is the list of moved methods:

1. openAlertModal
2. openCategorySelectionModal
3. openConfirmModal
4. openModal
5. openPortletModal
6. openPortletWindow
7. openSelectionModal
8. openSimpleInputModal
9. openTagSelectionModal
10. openToast