### PR TITLE
LPD-50701 Fix DepotPermission#CanAddFileInDMWidget

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -651,7 +651,7 @@ definition {
 			AssertElementNotPresent(locator1 = "Message#WORKFLOW_UNAPPROVED");
 		}
 
-		Portlet.clickPortletPlusIconPG(portletName = "Documents and Media");
+		Click(locator1 = "Button#PLUS");
 
 		if (isSet(dmDocumentTypeName)) {
 			var key_dmDocumentTypeName = ${dmDocumentTypeName};


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50701

At some point, the `[+]` button changed to `[New]`. Update the test so that it finds the correct element.

Note that the test will fail later for a different reason. That will be fixed by https://liferay.atlassian.net/browse/LPD-33264