### PR TITLE
LPD-48254 Protect system object entry folder deletion

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntryFolderConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectEntryFolderConstants.java
@@ -10,6 +10,9 @@ package com.liferay.object.constants;
  */
 public class ObjectEntryFolderConstants {
 
+	public static final String
+		EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_ENTRY_FOLDER = "L_";
+
 	public static final long PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT = 0;
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryFolderThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryFolderThreadLocal.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.entry.util;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.lang.SafeCloseable;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class ObjectEntryFolderThreadLocal {
+
+	public static boolean isSkipSystemObjectEntryFolderProtection() {
+		return _skipSystemObjectEntryFolderProtection.get();
+	}
+
+	public static SafeCloseable
+		setSkipSystemObjectEntryFolderProtectionWithSafeCloseable(
+			boolean skipSystemObjectEntryFolderProtection) {
+
+		return _skipSystemObjectEntryFolderProtection.setWithSafeCloseable(
+			skipSystemObjectEntryFolderProtection);
+	}
+
+	private static final CentralizedThreadLocal<Boolean>
+		_skipSystemObjectEntryFolderProtection = new CentralizedThreadLocal<>(
+			ObjectEntryFolderThreadLocal.class +
+				"._skipSystemObjectEntryFolderProtection",
+			() -> false);
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -126,7 +126,9 @@ public class ObjectEntryFolderLocalServiceImpl
 		if (!ObjectEntryFolderThreadLocal.
 				isSkipSystemObjectEntryFolderProtection() &&
 			StringUtil.startsWith(
-				objectEntryFolder.getExternalReferenceCode(), "L_")) {
+				objectEntryFolder.getExternalReferenceCode(),
+				ObjectEntryFolderConstants.
+					EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_ENTRY_FOLDER)) {
 
 			throw new PortalException(
 				"Object entry folder " +

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.object.service.impl;
 
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.entry.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
 import com.liferay.object.exception.ObjectEntryFolderNameException;
 import com.liferay.object.exception.ObjectEntryFolderScopeException;
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -120,6 +122,17 @@ public class ObjectEntryFolderLocalServiceImpl
 	public ObjectEntryFolder deleteObjectEntryFolder(
 			ObjectEntryFolder objectEntryFolder)
 		throws PortalException {
+
+		if (!ObjectEntryFolderThreadLocal.
+				isSkipSystemObjectEntryFolderProtection() &&
+			StringUtil.startsWith(
+				objectEntryFolder.getExternalReferenceCode(), "L_")) {
+
+			throw new PortalException(
+				"Object entry folder " +
+					objectEntryFolder.getExternalReferenceCode() +
+						" cannot be deleted");
+		}
 
 		// Object entries
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -60,11 +60,11 @@ public class ObjectEntryFolderLocalServiceImpl
 		User user = _userLocalService.getUser(userId);
 
 		_validateExternalReferenceCode(
-			externalReferenceCode, user.getCompanyId(), groupId);
+			externalReferenceCode, groupId, user.getCompanyId());
 
 		_validateParentObjectEntryFolderId(groupId, parentObjectEntryFolderId);
 		_validateName(
-			user.getCompanyId(), groupId, 0, parentObjectEntryFolderId, name);
+			groupId, user.getCompanyId(), 0, parentObjectEntryFolderId, name);
 
 		ObjectEntryFolder objectEntryFolder =
 			objectEntryFolderPersistence.create(
@@ -237,7 +237,7 @@ public class ObjectEntryFolderLocalServiceImpl
 		_validateParentObjectEntryFolderId(
 			objectEntryFolder.getGroupId(), parentObjectEntryFolderId);
 		_validateName(
-			objectEntryFolder.getCompanyId(), objectEntryFolder.getGroupId(),
+			objectEntryFolder.getGroupId(), objectEntryFolder.getCompanyId(),
 			objectEntryFolderId, parentObjectEntryFolderId, name);
 
 		objectEntryFolder.setParentObjectEntryFolderId(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -185,7 +185,10 @@ public class ObjectEntryFolderLocalServiceTest {
 
 		// Protected system folder
 
-		String externalReferenceCode = "L_" + StringUtil.randomString();
+		String externalReferenceCode =
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_ENTRY_FOLDER +
+					StringUtil.randomString();
 
 		AssertUtils.assertFailure(
 			PortalException.class,
@@ -206,8 +209,10 @@ public class ObjectEntryFolderLocalServiceTest {
 		// Unprotected system folder
 
 		ObjectEntryFolder systemObjectEntryFolder = _addObjectEntryFolder(
-			"L_" + StringUtil.randomString(), _group.getGroupId(),
-			StringUtil.randomString(),
+			ObjectEntryFolderConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_ENTRY_FOLDER +
+					StringUtil.randomString(),
+			_group.getGroupId(), StringUtil.randomString(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
 
 		try (SafeCloseable safeCloseable =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.entry.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
 import com.liferay.object.exception.ObjectEntryFolderNameException;
 import com.liferay.object.exception.ObjectEntryFolderScopeException;
@@ -19,7 +20,9 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -144,6 +147,9 @@ public class ObjectEntryFolderLocalServiceTest {
 
 	@Test
 	public void testDeleteObjectEntryFolder() throws Exception {
+
+		// Nonsystem folder
+
 		ObjectEntryFolder objectEntryFolder1 = _addObjectEntryFolder(
 			StringUtil.randomString(), _group.getGroupId(),
 			StringUtil.randomString(),
@@ -176,6 +182,46 @@ public class ObjectEntryFolderLocalServiceTest {
 		Assert.assertNull(
 			_objectEntryFolderLocalService.fetchObjectEntryFolder(
 				objectEntryFolder3.getObjectEntryFolderId()));
+
+		// Protected system folder
+
+		String externalReferenceCode = "L_" + StringUtil.randomString();
+
+		AssertUtils.assertFailure(
+			PortalException.class,
+			"Object entry folder " + externalReferenceCode +
+				" cannot be deleted",
+			() -> {
+				ObjectEntryFolder systemObjectEntryFolder =
+					_addObjectEntryFolder(
+						externalReferenceCode, _group.getGroupId(),
+						StringUtil.randomString(),
+						ObjectEntryFolderConstants.
+							PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
+
+				_objectEntryFolderLocalService.deleteObjectEntryFolder(
+					systemObjectEntryFolder.getObjectEntryFolderId());
+			});
+
+		// Unprotected system folder
+
+		ObjectEntryFolder systemObjectEntryFolder = _addObjectEntryFolder(
+			"L_" + StringUtil.randomString(), _group.getGroupId(),
+			StringUtil.randomString(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
+
+		try (SafeCloseable safeCloseable =
+				ObjectEntryFolderThreadLocal.
+					setSkipSystemObjectEntryFolderProtectionWithSafeCloseable(
+						true)) {
+
+			_objectEntryFolderLocalService.deleteObjectEntryFolder(
+				systemObjectEntryFolder.getObjectEntryFolderId());
+		}
+
+		Assert.assertNull(
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(
+				systemObjectEntryFolder.getObjectEntryFolderId()));
 	}
 
 	@Test

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -19,5 +19,6 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/GroupModelListener.java
@@ -6,7 +6,9 @@
 package com.liferay.site.cms.site.initializer.internal.model.listener;
 
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.entry.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -53,9 +55,6 @@ public class GroupModelListener extends BaseModelListener<Group> {
 			return;
 		}
 
-		// TODO We need to protect L_ in ObjectEntryFolderLocalServiceImpl
-		// via a thread local
-
 		_objectEntryFolderLocalService.addObjectEntryFolder(
 			"L_CONTENTS", group.getCreatorUserId(), group.getGroupId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
@@ -80,10 +79,16 @@ public class GroupModelListener extends BaseModelListener<Group> {
 			return;
 		}
 
-		_objectEntryFolderLocalService.deleteObjectEntryFolder(
-			"L_CONTENTS", group.getGroupId(), group.getCompanyId());
-		_objectEntryFolderLocalService.deleteObjectEntryFolder(
-			"L_FILES", group.getGroupId(), group.getCompanyId());
+		try (SafeCloseable safeCloseable =
+				ObjectEntryFolderThreadLocal.
+					setSkipSystemObjectEntryFolderProtectionWithSafeCloseable(
+						true)) {
+
+			_objectEntryFolderLocalService.deleteObjectEntryFolder(
+				"L_CONTENTS", group.getGroupId(), group.getCompanyId());
+			_objectEntryFolderLocalService.deleteObjectEntryFolder(
+				"L_FILES", group.getGroupId(), group.getCompanyId());
+		}
 	}
 
 	@Reference


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48254

This is a followup PR; System folders (those with ERCs prefixed by "L_") need to be protected against deletion.

# How am I fixing it?

By default, system folder deletion is forbidden. It can be enabled by using a new thread local variable.

# How can you verify that it works?

Execute the `ObjectEntryFolderLocalServiceTest` integration tests.