### PR TITLE
LPD-48844 Fluid Layout fixes in Content Management

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -14,6 +14,7 @@
 
 <clay:container-fluid
 	cssClass="container-view"
+	size="xl"
 >
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= BreadcrumbEntriesUtil.getBreadcrumbEntries(request, true, false, false, true, true) %>"

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,7 +16,7 @@
 	<portlet:param name="redirect" value="<%= currentURL %>" />
 </portlet:actionURL>
 
-<aui:form action="<%= deleteTagURL %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
+<aui:form action="<%= deleteTagURL %>" cssClass="container-fluid container-fluid-max-xxxl" name="fm">
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= BreadcrumbEntriesUtil.getBreadcrumbEntries(request, true, false, false, true, true) %>"
 	/>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/ddm/edit_ddm_structure.jsp
@@ -51,7 +51,9 @@ renderResponse.setTitle(title);
 		<aui:model-context bean="<%= ddmStructure %>" model="<%= com.liferay.dynamic.data.mapping.model.DDMStructure.class %>" />
 
 		<nav class="component-tbar subnav-tbar-light tbar tbar-metadata-type">
-			<clay:container-fluid>
+			<clay:container-fluid
+				fullWidth="<%= true %>"
+			>
 				<ul class="tbar-nav">
 					<li class="tbar-item tbar-item-expand">
 						<aui:input cssClass="form-control-inline" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" name="name" placeholder='<%= LanguageUtil.format(request, "untitled", "metadata-set") %>' wrapperCssClass="mb-0" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -126,7 +126,9 @@ renderResponse.setTitle(headerTitle);
 	%>
 
 	<div class="management-bar management-bar-light navbar navbar-expand-md">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="m-auto navbar-nav"></ul>
 
 			<ul class="middle navbar-nav">
@@ -142,6 +144,7 @@ renderResponse.setTitle(headerTitle);
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<c:if test="<%= checkedOut %>">
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry_type.jsp
@@ -55,7 +55,9 @@ renderResponse.setTitle((fileEntryType == null) ? LanguageUtil.get(request, "new
 	<aui:model-context bean="<%= fileEntryType %>" model="<%= DLFileEntryType.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-metadata-type">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()) %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" name="name" placeholder='<%= LanguageUtil.format(request, "untitled", "structure") %>' wrapperCssClass="article-content-title mb-0" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_shortcut.jsp
@@ -17,6 +17,7 @@ renderResponse.setTitle(dlEditFileShortcutDisplayContext.getTitle());
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<aui:form action="<%= dlEditFileShortcutDisplayContext.getEditFileShortcutURL() %>" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_folder.jsp
@@ -31,6 +31,7 @@ renderResponse.setTitle(dlEditFolderDisplayContext.getHeaderTitle());
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<portlet:actionURL name="/document_library/edit_folder" var="editFolderURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_folder" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_repository.jsp
@@ -26,6 +26,7 @@ renderResponse.setTitle(headerTitle);
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<portlet:actionURL name="/document_library/edit_repository" var="editRepositoryURL">
 		<portlet:param name="mvcRenderCommandName" value="/document_library/edit_repository" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_upper_tbar.jsp
@@ -15,7 +15,9 @@ FileVersion fileVersion = dlViewFileEntryDisplayContext.getFileVersion();
 %>
 
 <nav class="component-tbar subnav-tbar-light tbar upper-tbar" role="navigation">
-	<clay:container-fluid>
+	<clay:container-fluid
+		fullWidth="<%= true %>"
+	>
 		<ul class="tbar-nav">
 			<li class="tbar-item tbar-item-expand">
 				<div class="tbar-section text-left">

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries.jsp
@@ -33,7 +33,7 @@ if (portletTitleBasedNavigation) {
 }
 %>
 
-<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-xl container-form-lg\"" : StringPool.BLANK %>>
+<div <%= portletTitleBasedNavigation ? "class=\"container-fluid container-fluid-max-lg container-form-lg\"" : StringPool.BLANK %>>
 	<c:if test="<%= !portletTitleBasedNavigation %>">
 		<liferay-ui:header
 			backURL="<%= redirect %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view.jsp
@@ -136,7 +136,7 @@ DLViewDisplayContext dlViewDisplayContext = new DLViewDisplayContext(dlAdminDisp
 					<liferay-util:include page="/document_library/info_panel.jsp" servletContext="<%= application %>" />
 				</liferay-frontend:sidebar-panel>
 
-				<div class="sidenav-content <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl container-view" : StringPool.BLANK %>">
+				<div class="sidenav-content <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xxxl container-view" : StringPool.BLANK %>">
 					<c:if test="<%= dlAdminDisplayContext.hasFilterParameters() && ListUtil.isNotEmpty(dlAdminDisplayContext.getMountFolders()) %>">
 						<clay:alert
 							displayType="info"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_history.jsp
@@ -23,7 +23,7 @@ renderResponse.setTitle(fileEntry.getTitle());
 	navigationItems="<%= dlViewEntryHistoryDisplayContext.getNavigationItems() %>"
 />
 
-<div class="container-fluid container-fluid-max-xl">
+<div class="container-fluid container-fluid-max-xxxl">
 	<liferay-ui:search-container
 		id="articleVersions"
 		searchContainer="<%= dlViewEntryHistoryDisplayContext.getSearchContainer() %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_metadata_sets.jsp
@@ -20,10 +20,12 @@ DLViewFileEntryMetadataSetsDisplayContext dLViewFileEntryMetadataSetsDisplayCont
 
 <portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/document_library/delete_data_definition" var="deleteDataDefinitionURL" />
 
-<aui:form action="<%= deleteDataDefinitionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<aui:form action="<%= deleteDataDefinitionURL %>" cssClass="container-fluid container-fluid-max-xxxl" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-	<clay:container-fluid>
+	<clay:container-fluid
+		size="xxxl"
+	>
 		<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 		<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />
 		<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureThatHasChild.class %>" message="the-structure-cannot-be-deleted-because-it-has-one-or-more-substructures" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry_types.jsp
@@ -23,7 +23,9 @@ DLViewFileEntryTypesDisplayContext dlViewFileEntryTypesDisplayContext = new DLVi
 	selectable="<%= false %>"
 />
 
-<clay:container-fluid>
+<clay:container-fluid
+	size="xxxl"
+>
 	<liferay-site-navigation:breadcrumb
 		breadcrumbEntries="<%= BreadcrumbEntriesUtil.getBreadcrumbEntries(request, true, false, false, true, true) %>"
 	/>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_more_menu_items.jsp
@@ -26,7 +26,7 @@ DLViewMoreMenuItemsDisplayContext dlViewMoreMenuItemsDisplayContext = new DLView
 	selectable="<%= false %>"
 />
 
-<aui:form cssClass="container-fluid container-fluid-max-xl" name="addMenuItemFm">
+<aui:form cssClass="container-fluid container-fluid-max-xxxl" name="addMenuItemFm">
 	<liferay-ui:search-container
 		searchContainer="<%= dlViewMoreMenuItemsDisplayContext.getSearchContainer() %>"
 	>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -101,7 +101,9 @@ journalEditArticleDisplayContext.setViewAttributes();
 		DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		%>
 
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<div class="autofit-row sidebar-section">
@@ -334,6 +336,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 	<div class="contextual-sidebar-content">
 		<clay:container-fluid
 			cssClass="container-view"
+			size="lg"
 		>
 			<div class="article-content-content">
 				<%@ include file="/edit_article_exceptions.jspf" %>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -57,7 +57,9 @@ editDDMStructureURL.setParameter("structureKey", String.valueOf(ddmStructureKey)
 	<aui:model-context bean="<%= ddmStructure %>" model="<%= DDMStructure.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" languagesDropdownDirection="down" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title c-mb-0" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -43,7 +43,9 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 	<aui:model-context bean="<%= ddmTemplate %>" model="<%= DDMTemplate.class %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-article">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmTemplate == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): ddmTemplate.getDefaultLanguageId() %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "template") %>' wrapperCssClass="article-content-title mb-0" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view.jsp
@@ -143,6 +143,7 @@ else {
 
 	<clay:container-fluid
 		cssClass="container-view sidenav-content"
+		size="xxxl"
 	>
 
 		<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -34,7 +34,7 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 	/>
 </div>
 
-<aui:form action="<%= deleteDataDefinitionURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<aui:form action="<%= deleteDataDefinitionURL %>" cssClass="container-fluid container-fluid-max-xxxl" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
 	<liferay-ui:success key="importDataDefinitionSuccessMessage" message="the-structure-was-successfully-imported" />

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
@@ -34,7 +34,7 @@ if (ddmStructure != null) {
 	<portlet:param name="mvcPath" value="/view_ddm_templates.jsp" />
 </portlet:actionURL>
 
-<aui:form action="<%= deleteDDMTemplateURL %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+<aui:form action="<%= deleteDDMTemplateURL %>" cssClass="container-fluid container-fluid-max-xxxl" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
 	<c:if test="<%= !journalDisplayContext.isNavigationMine() && !journalDisplayContext.isNavigationRecent() %>">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/EditKBArticleDisplayContext.java
@@ -179,7 +179,7 @@ public class EditKBArticleDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		return "class=\"container-fluid container-fluid-max-xl " +
+		return "class=\"container-fluid container-fluid-max-lg " +
 			"container-form-lg\"";
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp
@@ -33,7 +33,9 @@ if (editKBArticleDisplayContext.isPortletTitleBasedNavigation()) {
 	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_SAVE_DRAFT %>" />
 
 	<nav class="component-tbar subnav-tbar-light tbar tbar-knowledge-base-edit-article">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="tbar-nav">
 				<li class="tbar-item tbar-item-expand">
 					<aui:input autocomplete="off" cssClass="form-control-inline" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" name="title" placeholder='<%= LanguageUtil.format(request, "untitled-x", "article") %>' required="<%= true %>" type="text" value="<%= HtmlUtil.escape(editKBArticleDisplayContext.getKBArticleTitle()) %>" wrapperCssClass="mb-0" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_folder.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_folder.jsp
@@ -35,6 +35,7 @@ renderResponse.setTitle((kbFolder == null) ? LanguageUtil.get(resourceBundle, "n
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<aui:form action="<%= updateKBFolderURL %>" method="post" name="fm">
 		<aui:input name="mvcPath" type="hidden" value="/admin/common/edit_kb_folder.jsp" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_template.jsp
@@ -26,6 +26,7 @@ renderResponse.setTitle((kbTemplate == null) ? LanguageUtil.get(request, "new-te
 
 <clay:container-fluid
 	cssClass="container-form-lg"
+	size="lg"
 >
 	<aui:form action="<%= updateKBTemplateURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "updateKBTemplate();" %>'>
 		<aui:input name="mvcPath" type="hidden" value="/admin/common/edit_kb_template.jsp" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -54,7 +54,9 @@ if (portletTitleBasedNavigation) {
 	%>
 
 	<div class="management-bar management-bar-light navbar navbar-expand-md">
-		<clay:container-fluid>
+		<clay:container-fluid
+			fullWidth="<%= true %>"
+		>
 			<ul class="justify-content-end navbar-nav navbar-nav-expand">
 				<li class="nav-item">
 					<clay:link
@@ -107,7 +109,7 @@ if (portletTitleBasedNavigation) {
 		</liferay-frontend:sidebar-panel>
 	</c:if>
 
-	<div class="sidenav-content <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-xl container-form-lg" : StringPool.BLANK %>">
+	<div class="sidenav-content <%= portletTitleBasedNavigation ? "container-fluid container-fluid-max-lg container-form-lg" : StringPool.BLANK %>">
 		<c:if test="<%= !portletTitleBasedNavigation %>">
 			<div class="autofit-row">
 				<div class="autofit-col autofit-col-expand">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
@@ -21,7 +21,9 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import"));
 	<portlet:param name="redirect" value="<%= redirect %>" />
 </portlet:actionURL>
 
-<clay:container-fluid>
+<clay:container-fluid
+	size="lg"
+>
 	<aui:form action="<%= importFileURL %>" class="lfr-dynamic-form" enctype="multipart/form-data" method="post" name="fm">
 		<aui:input name="mvcPath" type="hidden" value="/admin/import.jsp" />
 		<aui:input name="parentKBFolderId" type="hidden" value="<%= String.valueOf(parentKBFolderId) %>" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -70,6 +70,7 @@ KBAdminManagementToolbarDisplayContext kbAdminManagementToolbarDisplayContext = 
 
 		<clay:container-fluid
 			cssClass="container-view sidenav-content"
+			size="xxxl"
 		>
 
 			<%

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_suggestions.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_suggestions.jsp
@@ -71,7 +71,9 @@ request.setAttribute("view_kb_suggestions.jsp-searchContainer", kbCommentsSearch
 		sortingURL="<%= String.valueOf(kbSuggestionListManagementToolbarDisplayContext.getSortingURL()) %>"
 	/>
 
-	<clay:container-fluid>
+	<clay:container-fluid
+		size="xxxl"
+	>
 		<liferay-ui:success key="suggestionDeleted" message="suggestion-was-deleted-successfully" />
 
 		<liferay-ui:success key="suggestionsDeleted" message="suggestions-were-deleted-successfully" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_template.jsp
@@ -39,7 +39,9 @@
 		%>
 
 		<div class="management-bar management-bar-light navbar navbar-expand-md">
-			<clay:container-fluid>
+			<clay:container-fluid
+				fullWidth="<%= true %>"
+			>
 				<ul class="justify-content-end navbar-nav navbar-nav-expand">
 					<li class="nav-item">
 						<clay:link
@@ -73,7 +75,7 @@
 		</div>
 	</c:if>
 
-	<div class="container-fluid container-fluid-max-xl container-form-lg">
+	<div class="container-fluid container-fluid-max-lg container-form-lg">
 		<div class="kb-article sheet">
 			<div class="kb-entity-body">
 				<div class="kb-article-title">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_templates.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/view_kb_templates.jsp
@@ -20,7 +20,9 @@ ViewKBTemplatesDisplayContext viewKBTemplatesDisplayContext = (ViewKBTemplatesDi
 		searchContainerId="kbTemplates"
 	/>
 
-	<clay:container-fluid>
+	<clay:container-fluid
+		size="xxxl"
+	>
 		<aui:form action="<%= viewKBTemplatesDisplayContext.getSearchURL() %>" method="get" name="fm">
 			<aui:input name="kbTemplateIds" type="hidden" />
 


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-48844 - Review and address potential fixes for fluid layout issues in Content Management

Web Content - https://liferay.atlassian.net/browse/LPD-50054
Documents & Media - https://liferay.atlassian.net/browse/LPD-50055
Knowledge Base - https://liferay.atlassian.net/browse/LPD-50056
Categories + Tags - https://liferay.atlassian.net/browse/LPD-50057

Usually fixed by adding the appropriate size marker or `fullWidth` to the container, based on the chart [here](https://liferay.atlassian.net/wiki/spaces/ENGLIMA/pages/3579707611/Fluid+Layout+Testing+-+LPD-48844#Spike-Decisions%3A).

Some screenshots of the new look:
<img width="1784" alt="Screenshot 2025-03-12 at 5 42 32 PM" src="https://github.com/user-attachments/assets/ca3a3692-3878-4e17-b233-a0a186865817" />
<img width="1787" alt="Screenshot 2025-03-12 at 5 42 12 PM" src="https://github.com/user-attachments/assets/bec6b94e-c24d-4be8-a5a3-1a7204cccec5" />
<img width="1772" alt="Screenshot 2025-03-12 at 5 41 59 PM" src="https://github.com/user-attachments/assets/db346bde-6cf2-4730-9127-2e3faebe73b4" />
<img width="1789" alt="Screenshot 2025-03-12 at 5 41 26 PM" src="https://github.com/user-attachments/assets/5d62ae91-d815-433d-b6f5-830b1be2a067" />


I noticed a few things, mentioning them here:

- The edit-form taglib `liferay-frontend:edit-form` defines its own sizes and uses a `sheet-lg` class that gives it a width of 800px, so I did not make updates to use `container-fluid-max-lg`.
    - Web Content - New Folder page `edit_folder.jsp`
    - Tag, Category, and Vocabulary - Edit pages `edit_tag.jsp`, `details.jsp`, `edit_asset_vocabulary.jsp`

- Some edit pages have a `liferay-data-engine:data-layout-builder` taglib to help adjust the main screen depending on the sidebar opening and closing. I think they were originally at `xl`, but setting the container’s size to `lg` makes it look much narrower when the sidebar is open, so I did not make any updates for that.
    - Web Content - Edit Structure `edit_data_definition.jsp`
    - Documents & Media - Edit Document Type `edit_file_entry_type.jsp`
    - Documents & Media - Edit Metadata Set `edit_ddm_structure.jsp`

- There was a recent change to Web Content on https://liferay.atlassian.net/browse/LPD-49738 which capped the max length of navigation bars to 1920px. I take this was intentional! For consistency, the property `fullWidth` was still added to the `container-fluid`.

Thanks for following along! Let me know if additional changes would be necessary, but hopefully this addresses most of the changes.