### PR TITLE
LPD-46294 cache the values of the configuration to do not check the configuration every time

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/persistence/listener/FriendlyURLSeparatorCompanyConfigurationModelListener.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/persistence/listener/FriendlyURLSeparatorCompanyConfigurationModelListener.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.friendly.url.internal.configuration.persistence.listener;
+
+import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	property = "model.class.name=com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class FriendlyURLSeparatorCompanyConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onAfterSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+
+		_portalCache.remove(
+			GetterUtil.getLong(
+				properties.get("companyId"), CompanyConstants.SYSTEM));
+	}
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, JSONObject> _portalCache;
+
+}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
@@ -7,12 +7,18 @@ package com.liferay.friendly.url.internal.provider;
 
 import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfigurationManager;
 import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -25,10 +31,18 @@ public class FriendlyURLSeparatorProviderImpl
 	@Override
 	public String getFriendlyURLSeparator(long companyId, String key) {
 		try {
+			JSONObject jsonObject = _portalCache.get(companyId);
+
+			if (jsonObject != null) {
+				return jsonObject.getString(key);
+			}
+
 			JSONObject friendlyURLSeparatorsJSONObject =
 				_jsonFactory.createJSONObject(
 					_friendlyURLSeparatorConfigurationManager.
 						getFriendlyURLSeparatorsJSON(companyId));
+
+			_portalCache.put(companyId, friendlyURLSeparatorsJSONObject);
 
 			return friendlyURLSeparatorsJSONObject.getString(key);
 		}
@@ -41,6 +55,19 @@ public class FriendlyURLSeparatorProviderImpl
 		return null;
 	}
 
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(
+			FriendlyURLSeparatorProvider.class.getName());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		FriendlyURLSeparatorProviderImpl.class.getName());
 
@@ -50,5 +77,10 @@ public class FriendlyURLSeparatorProviderImpl
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, JSONObject> _portalCache;
 
 }


### PR DESCRIPTION
LPD-46294 Portal performance decreased after removing FF LPD-11147

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46294

After removing this FF LPD-11147, the portal's performance regressed

# How am I fixing it?

There is severals calls to FriendlyURLSeparatorProvider:getFriendlyURLSeparator and each call is looking at the configuration. So we want to mitigate the performance adding a cache.


# Why doesn't this include any test?

It is a performance improvement, not a functional change.


# Commits
- **LPD-46294 generate a cache to store the JSONObject for each company for the FriendlyURLSeparatorCompanyConfiguration**
- **LPD-46294 when changing the FriendlyURLSeparatorCompanyConfiguration, remove the cache for that company**
