### PR TITLE
LPD-50907, LPD-50913, LPD-50927 Fluid layout changes for Blogs, Bookmarks and Recycle Bin

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -20,6 +20,7 @@ renderResponse.setTitle(blogsEditEntryDisplayContext.getPageTitle(resourceBundle
 
 <clay:container-fluid
 	cssClass="container-form-lg entry-body"
+	size="lg"
 >
 	<aui:form action="<%= blogsEditEntryDisplayContext.getEditEntryURL() %>" cssClass="edit-entry" enctype="multipart/form-data" method="post" name="fm" onSubmit="event.preventDefault();">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/view_entries.jsp
@@ -33,7 +33,9 @@ PortletURL portletURL = entriesSearchContainer.getIteratorURL();
 	portletURL="<%= restoreTrashEntriesURL %>"
 />
 
-<clay:container-fluid>
+<clay:container-fluid
+	size="xxxl"
+>
 	<aui:form action="<%= portletURL %>" method="get" name="fm">
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -46,6 +46,7 @@ renderResponse.setTitle(headerTitle);
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<portlet:actionURL name="/bookmarks/edit_entry" var="editEntryURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_entry" />

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -48,6 +48,7 @@ renderResponse.setTitle(headerTitle);
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<portlet:actionURL name="/bookmarks/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/bookmarks/edit_folder" />

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view.jsp
@@ -77,6 +77,7 @@ BookmarksUtil.addPortletBreadcrumbEntries(folder, request, renderResponse);
 
 	<clay:container-fluid
 		cssClass="container-view sidenav-content"
+		size="xxxl"
 	>
 		<div class="bookmarks-breadcrumb" id="<portlet:namespace />breadcrumbContainer">
 			<c:if test="<%= !bookmarksDisplayContext.isNavigationRecent() && !bookmarksDisplayContext.isNavigationMine() %>">

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,6 +30,7 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 
 	<clay:container-fluid
 		cssClass="sidenav-content"
+		size="xxxl"
 	>
 		<c:if test="<%= Validator.isNull(trashDisplayContext.getKeywords()) %>">
 			<liferay-site-navigation:breadcrumb


### PR DESCRIPTION
Link to issues: 

https://liferay.atlassian.net/browse/LPD-50907
https://liferay.atlassian.net/browse/LPD-50913
https://liferay.atlassian.net/browse/LPD-50927

Example in Blogs: 

### Before: 
![Before - list view](https://github.com/user-attachments/assets/3817fc59-d19a-49ee-b223-6afabd19080b)

### After: 
![Screenshot 2025-03-10 at 14 18 34](https://github.com/user-attachments/assets/6e1f36a0-bddc-4bed-ba97-d28b0103d789)


**Note**: cards width is set in Clay, and there is currently a conversation in Platform Experience team to change and coordinate this (they have to take in mind the pagination)