### PR TITLE
LPD-52126 Hide delete button for latest verison of web content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryManagementToolbarDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -119,7 +120,8 @@ public class JournalHistoryManagementToolbarDisplayContext
 
 		if (JournalArticlePermission.contains(
 				themeDisplay.getPermissionChecker(), article,
-				ActionKeys.DELETE)) {
+				ActionKeys.DELETE) &&
+			!Objects.equals(_article.getVersion(), article.getVersion())) {
 
 			availableActions.add("deleteArticles");
 		}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -308,6 +308,9 @@ public class JournalArticleActionDropdownItemsProvider {
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
+			() -> !JournalArticleLocalServiceUtil.isLatestVersion(
+				_article.getGroupId(), _article.getArticleId(),
+				_article.getVersion()),
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(

--- a/modules/test/playwright/tests/journal-web/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalPage.spec.ts
@@ -165,3 +165,36 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Latest version of Web Content should not have delete option',
+	{
+		tag: '@LPD-52126',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'Basic Web content'},
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('button', {name: 'Actions'}).click();
+
+		await page.getByRole('menuitem', {name: 'View History'}).click();
+
+		await page.getByRole('button', {name: 'Actions'}).first().click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Delete'})
+		).not.toBeVisible();
+
+		await page.locator('.management-bar input[type="checkbox"]').click();
+
+		await expect(page.getByRole('button', {name: 'Delete'})).toBeDisabled();
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-52126
 It addresses an issue where the Delete button is available even when there is only one version of a web content entry

### **How am I fixing it?**
The fix ensures that the Delete button is disabled for the latest version of web content from both **Action Dropdown** and **Management toolbar**

### **How can you verify that it works?**

1. Start the Liferay instance.
2. Navigate to Web Content.
3. Create a new Basic Web Content entry.
4. Click on View History.
5. Verify that the Delete button is not available for the latest version of the web content.