### PR TITLE
LPD-33264 Apply ERC to Media Gallery widget configuration

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
@@ -535,7 +535,11 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 
 	@Override
 	protected String[] getDataPortletPreferences() {
-		return new String[] {"rootFolderId", "selectedRepositoryId"};
+		return new String[] {
+			"rootFolderExternalReferenceCode",
+			"selectedGroupExternalReferenceCode",
+			"selectedRepositoryExternalReferenceCode"
+		};
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/IGDisplayPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/IGDisplayPortletDataHandlerTest.java
@@ -52,7 +52,11 @@ public class IGDisplayPortletDataHandlerTest
 
 	@Override
 	protected String[] getDataPortletPreferences() {
-		return new String[] {"rootFolderId", "selectedRepositoryId"};
+		return new String[] {
+			"rootFolderExternalReferenceCode",
+			"selectedGroupExternalReferenceCode",
+			"selectedRepositoryExternalReferenceCode"
+		};
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/IGExportImportPortletPreferencesProcessorTest.java
@@ -1,0 +1,813 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.exportimport.portlet.preferences.processor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.exportimport.controller.PortletExportController;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
+import com.liferay.exportimport.test.util.TestReaderWriter;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.comment.CommentManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.IdentityServiceContextFunction;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.zip.ZipReader;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.ratings.kernel.model.RatingsEntry;
+import com.liferay.ratings.test.util.RatingsTestUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class IGExportImportPortletPreferencesProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group.getGroupId());
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), _layout,
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY, "column-1",
+			new HashMap<String, String[]>());
+
+		_portletDataContextExport =
+			ExportImportTestUtil.getExportPortletDataContext(
+				_group.getGroupId());
+
+		_portletDataContextExport.setPlid(_layout.getPlid());
+		_portletDataContextExport.setPortletId(
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+
+		_portletDataContextImport =
+			ExportImportTestUtil.getImportPortletDataContext(
+				_group.getGroupId());
+
+		_portletDataContextImport.setPlid(_layout.getPlid());
+		_portletDataContextImport.setPortletId(
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+
+		_portletPreferences =
+			PortletPreferencesFactoryUtil.getStrictPortletSetup(
+				_layout, DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+
+		_portletPreferences.setValue("selectionStyle", "manual");
+	}
+
+	@Test
+	public void testExportDLFileEntryIdWithComments() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_setPortletPreferences(fileEntry);
+
+		User user = TestPropsValues.getUser();
+
+		long commentPrimaryKey = CommentManagerUtil.addComment(
+			user.getUserId(), _group.getGroupId(), DLFileEntry.class.getName(),
+			fileEntry.getFileEntryId(), RandomTestUtil.randomString(),
+			new IdentityServiceContextFunction(
+				ServiceContextTestUtil.getServiceContext()));
+
+		_exportPortlet();
+
+		Map<String, String[]> parameterMap =
+			_portletDataContextExport.getParameterMap();
+
+		Assert.assertEquals(
+			parameterMap.get(PortletDataHandlerKeys.COMMENTS)[0],
+			Boolean.TRUE.toString());
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(),
+					"#com.liferay.message.boards.model.MBMessage#",
+					commentPrimaryKey)));
+	}
+
+	@Test
+	public void testExportDLFileEntryIdWithRatings() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_setPortletPreferences(fileEntry);
+
+		RatingsEntry ratingsEntry = RatingsTestUtil.addEntry(
+			DLFileEntry.class.getName(), fileEntry.getFileEntryId());
+
+		_exportPortlet();
+
+		Map<String, String[]> parameterMap =
+			_portletDataContextExport.getParameterMap();
+
+		Assert.assertEquals(
+			parameterMap.get(PortletDataHandlerKeys.COMMENTS)[0],
+			Boolean.TRUE.toString());
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					RatingsEntry.class.getName(), StringPool.POUND,
+					ratingsEntry.getEntryId())));
+	}
+
+	@Test
+	public void testExportDLFileEntryInDifferentGroup() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			TestPropsValues.getGroupId());
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+	}
+
+	@Test
+	public void testExportDLFileEntryInSameGroup() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_layout.getGroupId());
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				StringBundler.concat(
+					String.class.getName(), StringPool.POUND,
+					DLFileEntry.class.getName(), StringPool.POUND,
+					fileEntry.getFileEntryId())));
+	}
+
+	@Test
+	public void testExportHomeFolder() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+	}
+
+	@Test
+	public void testExportImportAssetLibraryHomeFolder() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			depotEntry.getGroupId());
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportAssetLibrarySubfolder() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Folder folder = DLAppTestUtil.addFolder(depotEntry.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportCustomPortletPreference() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_portletPreferences.setValue(
+			"fileEntryId", String.valueOf(fileEntry.getFileEntryId()));
+
+		_portletPreferences.store();
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferences();
+
+		String importedfileEntryId = importedPortletPreferences.getValue(
+			"fileEntryId", "");
+
+		Assert.assertEquals(
+			fileEntry.getFileEntryId(),
+			GetterUtil.getLong(importedfileEntryId));
+	}
+
+	@Test
+	public void testExportImportHomeFolder() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportHomeFolderInAssetLibraryWithStagingInProcessFromLive()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		FileEntry liveFileEntry = DLAppTestUtil.addFileEntry(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			liveFileEntry.getTitle());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPortletPreferencesValues(liveFileEntry),
+			_getPortletPreferencesValues(stagingFileEntry));
+	}
+
+	@Test
+	public void testExportImportHomeFolderInAssetLibraryWithStagingInProcessFromStaging()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		FileEntry liveFileEntry = DLAppTestUtil.addFileEntry(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		FileEntry stagingFileEntry = _dlAppLocalService.getFileEntry(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			liveFileEntry.getTitle());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPortletPreferencesValues(stagingFileEntry),
+			_getPortletPreferencesValues(liveFileEntry));
+	}
+
+	@Test
+	public void testExportImportSubfolder() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_testExportImport(fileEntry);
+	}
+
+	@Test
+	public void testExportImportSubfolderInAssetLibraryWithStagingInProcessFromLive()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		Folder liveFolder = DLAppTestUtil.addFolder(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		Folder stagingFolder = _dlAppLocalService.getFolder(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPortletPreferencesValues(liveFolder),
+			_getPortletPreferencesValues(stagingFolder));
+	}
+
+	@Test
+	public void testExportImportSubfolderInAssetLibraryWithStagingInProcessFromStaging()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry();
+
+		Group depotLiveGroup = depotEntry.getGroup();
+
+		Folder liveFolder = DLAppTestUtil.addFolder(
+			depotLiveGroup.getGroupId());
+
+		GroupTestUtil.enableLocalStaging(depotLiveGroup);
+
+		Group depotStagingGroup = depotLiveGroup.getStagingGroup();
+
+		Folder stagingFolder = _dlAppLocalService.getFolder(
+			depotStagingGroup.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, liveFolder.getName());
+
+		_testExportImportFolderInAssetLibraryWithStagingInProcess(
+			_getPortletPreferencesValues(stagingFolder),
+			_getPortletPreferencesValues(liveFolder));
+	}
+
+	@Test
+	public void testExportImportSubfolderWithStagingInProcess()
+		throws Exception {
+
+		GroupTestUtil.enableLocalStaging(_group);
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			Group stagingGroup = _group.getStagingGroup();
+
+			Folder folder = DLAppTestUtil.addFolder(stagingGroup.getGroupId());
+
+			TestReaderWriter testReaderWriter = _getTestReaderWriter();
+
+			Map<String, String> portletPreferencesValues =
+				_getPortletPreferencesValues(folder);
+
+			_setPortletPreferences(portletPreferencesValues);
+
+			PortletPreferences exportedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processExportPortletPreferences(
+						_getExportPortletDataContext(
+							stagingGroup, testReaderWriter),
+						_portletPreferences);
+
+			Assert.assertEquals(
+				portletPreferencesValues,
+				_getPortletPreferencesValues(exportedPortletPreferences));
+
+			PortletDataContext importPortletDataContext =
+				_getImportPortletDataContext(_group, testReaderWriter);
+
+			Assert.assertNull(
+				importPortletDataContext.getZipEntryAsString(
+					String.format(
+						"%s/staging-preferences-mapping.json",
+						importPortletDataContext.getPortletId())));
+
+			PortletPreferences importedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processImportPortletPreferences(
+						importPortletDataContext, exportedPortletPreferences);
+
+			Assert.assertEquals(
+				portletPreferencesValues,
+				_getPortletPreferencesValues(importedPortletPreferences));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@Test
+	public void testExportRepository() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(repository);
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFolder.class.getName(), fileEntry.getFolderId())));
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					Repository.class.getName(), fileEntry.getRepositoryId())));
+	}
+
+	@Test
+	public void testExportSubfolder() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(folder);
+
+		_setPortletPreferences(fileEntry);
+
+		_exportPortlet();
+
+		Set<String> primaryKeys = _portletDataContextExport.getPrimaryKeys();
+
+		Assert.assertFalse(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFileEntry.class.getName(), fileEntry.getFileEntryId())));
+		Assert.assertTrue(
+			primaryKeys.toString(),
+			primaryKeys.contains(
+				_getPrimaryKey(
+					DLFolder.class.getName(), folder.getFolderId())));
+	}
+
+	private DepotEntry _addDepotEntry() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private PortletPreferences _exportImportPortletPreferences()
+		throws Exception {
+
+		PortletPreferences exportedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processExportPortletPreferences(
+					_portletDataContextExport, _portletPreferences);
+
+		return _exportImportPortletPreferencesProcessor.
+			processImportPortletPreferences(
+				_portletDataContextImport, exportedPortletPreferences);
+	}
+
+	private void _exportPortlet() throws Exception {
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		_portletExportController.exportPortlet(
+			_portletDataContextExport, _layout.getPlid(), rootElement, false,
+			false, true, true, false);
+	}
+
+	private PortletDataContext _getExportPortletDataContext(
+			Group group, ZipWriter zipWriter)
+		throws Exception {
+
+		PortletDataContext exportPortletDataContext =
+			ExportImportTestUtil.getExportPortletDataContext(
+				group.getGroupId());
+
+		exportPortletDataContext.setPortletId(
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+		exportPortletDataContext.setZipWriter(zipWriter);
+
+		return exportPortletDataContext;
+	}
+
+	private String _getFolderExternalReferenceCode(long folderId)
+		throws Exception {
+
+		if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return StringPool.BLANK;
+		}
+
+		Folder folder = _dlAppLocalService.getFolder(folderId);
+
+		return folder.getExternalReferenceCode();
+	}
+
+	private String _getGroupExternalReferenceCode(
+			long groupId, Repository repository)
+		throws Exception {
+
+		Group group;
+
+		if (repository == null) {
+			group = _groupLocalService.getGroup(groupId);
+		}
+		else {
+			group = _groupLocalService.getGroup(repository.getGroupId());
+		}
+
+		return group.getExternalReferenceCode();
+	}
+
+	private PortletDataContext _getImportPortletDataContext(
+			Group group, ZipReader zipReader)
+		throws Exception {
+
+		PortletDataContext importPortletDataContext =
+			ExportImportTestUtil.getImportPortletDataContext(
+				group.getGroupId());
+
+		importPortletDataContext.setPortletId(
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+		importPortletDataContext.setZipReader(zipReader);
+
+		return importPortletDataContext;
+	}
+
+	private Map<String, String> _getPortletPreferencesValues(
+			FileEntry fileEntry)
+		throws Exception {
+
+		Repository repository = _repositoryLocalService.fetchRepository(
+			fileEntry.getRepositoryId());
+
+		return _getPortletPreferencesValues(
+			_getFolderExternalReferenceCode(fileEntry.getFolderId()),
+			_getGroupExternalReferenceCode(
+				fileEntry.getRepositoryId(), repository),
+			_getRepositoryExternalReferenceCode(repository));
+	}
+
+	private Map<String, String> _getPortletPreferencesValues(Folder folder)
+		throws Exception {
+
+		Repository repository = _repositoryLocalService.fetchRepository(
+			folder.getRepositoryId());
+
+		return _getPortletPreferencesValues(
+			folder.getExternalReferenceCode(),
+			_getGroupExternalReferenceCode(
+				folder.getRepositoryId(), repository),
+			_getRepositoryExternalReferenceCode(repository));
+	}
+
+	private Map<String, String> _getPortletPreferencesValues(
+		PortletPreferences portletPreferences) {
+
+		return _getPortletPreferencesValues(
+			portletPreferences.getValue(
+				"rootFolderExternalReferenceCode", null),
+			portletPreferences.getValue(
+				"selectedGroupExternalReferenceCode", null),
+			portletPreferences.getValue(
+				"selectedRepositoryExternalReferenceCode", null));
+	}
+
+	private Map<String, String> _getPortletPreferencesValues(
+		String rootFolderExternalReferenceCode,
+		String selectedGroupExternalReferenceCode,
+		String selectedRepositoryExternalReferenceCode) {
+
+		return HashMapBuilder.put(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode
+		).put(
+			"selectedGroupExternalReferenceCode",
+			selectedGroupExternalReferenceCode
+		).put(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode
+		).build();
+	}
+
+	private String _getPrimaryKey(String className, Serializable classPK) {
+		return StringBundler.concat(
+			String.class.getName(), StringPool.POUND, className,
+			StringPool.POUND, classPK);
+	}
+
+	private String _getRepositoryExternalReferenceCode(Repository repository) {
+		if (repository == null) {
+			return StringPool.BLANK;
+		}
+
+		return repository.getExternalReferenceCode();
+	}
+
+	private TestReaderWriter _getTestReaderWriter() {
+		TestReaderWriter testReaderWriter = new TestReaderWriter();
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element manifestRootElement = document.addElement("root");
+
+		manifestRootElement.addElement("header");
+
+		testReaderWriter.addEntry("/manifest.xml", document.asXML());
+
+		return testReaderWriter;
+	}
+
+	private void _setPortletPreferences(FileEntry fileEntry) throws Exception {
+		_setPortletPreferences(_getPortletPreferencesValues(fileEntry));
+	}
+
+	private void _setPortletPreferences(
+			Map<String, String> portletPreferencesValues)
+		throws Exception {
+
+		for (Map.Entry<String, String> entry :
+				portletPreferencesValues.entrySet()) {
+
+			_portletPreferences.setValue(entry.getKey(), entry.getValue());
+		}
+
+		_portletPreferences.store();
+	}
+
+	private void _testExportImport(FileEntry fileEntry) throws Exception {
+		Map<String, String> portletPreferencesValues =
+			_getPortletPreferencesValues(fileEntry);
+
+		_setPortletPreferences(portletPreferencesValues);
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferences();
+
+		Assert.assertEquals(
+			portletPreferencesValues,
+			_getPortletPreferencesValues(importedPortletPreferences));
+	}
+
+	private void _testExportImportFolderInAssetLibraryWithStagingInProcess(
+			Map<String, String> originalPortletPreferencesValues,
+			Map<String, String> expectedPortletPreferencesValues)
+		throws Exception {
+
+		ExportImportThreadLocal.setPortletStagingInProcess(true);
+
+		try {
+			TestReaderWriter testReaderWriter = _getTestReaderWriter();
+
+			_setPortletPreferences(originalPortletPreferencesValues);
+
+			PortletPreferences exportedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processExportPortletPreferences(
+						_getExportPortletDataContext(_group, testReaderWriter),
+						_portletPreferences);
+
+			Assert.assertEquals(
+				originalPortletPreferencesValues,
+				_getPortletPreferencesValues(exportedPortletPreferences));
+
+			PortletDataContext importPortletDataContext =
+				_getImportPortletDataContext(_group, testReaderWriter);
+
+			Assert.assertNotNull(
+				importPortletDataContext.getZipEntryAsString(
+					String.format(
+						"%s/staging-preferences-mapping.json",
+						importPortletDataContext.getPortletId())));
+
+			PortletPreferences importedPortletPreferences =
+				_exportImportPortletPreferencesProcessor.
+					processImportPortletPreferences(
+						importPortletDataContext, exportedPortletPreferences);
+
+			Assert.assertEquals(
+				expectedPortletPreferencesValues,
+				_getPortletPreferencesValues(importedPortletPreferences));
+		}
+		finally {
+			ExportImportThreadLocal.setPortletStagingInProcess(false);
+		}
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject(
+		filter = "javax.portlet.name=" + DLPortletKeys.MEDIA_GALLERY_DISPLAY
+	)
+	private ExportImportPortletPreferencesProcessor
+		_exportImportPortletPreferencesProcessor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private Layout _layout;
+
+	@Inject
+	private Portal _portal;
+
+	private PortletDataContext _portletDataContextExport;
+	private PortletDataContext _portletDataContextImport;
+
+	@Inject
+	private PortletExportController _portletExportController;
+
+	private PortletPreferences _portletPreferences;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/test/UpgradePortletPreferencesTest.java
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletPreferencesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, DLPortletKeys.MEDIA_GALLERY_DISPLAY);
+	}
+
+	@Test
+	public void testUpgradeHomeFolderSelected() throws Exception {
+		_testUpgrade(
+			_getMap(
+				StringPool.BLANK, _group.getExternalReferenceCode(),
+				StringPool.BLANK),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				_group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeInvalidRepository() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testUpgradeInvalidRootFolder() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			_getMap(RandomTestUtil.randomLong(), _group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeMissingRepository() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			HashMapBuilder.put(
+				"rootFolderId",
+				String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)
+			).build());
+	}
+
+	@Test
+	public void testUpgradeMissingRootFolder() throws Exception {
+		_testUpgrade(
+			Collections.emptyMap(),
+			HashMapBuilder.put(
+				"selectedRepositoryId", String.valueOf(_group.getGroupId())
+			).build());
+	}
+
+	@Test
+	public void testUpgradeRepositoryHomeFolderSelected() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		_testUpgrade(
+			_getMap(
+				StringPool.BLANK, _group.getExternalReferenceCode(),
+				repository.getExternalReferenceCode()),
+			_getMap(
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				repository.getRepositoryId()));
+	}
+
+	@Test
+	public void testUpgradeRepositorySubfolderSelected() throws Exception {
+		Repository repository = DLAppTestUtil.addRepository(
+			_group.getGroupId());
+
+		Folder folder = DLAppTestUtil.addFolder(repository);
+
+		_testUpgrade(
+			_getMap(
+				folder.getExternalReferenceCode(),
+				_group.getExternalReferenceCode(),
+				repository.getExternalReferenceCode()),
+			_getMap(folder.getFolderId(), repository.getRepositoryId()));
+	}
+
+	@Test
+	public void testUpgradeSubfolderSelected() throws Exception {
+		Folder folder = DLAppTestUtil.addFolder(_group.getGroupId());
+
+		_testUpgrade(
+			_getMap(
+				folder.getExternalReferenceCode(),
+				_group.getExternalReferenceCode(), StringPool.BLANK),
+			_getMap(folder.getFolderId(), _group.getGroupId()));
+	}
+
+	@Test
+	public void testUpgradeWithoutSelectedFolder() throws Exception {
+		_testUpgrade(Collections.emptyMap(), Collections.emptyMap());
+	}
+
+	private void _assertPortletPreferences(Map<String, String> expectedMap)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		Map<String, String[]> map = portletPreferences.getMap();
+
+		Assert.assertEquals(
+			MapUtil.toString(map), expectedMap.size(), map.size());
+
+		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
+			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
+
+			Assert.assertArrayEquals(
+				new String[] {entry.getValue()}, map.get(entry.getKey()));
+		}
+	}
+
+	private Map<String, String> _getMap(
+		long rootFolderId, long selectedRepositoryId) {
+
+		return HashMapBuilder.put(
+			"rootFolderId", String.valueOf(rootFolderId)
+		).put(
+			"selectedRepositoryId", String.valueOf(selectedRepositoryId)
+		).build();
+	}
+
+	private Map<String, String> _getMap(
+		String rootFolderExternalReferenceCode,
+		String selectedGroupExternalReferenceCode,
+		String selectedRepositoryExternalReferenceCode) {
+
+		return HashMapBuilder.put(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode
+		).put(
+			"selectedGroupExternalReferenceCode",
+			selectedGroupExternalReferenceCode
+		).put(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode
+		).build();
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _testUpgrade(
+			Map<String, String> expectedMap, Map<String, String> map)
+		throws Exception {
+
+		LayoutTestUtil.updateLayoutPortletPreferences(_layout, _portletId, map);
+
+		_assertPortletPreferences(map);
+
+		_runUpgrade();
+
+		_assertPortletPreferences(expectedMap);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.document.library.web.internal.upgrade.v1_2_0." +
+			"UpgradePortletPreferences";
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private String _portletId;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.document.library.web.internal.upgrade.registry.DLWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -23,7 +23,6 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
-import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
@@ -98,7 +97,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.trash.TrashHelper;
 
@@ -391,7 +389,8 @@ public class DLAdminDisplayContext {
 			repositoryId = folder.getRepositoryId();
 		}
 		else {
-			repositoryId = _getSelectedRepositoryId();
+			repositoryId =
+				_dlPortletInstanceSettingsHelper.getSelectedRepositoryId();
 		}
 
 		if (repositoryId == 0) {
@@ -456,7 +455,8 @@ public class DLAdminDisplayContext {
 			return _selectedRepositoryId;
 		}
 
-		long repositoryId = _getSelectedRepositoryId();
+		long repositoryId =
+			_dlPortletInstanceSettingsHelper.getSelectedRepositoryId();
 
 		if (repositoryId != 0) {
 			_selectedRepositoryId = repositoryId;
@@ -602,32 +602,17 @@ public class DLAdminDisplayContext {
 	}
 
 	private void _computeRootFolder() {
-		_rootFolder = null;
 		_rootFolderName = StringPool.BLANK;
 
-		String rootFolderExternalReferenceCode =
-			_dlPortletInstanceSettings.getRootFolderExternalReferenceCode();
-
-		if (Validator.isBlank(rootFolderExternalReferenceCode)) {
-			_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
-			_rootFolderName = LanguageUtil.get(_httpServletRequest, "home");
-
-			return;
-		}
-
-		String selectedGroupExternalReferenceCode =
-			_dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode();
-
 		try {
-			Group selectedGroup =
-				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
-					selectedGroupExternalReferenceCode,
-					_themeDisplay.getCompanyId());
+			_rootFolder = _dlPortletInstanceSettingsHelper.getRootFolder();
 
-			_rootFolder = new LiferayFolder(
-				DLFolderLocalServiceUtil.getDLFolderByExternalReferenceCode(
-					rootFolderExternalReferenceCode,
-					selectedGroup.getGroupId()));
+			if (_rootFolder == null) {
+				_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+				_rootFolderName = LanguageUtil.get(_httpServletRequest, "home");
+
+				return;
+			}
 
 			_rootFolderId = _rootFolder.getFolderId();
 
@@ -656,9 +641,12 @@ public class DLAdminDisplayContext {
 				_log.warn(
 					StringBundler.concat(
 						"Could not find folder {folderExternalReferenceCode=",
-						rootFolderExternalReferenceCode,
+						_dlPortletInstanceSettings.
+							getRootFolderExternalReferenceCode(),
 						", groupExternalReferenceCode=",
-						selectedGroupExternalReferenceCode, "}"),
+						_dlPortletInstanceSettings.
+							getSelectedGroupExternalReferenceCode(),
+						"}"),
 					noSuchFolderException);
 			}
 
@@ -1168,40 +1156,6 @@ public class DLAdminDisplayContext {
 			() -> _getSearchResults(hits), hits.getLength());
 
 		return searchContainer;
-	}
-
-	private long _getSelectedRepositoryId() {
-		String selectedGroupExternalReferenceCode =
-			_dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode();
-
-		if (Validator.isBlank(selectedGroupExternalReferenceCode)) {
-			return 0;
-		}
-
-		try {
-			Group selectedGroup =
-				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
-					selectedGroupExternalReferenceCode,
-					_themeDisplay.getCompanyId());
-
-			String selectedRepositoryExternalReferenceCode =
-				_dlPortletInstanceSettings.
-					getSelectedRepositoryExternalReferenceCode();
-
-			if (Validator.isBlank(selectedRepositoryExternalReferenceCode)) {
-				return selectedGroup.getGroupId();
-			}
-
-			Repository selectedRepository =
-				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
-					selectedRepositoryExternalReferenceCode,
-					selectedGroup.getGroupId());
-
-			return selectedRepository.getRepositoryId();
-		}
-		catch (PortalException portalException) {
-			throw new SystemException(portalException);
-		}
 	}
 
 	private Sort _getSort(String orderByCol, String orderByType) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGConfigurationDisplayContext.java
@@ -8,10 +8,8 @@ package com.liferay.document.library.web.internal.display.context;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
 import com.liferay.document.library.web.internal.display.context.helper.IGRequestHelper;
-import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
 import com.liferay.document.library.web.internal.util.DLFolderUtil;
 import com.liferay.document.library.web.internal.util.FolderItemSelectorURLProvider;
 import com.liferay.item.selector.ItemSelector;
@@ -35,7 +33,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.trash.TrashHelper;
 
 import java.util.List;
-import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
@@ -48,12 +45,10 @@ import javax.servlet.http.HttpServletRequest;
 public class IGConfigurationDisplayContext {
 
 	public IGConfigurationDisplayContext(
-		DLAppLocalService dlAppLocalService, ItemSelector itemSelector,
-		HttpServletRequest httpServletRequest,
+		ItemSelector itemSelector, HttpServletRequest httpServletRequest,
 		PortletPreferencesLocalService portletPreferencesLocalService,
 		TrashHelper trashHelper) {
 
-		_dlAppLocalService = dlAppLocalService;
 		_itemSelector = itemSelector;
 		_httpServletRequest = httpServletRequest;
 		_portletPreferencesLocalService = portletPreferencesLocalService;
@@ -109,10 +104,6 @@ public class IGConfigurationDisplayContext {
 	public String getRootFolderName() throws PortalException {
 		_initFolder();
 
-		if (Objects.equals(_folderName, StringPool.BLANK)) {
-			_folderName = _getFolderName();
-		}
-
 		return _folderName;
 	}
 
@@ -147,41 +138,6 @@ public class IGConfigurationDisplayContext {
 		return _dlPortletInstanceSettingsHelper.isShowActions();
 	}
 
-	private Folder _getFolder() {
-		try {
-			return _dlAppLocalService.getFolder(_folderId);
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			_folderNotFound = true;
-
-			return null;
-		}
-	}
-
-	private String _getFolderName() {
-		if ((_folderId == null) ||
-			(_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
-
-			return LanguageUtil.get(_httpServletRequest, "home");
-		}
-
-		Folder folder = _getFolder();
-
-		if (folder == null) {
-			return StringPool.BLANK;
-		}
-
-		if (_folderInTrash) {
-			return _trashHelper.getOriginalTitle(_folder.getName());
-		}
-
-		return folder.getName();
-	}
-
 	private PortletPreferences _getPortletPreferences() {
 		if (_portletPreferences != null) {
 			return _portletPreferences;
@@ -212,25 +168,31 @@ public class IGConfigurationDisplayContext {
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 		_folderInTrash = false;
 		_folderName = StringPool.BLANK;
+
 		_folderNotFound = false;
 
-		DLPortletInstanceSettings dlPortletInstanceSettings =
-			_igRequestHelper.getDLPortletInstanceSettings();
+		try {
+			_folder = _dlPortletInstanceSettingsHelper.getRootFolder();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
 
-		_folderId = dlPortletInstanceSettings.getRootFolderId();
+			_folderNotFound = true;
 
-		if (_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			return;
 		}
 
-		Folder folder = _getFolder();
+		if (_folder == null) {
+			_folderName = LanguageUtil.get(_httpServletRequest, "home");
 
-		if (folder == null) {
 			return;
 		}
 
-		_folder = folder;
-		_folderName = folder.getName();
+		_folderId = _folder.getFolderId();
+
+		_folderName = _folder.getName();
 
 		if (_folder.isRepositoryCapabilityProvided(TrashCapability.class)) {
 			TrashCapability trashCapability = _folder.getRepositoryCapability(
@@ -262,23 +224,14 @@ public class IGConfigurationDisplayContext {
 			return;
 		}
 
-		DLPortletInstanceSettings dlPortletInstanceSettings =
-			_igRequestHelper.getDLPortletInstanceSettings();
-
 		_selectedRepositoryId =
-			dlPortletInstanceSettings.getSelectedRepositoryId();
+			_dlPortletInstanceSettingsHelper.getSelectedRepositoryId();
 
 		if (_selectedRepositoryId != 0) {
 			return;
 		}
 
 		_initFolder();
-
-		if ((_folder == null) && (_folderId != null) &&
-			(_folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
-
-			_folder = _getFolder();
-		}
 
 		if (_folder != null) {
 			_selectedRepositoryId = _folder.getRepositoryId();
@@ -293,7 +246,6 @@ public class IGConfigurationDisplayContext {
 	private static final Log _log = LogFactoryUtil.getLog(
 		IGConfigurationDisplayContext.class);
 
-	private final DLAppLocalService _dlAppLocalService;
 	private final DLPortletInstanceSettingsHelper
 		_dlPortletInstanceSettingsHelper;
 	private Folder _folder;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/IGViewDisplayContext.java
@@ -13,6 +13,7 @@ import com.liferay.document.library.kernel.model.DLFileShortcutConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
 import com.liferay.document.library.web.internal.display.context.helper.IGRequestHelper;
 import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
@@ -52,6 +53,9 @@ public class IGViewDisplayContext {
 		_igRequestHelper = igRequestHelper;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
+
+		_dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(
+			igRequestHelper);
 
 		_httpServletRequest = igRequestHelper.getRequest();
 
@@ -213,15 +217,10 @@ public class IGViewDisplayContext {
 			return _repositoryId;
 		}
 
-		DLPortletInstanceSettings dlPortletInstanceSettings =
-			_getDLPortletInstanceSettings();
+		_repositoryId =
+			_dlPortletInstanceSettingsHelper.getSelectedRepositoryId();
 
-		_repositoryId = dlPortletInstanceSettings.getSelectedRepositoryId();
-
-		if ((_folder != null) &&
-			(dlPortletInstanceSettings.getSelectedRepositoryId() !=
-				_folder.getRepositoryId())) {
-
+		if ((_folder != null) && (_repositoryId != _folder.getRepositoryId())) {
 			_repositoryId = _folder.getRepositoryId();
 		}
 		else if (_repositoryId == 0) {
@@ -236,26 +235,21 @@ public class IGViewDisplayContext {
 			return _rootFolderId;
 		}
 
-		DLPortletInstanceSettings dlPortletInstanceSettings =
-			_getDLPortletInstanceSettings();
+		_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 
-		_rootFolderId = dlPortletInstanceSettings.getRootFolderId();
+		try {
+			Folder rootFolder =
+				_dlPortletInstanceSettingsHelper.getRootFolder();
 
-		if (_rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			try {
-				Folder rootFolder = DLAppLocalServiceUtil.getFolder(
-					_rootFolderId);
+			if ((rootFolder != null) &&
+				(rootFolder.getGroupId() == _themeDisplay.getScopeGroupId())) {
 
-				if (rootFolder.getGroupId() !=
-						_themeDisplay.getScopeGroupId()) {
-
-					_rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
-				}
+				_rootFolderId = rootFolder.getFolderId();
 			}
-			catch (Exception exception) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(exception);
-				}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
 			}
 		}
 
@@ -358,9 +352,7 @@ public class IGViewDisplayContext {
 			WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 		_folderId = BeanParamUtil.getLong(
-			(Folder)_httpServletRequest.getAttribute(
-				WebKeys.DOCUMENT_LIBRARY_FOLDER),
-			_httpServletRequest, "folderId", getRootFolderId());
+			_folder, _httpServletRequest, "folderId", getRootFolderId());
 
 		_defaultFolderView = false;
 
@@ -391,6 +383,8 @@ public class IGViewDisplayContext {
 	private String _assetTagName;
 	private Boolean _defaultFolderView;
 	private DLPortletInstanceSettings _dlPortletInstanceSettings;
+	private final DLPortletInstanceSettingsHelper
+		_dlPortletInstanceSettingsHelper;
 	private Folder _folder;
 	private long _folderId;
 	private Integer _folderImagesCount;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
@@ -8,7 +8,7 @@ package com.liferay.document.library.web.internal.display.context.helper;
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -31,7 +31,6 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.view.count.ViewCountManagerUtil;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
@@ -137,9 +136,8 @@ public class DLPortletInstanceSettingsHelper {
 					getSelectedGroupExternalReferenceCode(),
 				themeDisplay.getCompanyId());
 
-		return new LiferayFolder(
-			DLFolderLocalServiceUtil.getDLFolderByExternalReferenceCode(
-				rootFolderExternalReferenceCode, selectedGroup.getGroupId()));
+		return DLAppLocalServiceUtil.getFolderByExternalReferenceCode(
+			rootFolderExternalReferenceCode, selectedGroup.getGroupId());
 	}
 
 	public long getRootFolderId() throws PortalException {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
@@ -7,10 +7,19 @@ package com.liferay.document.library.web.internal.display.context.helper;
 
 import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -20,7 +29,9 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.view.count.ViewCountManagerUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
@@ -105,6 +116,79 @@ public class DLPortletInstanceSettingsHelper {
 		}
 
 		return entryColumns;
+	}
+
+	public Folder getRootFolder() throws PortalException {
+		DLPortletInstanceSettings dlPortletInstanceSettings =
+			_dlRequestHelper.getDLPortletInstanceSettings();
+
+		String rootFolderExternalReferenceCode =
+			dlPortletInstanceSettings.getRootFolderExternalReferenceCode();
+
+		if (Validator.isBlank(rootFolderExternalReferenceCode)) {
+			return null;
+		}
+
+		ThemeDisplay themeDisplay = _dlRequestHelper.getThemeDisplay();
+
+		Group selectedGroup =
+			GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+				dlPortletInstanceSettings.
+					getSelectedGroupExternalReferenceCode(),
+				themeDisplay.getCompanyId());
+
+		return new LiferayFolder(
+			DLFolderLocalServiceUtil.getDLFolderByExternalReferenceCode(
+				rootFolderExternalReferenceCode, selectedGroup.getGroupId()));
+	}
+
+	public long getRootFolderId() throws PortalException {
+		Folder rootFolder = getRootFolder();
+
+		if (rootFolder == null) {
+			return DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+		}
+
+		return rootFolder.getFolderId();
+	}
+
+	public long getSelectedRepositoryId() {
+		DLPortletInstanceSettings dlPortletInstanceSettings =
+			_dlRequestHelper.getDLPortletInstanceSettings();
+
+		String selectedGroupExternalReferenceCode =
+			dlPortletInstanceSettings.getSelectedGroupExternalReferenceCode();
+
+		if (Validator.isBlank(selectedGroupExternalReferenceCode)) {
+			return 0;
+		}
+
+		try {
+			ThemeDisplay themeDisplay = _dlRequestHelper.getThemeDisplay();
+
+			Group selectedGroup =
+				GroupLocalServiceUtil.getGroupByExternalReferenceCode(
+					selectedGroupExternalReferenceCode,
+					themeDisplay.getCompanyId());
+
+			String selectedRepositoryExternalReferenceCode =
+				dlPortletInstanceSettings.
+					getSelectedRepositoryExternalReferenceCode();
+
+			if (Validator.isBlank(selectedRepositoryExternalReferenceCode)) {
+				return selectedGroup.getGroupId();
+			}
+
+			Repository selectedRepository =
+				RepositoryLocalServiceUtil.getRepositoryByExternalReferenceCode(
+					selectedRepositoryExternalReferenceCode,
+					selectedGroup.getGroupId());
+
+			return selectedRepository.getRepositoryId();
+		}
+		catch (PortalException portalException) {
+			throw new SystemException(portalException);
+		}
 	}
 
 	public boolean isShowActions() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLAdminPortletDataHandler.java
@@ -190,9 +190,12 @@ public class DLAdminPortletDataHandler extends BasePortletDataHandler {
 		portletPreferences.setValue("fileEntryColumns", StringPool.BLANK);
 		portletPreferences.setValue("folderColumns", StringPool.BLANK);
 		portletPreferences.setValue("foldersPerPage", StringPool.BLANK);
-		portletPreferences.setValue("repositoryId", StringPool.BLANK);
-		portletPreferences.setValue("rootFolderId", StringPool.BLANK);
-		portletPreferences.setValue("selectedRepositoryId", StringPool.BLANK);
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", StringPool.BLANK);
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode", StringPool.BLANK);
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode", StringPool.BLANK);
 		portletPreferences.setValue("showFoldersSearch", StringPool.BLANK);
 		portletPreferences.setValue("showSubfolders", StringPool.BLANK);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/DLPortletDataHandler.java
@@ -110,7 +110,10 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);
 		setDataLocalized(true);
-		setDataPortletPreferences("rootFolderId", "selectedRepositoryId");
+		setDataPortletPreferences(
+			"rootFolderExternalReferenceCode",
+			"selectedGroupExternalReferenceCode",
+			"selectedRepositoryExternalReferenceCode");
 		setDeletionSystemEventStagedModelTypes(
 			new StagedModelType(DLFileEntryType.class),
 			new StagedModelType(DLFileShortcut.class),

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/IGDisplayPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/lar/IGDisplayPortletDataHandler.java
@@ -38,7 +38,10 @@ public class IGDisplayPortletDataHandler extends BasePortletDataHandler {
 	@Activate
 	protected void activate() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);
-		setDataPortletPreferences("rootFolderId", "selectedRepositoryId");
+		setDataPortletPreferences(
+			"rootFolderExternalReferenceCode",
+			"selectedGroupExternalReferenceCode",
+			"selectedRepositoryExternalReferenceCode");
 		setExportControls(new PortletDataHandlerControl[0]);
 		setPublishToLiveByDefault(PropsValues.DL_PUBLISH_TO_LIVE_BY_DEFAULT);
 	}
@@ -57,9 +60,12 @@ public class IGDisplayPortletDataHandler extends BasePortletDataHandler {
 		portletPreferences.setValue("fileEntryColumns", StringPool.BLANK);
 		portletPreferences.setValue("folderColumns", StringPool.BLANK);
 		portletPreferences.setValue("foldersPerPage", StringPool.BLANK);
-		portletPreferences.setValue("repositoryId", StringPool.BLANK);
-		portletPreferences.setValue("rootFolderId", StringPool.BLANK);
-		portletPreferences.setValue("selectedRepositoryId", StringPool.BLANK);
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", StringPool.BLANK);
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode", StringPool.BLANK);
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode", StringPool.BLANK);
 		portletPreferences.setValue("showSubfolders", StringPool.BLANK);
 
 		return portletPreferences;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ActionUtil.java
@@ -12,6 +12,8 @@ import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.processor.RawMetadataProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.service.DLFileVersionPreviewLocalServiceUtil;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
 import com.liferay.document.library.web.internal.security.permission.resource.DLPermission;
 import com.liferay.document.library.web.internal.util.DLFolderUtil;
 import com.liferay.petra.lang.SafeCloseable;
@@ -20,7 +22,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.repository.capabilities.TrashCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -29,10 +30,8 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RepositoryServiceUtil;
-import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,7 +40,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
 import javax.servlet.http.HttpServletRequest;
@@ -213,20 +211,16 @@ public class ActionUtil {
 			httpServletRequest, "ignoreRootFolder");
 
 		if ((folderId <= 0) && !ignoreRootFolder) {
-			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
-
-			String portletId = portletDisplay.getId();
-
 			try (SafeCloseable safeCloseable =
 					CTCollectionThreadLocal.
 						setProductionModeWithSafeCloseable()) {
 
-				PortletPreferences portletPreferences =
-					PortletPreferencesFactoryUtil.getPortletPreferences(
-						httpServletRequest, portletId);
+				DLPortletInstanceSettingsHelper
+					dlPortletInstanceSettingsHelper =
+						new DLPortletInstanceSettingsHelper(
+							new DLRequestHelper(httpServletRequest));
 
-				folderId = GetterUtil.getLong(
-					portletPreferences.getValue("rootFolderId", null));
+				folderId = dlPortletInstanceSettingsHelper.getRootFolderId();
 			}
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/BaseValidateRootFolderConfigurationAction.java
@@ -7,13 +7,23 @@ package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchRepositoryEntryException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.BaseJSPSettingsConfigurationAction;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
+import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -22,6 +32,11 @@ import com.liferay.portal.kernel.util.Validator;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+import javax.portlet.ReadOnlyException;
+
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -45,10 +60,87 @@ public abstract class BaseValidateRootFolderConfigurationAction
 		super.processAction(portletConfig, actionRequest, actionResponse);
 	}
 
+	@Override
+	protected void postProcess(
+			long companyId, PortletRequest portletRequest, Settings settings)
+		throws PortalException {
+
+		PortletPreferencesSettings portletPreferencesSettings =
+			(PortletPreferencesSettings)settings.getParentSettings();
+
+		PortletPreferences portletPreferences =
+			portletPreferencesSettings.getPortletPreferences();
+
+		long rootFolderId = GetterUtil.getLong(
+			portletPreferences.getValue("rootFolderId", null));
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", null));
+
+		try {
+			_setPortletPreferences(
+				portletPreferences, rootFolderId, selectedRepositoryId);
+		}
+		catch (ReadOnlyException readOnlyException) {
+			throw new SystemException(readOnlyException);
+		}
+	}
+
 	protected void validate(ActionRequest actionRequest)
 		throws PortalException {
 
 		_validateRootFolder(actionRequest);
+	}
+
+	@Reference
+	protected DLAppLocalService dlAppLocalService;
+
+	@Reference
+	protected GroupLocalService groupLocalService;
+
+	@Reference
+	protected RepositoryLocalService repositoryLocalService;
+
+	private void _setPortletPreferences(
+			PortletPreferences portletPreferences, long rootFolderId,
+			long selectedRepositoryId)
+		throws PortalException, ReadOnlyException {
+
+		String rootFolderExternalReferenceCode = StringPool.BLANK;
+
+		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			Folder folder = dlAppLocalService.getFolder(rootFolderId);
+
+			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
+		}
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
+
+		Group selectedGroup = null;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		Repository selectedRepository = repositoryLocalService.fetchRepository(
+			selectedRepositoryId);
+
+		if (selectedRepository == null) {
+			selectedGroup = groupLocalService.getGroup(selectedRepositoryId);
+		}
+		else {
+			selectedGroup = groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode",
+			selectedGroup.getExternalReferenceCode());
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode);
+
+		portletPreferences.reset("rootFolderId");
+		portletPreferences.reset("selectedRepositoryId");
 	}
 
 	private void _validateRootFolder(ActionRequest actionRequest)

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLConfigurationAction.java
@@ -6,31 +6,17 @@
 package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.kernel.model.DLFolderConstants;
-import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.display.context.DLAdminDisplayContext;
 import com.liferay.document.library.web.internal.display.context.DLAdminDisplayContextProvider;
 import com.liferay.item.selector.ItemSelector;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
-import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
-import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.PortletConfig;
-import javax.portlet.PortletPreferences;
-import javax.portlet.PortletRequest;
-import javax.portlet.ReadOnlyException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -70,80 +56,12 @@ public class DLConfigurationAction
 	}
 
 	@Override
-	protected void postProcess(
-			long companyId, PortletRequest portletRequest, Settings settings)
-		throws PortalException {
-
-		PortletPreferencesSettings portletPreferencesSettings =
-			(PortletPreferencesSettings)settings.getParentSettings();
-
-		PortletPreferences portletPreferences =
-			portletPreferencesSettings.getPortletPreferences();
-
-		long rootFolderId = GetterUtil.getLong(
-			portletPreferences.getValue("rootFolderId", null));
-		long selectedRepositoryId = GetterUtil.getLong(
-			portletPreferences.getValue("selectedRepositoryId", null));
-
-		try {
-			_setPortletPreferences(
-				portletPreferences, rootFolderId, selectedRepositoryId);
-		}
-		catch (ReadOnlyException readOnlyException) {
-			throw new SystemException(readOnlyException);
-		}
-	}
-
-	@Override
 	protected void validate(ActionRequest actionRequest)
 		throws PortalException {
 
 		_validateDisplayStyleViews(actionRequest);
 
 		super.validate(actionRequest);
-	}
-
-	private void _setPortletPreferences(
-			PortletPreferences portletPreferences, long rootFolderId,
-			long selectedRepositoryId)
-		throws PortalException, ReadOnlyException {
-
-		String rootFolderExternalReferenceCode = StringPool.BLANK;
-
-		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			Folder folder = _dlAppLocalService.getFolder(rootFolderId);
-
-			rootFolderExternalReferenceCode = folder.getExternalReferenceCode();
-		}
-
-		portletPreferences.setValue(
-			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
-
-		Group selectedGroup = null;
-		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
-
-		Repository selectedRepository = _repositoryLocalService.fetchRepository(
-			selectedRepositoryId);
-
-		if (selectedRepository == null) {
-			selectedGroup = _groupLocalService.getGroup(selectedRepositoryId);
-		}
-		else {
-			selectedGroup = _groupLocalService.getGroup(
-				selectedRepository.getGroupId());
-			selectedRepositoryExternalReferenceCode =
-				selectedRepository.getExternalReferenceCode();
-		}
-
-		portletPreferences.setValue(
-			"selectedGroupExternalReferenceCode",
-			selectedGroup.getExternalReferenceCode());
-		portletPreferences.setValue(
-			"selectedRepositoryExternalReferenceCode",
-			selectedRepositoryExternalReferenceCode);
-
-		portletPreferences.reset("rootFolderId");
-		portletPreferences.reset("selectedRepositoryId");
 	}
 
 	private void _validateDisplayStyleViews(ActionRequest actionRequest) {
@@ -159,15 +77,6 @@ public class DLConfigurationAction
 	private DLAdminDisplayContextProvider _dlAdminDisplayContextProvider;
 
 	@Reference
-	private DLAppLocalService _dlAppLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
 	private ItemSelector _itemSelector;
-
-	@Reference
-	private RepositoryLocalService _repositoryLocalService;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/IGDisplayConfigurationAction.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/IGDisplayConfigurationAction.java
@@ -6,7 +6,6 @@
 package com.liferay.document.library.web.internal.portlet.action;
 
 import com.liferay.document.library.constants.DLPortletKeys;
-import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.web.internal.display.context.IGConfigurationDisplayContext;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
@@ -45,14 +44,11 @@ public class IGDisplayConfigurationAction
 		httpServletRequest.setAttribute(
 			IGConfigurationDisplayContext.class.getName(),
 			new IGConfigurationDisplayContext(
-				_dlAppLocalService, _itemSelector, httpServletRequest,
+				_itemSelector, httpServletRequest,
 				_portletPreferencesLocalService, _trashHelper));
 
 		super.include(portletConfig, httpServletRequest, httpServletResponse);
 	}
-
-	@Reference
-	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/util/DLPortletToolbarContributorUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/util/DLPortletToolbarContributorUtil.java
@@ -9,6 +9,8 @@ import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
 import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -18,6 +20,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.PortletRequest;
@@ -58,41 +61,24 @@ public class DLPortletToolbarContributorUtil {
 			_log.error(portalException);
 		}
 
-		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
-
-		long rootFolderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
-
 		try {
-			DLPortletInstanceSettings dlPortletInstanceSettings =
-				DLPortletInstanceSettings.getInstance(
-					themeDisplay.getLayout(), portletDisplay.getId());
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				new DLPortletInstanceSettingsHelper(
+					new DLRequestHelper(
+						PortalUtil.getHttpServletRequest(portletRequest)));
 
-			rootFolderId = dlPortletInstanceSettings.getRootFolderId();
+			return dlPortletInstanceSettingsHelper.getRootFolder();
+		}
+		catch (NoSuchFolderException | PrincipalException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
 
-		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			try {
-				folder = dlAppLocalService.getFolder(rootFolderId);
-			}
-			catch (NoSuchFolderException | PrincipalException exception) {
-
-				// LPS-52675
-
-				if (_log.isDebugEnabled()) {
-					_log.debug(exception);
-				}
-
-				folder = null;
-			}
-			catch (PortalException portalException) {
-				_log.error(portalException);
-			}
-		}
-
-		return folder;
+		return null;
 	}
 
 	public static Boolean isShowActionsEnabled(ThemeDisplay themeDisplay) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/registry/DLWebUpgradeStepRegistrator.java
@@ -49,6 +49,13 @@ public class DLWebUpgradeStepRegistrator implements UpgradeStepRegistrator {
 				UpgradePortletPreferences(
 					_dlAppLocalService, _groupLocalService,
 					_repositoryLocalService));
+
+		registry.register(
+			"1.1.0", "1.2.0",
+			new com.liferay.document.library.web.internal.upgrade.v1_2_0.
+				UpgradePortletPreferences(
+					_dlAppLocalService, _groupLocalService,
+					_repositoryLocalService));
 	}
 
 	@Reference

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/UpgradePortletPreferences.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upgrade/v1_2_0/UpgradePortletPreferences.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.web.internal.upgrade.v1_2_0;
+
+import com.liferay.document.library.constants.DLPortletKeys;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import javax.portlet.PortletPreferences;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class UpgradePortletPreferences
+	extends BasePortletPreferencesUpgradeProcess {
+
+	public UpgradePortletPreferences(
+		DLAppLocalService dlAppLocalService,
+		GroupLocalService groupLocalService,
+		RepositoryLocalService repositoryLocalService) {
+
+		_dlAppLocalService = dlAppLocalService;
+		_groupLocalService = groupLocalService;
+		_repositoryLocalService = repositoryLocalService;
+	}
+
+	@Override
+	protected String[] getPortletIds() {
+		return new String[] {
+			DLPortletKeys.MEDIA_GALLERY_DISPLAY + "_INSTANCE_%"
+		};
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		long rootFolderId = GetterUtil.getLong(
+			portletPreferences.getValue("rootFolderId", "-1"));
+
+		if (rootFolderId == -1) {
+			return _toXML(portletPreferences);
+		}
+
+		String rootFolderExternalReferenceCode = StringPool.BLANK;
+
+		if (rootFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			try {
+				Folder folder = _dlAppLocalService.getFolder(rootFolderId);
+
+				rootFolderExternalReferenceCode =
+					folder.getExternalReferenceCode();
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to get root folder ID ", rootFolderId, ": ",
+							portalException));
+				}
+
+				return _toXML(portletPreferences);
+			}
+		}
+
+		long selectedRepositoryId = GetterUtil.getLong(
+			portletPreferences.getValue("selectedRepositoryId", "-1"));
+
+		if (selectedRepositoryId == -1) {
+			return _toXML(portletPreferences);
+		}
+
+		Repository selectedRepository = _repositoryLocalService.fetchRepository(
+			selectedRepositoryId);
+
+		Group selectedGroup = null;
+		String selectedRepositoryExternalReferenceCode = StringPool.BLANK;
+
+		if (selectedRepository != null) {
+			selectedGroup = _groupLocalService.getGroup(
+				selectedRepository.getGroupId());
+
+			selectedRepositoryExternalReferenceCode =
+				selectedRepository.getExternalReferenceCode();
+		}
+		else {
+			selectedGroup = _groupLocalService.fetchGroup(selectedRepositoryId);
+
+			if (selectedGroup == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to get selected repository ID " +
+							selectedRepositoryId);
+				}
+
+				return _toXML(portletPreferences);
+			}
+		}
+
+		portletPreferences.setValue(
+			"rootFolderExternalReferenceCode", rootFolderExternalReferenceCode);
+		portletPreferences.setValue(
+			"selectedGroupExternalReferenceCode",
+			selectedGroup.getExternalReferenceCode());
+		portletPreferences.setValue(
+			"selectedRepositoryExternalReferenceCode",
+			selectedRepositoryExternalReferenceCode);
+
+		return _toXML(portletPreferences);
+	}
+
+	private String _toXML(PortletPreferences portletPreferences)
+		throws Exception {
+
+		portletPreferences.reset("rootFolderId");
+		portletPreferences.reset("selectedRepositoryId");
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletPreferences.class);
+
+	private final DLAppLocalService _dlAppLocalService;
+	private final GroupLocalService _groupLocalService;
+	private final RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -7,14 +7,14 @@ package com.liferay.document.library.web.internal.util;
 
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.document.library.web.internal.settings.DLPortletInstanceSettings;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.portlet.PortletURL;
 import javax.portlet.RenderResponse;
@@ -104,25 +103,22 @@ public class DLBreadcrumbUtil {
 			"/document_library/view"
 		).buildPortletURL();
 
-		Map<String, Object> data = HashMapBuilder.<String, Object>put(
-			"direction-right", Boolean.TRUE.toString()
-		).put(
-			"folder-id",
-			() -> {
-				PortletDisplay portletDisplay =
-					themeDisplay.getPortletDisplay();
-
-				DLPortletInstanceSettings dlPortletInstanceSettings =
-					DLPortletInstanceSettings.getInstance(
-						themeDisplay.getLayout(), portletDisplay.getId());
-
-				return dlPortletInstanceSettings.getRootFolderId();
-			}
-		).build();
-
 		PortalUtil.addPortletBreadcrumbEntry(
 			httpServletRequest, themeDisplay.translate("home"),
-			portletURL.toString(), data);
+			portletURL.toString(),
+			HashMapBuilder.<String, Object>put(
+				"direction-right", Boolean.TRUE.toString()
+			).put(
+				"folder-id",
+				() -> {
+					DLPortletInstanceSettingsHelper
+						dlPortletInstanceSettingsHelper =
+							new DLPortletInstanceSettingsHelper(
+								new DLRequestHelper(httpServletRequest));
+
+					return dlPortletInstanceSettingsHelper.getRootFolderId();
+				}
+			).build());
 
 		portletURL.setParameter(
 			"mvcRenderCommandName", "/document_library/view_folder");
@@ -141,17 +137,11 @@ public class DLBreadcrumbUtil {
 			httpServletRequest, "ignoreRootFolder");
 
 		if (!ignoreRootFolder) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+			DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+				new DLPortletInstanceSettingsHelper(
+					new DLRequestHelper(httpServletRequest));
 
-			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
-
-			DLPortletInstanceSettings dlPortletInstanceSettings =
-				DLPortletInstanceSettings.getInstance(
-					themeDisplay.getLayout(), portletDisplay.getId());
-
-			rootFolderId = dlPortletInstanceSettings.getRootFolderId();
+			rootFolderId = dlPortletInstanceSettingsHelper.getRootFolderId();
 		}
 
 		List<Folder> ancestorFolders = Collections.emptyList();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/IGUtil.java
@@ -7,17 +7,16 @@ package com.liferay.document.library.web.internal.util;
 
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
+import com.liferay.document.library.web.internal.display.context.helper.IGRequestHelper;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.portlet.PortletPreferences;
 import javax.portlet.PortletURL;
 import javax.portlet.RenderResponse;
 
@@ -39,7 +38,11 @@ public class IGUtil {
 			"/image_gallery_display/view"
 		).buildRenderURL();
 
-		long rootFolderId = getRootFolderId(httpServletRequest);
+		DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper =
+			new DLPortletInstanceSettingsHelper(
+				new IGRequestHelper(httpServletRequest));
+
+		long rootFolderId = dlPortletInstanceSettingsHelper.getRootFolderId();
 
 		List<Folder> ancestorFolders = Collections.emptyList();
 
@@ -63,7 +66,15 @@ public class IGUtil {
 
 		Collections.reverse(new ArrayList<>(ancestorFolders));
 
-		long repositoryId = getRepositoryId(folder, httpServletRequest);
+		long repositoryId = 0;
+
+		if (folder != null) {
+			repositoryId = folder.getRepositoryId();
+		}
+		else {
+			repositoryId =
+				dlPortletInstanceSettingsHelper.getSelectedRepositoryId();
+		}
 
 		for (Folder ancestorFolder : ancestorFolders) {
 			portletURL.setParameter(
@@ -102,34 +113,6 @@ public class IGUtil {
 		addPortletBreadcrumbEntries(
 			DLAppLocalServiceUtil.getFolder(folderId), httpServletRequest,
 			renderResponse);
-	}
-
-	protected static long getRepositoryId(
-			Folder folder, HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		PortletPreferences portletPreferences =
-			PortletPreferencesFactoryUtil.getPortletPreferences(
-				httpServletRequest,
-				PortalUtil.getPortletId(httpServletRequest));
-
-		return GetterUtil.getLong(
-			portletPreferences.getValue(
-				"repositoryId", String.valueOf(folder.getRepositoryId())));
-	}
-
-	protected static long getRootFolderId(HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		PortletPreferences portletPreferences =
-			PortletPreferencesFactoryUtil.getPortletPreferences(
-				httpServletRequest,
-				PortalUtil.getPortletId(httpServletRequest));
-
-		return GetterUtil.getLong(
-			portletPreferences.getValue(
-				"rootFolderId",
-				String.valueOf(DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -484,6 +484,16 @@ public class LiferayLocalRepository
 	}
 
 	@Override
+	public FileShortcut getFileShortcutByExternalReferenceCode(
+			String externalReferenceCode)
+		throws PortalException {
+
+		return new LiferayFileShortcut(
+			dlFileShortcutLocalService.getDLFileShortcutByExternalReferenceCode(
+				externalReferenceCode, getGroupId()));
+	}
+
+	@Override
 	public FileVersion getFileVersion(long fileVersionId)
 		throws PortalException {
 
@@ -509,6 +519,15 @@ public class LiferayLocalRepository
 			getGroupId(), toFolderId(parentFolderId), name);
 
 		return new LiferayFolder(dlFolder);
+	}
+
+	@Override
+	public Folder getFolderByExternalReferenceCode(String externalReferenceCode)
+		throws PortalException {
+
+		return new LiferayFolder(
+			dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				externalReferenceCode, getGroupId()));
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33264

Change Media Gallery widget settings to use ERC instead of IDs.
I'm also fixing other places that affects the Documents & Media widget, which weren't fixed in [LPD-31720](https://liferay.atlassian.net/browse/LPD-31720)

# How am I fixing it?

Replacing usage of IDs with ERCs

# How can you verify that it works?

Execute included integration tests. Also there are POSHI tests like this that are currently failing that now work:

`DepotLocalStagingMG#CanPublishImageFromFolder`
