### PR TITLE
LPD-51416 Removing translation does not trigger web content cache update

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/JournalContent.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/JournalContent.java
@@ -23,6 +23,10 @@ public interface JournalContent {
 	public void clearCache(
 		long groupId, String articleId, String ddmTemplateKey);
 
+	public void clearCache(
+		long groupId, String articleId, String ddmTemplateKey,
+		String[] languageIds);
+
 	public void clearCache(String ddmTemplateKey);
 
 	public String getContent(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalContentImpl.java
@@ -41,8 +41,11 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.portlet.RenderRequest;
 
@@ -84,6 +87,27 @@ public class JournalContentImpl implements JournalContent {
 					new MethodHandler(
 						_clearArticleCacheMethodKey, groupId, articleId,
 						ddmTemplateKey),
+					true);
+
+			clusterRequest.setFireAndForget(true);
+
+			ClusterExecutorUtil.execute(clusterRequest);
+		}
+	}
+
+	@Override
+	public void clearCache(
+		long groupId, String articleId, String ddmTemplateKey,
+		String[] languageIds) {
+
+		_clearCache(groupId, articleId, ddmTemplateKey, languageIds);
+
+		if (ClusterInvokeThreadLocal.isEnabled()) {
+			ClusterRequest clusterRequest =
+				ClusterRequest.createMulticastRequest(
+					new MethodHandler(
+						_clearArticleLocalizationCacheMethodKey, groupId,
+						articleId, ddmTemplateKey, languageIds),
 					true);
 
 			clusterRequest.setFireAndForget(true);
@@ -473,6 +497,27 @@ public class JournalContentImpl implements JournalContent {
 				groupId, articleId, ddmTemplateKey));
 	}
 
+	private static void _clearCache(
+		long groupId, String articleId, String ddmTemplateKey,
+		String[] languageIds) {
+
+		Set<JournalContentKey> keys = _journalArticlePortalCacheIndexer.getKeys(
+			JournalContentArticleKeyIndexEncoder.encode(
+				groupId, articleId, ddmTemplateKey));
+
+		if ((keys == null) || keys.isEmpty()) {
+			return;
+		}
+
+		Set<String> languageIdsSet = new HashSet<>(Arrays.asList(languageIds));
+
+		for (JournalContentKey key : keys) {
+			if (languageIdsSet.contains(key._languageId)) {
+				_portalCache.remove(key);
+			}
+		}
+	}
+
 	private static void _clearCache(String ddmTemplateKey) {
 		_journalTemplatePortalCacheIndexer.removeKeys(ddmTemplateKey);
 	}
@@ -494,6 +539,10 @@ public class JournalContentImpl implements JournalContent {
 	private static final MethodKey _clearArticleCacheMethodKey = new MethodKey(
 		JournalContentImpl.class, "_clearCache", long.class, String.class,
 		String.class);
+	private static final MethodKey _clearArticleLocalizationCacheMethodKey =
+		new MethodKey(
+			JournalContentImpl.class, "_clearCache", long.class, String.class,
+			String.class, String[].class);
 	private static final MethodKey _clearTemplateCacheMethodKey = new MethodKey(
 		JournalContentImpl.class, "_clearCache", String.class);
 	private static PortalCacheIndexer

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/example/test/JournalContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/example/test/JournalContentTest.java
@@ -14,6 +14,7 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.Theme;
@@ -26,6 +27,8 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -70,9 +74,11 @@ public class JournalContentTest {
 		new LiferayIntegrationTestRule();
 
 	@Before
-	public void setUp() throws PortalException {
+	public void setUp() throws Exception {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
+
+		_group = GroupTestUtil.addGroup();
 
 		setUpPortletRequestModel(mockHttpServletRequest);
 		setUpServiceContext(mockHttpServletRequest);
@@ -81,6 +87,130 @@ public class JournalContentTest {
 	@After
 	public void tearDown() {
 		tearDownServiceContext();
+	}
+
+	@Test
+	public void testClearCacheForLocalization() throws Exception {
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+		String spainLanguageId = LocaleUtil.toLanguageId(LocaleUtil.SPAIN);
+
+		_journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Este es el titulo"
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Esta es la descripcion"
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Este es el contenido"
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			LocaleUtil.getSiteDefault(), false, true, _serviceContext);
+
+		long groupId = _journalArticle.getGroupId();
+		String articleId = _journalArticle.getArticleId();
+		String ddmTemplateKey = _journalArticle.getDDMTemplateKey();
+
+		JournalArticleDisplay displayEn1 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, defaultLanguageId,
+			_portletRequestModel);
+		JournalArticleDisplay displayEs1 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, spainLanguageId,
+			_portletRequestModel);
+
+		Assert.assertNotNull(displayEn1);
+		Assert.assertNotNull(displayEs1);
+
+		Assert.assertEquals("Este es el contenido", displayEs1.getContent());
+
+		_journalArticleLocalService.removeArticleLocale(
+			_journalArticle.getGroupId(), _journalArticle.getArticleId(),
+			_journalArticle.getVersion(), spainLanguageId);
+
+		_journalContent.clearCache(
+			groupId, articleId, ddmTemplateKey, new String[] {spainLanguageId});
+
+		JournalArticleDisplay displayEn2 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, defaultLanguageId,
+			_portletRequestModel);
+		JournalArticleDisplay displayEs2 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, spainLanguageId,
+			_portletRequestModel);
+
+		Assert.assertEquals(
+			"US display should remain cached", displayEn1.getContent(),
+			displayEn2.getContent());
+		Assert.assertNotEquals(
+			"Spanish display should have been cleared from cache",
+			displayEs1.getContent(), displayEs2.getContent());
+	}
+
+	@Test
+	public void testClearCacheForPartialLocalization() throws Exception {
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+		String spainLanguageId = LocaleUtil.toLanguageId(LocaleUtil.SPAIN);
+
+		_journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, "Este es el contenido"
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			LocaleUtil.getSiteDefault(), false, true, _serviceContext);
+
+		long groupId = _journalArticle.getGroupId();
+		String articleId = _journalArticle.getArticleId();
+		String ddmTemplateKey = _journalArticle.getDDMTemplateKey();
+
+		JournalArticleDisplay displayEn1 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, defaultLanguageId,
+			_portletRequestModel);
+		JournalArticleDisplay displayEs1 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, spainLanguageId,
+			_portletRequestModel);
+
+		Assert.assertNotNull(displayEn1);
+		Assert.assertNotNull(displayEs1);
+
+		Assert.assertEquals("Este es el contenido", displayEs1.getContent());
+
+		_journalArticleLocalService.removeArticleLocale(
+			_journalArticle.getGroupId(), _journalArticle.getArticleId(),
+			_journalArticle.getVersion(), spainLanguageId);
+
+		_journalContent.clearCache(
+			groupId, articleId, ddmTemplateKey, new String[] {spainLanguageId});
+
+		JournalArticleDisplay displayEn2 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, defaultLanguageId,
+			_portletRequestModel);
+		JournalArticleDisplay displayEs2 = _journalContent.getDisplay(
+			groupId, articleId, Constants.VIEW, spainLanguageId,
+			_portletRequestModel);
+
+		Assert.assertEquals(
+			"US display should remain cached", displayEn1.getContent(),
+			displayEn2.getContent());
+		Assert.assertNotEquals(
+			"Spanish display should have been cleared from cache",
+			displayEs1.getContent(), displayEs2.getContent());
 	}
 
 	@Test
@@ -197,6 +327,8 @@ public class JournalContentTest {
 			MockHttpServletRequest mockHttpServletRequest)
 		throws PortalException {
 
+		_serviceContext = getServiceContext(mockHttpServletRequest);
+
 		ServiceContextThreadLocal.pushServiceContext(
 			getServiceContext(mockHttpServletRequest));
 	}
@@ -207,6 +339,9 @@ public class JournalContentTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@DeleteAfterTestRun
 	private JournalArticle _journalArticle;
@@ -224,6 +359,7 @@ public class JournalContentTest {
 	private LayoutSetLocalService _layoutSetLocalService;
 
 	private PortletRequestModel _portletRequestModel;
+	private ServiceContext _serviceContext;
 
 	@Inject
 	private ThemeLocalService _themeLocalService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/DeleteArticleTranslationsMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/DeleteArticleTranslationsMVCActionCommand.java
@@ -8,6 +8,7 @@ package com.liferay.journal.web.internal.portlet.action;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleService;
+import com.liferay.journal.util.JournalContent;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -55,9 +56,16 @@ public class DeleteArticleTranslationsMVCActionCommand
 				article.getGroupId(), article.getArticleId(),
 				article.getVersion(), languageId);
 		}
+
+		_journalContent.clearCache(
+			article.getGroupId(), article.getArticleId(),
+			article.getDDMTemplateKey(), languageIds);
 	}
 
 	@Reference
 	private JournalArticleService _journalArticleService;
+
+	@Reference
+	private JournalContent _journalContent;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

Deleting a translation does not trigger a web content cache update.

# How am I fixing it?

Ensure the portalCache is cleared specifically based on languageId when a translation is deleted.

# How can you verify that it works?

Run the included automated tests.
