### PR TITLE
LPD-50971 | Unable to filter by category if their vocabulary is related with a specific document type

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContextProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContextProvider.java
@@ -10,6 +10,7 @@ import com.liferay.asset.auto.tagger.configuration.AssetAutoTaggerConfigurationF
 import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.document.library.configuration.DLFileOrderConfigurationProvider;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.web.internal.display.context.helper.DLRequestHelper;
 import com.liferay.document.library.web.internal.helper.DLTrashHelper;
@@ -62,9 +63,9 @@ public class DLAdminDisplayContextProvider {
 			httpServletRequest);
 
 		return new DLAdminManagementToolbarDisplayContext(
-			_assetVocabularyService, dlAdminDisplayContext, _dlTrashHelper,
-			httpServletRequest, _itemSelector,
-			dlRequestHelper.getLiferayPortletRequest(),
+			_assetVocabularyService, dlAdminDisplayContext,
+			_dlFileEntryTypeService, _dlTrashHelper, httpServletRequest,
+			_itemSelector, dlRequestHelper.getLiferayPortletRequest(),
 			dlRequestHelper.getLiferayPortletResponse(),
 			_siteConnectedGroupGroupProvider);
 	}
@@ -92,6 +93,9 @@ public class DLAdminDisplayContextProvider {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private DLFileEntryTypeService _dlFileEntryTypeService;
 
 	@Reference
 	private DLFileOrderConfigurationProvider _dlFileOrderConfigurationProvider;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.document.library.web.internal.constants.DLWebKeys;
 import com.liferay.document.library.web.internal.display.context.helper.DLPortletInstanceSettingsHelper;
@@ -78,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletResponse;
@@ -94,6 +96,7 @@ public class DLAdminManagementToolbarDisplayContext
 	public DLAdminManagementToolbarDisplayContext(
 		AssetVocabularyService assetVocabularyService,
 		DLAdminDisplayContext dlAdminDisplayContext,
+		DLFileEntryTypeService dLFileEntryTypeService,
 		DLTrashHelper dlTrashHelper, HttpServletRequest httpServletRequest,
 		ItemSelector itemSelector, LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
@@ -111,6 +114,8 @@ public class DLAdminManagementToolbarDisplayContext
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_siteConnectedGroupGroupProvider = siteConnectedGroupGroupProvider;
+
+		_dlFileEntryTypeService = dLFileEntryTypeService;
 
 		_currentURLObj = PortletURLUtil.getCurrent(
 			liferayPortletRequest, liferayPortletResponse);
@@ -582,13 +587,7 @@ public class DLAdminManagementToolbarDisplayContext
 			"selectedCategoryIds",
 			StringUtil.merge(_getAssetCategoryIds(), StringPool.COMMA)
 		).setParameter(
-			"vocabularyIds",
-			StringUtil.merge(
-				_assetVocabularyService.getGroupsVocabularies(
-					_getGroupIds(), DLFileEntryConstants.getClassName()),
-				assetVocabulary -> String.valueOf(
-					assetVocabulary.getVocabularyId()),
-				StringPool.COMMA)
+			"vocabularyIds", _getVocabularyIds()
 		).buildString();
 	}
 
@@ -988,6 +987,25 @@ public class DLAdminManagementToolbarDisplayContext
 		).buildString();
 	}
 
+	private String _getVocabularyIds() {
+		Set<AssetVocabulary> vocabularies = new TreeSet<>();
+
+		for (DLFileEntryType dlFileEntryType :
+				_dlFileEntryTypeService.getFileEntryTypes(_getGroupIds())) {
+
+			vocabularies.addAll(
+				_assetVocabularyService.getGroupsVocabularies(
+					_getGroupIds(), DLFileEntryConstants.getClassName(),
+					dlFileEntryType.getFileEntryTypeId()));
+		}
+
+		return StringUtil.merge(
+			vocabularies,
+			assetVocabulary -> String.valueOf(
+				assetVocabulary.getVocabularyId()),
+			StringPool.COMMA);
+	}
+
 	private boolean _hasValidAssetVocabularies() {
 		if (_hasValidAssetVocabularies != null) {
 			return _hasValidAssetVocabularies;
@@ -1059,6 +1077,7 @@ public class DLAdminManagementToolbarDisplayContext
 	private final AssetVocabularyService _assetVocabularyService;
 	private final PortletURL _currentURLObj;
 	private final DLAdminDisplayContext _dlAdminDisplayContext;
+	private final DLFileEntryTypeService _dlFileEntryTypeService;
 	private final DLPortletInstanceSettingsHelper
 		_dlPortletInstanceSettingsHelper;
 	private final DLRequestHelper _dlRequestHelper;

--- a/modules/test/playwright/helpers/CreateCategories.ts
+++ b/modules/test/playwright/helpers/CreateCategories.ts
@@ -13,17 +13,20 @@ export type TCategory = Omit<
 
 export async function createCategories({
 	apiHelpers,
+	assetTypes,
 	categoryNames,
 	siteId,
 	vocabularyName,
 }: {
 	apiHelpers: ApiHelpers;
+	assetTypes?: AssetType[];
 	categoryNames: TCategory[];
 	siteId: string;
 	vocabularyName: string;
 }): Promise<({id: number} & TCategory)[]> {
 	const {id: vocabularyId} =
 		await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
+			assetTypes,
 			name: vocabularyName,
 			siteId,
 		});

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -357,6 +357,54 @@ test(
 );
 
 test(
+	'Unable to filter by category if their vocabulary is related with a specific document type',
+	{
+		tag: '@LPD-50971',
+	},
+
+	async ({apiHelpers, documentLibraryPage, page, site}) => {
+		const vocabularyName = getRandomString();
+
+		const categories = await createCategories({
+			apiHelpers,
+			assetTypes: [
+				{
+					required: false,
+					subtype: 'Basic Document',
+					type: 'Document',
+				},
+			],
+			categoryNames: [{name: 'Books'}],
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		await apiHelpers.headlessDelivery.postDocument(
+			site.id,
+			createReadStream(path.join(__dirname, '/dependencies/image1.jpeg')),
+			{
+				description: getRandomString(),
+				fileName: getRandomString(),
+				taxonomyCategoryIds: [categories[0].id],
+				title: getRandomString(),
+			}
+		);
+
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Categories'}).click();
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Filter by Categories"]')
+				.getByText(vocabularyName)
+		).toBeVisible();
+	}
+);
+
+test(
 	'Only one well formatted success message on scheduling file from widget page',
 	{
 		tag: ['@LPD-45614', '@LPD-45658'],


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-50971
### How am I fixing it?
By adding nongeneral vocabularies to the category filter list.

### How can you verify that it works?

To test run:
`npm run playwright -- test -g 'LPD-50971'`

Or manually test based on the LPD steps