### PR TITLE
LPD-52024 update lucene version in document library repository search

### DIFF
--- a/modules/apps/document-library/document-library-repository-search/bnd.bnd
+++ b/modules/apps/document-library/document-library-repository-search/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Document Library Repository Search
 Bundle-SymbolicName: com.liferay.document.library.repository.search
 Bundle-Version: 7.0.15
+-fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=ignore

--- a/modules/apps/document-library/document-library-repository-search/build.gradle
+++ b/modules/apps/document-library/document-library-repository-search/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-	compileInclude group: "org.apache.lucene", name: "lucene-analyzers-common", version: "7.1.0"
-	compileInclude group: "org.apache.lucene", name: "lucene-core", version: "7.1.0"
-	compileInclude group: "org.apache.lucene", name: "lucene-queries", version: "7.1.0"
-	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: "7.1.0"
-	compileInclude group: "org.apache.lucene", name: "lucene-sandbox", version: "7.1.0"
+	compileInclude group: "org.apache.lucene", name: "lucene-analyzers-common", version: "8.6.2"
+	compileInclude group: "org.apache.lucene", name: "lucene-core", version: "8.6.2"
+	compileInclude group: "org.apache.lucene", name: "lucene-queries", version: "8.6.2"
+	compileInclude group: "org.apache.lucene", name: "lucene-queryparser", version: "8.6.2"
+	compileInclude group: "org.apache.lucene", name: "lucene-sandbox", version: "8.6.2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":core:petra:petra-string")


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52024

To avoid a security vulnerability I am increasing the lucene versions in document library repository search.

# How am I fixing it?

Increaseing the lucene version to 8.6.2

# How can you verify that it works?

Tests not needed.