### PR TITLE
LPD-50338 UndoRedo buttons become disabled when opening language selector

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -54,7 +54,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 					}
 
 					function <%= namespace + randomNamespace %>onChangeEditor() {
-						if (Liferay.FeatureFlags['LPD-11228'] && document.activeElement.name !== 'journal_undo_redo' && document.body !== document.activeElement) {
+						if (Liferay.FeatureFlags['LPD-11228'] && document.activeElement.title === 'editor') {
 							Liferay.fire('journal:lock')
 							edited = true;
 						}


### PR DESCRIPTION
[LPD-50338](https://liferay.atlassian.net/browse/LPD-50338)

Hey,
The root cause of the problem is we are rerendering the metadataFields when opening the language selector, this will trigger the onChangeEditor. We only want to fire 'lock' if the activeElement is the description field.

Please review my change