### PR TITLE
LPD-47621 Technical Task | Add workflow functionalities for folders

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -281,7 +281,10 @@ public class ObjectEntryFolderResourceImpl
 					contextAcceptLanguage.getPreferredLocale(),
 					objectEntryFolder.getLabel(),
 					objectEntryFolder.getLabel_i18n()),
-				objectEntryFolder.getName()));
+				objectEntryFolder.getName(),
+				ServiceContextBuilder.create(
+					groupId, contextHttpServletRequest, null
+				).build()));
 	}
 
 	private ObjectEntryFolder _addObjectEntryFolder(
@@ -411,7 +414,11 @@ public class ObjectEntryFolderResourceImpl
 					labelMap),
 				GetterUtil.getString(
 					objectEntryFolder.getName(),
-					persistedObjectEntryFolder.getName())));
+					persistedObjectEntryFolder.getName()),
+				ServiceContextBuilder.create(
+					persistedObjectEntryFolder.getGroupId(),
+					contextHttpServletRequest, null
+				).build()));
 	}
 
 	private ObjectEntryFolder _toObjectEntryFolder(

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 103.1.0
+Bundle-Version: 104.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectDefinitionConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectDefinitionConstants.java
@@ -16,6 +16,8 @@ public class ObjectDefinitionConstants {
 	public static final String
 		EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION = "L_";
 
+	public static final long OBJECT_DEFINITION_ID_ALL = -1;
+
 	public static final String SCOPE_COMPANY = "company";
 
 	public static final String SCOPE_DEPOT = "depot";

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryThreadLocal.java
@@ -33,6 +33,10 @@ public class ObjectEntryThreadLocal {
 		return _expandoBridgeAttributes.get();
 	}
 
+	public static Long getObjectEntryFolderId() {
+		return _objectEntryFolderId.get();
+	}
+
 	public static boolean isDisassociateRelatedModels() {
 		return _disassociateRelatedModels.get();
 	}
@@ -68,6 +72,12 @@ public class ObjectEntryThreadLocal {
 		_expandoBridgeAttributes.set(expandoValues);
 	}
 
+	public static SafeCloseable setObjectEntryFolderIdWithSafeCloseable(
+		Long objectEntryFolderId) {
+
+		return _objectEntryFolderId.setWithSafeCloseable(objectEntryFolderId);
+	}
+
 	public static void setSkipObjectEntryResourcePermission(
 		boolean skipObjectEntryResourcePermission) {
 
@@ -94,6 +104,9 @@ public class ObjectEntryThreadLocal {
 	private static final ThreadLocal<Map<String, Serializable>>
 		_expandoBridgeAttributes = new CentralizedThreadLocal<>(
 			ObjectEntryThreadLocal.class + "._expandoBridgeAttributes");
+	private static final CentralizedThreadLocal<Long> _objectEntryFolderId =
+		new CentralizedThreadLocal<>(
+			ObjectEntryThreadLocal.class + "._objectEntryFolderId", () -> null);
 	private static final ThreadLocal<Boolean>
 		_skipObjectEntryResourcePermission = new CentralizedThreadLocal<>(
 			ObjectEntryThreadLocal.class +

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
@@ -341,7 +341,7 @@ public interface ObjectEntryFolderLocalService
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
@@ -409,12 +409,13 @@ public class ObjectEntryFolderLocalServiceUtil {
 	public static ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId,
-			Map<java.util.Locale, String> labelMap, String name)
+			Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
@@ -463,12 +463,13 @@ public class ObjectEntryFolderLocalServiceWrapper
 	public com.liferay.object.model.ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId,
-			java.util.Map<java.util.Locale, String> labelMap, String name)
+			java.util.Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryFolderLocalService.updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderService.java
@@ -92,7 +92,8 @@ public interface ObjectEntryFolderService extends BaseService {
 
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<Locale, String> labelMap, String name)
+			Map<Locale, String> labelMap, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceUtil.java
@@ -111,11 +111,13 @@ public class ObjectEntryFolderServiceUtil {
 
 	public static ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<java.util.Locale, String> labelMap, String name)
+			Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateObjectEntryFolder(
-			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name);
+			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name,
+			serviceContext);
 	}
 
 	public static ObjectEntryFolderService getService() {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceWrapper.java
@@ -125,11 +125,13 @@ public class ObjectEntryFolderServiceWrapper
 	@Override
 	public com.liferay.object.model.ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			java.util.Map<java.util.Locale, String> labelMap, String name)
+			java.util.Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryFolderService.updateObjectEntryFolder(
-			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name);
+			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 70.0.0
+version 71.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -78,6 +78,7 @@ import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -145,6 +146,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		SearchLocalizationHelper searchLocalizationHelper,
 		SharingModelResourcePermissionConfigurator
 			sharingModelResourcePermissionConfigurator,
+		WorkflowDefinitionLinkLocalService workflowDefinitionLinkLocalService,
 		ModelPreFilterContributor workflowStatusModelPreFilterContributor,
 		UserGroupRoleLocalService userGroupRoleLocalService) {
 
@@ -178,6 +180,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_searchLocalizationHelper = searchLocalizationHelper;
 		_sharingModelResourcePermissionConfigurator =
 			sharingModelResourcePermissionConfigurator;
+		_workflowDefinitionLinkLocalService =
+			workflowDefinitionLinkLocalService;
 		_workflowStatusModelPreFilterContributor =
 			workflowStatusModelPreFilterContributor;
 		_userGroupRoleLocalService = userGroupRoleLocalService;
@@ -400,7 +404,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				WorkflowHandler.class,
 				new ObjectEntryWorkflowHandler(
-					objectDefinition, _objectEntryLocalService),
+					objectDefinition, _objectEntryLocalService,
+					_workflowDefinitionLinkLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"model.class.name", objectDefinition.getClassName()
 				).build()),
@@ -632,6 +637,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_sharingModelResourcePermissionConfigurator;
 	private final UserGroupRoleLocalService _userGroupRoleLocalService;
 	private final UserLocalService _userLocalService;
+	private final WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 	private final ModelPreFilterContributor
 		_workflowStatusModelPreFilterContributor;
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
@@ -6,6 +6,7 @@
 package com.liferay.object.internal.workflow;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -78,13 +79,10 @@ public class ObjectEntryWorkflowHandler
 			long companyId, long groupId, long classPK)
 		throws PortalException {
 
-		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-			classPK);
-
 		WorkflowDefinitionLink workflowDefinitionLink =
 			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
 				companyId, groupId, ObjectEntryFolder.class.getName(),
-				objectEntry.getObjectEntryFolderId(),
+				_getObjectEntryFolderId(classPK),
 				ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL, true);
 
 		if (workflowDefinitionLink != null) {
@@ -139,6 +137,20 @@ public class ObjectEntryWorkflowHandler
 
 		return _objectEntryLocalService.updateStatus(
 			userId, objectEntry, status, serviceContext);
+	}
+
+	private long _getObjectEntryFolderId(long classPK) throws PortalException {
+		Long objectEntryFolderId =
+			ObjectEntryThreadLocal.getObjectEntryFolderId();
+
+		if (objectEntryFolderId != null) {
+			return objectEntryFolderId;
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			classPK);
+
+		return objectEntry.getObjectEntryFolderId();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/workflow/ObjectEntryWorkflowHandler.java
@@ -8,13 +8,16 @@ package com.liferay.object.internal.workflow;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -34,10 +37,13 @@ public class ObjectEntryWorkflowHandler
 
 	public ObjectEntryWorkflowHandler(
 		ObjectDefinition objectDefinition,
-		ObjectEntryLocalService objectEntryLocalService) {
+		ObjectEntryLocalService objectEntryLocalService,
+		WorkflowDefinitionLinkLocalService workflowDefinitionLinkLocalService) {
 
 		_objectDefinition = objectDefinition;
 		_objectEntryLocalService = objectEntryLocalService;
+		_workflowDefinitionLinkLocalService =
+			workflowDefinitionLinkLocalService;
 	}
 
 	@Override
@@ -65,6 +71,27 @@ public class ObjectEntryWorkflowHandler
 	@Override
 	public String getType(Locale locale) {
 		return _objectDefinition.getLabel(locale);
+	}
+
+	@Override
+	public WorkflowDefinitionLink getWorkflowDefinitionLink(
+			long companyId, long groupId, long classPK)
+		throws PortalException {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			classPK);
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+				companyId, groupId, ObjectEntryFolder.class.getName(),
+				objectEntry.getObjectEntryFolderId(),
+				ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL, true);
+
+		if (workflowDefinitionLink != null) {
+			return workflowDefinitionLink;
+		}
+
+		return super.getWorkflowDefinitionLink(companyId, groupId, classPK);
 	}
 
 	@Override
@@ -119,5 +146,7 @@ public class ObjectEntryWorkflowHandler
 
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryFolderServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryFolderServiceHttp.java
@@ -387,7 +387,8 @@ public class ObjectEntryFolderServiceHttp {
 			updateObjectEntryFolder(
 				HttpPrincipal httpPrincipal, long objectEntryFolderId,
 				long parentObjectEntryFolderId,
-				java.util.Map<java.util.Locale, String> labelMap, String name)
+				java.util.Map<java.util.Locale, String> labelMap, String name,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -397,7 +398,7 @@ public class ObjectEntryFolderServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryFolderId, parentObjectEntryFolderId,
-				labelMap, name);
+				labelMap, name, serviceContext);
 
 			Object returnObj = null;
 
@@ -453,6 +454,9 @@ public class ObjectEntryFolderServiceHttp {
 	private static final Class<?>[] _getObjectEntryFoldersCountParameterTypes7 =
 		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _updateObjectEntryFolderParameterTypes8 =
-		new Class[] {long.class, long.class, java.util.Map.class, String.class};
+		new Class[] {
+			long.class, long.class, java.util.Map.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -141,6 +141,7 @@ import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.service.persistence.ResourcePermissionPersistence;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -979,6 +980,7 @@ public class ObjectDefinitionLocalServiceImpl
 				_portletLocalService, _resourceActions, _userLocalService,
 				_resourcePermissionLocalService, _searchLocalizationHelper,
 				_sharingModelResourcePermissionConfigurator,
+				_workflowDefinitionLinkLocalService,
 				_workflowStatusModelPreFilterContributor,
 				_userGroupRoleLocalService);
 
@@ -3191,6 +3193,10 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 	@Reference
 	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -246,7 +246,7 @@ public class ObjectEntryFolderLocalServiceImpl
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException {
 
 		ObjectEntryFolder objectEntryFolder =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.service.impl;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.entry.folder.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
@@ -27,12 +28,17 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -264,6 +270,8 @@ public class ObjectEntryFolderLocalServiceImpl
 		objectEntryFolder.setName(name);
 		objectEntryFolder.setTreePath(objectEntryFolder.buildTreePath());
 
+		_updateWorkflowDefinitionLinks(objectEntryFolderId, serviceContext);
+
 		return objectEntryFolderPersistence.update(objectEntryFolder);
 	}
 
@@ -281,6 +289,31 @@ public class ObjectEntryFolderLocalServiceImpl
 		}
 
 		return labelMap;
+	}
+
+	private void _updateWorkflowDefinitionLinks(
+			long objectEntryFolderId, ServiceContext serviceContext)
+		throws PortalException {
+
+		if (!GetterUtil.getBoolean(
+				serviceContext.getAttribute("updateWorkflowDefinitionLinks"),
+				true)) {
+
+			return;
+		}
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLinks(
+			serviceContext.getUserId(), serviceContext.getCompanyId(),
+			serviceContext.getScopeGroupId(), ObjectEntryFolder.class.getName(),
+			objectEntryFolderId,
+			Collections.singletonList(
+				new ObjectValuePair<>(
+					ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL,
+					ParamUtil.getString(
+						serviceContext,
+						"workflowDefinition" +
+							ObjectDefinitionConstants.
+								OBJECT_DEFINITION_ID_ALL))));
 	}
 
 	private void _validateExternalReferenceCode(
@@ -351,5 +384,9 @@ public class ObjectEntryFolderLocalServiceImpl
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -197,6 +197,12 @@ public class ObjectEntryFolderLocalServiceImpl
 			objectEntryFolder.getGroupId(), objectEntryFolder.getCompanyId(),
 			objectEntryFolder.getTreePath() + "%");
 
+		_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+			objectEntryFolder.getCompanyId(), objectEntryFolder.getGroupId(),
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId(),
+			ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL);
+
 		return objectEntryFolder;
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderServiceImpl.java
@@ -163,7 +163,8 @@ public class ObjectEntryFolderServiceImpl
 	@Override
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<Locale, String> labelMap, String name)
+			Map<Locale, String> labelMap, String name,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_modelResourcePermission.check(
@@ -171,7 +172,7 @@ public class ObjectEntryFolderServiceImpl
 
 		return objectEntryFolderLocalService.updateObjectEntryFolder(
 			getUserId(), objectEntryFolderId, parentObjectEntryFolderId,
-			labelMap, name);
+			labelMap, name, serviceContext);
 	}
 
 	@Reference(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -420,7 +420,12 @@ public class ObjectEntryLocalServiceImpl
 		_addFriendlyURLEntry(
 			objectDefinition, objectEntry, serviceContext, values);
 
-		_startWorkflowInstance(userId, objectEntry, serviceContext, false);
+		try (SafeCloseable safeCloseable =
+				ObjectEntryThreadLocal.setObjectEntryFolderIdWithSafeCloseable(
+					objectEntryFolderId)) {
+
+			_startWorkflowInstance(userId, objectEntry, serviceContext, false);
+		}
 
 		_updateResourcePermissions(
 			objectDefinition, objectEntry, serviceContext);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/workflow/test/ObjectEntryWorkflowHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/workflow/test/ObjectEntryWorkflowHandlerTest.java
@@ -1,0 +1,260 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.workflow.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryWorkflowHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId(), TestPropsValues.getUserId());
+
+		_objectDefinition = _addObjectDefinition();
+		_objectEntryFolder = _addObjectEntryFolder();
+
+		_serviceContext.setWorkflowAction(WorkflowConstants.ACTION_PUBLISH);
+	}
+
+	@Test
+	public void testDeleteObjectEntryFolderDeletesWorkflowDefinitionLink()
+		throws PortalException {
+
+		_objectEntryFolder = _updateObjectEntryFolderSingleApprover(
+			_serviceContext);
+
+		long objectEntryFolderId = _objectEntryFolder.getObjectEntryFolderId();
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+				TestPropsValues.getCompanyId(), _group.getGroupId(),
+				ObjectEntryFolder.class.getName(), objectEntryFolderId,
+				ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL, true);
+
+		Assert.assertNotNull(workflowDefinitionLink);
+
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(
+			objectEntryFolderId);
+
+		workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+				TestPropsValues.getCompanyId(), _group.getGroupId(),
+				ObjectEntryFolder.class.getName(), objectEntryFolderId,
+				ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL, true);
+
+		Assert.assertNull(workflowDefinitionLink);
+	}
+
+	@Test
+	public void testWorkflowApprovesObjectEntry() throws PortalException {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_objectEntryFolder.getObjectEntryFolderId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, objectEntry1.getStatus());
+
+		_objectEntryFolder = _updateObjectEntryFolderSingleApprover(
+			_serviceContext);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectEntryFolder.getObjectEntryFolderId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_PENDING, objectEntry2.getStatus());
+
+		_updateStatus(objectEntry2, WorkflowConstants.STATUS_APPROVED);
+
+		objectEntry2 = _objectEntryLocalService.getObjectEntry(
+			objectEntry2.getObjectEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, objectEntry2.getStatus());
+	}
+
+	@Test
+	public void testWorkflowRejectsObjectEntry() throws PortalException {
+		_objectEntryFolder = _updateObjectEntryFolderSingleApprover(
+			_serviceContext);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectEntryFolder.getObjectEntryFolderId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_PENDING, objectEntry.getStatus());
+
+		_updateStatus(objectEntry, WorkflowConstants.STATUS_DENIED);
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DENIED, objectEntry.getStatus());
+	}
+
+	private ObjectDefinition _addObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				TestPropsValues.getUserId(), 0, null, false, false, false,
+				false, false, false,
+				LocalizedMapUtil.getLocalizedMap(StringUtil.randomString()),
+				"A" + StringUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, ObjectDefinitionConstants.SCOPE_SITE,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.emptyList(),
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), "fieldName")));
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	private ObjectEntry _addObjectEntry(long objectEntryFolderId)
+		throws PortalException {
+
+		return _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_objectDefinition.getObjectDefinitionId(), objectEntryFolderId,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"fieldName", StringUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private ObjectEntryFolder _addObjectEntryFolder() throws Exception {
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			StringUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			StringUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntryFolder _updateObjectEntryFolderSingleApprover(
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		serviceContext.setAttribute(
+			"workflowDefinition" +
+				ObjectDefinitionConstants.OBJECT_DEFINITION_ID_ALL,
+			"Single Approver@1");
+
+		return _objectEntryFolderLocalService.updateObjectEntryFolder(
+			TestPropsValues.getUserId(),
+			_objectEntryFolder.getObjectEntryFolderId(),
+			_objectEntryFolder.getParentObjectEntryFolderId(),
+			_objectEntryFolder.getLabelMap(), _objectEntryFolder.getName(),
+			serviceContext);
+	}
+
+	private void _updateStatus(ObjectEntry objectEntry, int status)
+		throws PortalException {
+
+		WorkflowHandler<ObjectEntry> workflowHandler =
+			WorkflowHandlerRegistryUtil.getWorkflowHandler(
+				_objectDefinition.getClassName());
+
+		workflowHandler.updateStatus(
+			status,
+			HashMapBuilder.<String, Serializable>put(
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK,
+				String.valueOf(objectEntry.getObjectEntryId())
+			).put(
+				WorkflowConstants.CONTEXT_USER_ID,
+				String.valueOf(TestPropsValues.getUserId())
+			).put(
+				"serviceContext", _serviceContext
+			).build());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectEntryFolder _objectEntryFolder;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -251,7 +251,8 @@ public class ObjectEntryFolderLocalServiceTest {
 					TestPropsValues.getUserId(),
 					objectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getParentObjectEntryFolderId(),
-					objectEntryFolder.getLabelMap(), name);
+					objectEntryFolder.getLabelMap(), name,
+					ServiceContextTestUtil.getServiceContext());
 			});
 
 		AssertUtils.assertFailure(
@@ -267,7 +268,8 @@ public class ObjectEntryFolderLocalServiceTest {
 					TestPropsValues.getUserId(),
 					objectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getParentObjectEntryFolderId(),
-					objectEntryFolder.getLabelMap(), null);
+					objectEntryFolder.getLabelMap(), null,
+					ServiceContextTestUtil.getServiceContext());
 			});
 		AssertUtils.assertFailure(
 			ObjectEntryFolderScopeException.class,
@@ -294,7 +296,8 @@ public class ObjectEntryFolderLocalServiceTest {
 					objectEntryFolder.getObjectEntryFolderId(),
 					parentObjectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getLabelMap(),
-					objectEntryFolder.getName());
+					objectEntryFolder.getName(),
+					ServiceContextTestUtil.getServiceContext());
 			});
 
 		ObjectEntryFolder objectEntryFolder1 = _addObjectEntryFolder(
@@ -312,7 +315,8 @@ public class ObjectEntryFolderLocalServiceTest {
 				objectEntryFolder1.getObjectEntryFolderId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null, objectEntryFolder1.getName());
+				null, objectEntryFolder1.getName(),
+				ServiceContextTestUtil.getServiceContext());
 
 		AssertUtils.assertEquals(
 			HashMapBuilder.put(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -350,20 +350,14 @@ public class ObjectEntryFolderLocalServiceTest {
 	private ObjectEntry _addObjectEntry(long objectEntryFolderId)
 		throws Exception {
 
-		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+		return _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), _group.getGroupId(),
-			_objectDefinition.getObjectDefinitionId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			_objectDefinition.getObjectDefinitionId(), objectEntryFolderId,
 			null,
 			HashMapBuilder.<String, Serializable>put(
 				"fieldName", StringUtil.randomString()
 			).build(),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		objectEntry.setObjectEntryFolderId(objectEntryFolderId);
-		objectEntry.setTreePath(objectEntry.buildTreePath());
-
-		return _objectEntryLocalService.updateObjectEntry(objectEntry);
 	}
 
 	private ObjectEntryFolder _addObjectEntryFolder(

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -36,12 +37,12 @@ public class SharingEntryObjectEntryFolderServiceWrapper
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException {
 
 		ObjectEntryFolder objectEntryFolder = super.updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 
 		return _reindexSharingEntries(objectEntryFolder);
 	}


### PR DESCRIPTION
LPD-47621 Technical Task | Add workflow functionalities for folders

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46681

Following the same pattern as Documents and Media, we want that ObjectEntryFolder and ObjectEntry services so that the Objects workflow components take into consideration folder restrictions of workflow.

# How am I fixing it?

We add the workflow capabilities to the ObjectEntryFolder entity and modify ObjectEntryWorkflowHandler to take into account that firsly if there is workflow active on ObjectEntryFolder take propiroty to the workflow capability of the objectDefinition of the ObjectEntry

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-47621 add serviceContext when updating an object entry folder**
- **LPD-47621 buildService**
- **LPD-47621 updateWorkflowDefinitionLinks when updating a ObjectEntryFolder**
- **LPD-47621 fix test with new param needed**
- **LPD-47621 implement getWorkflowDefinitionLink on ObjectEntryWorkflowHandler**
- **LPD-47621 update object entry on all the cases not only on draft**
- **LPD-47621 startWorkflowInstance when publish**
- **LPD-47621 add test to check the workflow on object entries when object folder entry active**
- **LPD-47621 no longer needed**
