### PR TITLE
[CMS] LPD-51906 Check udpate permission key to show the import and override action

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContext.java
@@ -99,7 +99,7 @@ public class StructuresSectionDisplayContext {
 						_themeDisplay),
 					"objectDefinitionId", "{id}"),
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
-				"get", null, null),
+				"get", "update", null),
 			new FDSActionDropdownItem(
 				"", "copy", "copy",
 				LanguageUtil.get(_httpServletRequest, "make-a-copy"), null,
@@ -121,7 +121,7 @@ public class StructuresSectionDisplayContext {
 			new FDSActionDropdownItem(
 				"", "import", "import",
 				LanguageUtil.get(_httpServletRequest, "import-and-override"),
-				null, null, null),
+				null, "update", null),
 			new FDSActionDropdownItem(
 				"", "password-policies", "permissions",
 				LanguageUtil.get(_httpServletRequest, "permissions"), "get",


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-51906)

### Motivation
Default structures (the ones that are created for the CMS) should not be updated or overriden, but this depends on https://liferay.atlassian.net/browse/LPD-47021. 

However, I am assuming that once that epic is complete, the `update` permission will not be available, and that is the one we need to check to not show this Edit and Import & Override actions. 