### PR TITLE
LPD-51212 Mime type is not checked for message board uploads

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandler.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandler.java
@@ -47,6 +47,9 @@ public abstract class BaseMBUploadFileEntryHandler
 
 		String contentType = _getContentType(uploadPortletRequest);
 
+		_dlValidator.validateFileMimeType(
+			themeDisplay.getCompanyId(), contentType);
+
 		_dlValidator.validateFileSize(
 			themeDisplay.getScopeGroupId(), fileName, contentType,
 			uploadPortletRequest.getSize(getParameterName()));

--- a/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandlerTest.java
+++ b/modules/apps/message-boards/message-boards-web/src/test/java/com/liferay/message/boards/web/internal/upload/BaseMBUploadFileEntryHandlerTest.java
@@ -6,10 +6,13 @@
 package com.liferay.message.boards.web.internal.upload;
 
 import com.liferay.document.library.kernel.exception.FileExtensionException;
+import com.liferay.document.library.kernel.exception.FileMimeTypeException;
 import com.liferay.document.library.kernel.util.DLValidator;
 import com.liferay.message.boards.service.MBMessageService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.ClassRule;
@@ -46,6 +49,36 @@ public class BaseMBUploadFileEntryHandlerTest {
 		).thenReturn(
 			RandomTestUtil.randomString()
 		);
+
+		testMBUploadFileEntryHandler.upload(_uploadPortletRequest);
+	}
+
+	@Test(expected = FileMimeTypeException.class)
+	public void testUploadValidatesFileMimeType() throws Exception {
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			_uploadPortletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Mockito.doThrow(
+			FileMimeTypeException.class
+		).when(
+			_dlValidator
+		).validateFileMimeType(
+			Mockito.anyLong(), Mockito.anyString()
+		);
+
+		Mockito.when(
+			_uploadPortletRequest.getContentType(Mockito.anyString())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		TestMBUploadFileEntryHandler testMBUploadFileEntryHandler =
+			new TestMBUploadFileEntryHandler(_dlValidator, _mbMessageService);
 
 		testMBUploadFileEntryHandler.upload(_uploadPortletRequest);
 	}


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-51212
When uploading files with a different MIME type and extension are being uploaded to Message Boards without any validation error.

### **How am I fixing it?**
I am adding MIME type validation in BaseMBUploadFileEntryHandler, ensuring that uploaded files are properly verified before being accepted in Message Boards.

### **How can you verify that it works?**

1. Start the Liferay instance.
2. Navigate to Message Boards.
3. Upload a file with a MIME type that is different from the allowed configuration.
4. Confirm that an error occurs at the time of upload, preventing the file from being accepted.