### PR TITLE
LPD-50748 When replying to a message board thread, Data too long for column 'urlSubject' is occurred

### DIFF
--- a/modules/apps/message-boards/message-boards-service/bnd.bnd
+++ b/modules/apps/message-boards/message-boards-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Message Boards Service
 Bundle-SymbolicName: com.liferay.message.boards.service
 Bundle-Version: 5.0.113
-Liferay-Require-SchemaVersion: 6.6.0
+Liferay-Require-SchemaVersion: 6.6.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/registry/MBServiceUpgradeStepRegistrator.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/registry/MBServiceUpgradeStepRegistrator.java
@@ -180,6 +180,11 @@ public class MBServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 				}
 
 			});
+
+		registry.register(
+			"6.6.0", "6.6.1",
+			UpgradeProcessFactory.alterColumnType(
+				"MBMessage", "urlSubject", "VARCHAR(300) null"));
 	}
 
 	@Reference(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageModelImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageModelImpl.java
@@ -123,7 +123,7 @@ public class MBMessageModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table MBMessage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,messageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,categoryId LONG,threadId LONG,rootMessageId LONG,parentMessageId LONG,treePath STRING null,subject VARCHAR(255) null,urlSubject VARCHAR(255) null,body TEXT null,format VARCHAR(75) null,anonymous BOOLEAN,priority DOUBLE,allowPingbacks BOOLEAN,answer BOOLEAN,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (messageId, ctCollectionId))";
+		"create table MBMessage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,messageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classNameId LONG,classPK LONG,categoryId LONG,threadId LONG,rootMessageId LONG,parentMessageId LONG,treePath STRING null,subject VARCHAR(255) null,urlSubject VARCHAR(300) null,body TEXT null,format VARCHAR(75) null,anonymous BOOLEAN,priority DOUBLE,allowPingbacks BOOLEAN,answer BOOLEAN,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (messageId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table MBMessage";
 

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -126,7 +126,7 @@
 			<validator name="required" />
 		</field>
 		<field name="urlSubject" type="String">
-			<hint name="max-length">255</hint>
+			<hint name="max-length">300</hint>
 		</field>
 		<field name="body" type="String">
 			<hint-collection name="CLOB" />

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/indexes.sql
@@ -25,7 +25,7 @@ create index IX_51A8D44D on MBMessage (classNameId, classPK);
 create index IX_B1432D30 on MBMessage (companyId);
 create index IX_1073AB9F on MBMessage (groupId, categoryId);
 create unique index IX_CAD6292D on MBMessage (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
-create unique index IX_C3FB4E01 on MBMessage (groupId, ctCollectionId, urlSubject[$COLUMN_LENGTH:255$]);
+create unique index IX_C3FB4E01 on MBMessage (groupId, ctCollectionId, urlSubject[$COLUMN_LENGTH:300$]);
 create index IX_1D0DEF85 on MBMessage (groupId, status, categoryId);
 create index IX_5084DE7E on MBMessage (groupId, status, threadId, categoryId);
 create index IX_D12CECD2 on MBMessage (groupId, status, userId);

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/META-INF/sql/tables.sql
@@ -109,7 +109,7 @@ create table MBMessage (
 	parentMessageId LONG,
 	treePath STRING null,
 	subject VARCHAR(255) null,
-	urlSubject VARCHAR(255) null,
+	urlSubject VARCHAR(300) null,
 	body TEXT null,
 	format VARCHAR(75) null,
 	anonymous BOOLEAN,

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -11,10 +11,12 @@ import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
+import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
 import com.liferay.message.boards.test.util.MBTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -220,6 +222,42 @@ public class MBMessageLocalServiceTest {
 				externalReferenceCode, _group.getGroupId());
 
 		Assert.assertEquals(mbMessage1, mbMessage2);
+	}
+
+	@Test
+	public void testAddMultipleRepliesToParentThreadWithMaxSubjectLength()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		String subject = StringUtil.randomString(
+			ModelHintsUtil.getMaxLength(MBMessage.class.getName(), "subject"));
+
+		MBMessage parentMessage = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, StringPool.BLANK, "bbcode", Collections.emptyList(), false,
+			0.0, false, serviceContext);
+
+		for (int i = 0; i < 3; i++) {
+			MBMessageLocalServiceUtil.addMessage(
+				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+				_group.getGroupId(),
+				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				parentMessage.getThreadId(), parentMessage.getMessageId(),
+				subject, StringPool.BLANK, "bbcode", null, false, 0.0, false,
+				serviceContext);
+		}
+
+		MBThread thread = MBThreadLocalServiceUtil.getThread(
+			parentMessage.getThreadId());
+
+		List<MBMessage> messages = MBMessageLocalServiceUtil.getThreadMessages(
+			thread.getThreadId(), WorkflowConstants.STATUS_ANY);
+
+		Assert.assertEquals("Expected exactly 4 messages", 4, messages.size());
 	}
 
 	@Test


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-50748
When replying to a message board thread, a Data too long for column 'urlSubject' error occurs if the generated urlSubject exceeds the column's maximum length.

### **How am I fixing it?**
Increasing the size of the urlSubject form 255 to 300

### **How can you verify that it works?**
Start the Liferay instance.
Navigate to Message Boards.
Create a new thread with a title of exactly 255 characters (the max length allowed for urlSubject).
Add 3 replies to the thread.
The replies should now be created successfully without triggering the Data too long for column 'urlSubject' error.

**Note**:- Indexes are not updating in the MySQL database; however, the behavior has been verified in Hypersonic Database and PostgreSQL.