### PR TITLE
LPD-51843 Field Groups create nested Picture tags in HTML

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/main/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImpl.java
+++ b/modules/apps/adaptive-media/adaptive-media-content-transformer-impl/src/main/java/com/liferay/adaptive/media/content/transformer/internal/HtmlContentTransformerImpl.java
@@ -98,7 +98,8 @@ public class HtmlContentTransformerImpl implements ContentTransformer {
 
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-			if (!_amImageMimeTypeProvider.isMimeTypeSupported(
+			if (_processedFileEntry(fileEntry, html.substring(i, imgEnd)) ||
+				!_amImageMimeTypeProvider.isMimeTypeSupported(
 					fileEntry.getMimeType())) {
 
 				sb.append(html.substring(i, imgEnd));
@@ -118,6 +119,18 @@ public class HtmlContentTransformerImpl implements ContentTransformer {
 		}
 
 		return sb.toString();
+	}
+
+	private boolean _processedFileEntry(FileEntry fileEntry, String html) {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("<picture ");
+		sb.append(AMImageHTMLConstants.ATTRIBUTE_NAME_FILE_ENTRY_ID);
+		sb.append("=\"");
+		sb.append(fileEntry.getFileEntryId());
+		sb.append("\">");
+
+		return html.contains(sb.toString());
 	}
 
 	private static final String _OPEN_TAG_TOKEN_IMG = "<img ";

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-test/src/testIntegration/java/com/liferay/adaptive/media/image/content/transformer/test/AMImageContentTransformerTest.java
@@ -31,6 +31,9 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,23 +82,33 @@ public class AMImageContentTransformerTest {
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId()));
 
-		String rawHTML = String.format(
-			"<img data-fileentryid=\"%s\" src=\"%s\" />",
-			fileEntry.getFileEntryId(),
-			_dlURLHelper.getPreviewURL(
-				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
-				false, false));
+		String transformedHTML = _contentTransformerHandler.transform(
+			_getRawHTML(fileEntry, 1));
 
-		String regex = StringBundler.concat(
-			"<picture data-fileentryid=\".+\">",
-			"<source media=\"\\(max-width:.+px\\)\" srcset=\".+\" \\/>",
-			"<source media=\"\\(max-width:.+px\\) and \\(min-width:.+px\\)\" ",
-			"srcset=\".+\" \\/><img data-fileentryid=\".+\" src=\".+\" \\/>",
-			"<\\/picture>");
-
-		String transformedHTML = _contentTransformerHandler.transform(rawHTML);
+		String regex = _getRegex();
 
 		Assert.assertTrue(transformedHTML, transformedHTML.matches(regex));
+
+		_assertMatcher(1, regex, transformedHTML);
+	}
+
+	@Test
+	public void testTransformASingleImageMultipleTimes() throws Exception {
+		int fileEntryCount = 5;
+
+		FileEntry fileEntry = _addImageFileEntry(
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+
+		String transformedHTML = _contentTransformerHandler.transform(
+			_contentTransformerHandler.transform(
+				_getRawHTML(fileEntry, fileEntryCount)));
+
+		String regex = _getRegex();
+
+		Assert.assertTrue(transformedHTML, transformedHTML.matches(regex));
+
+		_assertMatcher(fileEntryCount, regex, transformedHTML);
 	}
 
 	private FileEntry _addImageFileEntry(ServiceContext serviceContext)
@@ -108,6 +121,49 @@ public class AMImageContentTransformerTest {
 			FileUtil.getBytes(
 				AMImageContentTransformerTest.class, "dependencies/image.jpg"),
 			null, null, null, serviceContext);
+	}
+
+	private void _assertMatcher(
+		int fileEntryCount, String regex, String transformedHTML) {
+
+		Pattern pattern = Pattern.compile(regex);
+
+		Matcher matcher = pattern.matcher(transformedHTML);
+
+		int count = 0;
+
+		while (matcher.find()) {
+			count++;
+		}
+
+		Assert.assertEquals(fileEntryCount, count);
+	}
+
+	private String _getRawHTML(FileEntry fileEntry, int imageCount)
+		throws Exception {
+
+		StringBuilder sb = new StringBuilder(imageCount);
+
+		for (int i = 0; i < imageCount; i++) {
+			sb.append(
+				String.format(
+					"<img data-fileentryid=\"%s\" src=\"%s\" />",
+					fileEntry.getFileEntryId(),
+					_dlURLHelper.getPreviewURL(
+						fileEntry, fileEntry.getFileVersion(), null,
+						StringPool.BLANK, false, false)));
+		}
+
+		return sb.toString();
+	}
+
+	private String _getRegex() {
+		return StringBundler.concat(
+			"<picture data-fileentryid=\".+?\">",
+			"<source media=\"\\(max-width:.+?px\\)\" srcset=\".+?\" \\/>",
+			"<source media=\"\\(max-width:.+?px\\) and ",
+			"\\(min-width:.+?px\\)\" srcset=\".+?\" \\/>",
+			"<img data-fileentryid=\".+?\" src=\".+?\" \\/><\\/picture>");
 	}
 
 	private AMImageConfigurationEntry _amImageConfigurationEntry;


### PR DESCRIPTION
Field Groups create nested Picture tags in HTML

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-51843)

In content pages, adaptive media is transforming the html twice because of LayoutAdaptiveMediaProcessorImpl. So there are nested elements in the markup

# How am I fixing it?

If the image has been processed before, do not process it again for the html where it resides

# How can you verify that it works?

Follow the steps in the ticket or execute the provided integration tests