### PR TITLE
[Blocker] LPD-50671 Cannot reply to a comment in DM 

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/js/Comments.js
@@ -18,7 +18,7 @@ function hideEl(elementId) {
 	const element = document.getElementById(elementId);
 
 	if (element) {
-		element.style.display = 'none';
+		element.classList.add('hide');
 	}
 }
 
@@ -395,7 +395,7 @@ export default function Comments({
 		const element = document.getElementById(elementId);
 
 		if (element) {
-			element.style.display = '';
+			element.classList.remove('hide');
 		}
 	};
 


### PR DESCRIPTION
LPD-50671 Cannot reply to a comment in DM

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50671 

We can not reply to the comments on DM.

# How am I fixing it?

Add or remove hide class in the comment js logic.

# How can you verify that it works?

Run the included automated tests.
Test failing: LocalFile.MentionsDM#CanViewReplyMentionViaDMComment (it covers this case, no need for additional tests)



# Commits

