### PR TITLE
LPD-50837 Fix POSHI test AssetsSharingUpgrade#CanViewSharedAssetsArchive72101

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocumentSharing.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocumentSharing.macro
@@ -91,7 +91,7 @@ definition {
 			AssertElementPresent(locator1 = "Sharing#MANAGE_COLLABORATORS_EMPTY_STATE_MESSAGE");
 		}
 
-		Button.clickSave();
+		Button.click(button = "Save");
 
 		SelectFrame(value1 = "relative=top");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/AssetsSharingUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/AssetsSharingUpgrade.testcase
@@ -23,6 +23,7 @@ definition {
 	@priority = 5
 	@refactordone
 	test CanViewSharedAssetsArchive72101 {
+		property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 		property data.archive.type = "data-archive-asset-sharing";
 		property portal.version = "7.2.10.1";
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50837

Fix POSHI test AssetsSharingUpgrade#CanViewSharedAssetsArchive72101

# How am I fixing it?

The problems come from issue [LPD-48249: Some of Upgrade functional tests are failing due to JSONWS calls not returning responses properly](https://liferay.atlassian.net/browse/LPD-48249)

This property must be added: `property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";`

# How can you verify that it works?

Add this property to `portal-ext.properties`: `passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000`

`ant -f build-test.xml run-selenium-test -Dtest.class=AssetsSharingUpgrade#CanViewSharedAssetsArchive72101`

