### PR TITLE
LPD-50230 | No success message when saving web content as draft

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -235,6 +235,10 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 				}
 			}
 		}
+		else {
+			MultiSessionMessages.add(
+				actionRequest, "articleSavedAsDraft", article.getId());
+		}
 
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			actionRequest);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -15,6 +15,54 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = (JournalEdit
 journalEditArticleDisplayContext.setViewAttributes();
 %>
 
+<c:if test='<%= MultiSessionMessages.contains(renderRequest, "articleSavedAsDraft") %>'>
+	<c:if test="<%= article != null %>">
+		<liferay-util:buffer
+			var="alertMessage"
+		>
+			<liferay-util:buffer
+				var="articleLink"
+			>
+				<clay:link
+					cssClass="alert-link"
+					href='<%=
+						PortletURLBuilder.createRenderURL(
+							liferayPortletResponse
+						).setMVCRenderCommandName(
+							"/journal/edit_article"
+						).setRedirect(
+							currentURL
+						).setParameter(
+							"articleId", article.getArticleId()
+						).setParameter(
+							"backURLTitle", portletDisplay.getPortletDisplayName()
+						).setParameter(
+							"folderId", article.getFolderId()
+						).setParameter(
+							"groupId", article.getGroupId()
+						).setParameter(
+							"version", article.getVersion()
+						).buildString()
+					%>'
+					label="<%= article.getTitle(locale) %>"
+					translated="<%= false %>"
+				/>
+			</liferay-util:buffer>
+
+			<liferay-ui:message arguments="<%= articleLink %>" key="x-was-successfully-saved-as-draft" />
+		</liferay-util:buffer>
+
+		<liferay-frontend:component
+			context='<%=
+				HashMapBuilder.<String, Object>put(
+					"alertMessage", alertMessage
+				).build()
+			%>'
+			module="{SuccessMessageWithLink} from journal-web"
+		/>
+	</c:if>
+</c:if>
+
 <aui:model-context bean="<%= article %>" model="<%= JournalArticle.class %>" />
 
 <portlet:actionURL var="editArticleActionURL" windowState="<%= WindowState.MAXIMIZED.toString() %>">

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -138,6 +138,24 @@ baseTest(
 );
 
 baseTest(
+	'Check success message on save as draft',
+	{
+		tag: '@LPD-50230',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const title = getRandomString();
+		await journalEditArticlePage.saveAsDraftWithPermissions(title);
+
+		await waitForAlert(
+			page,
+			`Success:${title} was successfully saved as a draft.`
+		);
+	}
+);
+
+baseTest(
 	'Select web content display template with the Preview feature',
 	{
 		tag: '@LPD-31427',


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-50230
### How am I fixing it?
We do not have a success message on saving as draft. I added it to the edit article JSP.

### How can you verify that it works?

To test run:
`npm run playwright -- test -g 'LPD-50230'`

Or manually test based on the LPD steps