### PR TITLE
LPD-50347 Issue with Web Content Expired and Review Emails

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6212,6 +6212,10 @@ public class JournalArticleLocalServiceImpl
 					article = journalArticleLocalService.updateJournalArticle(
 						article);
 
+					sendEmail(
+						article, _getArticleURL(article), "expired",
+						new ServiceContext());
+
 					notifySubscribers(
 						0, article, "expired", new ServiceContext());
 
@@ -7062,6 +7066,10 @@ public class JournalArticleLocalServiceImpl
 		if (emailType.equals("denied") &&
 			journalGroupServiceConfiguration.
 				emailArticleApprovalDeniedEnabled()) {
+		}
+		else if (emailType.equals("expired") &&
+				 journalGroupServiceConfiguration.
+					 emailArticleExpiredEnabled()) {
 		}
 		else if (emailType.equals("granted") &&
 				 journalGroupServiceConfiguration.

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6359,22 +6359,11 @@ public class JournalArticleLocalServiceImpl
 						article.getId());
 			}
 
-			String portletId = PortletProviderUtil.getPortletId(
-				JournalArticle.class.getName(), PortletProvider.Action.EDIT);
+			sendEmail(
+				article, _getArticleURL(article), "review",
+				new ServiceContext());
 
-			String articleURL = _portal.getControlPanelFullURL(
-				article.getGroupId(), portletId, null);
-
-			articleURL = HttpComponentsUtil.addParameter(
-				articleURL,
-				_portal.getPortletNamespace(portletId) + "mvcRenderCommandName",
-				"/journal/edit_article");
-
-			articleURL = buildArticleURL(
-				articleURL, article.getGroupId(), article.getFolderId(),
-				article.getArticleId());
-
-			sendEmail(article, articleURL, "review", new ServiceContext());
+			notifySubscribers(0, article, "review", new ServiceContext());
 		}
 	}
 
@@ -6869,6 +6858,9 @@ public class JournalArticleLocalServiceImpl
 				 journalGroupServiceConfiguration.
 					 emailArticleMovedToTrashEnabled()) {
 		}
+		else if (action.equals("review") &&
+				 journalGroupServiceConfiguration.emailArticleReviewEnabled()) {
+		}
 		else if (action.equals("update") &&
 				 journalGroupServiceConfiguration.
 					 emailArticleUpdatedEnabled()) {
@@ -6994,7 +6986,9 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setNotificationType(_getNotificationType(action));
 		subscriptionSender.setReplyToAddress(fromAddress);
 
-		if (action.equals("expired") && (serviceContext.getUserId() == 0)) {
+		if ((action.equals("expired") || action.equals("review")) &&
+			(serviceContext.getUserId() == 0)) {
+
 			subscriptionSender.setSendToCurrentUser(true);
 		}
 
@@ -7121,7 +7115,9 @@ public class JournalArticleLocalServiceImpl
 		subscriptionSender.setEntryTitle(article.getTitle(user.getLocale()));
 		subscriptionSender.setNotificationType(_getNotificationType(emailType));
 
-		if (emailType.equals("review") && (serviceContext.getUserId() == 0)) {
+		if ((emailType.equals("expired") || emailType.equals("review")) &&
+			(serviceContext.getUserId() == 0)) {
+
 			subscriptionSender.setSendToCurrentUser(true);
 		}
 
@@ -7778,6 +7774,27 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return StringPool.BLANK;
+	}
+
+	private String _getArticleURL(JournalArticle article)
+		throws PortalException {
+
+		String portletId = PortletProviderUtil.getPortletId(
+			JournalArticle.class.getName(), PortletProvider.Action.EDIT);
+
+		String articleURL = _portal.getControlPanelFullURL(
+			article.getGroupId(), portletId, null);
+
+		articleURL = HttpComponentsUtil.addParameter(
+			articleURL,
+			_portal.getPortletNamespace(portletId) + "mvcRenderCommandName",
+			"/journal/edit_article");
+
+		articleURL = buildArticleURL(
+			articleURL, article.getGroupId(), article.getFolderId(),
+			article.getArticleId());
+
+		return articleURL;
 	}
 
 	private Predicate<String> _getEmptyValuePredicate(String fieldType) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/notifications/test/JournalUserNotificationTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/notifications/test/JournalUserNotificationTest.java
@@ -66,8 +66,8 @@ public class JournalUserNotificationTest extends BaseUserNotificationTestCase {
 		_journalArticleLocalService.checkArticles(group.getCompanyId());
 
 		_assertJournalArticleNotifications(
-			expiredArticle,
-			UserNotificationDefinition.NOTIFICATION_TYPE_EXPIRED_ENTRY);
+			expiredArticle, 2,
+			UserNotificationDefinition.NOTIFICATION_TYPE_EXPIRED_ENTRY, 1);
 	}
 
 	@Test
@@ -85,8 +85,8 @@ public class JournalUserNotificationTest extends BaseUserNotificationTestCase {
 			ServiceContextTestUtil.getServiceContext());
 
 		_assertJournalArticleNotifications(
-			expiredArticle,
-			UserNotificationDefinition.NOTIFICATION_TYPE_EXPIRED_ENTRY);
+			expiredArticle, 1,
+			UserNotificationDefinition.NOTIFICATION_TYPE_EXPIRED_ENTRY, 1);
 	}
 
 	@Test
@@ -102,11 +102,13 @@ public class JournalUserNotificationTest extends BaseUserNotificationTestCase {
 		journalArticle = _journalArticleLocalService.updateJournalArticle(
 			journalArticle);
 
+		subscribeToContainer();
+
 		_journalArticleLocalService.checkArticles(group.getCompanyId());
 
 		_assertJournalArticleNotifications(
-			journalArticle,
-			UserNotificationDefinition.NOTIFICATION_TYPE_REVIEW_ENTRY);
+			journalArticle, 2,
+			UserNotificationDefinition.NOTIFICATION_TYPE_REVIEW_ENTRY, 2);
 	}
 
 	@Override
@@ -141,24 +143,27 @@ public class JournalUserNotificationTest extends BaseUserNotificationTestCase {
 	}
 
 	private void _assertJournalArticleNotifications(
-			JournalArticle expiredArticle, int notificationType)
+			JournalArticle article, int emailNotificationCount,
+			int notificationType, int userNotificationCount)
 		throws Exception {
 
-		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+		Assert.assertEquals(
+			emailNotificationCount, MailServiceTestUtil.getInboxSize());
 
 		List<JSONObject> userNotificationEventsJSONObjects =
 			getUserNotificationEventsJSONObjects(user.getUserId());
 
 		Assert.assertEquals(
-			userNotificationEventsJSONObjects.toString(), 1,
+			userNotificationEventsJSONObjects.toString(), userNotificationCount,
 			userNotificationEventsJSONObjects.size());
 
-		JSONObject jsonObject = userNotificationEventsJSONObjects.get(0);
+		for (int i = 0; i < userNotificationCount; i++) {
+			JSONObject jsonObject = userNotificationEventsJSONObjects.get(i);
 
-		Assert.assertEquals(
-			expiredArticle.getId(), jsonObject.getLong("classPK"));
-		Assert.assertEquals(
-			notificationType, jsonObject.getInt("notificationType"));
+			Assert.assertEquals(article.getId(), jsonObject.getLong("classPK"));
+			Assert.assertEquals(
+				notificationType, jsonObject.getInt("notificationType"));
+		}
 	}
 
 	private JournalFolder _folder;

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -14880,6 +14880,7 @@ receive-a-notification-when-background-task-fails=Background task fails.
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire.
 receive-a-notification-when-someone=Receive a notification when someone:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=فشلت مهمة الخلفي
 receive-a-notification-when-batch-plan-finishes=انتهى استيراد أو تصدير المهمة.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=انتهت صلاحية مستند في مجلد أنت مشرك به.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=يحدِّث مقالة قاعدة المعارف في التي اشتركت فيها.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=مراجعة مستند في المجلد الذي تشترك به.
 receive-a-notification-when-scim-access-token-is-about-to-expire=الرمز المميز للوصول إلى SCIM على وشك انتهاء الصلاحية.
 receive-a-notification-when-someone=تلقي إعلام عندما يقوم شخص بما يلي:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Прегледайте документ в папка, за която сте абонирани. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Получаване на известие, когато някой: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=La tasca en segon pla ha falla
 receive-a-notification-when-batch-plan-finishes=Finalitza el treball d'importació o exportació.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Un document d'una carpeta a què esteu subscrit ha caducat.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Reviseu un article de la base de coneixement a què esteu subscrit.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revisar un document en una carpeta a què esteu subscrit.
 receive-a-notification-when-scim-access-token-is-about-to-expire=El testimoni d'accés SCIM està a punt de caducar.
 receive-a-notification-when-someone=Rebre una notificació quan algú...

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Platnost dokumentu ve složce, kterou jste přihlášeni k odběru, vypršela. (Automatic Translation)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Zkontrolujte dokument ve složce, ke které jste přihlášeni. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Obdržíte oznámení, když někdo: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Modtag en notifikation, når en person: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Hintergrundaufgabe fehlgeschla
 receive-a-notification-when-batch-plan-finishes=Import- oder Export-Job abgeschlossen.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ein Dokument in einem Ordner, den Sie abonniert haben, ist abgelaufen.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Überprüfen Sie einen Wissensdatenbank-Artikel, den Sie abonniert haben.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Überprüfen Sie ein Dokument in einem Ordner, den Sie abonniert haben.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Das SCIM-Zugriffstoken läuft bald ab.
 receive-a-notification-when-someone=Erhalten Sie eine Benachrichtigung, wenn jemand:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Hintergrundaufgabe fehlgeschla
 receive-a-notification-when-batch-plan-finishes=Import- oder Export-Job abgeschlossen.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ein Dokument in einem Ordner, den Sie abonniert haben, ist abgelaufen.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Überprüfen Sie einen Wissensdatenbank-Artikel, den Sie abonniert haben.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Überprüfen Sie ein Dokument in einem Ordner, den Sie abonniert haben.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Das SCIM-Zugriffstoken läuft bald ab.
 receive-a-notification-when-someone=Erhalten Sie eine Benachrichtigung, wenn jemand:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Hintergrundaufgabe fehlgeschla
 receive-a-notification-when-batch-plan-finishes=Import- oder Export-Job abgeschlossen.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ein Dokument in einem Ordner, den Sie abonniert haben, ist abgelaufen.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Überprüfen Sie einen Wissensdatenbank-Artikel, den Sie abonniert haben.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Überprüfen Sie ein Dokument in einem Ordner, den Sie abonniert haben.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Das SCIM-Zugriffstoken läuft bald ab.
 receive-a-notification-when-someone=Erhalten Sie eine Benachrichtigung, wenn jemand:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Εξετάστε ένα έγγραφο σε ένα φάκελο στον οποίο είστε εγγεγραμμένοι. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Λάβετε μια ειδοποίηση όταν κάποιος: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -14880,6 +14880,7 @@ receive-a-notification-when-background-task-fails=Background task fails.
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire.
 receive-a-notification-when-someone=Receive a notification when someone:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Errores de tareas en progreso.
 receive-a-notification-when-batch-plan-finishes=Finaliza el trabajo de importación o exportación.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ha caducado un documento de una carpeta a la que está suscrito.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revise un artículo de la base de conocimiento a la que esté suscrito.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=El token de acceso SCIM está a punto de caducar.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Errores de tareas en progreso.
 receive-a-notification-when-batch-plan-finishes=Finaliza el trabajo de importación o exportación.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ha caducado un documento de una carpeta a la que está suscrito.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revise un artículo de la base de conocimiento a la que esté suscrito.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=El token de acceso SCIM está a punto de caducar.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Errores de tareas en progreso.
 receive-a-notification-when-batch-plan-finishes=Finaliza el trabajo de importación o exportación.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ha caducado un documento de una carpeta a la que está suscrito.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revise un artículo de la base de conocimiento a la que esté suscrito.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=El token de acceso SCIM está a punto de caducar.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Errores de tareas en progreso.
 receive-a-notification-when-batch-plan-finishes=Finaliza el trabajo de importación o exportación.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ha caducado un documento de una carpeta a la que está suscrito.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revise un artículo de la base de conocimiento a la que esté suscrito.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=El token de acceso SCIM está a punto de caducar.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Vaadake üle dokument, mis asub teie tellitud kaustas. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Saate teatise, kui keegi: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Harpidetuta zauden karpeta batean dagoen dokumentu bat iraungi da.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=سندی در پوشه ای که مشترک شده اید منقضی شده است. (Automatic Translation)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=یک سند را در پوشه ای که مشترک آن هستید مرور کنید. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=وقتی کسی اعلان دریافت می کند: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -14873,6 +14873,7 @@ receive-a-notification-when-background-task-fails=Taustatehtävä epäonnistuu.
 receive-a-notification-when-batch-plan-finishes=Tuonti- tai vientitehtävä on valmis.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Asiakirja tilaamassasi kansiossa on vanhentunut.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Tarkista tietämyskannan artikkeli, jonka olet tilannut.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Tarkasta asiakirja kansiossa, jonka olet tilannut.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM-käyttötunnus on vanhenemassa.
 receive-a-notification-when-someone=Saa ilmoitus, kun joku:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=La tâche en arrière-plan éc
 receive-a-notification-when-batch-plan-finishes=Importez ou exportez les tâches terminées.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Un document dans un dossier auquel vous êtes abonné(e) a expiré.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Passez en revue un article de la base de connaissances auquel vous êtes abonné.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Le jeton d'accès SCIM est sur le point d'expirer.
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=La tâche en arrière-plan éc
 receive-a-notification-when-batch-plan-finishes=Importez ou exportez les tâches terminées.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Un document dans un dossier auquel vous êtes abonné(e) a expiré.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Passez en revue un article de la base de connaissances auquel vous êtes abonné.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Le jeton d'accès SCIM est sur le point d'expirer.
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Un document dans un dossier auquel vous êtes abonné(e) a expiré.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=La tâche en arrière-plan éc
 receive-a-notification-when-batch-plan-finishes=Importez ou exportez les tâches terminées.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Un document dans un dossier auquel vous êtes abonné(e) a expiré.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Passez en revue un article de la base de connaissances auquel vous êtes abonné.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Le jeton d'accès SCIM est sur le point d'expirer.
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=A tarefa en segundo plano fall
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Recibir unha notificación cando alguén:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=किसी फ़ोल्डर में दस्तावेज़ की समीक्षा करें जिससे आप सब्सक्राइब होते हैं. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=जब कोई व्यक्ति सूचना प्राप्त करता है: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -14877,6 +14877,7 @@ receive-a-notification-when-background-task-fails=Háttérfeladat sikertelen.
 receive-a-notification-when-batch-plan-finishes=Az importálási vagy exportálási feladat befejeződik.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Egy dokumentum lejárt az egyik mappában, amelyre előfizetett.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Nézzen át egy tudásbázis-cikket, amire fel van iratkozva.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Ellenőrizze a dokumentumot a mappában, amelyre előfizetett.
 receive-a-notification-when-scim-access-token-is-about-to-expire=A SCIM hozzáférési token hamarosan lejár.
 receive-a-notification-when-someone=Értesítés megjelenítése amikor valaki...

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Tinjau dokumen dalam folder tempat Anda berlangganan. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Menerima pemberitahuan saat seseorang: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -14875,6 +14875,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Esaminare un documento in una cartella sottoscritta. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Ricevi una notifica quando qualcuno:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Esaminare un documento in una cartella sottoscritta. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Ricevi una notifica quando qualcuno:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=פג תוקפו של מסמך בתיקיה שאתה מנוי עליה. (Automatic Translation)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=סקור מסמך בתיקיה שאליה נרשמת כמנוי. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=קבל הודעה כאשר מישהו:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=バックグラウンドタス
 receive-a-notification-when-batch-plan-finishes=インポートまたはエクスポートジョブが完了する。
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=購読先のフォルダ内のドキュメントが期限切れになりました。
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=購読先のナレッジベース記事をレビューします。
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=購読先のフォルダ内のドキュメントをレビューしてください。
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM アクセストークンの期限切れが間近です。
 receive-a-notification-when-someone=以下からの通知を受け取る :

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -14880,6 +14880,7 @@ receive-a-notification-when-background-task-fails=Background task fails.
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=가져오기 혹은 내보내기 작업이 종료되었습니다.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=가입한 폴더의 문서가 만료되었습니다.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=구독 중인 폴더의 문서를 검토합니다.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=다음과 같은 경우 알림을 받습니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Peržiūrėkite dokumentą aplanke, kuriame esate užsiprenumeravę. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Gauti pranešimą, kai kas nors: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Semak dokumen dalam folder yang anda langgani. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Terima pemberitahuan apabila seseorang: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Se gjennom et dokument i en mappe du abonnerer på. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Motta en melding når noen:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -14877,6 +14877,7 @@ receive-a-notification-when-background-task-fails=Achtergrondtaak mislukt.
 receive-a-notification-when-batch-plan-finishes=Import- of exporttaak eindigt.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Een document in de map waarop u geabonneerd bent, is verlopen.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Geef een beoordeling over een kennisbankartikel waarop u bent geabonneerd.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Controleer een document in een map waarop u bent geabonneerd.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Het SCIM-toegangstoken verloopt binnenkort.
 receive-a-notification-when-someone=Ontvangt een melding wanneer iemand:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -14877,6 +14877,7 @@ receive-a-notification-when-background-task-fails=Achtergrondtaak mislukt.
 receive-a-notification-when-batch-plan-finishes=Import- of exporttaak eindigt.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Een document in de map waarop u geabonneerd bent, is verlopen.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Geef een beoordeling over een kennisbankartikel waarop u bent geabonneerd.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Controleer een document in een map waarop u bent geabonneerd.
 receive-a-notification-when-scim-access-token-is-about-to-expire=Het SCIM-toegangstoken verloopt binnenkort.
 receive-a-notification-when-someone=Ontvangt een melding wanneer iemand:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Se gjennom et dokument i en mappe du abonnerer på. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Motta en melding når noen:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Przejrzyj dokument w folderze, do którego jesteś subskrybentem. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Otrzymuj powiadomienie, gdy ktoś: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=A tarefa de fundo falhou.
 receive-a-notification-when-batch-plan-finishes=Importar ou exportar tarefas concluídas.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Um documento em uma pasta que você assina expirou.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revisar um artigo da base de conhecimento que você assina.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise um documento em uma pasta que você esteja inscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=O token de acesso SCIM está prestes a expirar.
 receive-a-notification-when-someone=Receber uma notificação quando alguém:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=A tarefa de fundo falhou.
 receive-a-notification-when-batch-plan-finishes=Importar ou exportar tarefas concluídas.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Um documento em uma pasta que você assina expirou.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revisar um artigo da base de conhecimento que você assina.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise um documento em uma pasta que você esteja inscrito.
 receive-a-notification-when-scim-access-token-is-about-to-expire=O token de acesso SCIM está prestes a expirar.
 receive-a-notification-when-someone=Receber uma notificação quando alguém...

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Examinați un document dintr-un folder la care sunteți abonat. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Primiți o notificare atunci când cineva: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Просмотрите документ в папке, на которую вы подписаны. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Получаем уведомление, когда кто-то: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Skontrolujte dokument v priečinku, na odber ktorý ste prihlásení. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Upozornenie, keď niekto: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Preglejte dokument v mapi, na kar ste naročeni. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Prejmite obvestilo, ko nekdo: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Bakgrundsuppgift misslyckas.
 receive-a-notification-when-batch-plan-finishes=Import- eller exportjobb slutförs.
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=Ett dokument i en mapp som du prenumererar på har slutat gälla.
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Recensera en artikel i kunskapsbasen som du prenumererar på.
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Granska ett dokument i en mapp som du prenumererar på.
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM-åtkomsttoken slutar snart att gälla.
 receive-a-notification-when-someone=Ta emot en avisering när någon:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=யாரேனும் இவற்றைச் செய்யும்போது அறிவிப்பைப் பெறவும்:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=งานอิมพอร์ตหรือเอ็กพอร์ตเสร็จสิ้น
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=เอกสารในโฟลเดอร์ที่คุณสมัครใช้งานหมดอายุแล้ว
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=ตรวจดูเอกสารในโฟลเดอร์ที่คุณสมัครไว้
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=รับการแจ้งเตือนเมื่อมีคน:

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Abone olduğunuz klasördeki bir belgeyi gözden geçirin. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Birisi: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Перегляньте документ у папці, на яку ви підписані. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Отримуйте сповіщення, коли хтось: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -14874,6 +14874,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=A document in a folder you are subscribed to has expired. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Xem lại tài liệu trong thư mục bạn đã đăng ký. (Automatic Translation)
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=Nhận thông báo khi có người: (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -14876,6 +14876,7 @@ receive-a-notification-when-background-task-fails=后台任务失败。
 receive-a-notification-when-batch-plan-finishes=导入或导出作业完成。
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=您订阅的文件夹中的文档已过期。
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=审阅您订阅的知识库文章。
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=审核您订阅的文件夹中的文档。
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM 访问令牌即将到期。
 receive-a-notification-when-someone=当有人……时收到通知

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -14875,6 +14875,7 @@ receive-a-notification-when-background-task-fails=Background task fails. (Automa
 receive-a-notification-when-batch-plan-finishes=Import or export job finishes. (Automatic Copy)
 receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-to=您訂閱的資料夾裡的文件已過期。
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
+receive-a-notification-when-review-is-needed-on-a-web-content-article-you-are-subscribed-to=Review a web content article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=檢視您訂閱的資料夾裡的文件。
 receive-a-notification-when-scim-access-token-is-about-to-expire=SCIM access token is about to expire. (Automatic Copy)
 receive-a-notification-when-someone=收到一個通知，當有人...


### PR DESCRIPTION
Issue with Web Content Expired and Review Emails

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-50347)

When the scheduled review date arrives:
An email notification is sent only to the content creator.
Folder subscribers do not receive the notification.

For Web Content Expired Notifications:
The notification is sent only to the folder subscribers, not to the content creator.

# How am I fixing it?

Notify the ownwer when an article expires.
Notify the subscribers when the article reaches review date.

# How can you verify that it works?

Follow the steps in the ticket
