### PR TITLE
LPD-50112 GroupItemSelector Fix

### DIFF
--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -59,6 +59,8 @@ public class GroupItemSelectorProviderImpl
 
 		LinkedHashMap<String, Object> groupParams =
 			LinkedHashMapBuilder.<String, Object>put(
+				"actionId", ActionKeys.VIEW
+			).put(
 				"active", Boolean.TRUE
 			).put(
 				"site", Boolean.TRUE


### PR DESCRIPTION
Group Item Selector Fix

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-50112)

Sites are lost when there is a large amount of sites that are not available to the user

# How am I fixing it?

Adding the view param, just like we do with the count

# How can you verify that it works?

Follow the steps in the ticket

There are no tests for this PR, we already have tests in place in GroupItemSelectorProviderImplTest
