### PR TITLE
LPD-49536 - Spaces (Asset Library) Rest API add and remove user and user groups methods

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Asset Library API
 Bundle-SymbolicName: com.liferay.headless.asset.library.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.headless.asset.library.dto.v1_0,\
 	com.liferay.headless.asset.library.resource.v1_0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
@@ -561,6 +561,47 @@ public class AssetLibrary implements Serializable {
 	@JsonIgnore
 	private Supplier<Long> _siteIdSupplier;
 
+	@Schema(description = "The asset library's users count.")
+	public Integer getUsersCount() {
+		if (_usersCountSupplier != null) {
+			usersCount = _usersCountSupplier.get();
+
+			_usersCountSupplier = null;
+		}
+
+		return usersCount;
+	}
+
+	public void setUsersCount(Integer usersCount) {
+		this.usersCount = usersCount;
+
+		_usersCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUsersCount(
+		UnsafeSupplier<Integer, Exception> usersCountUnsafeSupplier) {
+
+		_usersCountSupplier = () -> {
+			try {
+				return usersCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The asset library's users count.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer usersCount;
+
+	@JsonIgnore
+	private Supplier<Integer> _usersCountSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -782,6 +823,18 @@ public class AssetLibrary implements Serializable {
 			sb.append("\"siteId\": ");
 
 			sb.append(siteId);
+		}
+
+		Integer usersCount = getUsersCount();
+
+		if (usersCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"usersCount\": ");
+
+			sb.append(usersCount);
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/resource/v1_0/AssetLibraryResource.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/resource/v1_0/AssetLibraryResource.java
@@ -70,6 +70,22 @@ public interface AssetLibraryResource {
 			Long assetLibraryId, Long toSiteId)
 		throws Exception;
 
+	public AssetLibrary deleteAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public AssetLibrary postAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public AssetLibrary deleteAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
+	public AssetLibrary postAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
@@ -282,6 +282,27 @@ public class AssetLibrary implements Cloneable, Serializable {
 
 	protected Long siteId;
 
+	public Integer getUsersCount() {
+		return usersCount;
+	}
+
+	public void setUsersCount(Integer usersCount) {
+		this.usersCount = usersCount;
+	}
+
+	public void setUsersCount(
+		UnsafeSupplier<Integer, Exception> usersCountUnsafeSupplier) {
+
+		try {
+			usersCount = usersCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer usersCount;
+
 	@Override
 	public AssetLibrary clone() throws CloneNotSupportedException {
 		return (AssetLibrary)super.clone();

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/resource/v1_0/AssetLibraryResource.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/resource/v1_0/AssetLibraryResource.java
@@ -95,6 +95,39 @@ public interface AssetLibraryResource {
 			Long assetLibraryId, Long toSiteId)
 		throws Exception;
 
+	public AssetLibrary deleteAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteAssetLibraryUserAccountUserHttpResponse(
+				Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public AssetLibrary postAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postAssetLibraryUserAccountUserHttpResponse(
+			Long assetLibraryId, Long userId)
+		throws Exception;
+
+	public AssetLibrary deleteAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse deleteAssetLibraryUserGroupHttpResponse(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
+	public AssetLibrary postAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postAssetLibraryUserGroupHttpResponse(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -1151,6 +1184,444 @@ public interface AssetLibraryResource {
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("toSiteId", toSiteId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public AssetLibrary deleteAssetLibraryUserAccountUser(
+				Long assetLibraryId, Long userId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteAssetLibraryUserAccountUserHttpResponse(
+					assetLibraryId, userId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return AssetLibrarySerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteAssetLibraryUserAccountUserHttpResponse(
+					Long assetLibraryId, Long userId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-accounts/{userId}");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path("userId", userId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public AssetLibrary postAssetLibraryUserAccountUser(
+				Long assetLibraryId, Long userId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryUserAccountUserHttpResponse(
+					assetLibraryId, userId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return AssetLibrarySerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryUserAccountUserHttpResponse(
+					Long assetLibraryId, Long userId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-accounts/{userId}");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path("userId", userId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public AssetLibrary deleteAssetLibraryUserGroup(
+				Long assetLibraryId, Long userGroupId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteAssetLibraryUserGroupHttpResponse(
+					assetLibraryId, userGroupId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return AssetLibrarySerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse deleteAssetLibraryUserGroupHttpResponse(
+				Long assetLibraryId, Long userGroupId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path("userGroupId", userGroupId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public AssetLibrary postAssetLibraryUserGroup(
+				Long assetLibraryId, Long userGroupId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryUserGroupHttpResponse(
+					assetLibraryId, userGroupId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return AssetLibrarySerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postAssetLibraryUserGroupHttpResponse(
+				Long assetLibraryId, Long userGroupId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path("userGroupId", userGroupId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
@@ -226,6 +226,16 @@ public class AssetLibrarySerDes {
 			sb.append(assetLibrary.getSiteId());
 		}
 
+		if (assetLibrary.getUsersCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"usersCount\": ");
+
+			sb.append(assetLibrary.getUsersCount());
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -348,6 +358,13 @@ public class AssetLibrarySerDes {
 			map.put("siteId", String.valueOf(assetLibrary.getSiteId()));
 		}
 
+		if (assetLibrary.getUsersCount() == null) {
+			map.put("usersCount", null);
+		}
+		else {
+			map.put("usersCount", String.valueOf(assetLibrary.getUsersCount()));
+		}
+
 		return map;
 	}
 
@@ -405,6 +422,9 @@ public class AssetLibrarySerDes {
 				return true;
 			}
 			else if (Objects.equals(jsonParserFieldName, "siteId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "usersCount")) {
 				return false;
 			}
 
@@ -489,6 +509,12 @@ public class AssetLibrarySerDes {
 				if (jsonParserFieldValue != null) {
 					assetLibrary.setSiteId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "usersCount")) {
+				if (jsonParserFieldValue != null) {
+					assetLibrary.setUsersCount(
+						Integer.valueOf((String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -74,6 +74,11 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+                usersCount:
+                    description:
+                        The asset library's users count.
+                    readOnly: true
+                    type: integer
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
@@ -314,6 +319,116 @@ paths:
                       type: integer
                 - in: path
                   name: toSiteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+            tags: ["AssetLibrary"]
+    /asset-libraries/{assetLibraryId}/user-accounts/{userId}:
+        delete:
+            description:
+                Removes the user from the asset library. Returns the asset library.
+            operationId: deleteAssetLibraryUserAccountUser
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: userId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+            tags: ["AssetLibrary"]
+        post:
+            description:
+                Adds the user to the asset library. Returns the asset library.
+            operationId: postAssetLibraryUserAccountUser
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: userId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+            tags: ["AssetLibrary"]
+    /asset-libraries/{assetLibraryId}/user-groups/{userGroupId}:
+        delete:
+            description:
+                Removes the user group from the asset library. Returns the asset library.
+            operationId: deleteAssetLibraryUserGroup
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: userGroupId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/AssetLibrary"
+            tags: ["AssetLibrary"]
+        post:
+            description:
+                Adds the user group to the asset library. Returns the asset library.
+            operationId: postAssetLibraryUserGroup
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: userGroupId
                   required: true
                   schema:
                       format: int64

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -82,7 +82,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.asset.library.client', and version '1.0.0'."
+        'com.liferay.headless.asset.library.client', and version '1.0.2'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -13,6 +13,7 @@ import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.internal.resource.v1_0.BaseAssetLibraryResourceImpl;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.util.GroupUtil;
@@ -117,6 +118,9 @@ public class AssetLibraryDTOConverter
 						dtoConverterContext.isAcceptAllLanguages(),
 						group.getNameMap()));
 				setSiteId(group::getGroupId);
+				setUsersCount(
+					() -> _userLocalService.getGroupUsersCount(
+						group.getGroupId()));
 			}
 		};
 	}
@@ -129,5 +133,8 @@ public class AssetLibraryDTOConverter
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.service.UserGroupService;
+import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -77,6 +79,35 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 
 		_depotEntryGroupRelService.deleteDepotEntryGroupRel(
 			depotEntryGroupRel.getDepotEntryGroupRelId());
+
+		return getAssetLibrary(assetLibraryId);
+	}
+
+	@Override
+	public AssetLibrary deleteAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_userService.unsetGroupUsers(assetLibraryId, new long[] {userId}, null);
+
+		return getAssetLibrary(assetLibraryId);
+	}
+
+	@Override
+	public AssetLibrary deleteAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_userGroupService.unsetGroupUserGroups(
+			assetLibraryId, new long[] {userGroupId});
 
 		return getAssetLibrary(assetLibraryId);
 	}
@@ -203,6 +234,35 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		return getAssetLibrary(assetLibraryId);
 	}
 
+	@Override
+	public AssetLibrary postAssetLibraryUserAccountUser(
+			Long assetLibraryId, Long userId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_userService.addGroupUsers(assetLibraryId, new long[] {userId}, null);
+
+		return getAssetLibrary(assetLibraryId);
+	}
+
+	@Override
+	public AssetLibrary postAssetLibraryUserGroup(
+			Long assetLibraryId, Long userGroupId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		_userGroupService.addGroupUserGroups(
+			assetLibraryId, new long[] {userGroupId});
+
+		return getAssetLibrary(assetLibraryId);
+	}
+
 	private ServiceContext _getServiceContext() throws Exception {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DepotEntry.class.getName(), contextHttpServletRequest);
@@ -271,5 +331,11 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private UserGroupService _userGroupService;
+
+	@Reference
+	private UserService _userService;
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
@@ -373,6 +373,178 @@ public abstract class BaseAssetLibraryResourceImpl
 		return new AssetLibrary();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-accounts/{userId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Removes the user from the asset library. Returns the asset library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetLibrary")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/user-accounts/{userId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public AssetLibrary deleteAssetLibraryUserAccountUser(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("userId")
+			Long userId)
+		throws Exception {
+
+		return new AssetLibrary();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-accounts/{userId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Adds the user to the asset library. Returns the asset library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetLibrary")}
+	)
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/user-accounts/{userId}"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public AssetLibrary postAssetLibraryUserAccountUser(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("userId")
+			Long userId)
+		throws Exception {
+
+		return new AssetLibrary();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Removes the user group from the asset library. Returns the asset library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userGroupId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetLibrary")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public AssetLibrary deleteAssetLibraryUserGroup(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("userGroupId")
+			Long userGroupId)
+		throws Exception {
+
+		return new AssetLibrary();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Adds the user group to the asset library. Returns the asset library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userGroupId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AssetLibrary")}
+	)
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/user-groups/{userGroupId}"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public AssetLibrary postAssetLibraryUserGroup(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("userGroupId")
+			Long userGroupId)
+		throws Exception {
+
+		return new AssetLibrary();
+	}
+
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.asset.library.client', and version '1.0.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Asset Library Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.asset.library.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Asset Library Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -12,11 +12,19 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.asset.library.client.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
+
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,7 +33,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-@FeatureFlags("LPD-32649")
+@FeatureFlags({"LPD-17564", "LPD-32649"})
 @RunWith(Arquillian.class)
 public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
@@ -70,6 +78,60 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Override
 	@Test
+	public void testDeleteAssetLibraryUserAccountUser() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		Integer initialUsersCount = assetLibrary.getUsersCount();
+
+		User user1 = UserTestUtil.addUser();
+		User user2 = UserTestUtil.addUser();
+
+		assetLibraryResource.postAssetLibraryUserAccountUser(
+			assetLibrary.getId(), user1.getUserId());
+		assetLibraryResource.postAssetLibraryUserAccountUser(
+			assetLibrary.getId(), user2.getUserId());
+
+		assetLibrary = assetLibraryResource.deleteAssetLibraryUserAccountUser(
+			assetLibrary.getId(), user1.getUserId());
+
+		Assert.assertEquals(
+			(Integer)(initialUsersCount + 1), assetLibrary.getUsersCount());
+
+		List<User> groupUsers = _userLocalService.getGroupUsers(
+			assetLibrary.getSiteId());
+
+		Assert.assertFalse(groupUsers.contains(user1));
+		Assert.assertTrue(groupUsers.contains(user2));
+	}
+
+	@Override
+	@Test
+	public void testDeleteAssetLibraryUserGroup() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
+		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
+
+		assetLibraryResource.postAssetLibraryUserGroup(
+			assetLibrary.getId(), userGroup1.getUserGroupId());
+		assetLibraryResource.postAssetLibraryUserGroup(
+			assetLibrary.getId(), userGroup2.getUserGroupId());
+
+		assetLibrary = assetLibraryResource.deleteAssetLibraryUserGroup(
+			assetLibrary.getId(), userGroup1.getUserGroupId());
+
+		List<UserGroup> groupUserGroups =
+			_userGroupLocalService.getGroupUserGroups(assetLibrary.getSiteId());
+
+		Assert.assertEquals(
+			groupUserGroups.toString(), 1, groupUserGroups.size());
+
+		Assert.assertFalse(groupUserGroups.contains(userGroup1));
+		Assert.assertTrue(groupUserGroups.contains(userGroup2));
+	}
+
+	@Override
+	@Test
 	public void testPatchAssetLibraryBySite() throws Exception {
 		AssetLibrary postAssetLibrary =
 			testPatchAssetLibraryBySite_addAssetLibrary();
@@ -100,6 +162,55 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 				randomAssetLibrary());
 
 		_assertLinkedSites(assetLibrary);
+	}
+
+	@Override
+	@Test
+	public void testPostAssetLibraryUserAccountUser() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		Integer initialUsersCount = assetLibrary.getUsersCount();
+
+		User user1 = UserTestUtil.addUser();
+		User user2 = UserTestUtil.addUser();
+
+		assetLibraryResource.postAssetLibraryUserAccountUser(
+			assetLibrary.getId(), user1.getUserId());
+
+		assetLibrary = assetLibraryResource.postAssetLibraryUserAccountUser(
+			assetLibrary.getId(), user2.getUserId());
+
+		Assert.assertEquals(
+			(Integer)(initialUsersCount + 2), assetLibrary.getUsersCount());
+
+		List<User> groupUsers = _userLocalService.getGroupUsers(
+			assetLibrary.getSiteId());
+
+		Assert.assertTrue(groupUsers.contains(user1));
+		Assert.assertTrue(groupUsers.contains(user2));
+	}
+
+	@Override
+	@Test
+	public void testPostAssetLibraryUserGroup() throws Exception {
+		AssetLibrary assetLibrary = _addAssetLibrary();
+
+		UserGroup userGroup1 = UserGroupTestUtil.addUserGroup();
+		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
+
+		assetLibraryResource.postAssetLibraryUserGroup(
+			assetLibrary.getId(), userGroup1.getUserGroupId());
+
+		assetLibrary = assetLibraryResource.postAssetLibraryUserGroup(
+			assetLibrary.getId(), userGroup2.getUserGroupId());
+
+		List<UserGroup> groupUserGroups =
+			_userGroupLocalService.getGroupUserGroups(assetLibrary.getSiteId());
+
+		Assert.assertEquals(
+			groupUserGroups.toString(), 2, groupUserGroups.size());
+		Assert.assertTrue(groupUserGroups.contains(userGroup1));
+		Assert.assertTrue(groupUserGroups.contains(userGroup2));
 	}
 
 	@Override
@@ -240,5 +351,11 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
@@ -416,6 +416,100 @@ public abstract class BaseAssetLibraryResourceTestCase {
 			"This method needs to be implemented");
 	}
 
+	@Test
+	public void testDeleteAssetLibraryUserAccountUser() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AssetLibrary assetLibrary =
+			testDeleteAssetLibraryUserAccountUser_addAssetLibrary();
+
+		assertHttpResponseStatusCode(
+			204,
+			assetLibraryResource.deleteAssetLibraryUserAccountUserHttpResponse(
+				assetLibrary.getId(),
+				testDeleteAssetLibraryUserAccountUser_getUserId()));
+	}
+
+	protected Long testDeleteAssetLibraryUserAccountUser_getUserId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected AssetLibrary
+			testDeleteAssetLibraryUserAccountUser_addAssetLibrary()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostAssetLibraryUserAccountUser() throws Exception {
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		AssetLibrary postAssetLibrary =
+			testPostAssetLibraryUserAccountUser_addAssetLibrary(
+				randomAssetLibrary);
+
+		assertEquals(randomAssetLibrary, postAssetLibrary);
+		assertValid(postAssetLibrary);
+	}
+
+	protected AssetLibrary testPostAssetLibraryUserAccountUser_addAssetLibrary(
+			AssetLibrary assetLibrary)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteAssetLibraryUserGroup() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		AssetLibrary assetLibrary =
+			testDeleteAssetLibraryUserGroup_addAssetLibrary();
+
+		assertHttpResponseStatusCode(
+			204,
+			assetLibraryResource.deleteAssetLibraryUserGroupHttpResponse(
+				assetLibrary.getId(),
+				testDeleteAssetLibraryUserGroup_getUserGroupId()));
+	}
+
+	protected Long testDeleteAssetLibraryUserGroup_getUserGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected AssetLibrary testDeleteAssetLibraryUserGroup_addAssetLibrary()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostAssetLibraryUserGroup() throws Exception {
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		AssetLibrary postAssetLibrary =
+			testPostAssetLibraryUserGroup_addAssetLibrary(randomAssetLibrary);
+
+		assertEquals(randomAssetLibrary, postAssetLibrary);
+		assertValid(postAssetLibrary);
+	}
+
+	protected AssetLibrary testPostAssetLibraryUserGroup_addAssetLibrary(
+			AssetLibrary assetLibrary)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	protected AssetLibrary testGraphQLAssetLibrary_addAssetLibrary()
 		throws Exception {
 
@@ -585,6 +679,14 @@ public abstract class BaseAssetLibraryResourceTestCase {
 
 			if (Objects.equals("name_i18n", additionalAssertFieldName)) {
 				if (assetLibrary.getName_i18n() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("usersCount", additionalAssertFieldName)) {
+				if (assetLibrary.getUsersCount() == null) {
 					valid = false;
 				}
 
@@ -818,6 +920,17 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				if (!equals(
 						(Map)assetLibrary1.getName_i18n(),
 						(Map)assetLibrary2.getName_i18n())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("usersCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetLibrary1.getUsersCount(),
+						assetLibrary2.getUsersCount())) {
 
 					return false;
 				}
@@ -1208,6 +1321,12 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("usersCount")) {
+			sb.append(String.valueOf(assetLibrary.getUsersCount()));
+
+			return sb.toString();
+		}
+
 		throw new IllegalArgumentException(
 			"Invalid entity field " + entityFieldName);
 	}
@@ -1264,6 +1383,7 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				siteId = testGroup.getGroupId();
+				usersCount = RandomTestUtil.randomInt();
 			}
 		};
 	}


### PR DESCRIPTION
# What is this trying to solve?

[{Create API endpoints to connect user and user group to a space}](https://liferay.atlassian.net/browse/LPD-49342)


# How am I fixing it?

This is the first part of this story. In a second PR I'll send the methods to retrieve a list of this elements but it will be placed in headless-user-admin in order to reuse the existing schemas and do not introduce complexity in the Asset Library API.

Here I'm adding 4 new methods to add and remove users and user groups from Spaces 

<img width="1146" alt="Captura de pantalla 2025-02-28 a las 10 11 28" src="https://github.com/user-attachments/assets/469a084c-ddf8-4824-a124-d37da6a7016d" />

# How can you verify that it works?

Run the included automated tests.