### PR TITLE
LPD-50591 [Blocker] google-api-client version incompatible with current google-api-services-drive

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/build.gradle
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	compileInclude group: "com.google.api-client", name: "google-api-client-jackson2", version: "1.23.0"
 	compileInclude group: "com.google.api-client", name: "google-api-client-java6", version: "1.23.0"
 	compileInclude group: "com.google.api-client", name: "google-api-client-servlet", version: "1.23.0"
-	compileInclude group: "com.google.apis", name: "google-api-services-drive", version: "v3-rev20190311-1.28.0"
+	compileInclude group: "com.google.apis", name: "google-api-services-drive", version: "v3-rev20250216-2.0.0"
 	compileInclude group: "com.google.apis", name: "google-api-services-oauth2", version: "v2-rev137-1.23.0"
 	compileInclude group: "com.google.oauth-client", name: "google-oauth-client-java6", version: "1.34.1"
 	compileInclude group: "com.google.oauth-client", name: "google-oauth-client-servlet", version: "1.34.1"

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/build.gradle
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 	compileInclude group: "com.google.api-client", name: "google-api-client-java6", version: "1.23.0"
 	compileInclude group: "com.google.api-client", name: "google-api-client-servlet", version: "1.23.0"
 	compileInclude group: "com.google.apis", name: "google-api-services-drive", version: "v3-rev20250216-2.0.0"
-	compileInclude group: "com.google.apis", name: "google-api-services-oauth2", version: "v2-rev137-1.23.0"
+	compileInclude group: "com.google.apis", name: "google-api-services-oauth2", version: "v2-rev157-1.25.0"
 	compileInclude group: "com.google.oauth-client", name: "google-oauth-client-java6", version: "1.34.1"
 	compileInclude group: "com.google.oauth-client", name: "google-oauth-client-servlet", version: "1.34.1"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.2"


### PR DESCRIPTION
LPD-50591 [Blocker] google-api-client version incompatible with current google-api-services-drive

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50591

After some libraries version changed, the google drive API do not works

# How am I fixing it?

Upgrading the google api service drive library to a compatible version

# How can you verify that it works?

Run the automated tests.