### PR TITLE
LPD-49744 Also check if the article is a defaultValue entry

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1771,7 +1771,7 @@ public class JournalEditArticleDisplayContext {
 	}
 
 	private boolean _isShowPublishModal() throws PortalException {
-		if (_article == null) {
+		if ((_article == null) || (_article.getId() == 0)) {
 			return true;
 		}
 


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-49744
### How am I fixing it?
By checking whether or not the _article is pointing to an actual article or the default values of the DDM structure.

### How can you verify that it works?

TEST: 

currently there are poshi tests that covers this (once FF is removed, those tests should still pass), so I think there is no need to add additional functional tests: 

LocalFile.LocalizationWithWebContent#AddWebContentBasedOnStructureWithTranslatedDefaultValue

LocalFile.WebContentWithCustomStructures#ViewFieldWithPredefinedValue

LocalFile.WebContentWithStaging#PublishWebContentWithImportedStructureDefaultValues

LocalFile.WebContentWithPermissions#AddWebContentBasedOnGlobalStructureAndEditedDefaultValues

LocalFile.WebContentWithPermissions#AddWebContentWithImageBasedOnStructureFromParentSite

