### PR TITLE
LPD-49549 Add CMS site initializer tests to CM test suite

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/test.properties
+++ b/modules/apps/site/site-cms-site-initializer-test/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Content Management System

--- a/test.properties
+++ b/test.properties
@@ -3682,6 +3682,7 @@
         apps/repository/**,\
         apps/saved-content/**,\
         apps/sharing/**,\
+        apps/site/site-cms-site-initializer-test/**,\
         apps/social/**,\
         apps/subscription/**,\
         apps/translation/**,\
@@ -3751,6 +3752,7 @@
         **/reading-time/**/*Test.java,\
         **/repository/**/*Test.java,\
         **/sharing/**/*Test.java,\
+        **/site/site-cms-site-initializer-test/**/*Test.java,\
         **/social/**/*Test.java,\
         **/translation/**/*Test.java,\
         **/trash/**/*Test.java,\
@@ -7458,6 +7460,9 @@
         apps/site-initializer/**,\
         apps/site-navigation/**
 
+    test.batch.class.names.excludes[site-management]=\
+        apps/site/site-cms-site-initializer-test/**/*Test.java
+
     test.batch.class.names.includes[site-management]=\
         **/click-to-chat/**/*Test.java,\
         **/friendly-url-**/**/*Test.java,\
@@ -8730,6 +8735,7 @@
         Comment,\
         Content Dashboard,\
         Content Management Headless,\
+        Content Management System,\
         Content Page Review,\
         Depot,\
         Document Management,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-49549

Exclude CMS tests from Site Management suite and add them to the CM suite under its own component.