### PR TITLE
LPD-47994 Add `delete` action in Files, Contents, All Sections (recycle bin disabled)

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -119,7 +119,14 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 				).buildString(),
 				"password-policies", "permissions",
 				_language.get(httpServletRequest, "permissions"), "get", null,
-				"modal-permissions"));
+				"modal-permissions"),
+			new FDSActionDropdownItem(
+				_language.get(
+					httpServletRequest,
+					"are-you-sure-you-want-to-delete-this-entry"),
+				null, "trash", "delete",
+				_language.get(httpServletRequest, "delete"), "delete", "delete",
+				"headless"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -91,6 +91,17 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 		).build();
 	}
 
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				_language.get(
+					httpServletRequest,
+					"are-you-sure-you-want-to-delete-this-entry"),
+				null, "trash", "delete",
+				_language.get(httpServletRequest, "delete"), "delete", "delete",
+				"headless"));
+	}
+
 	@Override
 	public String[] getObjectDefinitionFolderExternalReferenceCodes() {
 		return cmsSiteInitializerConfiguration.


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47994

Add `delete` action in Files, Contents, All Sections (recycle bin disabled).

# How am I fixing it?

Applying https://github.com/liferay/liferay-portal/commit/31582865bca00d5615e33d4647a996b2ac39cb1e in `Files` and `Contents` Section.

# How can you verify that it works?

Create a new CMS file item and content item, navigate to the new cms [`Files`](http://localhost:8080/web/cms/files) and [`Contents`](http://localhost:8080/web/cms/contents) click on item action delete.

# Why doesn't this include any test?

Because isn't razonable test with playwright we don't need to test the FDS, may we can add some java test.