### PR TITLE
LPD-50834 GPX files are downloaded with extension .xml or gpx.xml on mobile browsers

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -151,6 +152,22 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		AssertUtils.assertEqualsSorted(assetTagNames, assetEntry.getTagNames());
+	}
+
+	@Test
+	public void testFileEntryShouldSaveCorrectMimeTypeForGpxExtension()
+		throws Exception {
+
+		String fileName = "test.gpx";
+
+		FileEntry fileEntry = dlAppService.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileName, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK,
+			FileUtil.getBytes(getClass(), _TEST_GPX), null, null, null,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertEquals("application/gpx+xml", fileEntry.getMimeType());
 	}
 
 	@Test
@@ -501,6 +518,9 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 			StringPool.BLANK, StringPool.BLANK, null, 0, null, null, null,
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
+
+	private static final String _TEST_GPX =
+		"/com/liferay/document/library/dependencies/test.gpx";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLAppServiceWhenAddingAFileEntryTest.class);

--- a/modules/apps/document-library/document-library-test/src/testIntegration/resources/com/liferay/document/library/dependencies/test.gpx
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/resources/com/liferay/document/library/dependencies/test.gpx
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<gpx creator="Test" version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+	<wpt lat="37.7749" lon="-122.4194">
+		<name>Test Point</name>
+	</wpt>
+</gpx>

--- a/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
+++ b/modules/apps/portal/portal-tika/src/main/resources/com/liferay/portal/tika/internal/mime/dependencies/custom-mimetypes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 
 <mime-info>
+	<mime-type type="application/gpx+xml">
+		<glob pattern="*.gpx" />
+	</mime-type>
 	<mime-type type="application/javascript">
 		<glob pattern="*.js" />
 	</mime-type>


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-50834
When uploading a file with a .gpx extension in Liferay, the system incorrectly assigns its MIME type as application/xml instead of the correct application/gpx+xml. This causes issues, particularly on Android devices, where the file may lose its correct .gpx extension after being downloaded.

### **How am I fixing it?**
The .gpx extension and its correct MIME type (application/gpx+xml) are being added to custom-mimetypes.xml

### **How can you verify that it works?**

1. Start the Liferay instance.
2. Navigate to Documents and Media.
3. Upload a file with a .gpx extension.
4. Copy the latest version URL of the uploaded file.
5. Open this URL in Chrome on an Android device.
6. Confirm that the file downloads correctly with the .gpx extension preserved.