### PR TITLE
LPD-50748 When replying to a message board thread, Data too long for column 'urlSubject' is occurred

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2358,12 +2358,23 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			return uniqueUrlSubject;
 		}
 
-		if (!StringUtil.endsWith(uniqueUrlSubject, StringPool.DASH)) {
-			urlSubject = urlSubject + StringPool.DASH;
-		}
+		int maxLength = ModelHintsUtil.getMaxLength(
+			MBMessage.class.getName(), "urlSubject");
 
 		for (int i = 1; mbMessage != null; i++) {
-			uniqueUrlSubject = urlSubject + i;
+			String suffix = StringPool.DASH + i;
+
+			if (urlSubject.length() > (maxLength - suffix.length())) {
+				urlSubject = urlSubject.substring(
+					0, maxLength - suffix.length());
+			}
+
+			if (urlSubject.endsWith(StringPool.DASH)) {
+				uniqueUrlSubject = urlSubject + i;
+			}
+			else {
+				uniqueUrlSubject = urlSubject + suffix;
+			}
 
 			mbMessage = mbMessagePersistence.fetchByG_US(
 				groupId, uniqueUrlSubject);

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -11,10 +11,12 @@ import com.liferay.message.boards.constants.MBMessageConstants;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
+import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
 import com.liferay.message.boards.test.util.MBTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -172,6 +174,42 @@ public class MBMessageLocalServiceTest {
 			StringPool.BLANK, ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(subject, mbMessage.getBody());
+	}
+
+	@Test
+	public void testAddMessageWithMultipleRepliesToParentThreadWithMaxSubjectLength()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		String subject = StringUtil.randomString(
+			ModelHintsUtil.getMaxLength(MBMessage.class.getName(), "subject"));
+
+		MBMessage parentMessage = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, StringPool.BLANK, "bbcode", Collections.emptyList(), false,
+			0.0, false, serviceContext);
+
+		for (int i = 0; i < 3; i++) {
+			MBMessageLocalServiceUtil.addMessage(
+				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+				_group.getGroupId(),
+				MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				parentMessage.getThreadId(), parentMessage.getMessageId(),
+				subject, StringPool.BLANK, "bbcode", null, false, 0.0, false,
+				serviceContext);
+		}
+
+		MBThread thread = MBThreadLocalServiceUtil.getThread(
+			parentMessage.getThreadId());
+
+		List<MBMessage> messages = MBMessageLocalServiceUtil.getThreadMessages(
+			thread.getThreadId(), WorkflowConstants.STATUS_ANY);
+
+		Assert.assertEquals(messages.toString(), 4, messages.size());
 	}
 
 	@Test


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-50748
When replying to a message board thread, a Data too long for column 'urlSubject' error occurs if the generated urlSubject exceeds the column's maximum length.

### **How am I fixing it?**
The urlSubject is now trimmed to ensure it does not exceed the maximum allowed length (255 characters). This is handled by retrieving the ModelHints configuration for the urlSubject field and applying a truncation when necessary.

### **How can you verify that it works?**

1. Start the Liferay instance.
2. Navigate to Message Boards.
3. Create a new thread with a title of exactly 255 characters (the max length allowed for urlSubject).
4. Add 3 replies to the thread.
5. The replies should now be created successfully without triggering the Data too long for column 'urlSubject' error.
