### PR TITLE
LPD-49727 Create shared by me and shared with me headless endpoints

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin User API
 Bundle-SymbolicName: com.liferay.headless.admin.user.api
-Bundle-Version: 26.1.1
+Bundle-Version: 26.2.0
 Export-Package:\
 	com.liferay.headless.admin.user.dto.v1_0,\
 	com.liferay.headless.admin.user.resource.v1_0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SharedAsset.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SharedAsset.java
@@ -1,0 +1,943 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(description = "Represents a shared asset.", value = "SharedAsset")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "SharedAsset")
+public class SharedAsset implements Serializable {
+
+	public static SharedAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(SharedAsset.class, json);
+	}
+
+	public static SharedAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(SharedAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset actions."
+	)
+	public String[] getActionIds() {
+		if (_actionIdsSupplier != null) {
+			actionIds = _actionIdsSupplier.get();
+
+			_actionIdsSupplier = null;
+		}
+
+		return actionIds;
+	}
+
+	public void setActionIds(String[] actionIds) {
+		this.actionIds = actionIds;
+
+		_actionIdsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActionIds(
+		UnsafeSupplier<String[], Exception> actionIdsUnsafeSupplier) {
+
+		_actionIdsSupplier = () -> {
+			try {
+				return actionIdsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset actions.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String[] actionIds;
+
+	@JsonIgnore
+	private Supplier<String[]> _actionIdsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		if (_actionsSupplier != null) {
+			actions = _actionsSupplier.get();
+
+			_actionsSupplier = null;
+		}
+
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+
+		_actionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		_actionsSupplier = () -> {
+			try {
+				return actionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
+	@JsonIgnore
+	private Supplier<Map<String, Map<String, String>>> _actionsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset type."
+	)
+	public String getAssetType() {
+		if (_assetTypeSupplier != null) {
+			assetType = _assetTypeSupplier.get();
+
+			_assetTypeSupplier = null;
+		}
+
+		return assetType;
+	}
+
+	public void setAssetType(String assetType) {
+		this.assetType = assetType;
+
+		_assetTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAssetType(
+		UnsafeSupplier<String, Exception> assetTypeUnsafeSupplier) {
+
+		_assetTypeSupplier = () -> {
+			try {
+				return assetTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset type.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String assetType;
+
+	@JsonIgnore
+	private Supplier<String> _assetTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getClassName() {
+		if (_classNameSupplier != null) {
+			className = _classNameSupplier.get();
+
+			_classNameSupplier = null;
+		}
+
+		return className;
+	}
+
+	public void setClassName(String className) {
+		this.className = className;
+
+		_classNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassName(
+		UnsafeSupplier<String, Exception> classNameUnsafeSupplier) {
+
+		_classNameSupplier = () -> {
+			try {
+				return classNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String className;
+
+	@JsonIgnore
+	private Supplier<String> _classNameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getClassPK() {
+		if (_classPKSupplier != null) {
+			classPK = _classPKSupplier.get();
+
+			_classPKSupplier = null;
+		}
+
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+
+		_classPKSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		_classPKSupplier = () -> {
+			try {
+				return classPKUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long classPK;
+
+	@JsonIgnore
+	private Supplier<Long> _classPKSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset creator."
+	)
+	@Valid
+	public Creator getCreator() {
+		if (_creatorSupplier != null) {
+			creator = _creatorSupplier.get();
+
+			_creatorSupplier = null;
+		}
+
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+
+		_creatorSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		_creatorSupplier = () -> {
+			try {
+				return creatorUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset creator.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Creator creator;
+
+	@JsonIgnore
+	private Supplier<Creator> _creatorSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset creation date."
+	)
+	public Date getDateCreated() {
+		if (_dateCreatedSupplier != null) {
+			dateCreated = _dateCreatedSupplier.get();
+
+			_dateCreatedSupplier = null;
+		}
+
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+
+		_dateCreatedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		_dateCreatedSupplier = () -> {
+			try {
+				return dateCreatedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset creation date.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateCreated;
+
+	@JsonIgnore
+	private Supplier<Date> _dateCreatedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset modified date."
+	)
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset modified date.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset external reference code."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset ID."
+	)
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Whether the shared asset is shareable or not"
+	)
+	public Boolean getShareable() {
+		if (_shareableSupplier != null) {
+			shareable = _shareableSupplier.get();
+
+			_shareableSupplier = null;
+		}
+
+		return shareable;
+	}
+
+	public void setShareable(Boolean shareable) {
+		this.shareable = shareable;
+
+		_shareableSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setShareable(
+		UnsafeSupplier<Boolean, Exception> shareableUnsafeSupplier) {
+
+		_shareableSupplier = () -> {
+			try {
+				return shareableUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "Whether the shared asset is shareable or not")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Boolean shareable;
+
+	@JsonIgnore
+	private Supplier<Boolean> _shareableSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The name of the site to which this shared asset is scoped."
+	)
+	public String getSiteName() {
+		if (_siteNameSupplier != null) {
+			siteName = _siteNameSupplier.get();
+
+			_siteNameSupplier = null;
+		}
+
+		return siteName;
+	}
+
+	public void setSiteName(String siteName) {
+		this.siteName = siteName;
+
+		_siteNameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSiteName(
+		UnsafeSupplier<String, Exception> siteNameUnsafeSupplier) {
+
+		_siteNameSupplier = () -> {
+			try {
+				return siteNameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The name of the site to which this shared asset is scoped."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String siteName;
+
+	@JsonIgnore
+	private Supplier<String> _siteNameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset title."
+	)
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset title.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SharedAsset)) {
+			return false;
+		}
+
+		SharedAsset sharedAsset = (SharedAsset)object;
+
+		return Objects.equals(toString(), sharedAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String[] actionIds = getActionIds();
+
+		if (actionIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < actionIds.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(actionIds[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < actionIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Map<String, Map<String, String>> actions = getActions();
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
+
+		String assetType = getAssetType();
+
+		if (assetType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(assetType));
+
+			sb.append("\"");
+		}
+
+		String className = getClassName();
+
+		if (className != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"className\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(className));
+
+			sb.append("\"");
+		}
+
+		Long classPK = getClassPK();
+
+		if (classPK != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(classPK);
+		}
+
+		Creator creator = getCreator();
+
+		if (creator != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(String.valueOf(creator));
+		}
+
+		Date dateCreated = getDateCreated();
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		Boolean shareable = getShareable();
+
+		if (shareable != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"shareable\": ");
+
+			sb.append(shareable);
+		}
+
+		String siteName = getSiteName();
+
+		if (siteName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(siteName));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.admin.user.dto.v1_0.SharedAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SharedAssetResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SharedAssetResource.java
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.resource.v1_0;
+
+import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-admin-user/v1.0
+ *
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface SharedAssetResource {
+
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedByMePage(
+			String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedWithMePage(
+			String search,
+			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public SharedAssetResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.21.0
+version 8.22.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 14.1.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/SharedAsset.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/SharedAsset.java
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.client.dto.v1_0;
+
+import com.liferay.headless.admin.user.client.function.UnsafeSupplier;
+import com.liferay.headless.admin.user.client.serdes.v1_0.SharedAssetSerDes;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class SharedAsset implements Cloneable, Serializable {
+
+	public static SharedAsset toDTO(String json) {
+		return SharedAssetSerDes.toDTO(json);
+	}
+
+	public String[] getActionIds() {
+		return actionIds;
+	}
+
+	public void setActionIds(String[] actionIds) {
+		this.actionIds = actionIds;
+	}
+
+	public void setActionIds(
+		UnsafeSupplier<String[], Exception> actionIdsUnsafeSupplier) {
+
+		try {
+			actionIds = actionIdsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] actionIds;
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
+	public String getAssetType() {
+		return assetType;
+	}
+
+	public void setAssetType(String assetType) {
+		this.assetType = assetType;
+	}
+
+	public void setAssetType(
+		UnsafeSupplier<String, Exception> assetTypeUnsafeSupplier) {
+
+		try {
+			assetType = assetTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String assetType;
+
+	public String getClassName() {
+		return className;
+	}
+
+	public void setClassName(String className) {
+		this.className = className;
+	}
+
+	public void setClassName(
+		UnsafeSupplier<String, Exception> classNameUnsafeSupplier) {
+
+		try {
+			className = classNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String className;
+
+	public Long getClassPK() {
+		return classPK;
+	}
+
+	public void setClassPK(Long classPK) {
+		this.classPK = classPK;
+	}
+
+	public void setClassPK(
+		UnsafeSupplier<Long, Exception> classPKUnsafeSupplier) {
+
+		try {
+			classPK = classPKUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long classPK;
+
+	public Creator getCreator() {
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+	}
+
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		try {
+			creator = creatorUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Creator creator;
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public Boolean getShareable() {
+		return shareable;
+	}
+
+	public void setShareable(Boolean shareable) {
+		this.shareable = shareable;
+	}
+
+	public void setShareable(
+		UnsafeSupplier<Boolean, Exception> shareableUnsafeSupplier) {
+
+		try {
+			shareable = shareableUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean shareable;
+
+	public String getSiteName() {
+		return siteName;
+	}
+
+	public void setSiteName(String siteName) {
+		this.siteName = siteName;
+	}
+
+	public void setSiteName(
+		UnsafeSupplier<String, Exception> siteNameUnsafeSupplier) {
+
+		try {
+			siteName = siteNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String siteName;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public SharedAsset clone() throws CloneNotSupportedException {
+		return (SharedAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof SharedAsset)) {
+			return false;
+		}
+
+		SharedAsset sharedAsset = (SharedAsset)object;
+
+		return Objects.equals(toString(), sharedAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return SharedAssetSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SharedAssetResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SharedAssetResource.java
@@ -1,0 +1,435 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.client.resource.v1_0;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.client.http.HttpInvoker;
+import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.pagination.Pagination;
+import com.liferay.headless.admin.user.client.problem.Problem;
+import com.liferay.headless.admin.user.client.serdes.v1_0.SharedAssetSerDes;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public interface SharedAssetResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedByMePage(
+			String search, List<String> aggregations, String filterString,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getMyUserAccountSharedAssetsSharedByMePageHttpResponse(
+				String search, List<String> aggregations, String filterString,
+				Pagination pagination, String sortString)
+		throws Exception;
+
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedWithMePage(
+			String search, List<String> aggregations, String filterString,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getMyUserAccountSharedAssetsSharedWithMePageHttpResponse(
+				String search, List<String> aggregations, String filterString,
+				Pagination pagination, String sortString)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public SharedAssetResource build() {
+			return new SharedAssetResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class SharedAssetResourceImpl implements SharedAssetResource {
+
+		public Page<SharedAsset> getMyUserAccountSharedAssetsSharedByMePage(
+				String search, List<String> aggregations, String filterString,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getMyUserAccountSharedAssetsSharedByMePageHttpResponse(
+					search, aggregations, filterString, pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SharedAssetSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getMyUserAccountSharedAssetsSharedByMePageHttpResponse(
+					String search, List<String> aggregations,
+					String filterString, Pagination pagination,
+					String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/my-user-account/shared-assets/shared-by-me");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<SharedAsset> getMyUserAccountSharedAssetsSharedWithMePage(
+				String search, List<String> aggregations, String filterString,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getMyUserAccountSharedAssetsSharedWithMePageHttpResponse(
+					search, aggregations, filterString, pagination, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SharedAssetSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getMyUserAccountSharedAssetsSharedWithMePageHttpResponse(
+					String search, List<String> aggregations,
+					String filterString, Pagination pagination,
+					String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (search != null) {
+				httpInvoker.parameter("search", String.valueOf(search));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/my-user-account/shared-assets/shared-with-me");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private SharedAssetResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			SharedAssetResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SharedAssetSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SharedAssetSerDes.java
@@ -1,0 +1,567 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.client.serdes.v1_0;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class SharedAssetSerDes {
+
+	public static SharedAsset toDTO(String json) {
+		SharedAssetJSONParser sharedAssetJSONParser =
+			new SharedAssetJSONParser();
+
+		return sharedAssetJSONParser.parseToDTO(json);
+	}
+
+	public static SharedAsset[] toDTOs(String json) {
+		SharedAssetJSONParser sharedAssetJSONParser =
+			new SharedAssetJSONParser();
+
+		return sharedAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(SharedAsset sharedAsset) {
+		if (sharedAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (sharedAsset.getActionIds() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < sharedAsset.getActionIds().length; i++) {
+				sb.append(_toJSON(sharedAsset.getActionIds()[i]));
+
+				if ((i + 1) < sharedAsset.getActionIds().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (sharedAsset.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(sharedAsset.getActions()));
+		}
+
+		if (sharedAsset.getAssetType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"assetType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getAssetType()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getClassName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"className\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getClassName()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getClassPK() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"classPK\": ");
+
+			sb.append(sharedAsset.getClassPK());
+		}
+
+		if (sharedAsset.getCreator() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(String.valueOf(sharedAsset.getCreator()));
+		}
+
+		if (sharedAsset.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(sharedAsset.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(sharedAsset.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(sharedAsset.getId());
+		}
+
+		if (sharedAsset.getShareable() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"shareable\": ");
+
+			sb.append(sharedAsset.getShareable());
+		}
+
+		if (sharedAsset.getSiteName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getSiteName()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		SharedAssetJSONParser sharedAssetJSONParser =
+			new SharedAssetJSONParser();
+
+		return sharedAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(SharedAsset sharedAsset) {
+		if (sharedAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (sharedAsset.getActionIds() == null) {
+			map.put("actionIds", null);
+		}
+		else {
+			map.put("actionIds", String.valueOf(sharedAsset.getActionIds()));
+		}
+
+		if (sharedAsset.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(sharedAsset.getActions()));
+		}
+
+		if (sharedAsset.getAssetType() == null) {
+			map.put("assetType", null);
+		}
+		else {
+			map.put("assetType", String.valueOf(sharedAsset.getAssetType()));
+		}
+
+		if (sharedAsset.getClassName() == null) {
+			map.put("className", null);
+		}
+		else {
+			map.put("className", String.valueOf(sharedAsset.getClassName()));
+		}
+
+		if (sharedAsset.getClassPK() == null) {
+			map.put("classPK", null);
+		}
+		else {
+			map.put("classPK", String.valueOf(sharedAsset.getClassPK()));
+		}
+
+		if (sharedAsset.getCreator() == null) {
+			map.put("creator", null);
+		}
+		else {
+			map.put("creator", String.valueOf(sharedAsset.getCreator()));
+		}
+
+		if (sharedAsset.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(sharedAsset.getDateCreated()));
+		}
+
+		if (sharedAsset.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(sharedAsset.getDateModified()));
+		}
+
+		if (sharedAsset.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(sharedAsset.getExternalReferenceCode()));
+		}
+
+		if (sharedAsset.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(sharedAsset.getId()));
+		}
+
+		if (sharedAsset.getShareable() == null) {
+			map.put("shareable", null);
+		}
+		else {
+			map.put("shareable", String.valueOf(sharedAsset.getShareable()));
+		}
+
+		if (sharedAsset.getSiteName() == null) {
+			map.put("siteName", null);
+		}
+		else {
+			map.put("siteName", String.valueOf(sharedAsset.getSiteName()));
+		}
+
+		if (sharedAsset.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(sharedAsset.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class SharedAssetJSONParser
+		extends BaseJSONParser<SharedAsset> {
+
+		@Override
+		protected SharedAsset createDTO() {
+			return new SharedAsset();
+		}
+
+		@Override
+		protected SharedAsset[] createDTOArray(int size) {
+			return new SharedAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "actions")) {
+				return true;
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "className")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "shareable")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "siteName")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			SharedAsset sharedAsset, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setActionIds(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setActions(
+						(Map<String, Map<String, String>>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetType")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setAssetType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "className")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setClassName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "classPK")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setClassPK(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setCreator(
+						CreatorSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setDateCreated(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "shareable")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setShareable((Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "siteName")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setSiteName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setTitle((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:subscription:subscription-api")
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1073,6 +1073,85 @@ components:
                     readOnly: true
                     type: string
             type: object
+        SharedAsset:
+            # @review
+            description:
+                Represents a shared asset.
+            properties:
+                actionIds:
+                    description:
+                        The shared asset actions.
+                    items:
+                        type: string
+                    readOnly: true
+                    type: array
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    # @review
+                    description:
+                        Block of actions allowed by the user making the request.
+                    readOnly: true
+                    type: object
+                assetType:
+                    description:
+                        The shared asset type.
+                    readOnly: true
+                    type: string
+                className:
+                    readOnly: true
+                    type: string
+                classPK:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                creator:
+                    $ref: "#/components/schemas/Creator"
+                    description:
+                        The shared asset creator.
+                    readOnly: true
+                dateCreated:
+                    description:
+                        The shared asset creation date.
+                    format: date-time
+                    readOnly: true
+                    type: string
+                dateModified:
+                    description:
+                        The shared asset modified date.
+                    format: date-time
+                    readOnly: true
+                    type: string
+                externalReferenceCode:
+                    # @review
+                    description:
+                        The shared asset external reference code.
+                    readOnly: true
+                    type: string
+                id:
+                    description:
+                        The shared asset ID.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                shareable:
+                    description:
+                        Whether the shared asset is shareable or not
+                    readOnly: true
+                    type: boolean
+                siteName:
+                    description:
+                        The name of the site to which this shared asset is scoped.
+                    readOnly: true
+                    type: string
+                title:
+                    description:
+                        The shared asset title.
+                    readOnly: true
+                    type: string
+            type: object
         Site:
             # @review
             description:
@@ -4067,6 +4146,94 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/UserAccount"
             tags: ["UserAccount"]
+    "/my-user-account/shared-assets/shared-by-me":
+        get:
+            operationId: getMyUserAccountSharedAssetsSharedByMePage
+            parameters:
+                - in: query
+                  name: aggregationTerms
+                  schema:
+                      items:
+                          type: string
+                      type: array
+                - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+                - in: query
+                  name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SharedAsset"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SharedAsset"
+                                type: array
+            tags: ["SharedAsset"]
+    "/my-user-account/shared-assets/shared-with-me":
+        get:
+            operationId: getMyUserAccountSharedAssetsSharedWithMePage
+            parameters:
+                - in: query
+                  name: aggregationTerms
+                  schema:
+                      items:
+                          type: string
+                      type: array
+                - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+                - in: query
+                  name: search
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SharedAsset"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/SharedAsset"
+                                type: array
+            tags: ["SharedAsset"]
     "/my-user-account/sites":
         get:
             operationId: getMyUserAccountSitesPage

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -4150,32 +4150,32 @@ paths:
         get:
             operationId: getMyUserAccountSharedAssetsSharedByMePage
             parameters:
-                - in: query
-                  name: aggregationTerms
-                  schema:
-                      items:
-                          type: string
-                      type: array
-                - in: query
-                  name: filter
-                  schema:
-                      type: string
-                - in: query
-                  name: page
-                  schema:
-                      type: integer
-                - in: query
-                  name: pageSize
-                  schema:
-                      type: integer
-                - in: query
-                  name: search
-                  schema:
-                      type: string
-                - in: query
-                  name: sort
-                  schema:
-                      type: string
+                -   in: query
+                    name: aggregationTerms
+                    schema:
+                        items:
+                            type: string
+                        type: array
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
             responses:
                 200:
                     content:
@@ -4194,32 +4194,32 @@ paths:
         get:
             operationId: getMyUserAccountSharedAssetsSharedWithMePage
             parameters:
-                - in: query
-                  name: aggregationTerms
-                  schema:
-                      items:
-                          type: string
-                      type: array
-                - in: query
-                  name: filter
-                  schema:
-                      type: string
-                - in: query
-                  name: page
-                  schema:
-                      type: integer
-                - in: query
-                  name: pageSize
-                  schema:
-                      type: integer
-                - in: query
-                  name: search
-                  schema:
-                      type: string
-                - in: query
-                  name: sort
-                  schema:
-                      type: string
+                -   in: query
+                    name: aggregationTerms
+                    schema:
+                        items:
+                            type: string
+                        type: array
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: search
+                    schema:
+                        type: string
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
             responses:
                 200:
                     content:

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.dto.v1_0.converter;
+
+import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.internal.dto.v1_0.util.CreatorUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.sharing.interpreter.SharingEntryInterpreter;
+import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	property = "dto.class.name=com.liferay.sharing.model.SharingEntry",
+	service = DTOConverter.class
+)
+public class SharedAssetDTOConverter
+	implements DTOConverter<SharingEntry, SharedAsset> {
+
+	@Override
+	public String getContentType() {
+		return SharingEntry.class.getSimpleName();
+	}
+
+	@Override
+	public SharedAsset toDTO(
+		DTOConverterContext dtoConverterContext, SharingEntry sharingEntry) {
+
+		SharingEntryInterpreter sharingEntryInterpreter =
+			_sharingEntryInterpreterProvider.getSharingEntryInterpreter(
+				sharingEntry);
+
+		return new SharedAsset() {
+			{
+				setActionIds(
+					() -> TransformUtil.transformToArray(
+						SharingEntryAction.getSharingEntryActions(
+							sharingEntry.getActionIds()),
+						SharingEntryAction::getActionId, String.class));
+				setAssetType(
+					() -> {
+						if (sharingEntryInterpreter == null) {
+							return null;
+						}
+
+						return sharingEntryInterpreter.getAssetTypeTitle(
+							sharingEntry, dtoConverterContext.getLocale());
+					});
+				setClassName(sharingEntry::getClassName);
+				setClassPK(sharingEntry::getClassPK);
+				setCreator(
+					() -> CreatorUtil.toCreator(
+						_portal,
+						_userLocalService.getUser(sharingEntry.getUserId())));
+				setDateCreated(sharingEntry::getCreateDate);
+				setDateModified(sharingEntry::getModifiedDate);
+				setExternalReferenceCode(
+					sharingEntry::getExternalReferenceCode);
+				setId(sharingEntry::getSharingEntryId);
+				setShareable(sharingEntry::isShareable);
+				setSiteName(
+					() -> {
+						Group group = _groupLocalService.getGroup(
+							sharingEntry.getGroupId());
+
+						return group.getName(dtoConverterContext.getLocale());
+					});
+				setTitle(
+					() -> {
+						if (sharingEntryInterpreter == null) {
+							return null;
+						}
+
+						return sharingEntryInterpreter.getTitle(
+							sharingEntry, dtoConverterContext.getLocale());
+					});
+			}
+		};
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -16,6 +16,7 @@ import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.RolePermission;
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
 import com.liferay.headless.admin.user.dto.v1_0.SegmentUser;
+import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
 import com.liferay.headless.admin.user.dto.v1_0.Site;
 import com.liferay.headless.admin.user.dto.v1_0.Subscription;
 import com.liferay.headless.admin.user.dto.v1_0.Ticket;
@@ -33,6 +34,7 @@ import com.liferay.headless.admin.user.resource.v1_0.PostalAddressResource;
 import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentUserResource;
+import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
 import com.liferay.headless.admin.user.resource.v1_0.SiteResource;
 import com.liferay.headless.admin.user.resource.v1_0.SubscriptionResource;
 import com.liferay.headless.admin.user.resource.v1_0.TicketResource;
@@ -45,12 +47,15 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.aggregation.Facet;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -150,6 +155,14 @@ public class Query {
 
 		_segmentUserResourceComponentServiceObjects =
 			segmentUserResourceComponentServiceObjects;
+	}
+
+	public static void setSharedAssetResourceComponentServiceObjects(
+		ComponentServiceObjects<SharedAssetResource>
+			sharedAssetResourceComponentServiceObjects) {
+
+		_sharedAssetResourceComponentServiceObjects =
+			sharedAssetResourceComponentServiceObjects;
 	}
 
 	public static void setSiteResourceComponentServiceObjects(
@@ -1432,6 +1445,65 @@ public class Query {
 			segmentUserResource -> new SegmentUserPage(
 				segmentUserResource.getSegmentUserAccountsPage(
 					segmentId, Pagination.of(page, pageSize))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {myUserAccountSharedAssetsSharedByMe(aggregation: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public SharedAssetPage myUserAccountSharedAssetsSharedByMe(
+			@GraphQLName("search") String search,
+			@GraphQLName("aggregation") List<String> aggregations,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_sharedAssetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			sharedAssetResource -> new SharedAssetPage(
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					search,
+					_aggregationBiFunction.apply(
+						sharedAssetResource, aggregations),
+					_filterBiFunction.apply(sharedAssetResource, filterString),
+					Pagination.of(page, pageSize),
+					_sortsBiFunction.apply(sharedAssetResource, sortsString))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {myUserAccountSharedAssetsSharedWithMe(aggregation: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public SharedAssetPage myUserAccountSharedAssetsSharedWithMe(
+			@GraphQLName("search") String search,
+			@GraphQLName("aggregation") List<String> aggregations,
+			@GraphQLName("filter") String filterString,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page,
+			@GraphQLName("sort") String sortsString)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_sharedAssetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			sharedAssetResource -> new SharedAssetPage(
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						search,
+						_aggregationBiFunction.apply(
+							sharedAssetResource, aggregations),
+						_filterBiFunction.apply(
+							sharedAssetResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							sharedAssetResource, sortsString))));
 	}
 
 	/**
@@ -3912,6 +3984,8 @@ public class Query {
 		public AccountPage(Page accountPage) {
 			actions = accountPage.getActions();
 
+			facets = accountPage.getFacets();
+
 			items = accountPage.getItems();
 			lastPage = accountPage.getLastPage();
 			page = accountPage.getPage();
@@ -3921,6 +3995,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Account> items;
@@ -3945,6 +4022,8 @@ public class Query {
 		public AccountGroupPage(Page accountGroupPage) {
 			actions = accountGroupPage.getActions();
 
+			facets = accountGroupPage.getFacets();
+
 			items = accountGroupPage.getItems();
 			lastPage = accountGroupPage.getLastPage();
 			page = accountGroupPage.getPage();
@@ -3954,6 +4033,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<AccountGroup> items;
@@ -3978,6 +4060,8 @@ public class Query {
 		public AccountRolePage(Page accountRolePage) {
 			actions = accountRolePage.getActions();
 
+			facets = accountRolePage.getFacets();
+
 			items = accountRolePage.getItems();
 			lastPage = accountRolePage.getLastPage();
 			page = accountRolePage.getPage();
@@ -3987,6 +4071,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<AccountRole> items;
@@ -4011,6 +4098,8 @@ public class Query {
 		public EmailAddressPage(Page emailAddressPage) {
 			actions = emailAddressPage.getActions();
 
+			facets = emailAddressPage.getFacets();
+
 			items = emailAddressPage.getItems();
 			lastPage = emailAddressPage.getLastPage();
 			page = emailAddressPage.getPage();
@@ -4020,6 +4109,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<EmailAddress> items;
@@ -4044,6 +4136,8 @@ public class Query {
 		public OrganizationPage(Page organizationPage) {
 			actions = organizationPage.getActions();
 
+			facets = organizationPage.getFacets();
+
 			items = organizationPage.getItems();
 			lastPage = organizationPage.getLastPage();
 			page = organizationPage.getPage();
@@ -4053,6 +4147,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Organization> items;
@@ -4077,6 +4174,8 @@ public class Query {
 		public PhonePage(Page phonePage) {
 			actions = phonePage.getActions();
 
+			facets = phonePage.getFacets();
+
 			items = phonePage.getItems();
 			lastPage = phonePage.getLastPage();
 			page = phonePage.getPage();
@@ -4086,6 +4185,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Phone> items;
@@ -4110,6 +4212,8 @@ public class Query {
 		public PostalAddressPage(Page postalAddressPage) {
 			actions = postalAddressPage.getActions();
 
+			facets = postalAddressPage.getFacets();
+
 			items = postalAddressPage.getItems();
 			lastPage = postalAddressPage.getLastPage();
 			page = postalAddressPage.getPage();
@@ -4119,6 +4223,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<PostalAddress> items;
@@ -4143,6 +4250,8 @@ public class Query {
 		public RolePage(Page rolePage) {
 			actions = rolePage.getActions();
 
+			facets = rolePage.getFacets();
+
 			items = rolePage.getItems();
 			lastPage = rolePage.getLastPage();
 			page = rolePage.getPage();
@@ -4152,6 +4261,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Role> items;
@@ -4176,6 +4288,8 @@ public class Query {
 		public SegmentPage(Page segmentPage) {
 			actions = segmentPage.getActions();
 
+			facets = segmentPage.getFacets();
+
 			items = segmentPage.getItems();
 			lastPage = segmentPage.getLastPage();
 			page = segmentPage.getPage();
@@ -4185,6 +4299,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Segment> items;
@@ -4209,6 +4326,8 @@ public class Query {
 		public SegmentUserPage(Page segmentUserPage) {
 			actions = segmentUserPage.getActions();
 
+			facets = segmentUserPage.getFacets();
+
 			items = segmentUserPage.getItems();
 			lastPage = segmentUserPage.getLastPage();
 			page = segmentUserPage.getPage();
@@ -4220,7 +4339,48 @@ public class Query {
 		protected Map<String, Map<String, String>> actions;
 
 		@GraphQLField
+		protected List<Facet> facets;
+
+		@GraphQLField
 		protected java.util.Collection<SegmentUser> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("SharedAssetPage")
+	public class SharedAssetPage {
+
+		public SharedAssetPage(Page sharedAssetPage) {
+			actions = sharedAssetPage.getActions();
+
+			facets = sharedAssetPage.getFacets();
+
+			items = sharedAssetPage.getItems();
+			lastPage = sharedAssetPage.getLastPage();
+			page = sharedAssetPage.getPage();
+			pageSize = sharedAssetPage.getPageSize();
+			totalCount = sharedAssetPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
+
+		@GraphQLField
+		protected java.util.Collection<SharedAsset> items;
 
 		@GraphQLField
 		protected long lastPage;
@@ -4242,6 +4402,8 @@ public class Query {
 		public SitePage(Page sitePage) {
 			actions = sitePage.getActions();
 
+			facets = sitePage.getFacets();
+
 			items = sitePage.getItems();
 			lastPage = sitePage.getLastPage();
 			page = sitePage.getPage();
@@ -4251,6 +4413,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Site> items;
@@ -4275,6 +4440,8 @@ public class Query {
 		public SubscriptionPage(Page subscriptionPage) {
 			actions = subscriptionPage.getActions();
 
+			facets = subscriptionPage.getFacets();
+
 			items = subscriptionPage.getItems();
 			lastPage = subscriptionPage.getLastPage();
 			page = subscriptionPage.getPage();
@@ -4284,6 +4451,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Subscription> items;
@@ -4308,6 +4478,8 @@ public class Query {
 		public TicketPage(Page ticketPage) {
 			actions = ticketPage.getActions();
 
+			facets = ticketPage.getFacets();
+
 			items = ticketPage.getItems();
 			lastPage = ticketPage.getLastPage();
 			page = ticketPage.getPage();
@@ -4317,6 +4489,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<Ticket> items;
@@ -4341,6 +4516,8 @@ public class Query {
 		public UserAccountPage(Page userAccountPage) {
 			actions = userAccountPage.getActions();
 
+			facets = userAccountPage.getFacets();
+
 			items = userAccountPage.getItems();
 			lastPage = userAccountPage.getLastPage();
 			page = userAccountPage.getPage();
@@ -4350,6 +4527,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<UserAccount> items;
@@ -4376,6 +4556,8 @@ public class Query {
 
 			actions = userAccountFullNameDefinitionPage.getActions();
 
+			facets = userAccountFullNameDefinitionPage.getFacets();
+
 			items = userAccountFullNameDefinitionPage.getItems();
 			lastPage = userAccountFullNameDefinitionPage.getLastPage();
 			page = userAccountFullNameDefinitionPage.getPage();
@@ -4385,6 +4567,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<UserAccountFullNameDefinition> items;
@@ -4409,6 +4594,8 @@ public class Query {
 		public UserGroupPage(Page userGroupPage) {
 			actions = userGroupPage.getActions();
 
+			facets = userGroupPage.getFacets();
+
 			items = userGroupPage.getItems();
 			lastPage = userGroupPage.getLastPage();
 			page = userGroupPage.getPage();
@@ -4418,6 +4605,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<UserGroup> items;
@@ -4442,6 +4632,8 @@ public class Query {
 		public WebUrlPage(Page webUrlPage) {
 			actions = webUrlPage.getActions();
 
+			facets = webUrlPage.getFacets();
+
 			items = webUrlPage.getItems();
 			lastPage = webUrlPage.getLastPage();
 			page = webUrlPage.getPage();
@@ -4451,6 +4643,9 @@ public class Query {
 
 		@GraphQLField
 		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
 
 		@GraphQLField
 		protected java.util.Collection<WebUrl> items;
@@ -4675,6 +4870,20 @@ public class Query {
 		segmentUserResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private void _populateResourceContext(
+			SharedAssetResource sharedAssetResource)
+		throws Exception {
+
+		sharedAssetResource.setContextAcceptLanguage(_acceptLanguage);
+		sharedAssetResource.setContextCompany(_company);
+		sharedAssetResource.setContextHttpServletRequest(_httpServletRequest);
+		sharedAssetResource.setContextHttpServletResponse(_httpServletResponse);
+		sharedAssetResource.setContextUriInfo(_uriInfo);
+		sharedAssetResource.setContextUser(_user);
+		sharedAssetResource.setGroupLocalService(_groupLocalService);
+		sharedAssetResource.setRoleLocalService(_roleLocalService);
+	}
+
 	private void _populateResourceContext(SiteResource siteResource)
 		throws Exception {
 
@@ -4796,6 +5005,8 @@ public class Query {
 		_segmentResourceComponentServiceObjects;
 	private static ComponentServiceObjects<SegmentUserResource>
 		_segmentUserResourceComponentServiceObjects;
+	private static ComponentServiceObjects<SharedAssetResource>
+		_sharedAssetResourceComponentServiceObjects;
 	private static ComponentServiceObjects<SiteResource>
 		_siteResourceComponentServiceObjects;
 	private static ComponentServiceObjects<SubscriptionResource>
@@ -4813,6 +5024,8 @@ public class Query {
 		_webUrlResourceComponentServiceObjects;
 
 	private AcceptLanguage _acceptLanguage;
+	private BiFunction<Object, List<String>, Aggregation>
+		_aggregationBiFunction;
 	private com.liferay.portal.kernel.model.Company _company;
 	private BiFunction
 		<Object, String, com.liferay.portal.kernel.search.filter.Filter>

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -17,6 +17,7 @@ import com.liferay.headless.admin.user.internal.resource.v1_0.PostalAddressResou
 import com.liferay.headless.admin.user.internal.resource.v1_0.RoleResourceImpl;
 import com.liferay.headless.admin.user.internal.resource.v1_0.SegmentResourceImpl;
 import com.liferay.headless.admin.user.internal.resource.v1_0.SegmentUserResourceImpl;
+import com.liferay.headless.admin.user.internal.resource.v1_0.SharedAssetResourceImpl;
 import com.liferay.headless.admin.user.internal.resource.v1_0.SiteResourceImpl;
 import com.liferay.headless.admin.user.internal.resource.v1_0.SubscriptionResourceImpl;
 import com.liferay.headless.admin.user.internal.resource.v1_0.TicketResourceImpl;
@@ -34,6 +35,7 @@ import com.liferay.headless.admin.user.resource.v1_0.PostalAddressResource;
 import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentUserResource;
+import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
 import com.liferay.headless.admin.user.resource.v1_0.SiteResource;
 import com.liferay.headless.admin.user.resource.v1_0.SubscriptionResource;
 import com.liferay.headless.admin.user.resource.v1_0.TicketResource;
@@ -113,6 +115,8 @@ public class ServletDataImpl implements ServletData {
 			_segmentResourceComponentServiceObjects);
 		Query.setSegmentUserResourceComponentServiceObjects(
 			_segmentUserResourceComponentServiceObjects);
+		Query.setSharedAssetResourceComponentServiceObjects(
+			_sharedAssetResourceComponentServiceObjects);
 		Query.setSiteResourceComponentServiceObjects(
 			_siteResourceComponentServiceObjects);
 		Query.setSubscriptionResourceComponentServiceObjects(
@@ -1323,6 +1327,16 @@ public class ServletDataImpl implements ServletData {
 							SegmentUserResourceImpl.class,
 							"getSegmentUserAccountsPage"));
 					put(
+						"query#myUserAccountSharedAssetsSharedByMe",
+						new ObjectValuePair<>(
+							SharedAssetResourceImpl.class,
+							"getMyUserAccountSharedAssetsSharedByMePage"));
+					put(
+						"query#myUserAccountSharedAssetsSharedWithMe",
+						new ObjectValuePair<>(
+							SharedAssetResourceImpl.class,
+							"getMyUserAccountSharedAssetsSharedWithMePage"));
+					put(
 						"query#myUserAccountSites",
 						new ObjectValuePair<>(
 							SiteResourceImpl.class,
@@ -1870,6 +1884,10 @@ public class ServletDataImpl implements ServletData {
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<SegmentUserResource>
 		_segmentUserResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SharedAssetResource>
+		_sharedAssetResourceComponentServiceObjects;
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<SiteResource>

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSharedAssetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSharedAssetResourceImpl.java
@@ -1,0 +1,586 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.resource.v1_0;
+
+import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/v1.0")
+public abstract class BaseSharedAssetResourceImpl
+	implements EntityModelResource, SharedAssetResource,
+			   VulcanBatchEngineTaskItemDelegate<SharedAsset> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/my-user-account/shared-assets/shared-by-me'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "aggregationTerms"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "SharedAsset")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/my-user-account/shared-assets/shared-by-me")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedByMePage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("search")
+			String search,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@javax.ws.rs.core.Context Pagination pagination,
+			@javax.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/my-user-account/shared-assets/shared-with-me'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "aggregationTerms"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "search"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "SharedAsset")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/my-user-account/shared-assets/shared-with-me")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedWithMePage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("search")
+			String search,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.vulcan.aggregation.Aggregation aggregation,
+			@javax.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@javax.ws.rs.core.Context Pagination pagination,
+			@javax.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<SharedAsset> sharedAssets,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<SharedAsset> sharedAssets,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getResourceName() {
+		return "SharedAsset";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<SharedAsset> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<SharedAsset> sharedAssets,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<SharedAsset>,
+			 UnsafeFunction<SharedAsset, SharedAsset, Exception>, Exception>
+				contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<SharedAsset>, UnsafeConsumer<SharedAsset, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-admin-user";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<SharedAsset>,
+		 UnsafeFunction<SharedAsset, SharedAsset, Exception>, Exception>
+			contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<SharedAsset>, UnsafeConsumer<SharedAsset, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSharedAssetResourceImpl.class);
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -105,6 +105,8 @@ public class OpenAPIResourceImpl {
 
 			add(SegmentUserResourceImpl.class);
 
+			add(SharedAssetResourceImpl.class);
+
 			add(SiteResourceImpl.class);
 
 			add(SubscriptionResourceImpl.class);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SharedAssetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SharedAssetResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.resource.v1_0;
+
+import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/shared-asset.properties",
+	scope = ServiceScope.PROTOTYPE, service = SharedAssetResource.class
+)
+public class SharedAssetResourceImpl extends BaseSharedAssetResourceImpl {
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SharedAssetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SharedAssetResourceImpl.java
@@ -5,9 +5,32 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
 import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.service.SharingEntryService;
+
+import java.util.HashMap;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -18,4 +41,112 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = SharedAssetResource.class
 )
 public class SharedAssetResourceImpl extends BaseSharedAssetResourceImpl {
+
+	@Override
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedByMePage(
+			String search, Aggregation aggregation, Filter filter,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return SearchUtil.search(
+			new HashMap<>(), _getSharedByMeBooleanQueryUnsafeConsumer(), filter,
+			SharingEntry.class.getName(), search, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames("sharingEntryId"),
+			searchContext -> {
+				searchContext.addVulcanAggregation(aggregation);
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+			},
+			sorts,
+			document -> _toSharedAsset(
+				_sharingEntryService.getSharingEntry(
+					GetterUtil.getLong(document.get("sharingEntryId")))));
+	}
+
+	@Override
+	public Page<SharedAsset> getMyUserAccountSharedAssetsSharedWithMePage(
+			String search, Aggregation aggregation, Filter filter,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return SearchUtil.search(
+			new HashMap<>(), _getSharedWithMeBooleanQueryUnsafeConsumer(),
+			filter, SharingEntry.class.getName(), search, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames("sharingEntryId"),
+			searchContext -> {
+				searchContext.addVulcanAggregation(aggregation);
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+			},
+			sorts,
+			document -> _toSharedAsset(
+				_sharingEntryService.getSharingEntry(
+					GetterUtil.getLong(document.get("sharingEntryId")))));
+	}
+
+	private UnsafeConsumer<BooleanQuery, Exception>
+		_getSharedByMeBooleanQueryUnsafeConsumer() {
+
+		return booleanQuery -> {
+			BooleanFilter booleanFilter = booleanQuery.getPreBooleanFilter();
+
+			booleanFilter.add(
+				new TermFilter(
+					"userId", String.valueOf(contextUser.getUserId())),
+				BooleanClauseOccur.MUST);
+		};
+	}
+
+	private UnsafeConsumer<BooleanQuery, Exception>
+		_getSharedWithMeBooleanQueryUnsafeConsumer() {
+
+		return booleanQuery -> {
+			BooleanFilter booleanFilter = booleanQuery.getPreBooleanFilter();
+
+			TermsFilter toUserGroupIdTermsFilter = new TermsFilter(
+				"toUserGroupId");
+
+			toUserGroupIdTermsFilter.addValues(
+				transformToArray(
+					_userGroupLocalService.getUserUserGroups(
+						contextUser.getUserId()),
+					userGroup -> String.valueOf(userGroup.getUserGroupId()),
+					String.class));
+
+			booleanFilter.add(
+				toUserGroupIdTermsFilter, BooleanClauseOccur.SHOULD);
+
+			TermsFilter toUserIdTermsFilter = new TermsFilter("toUserId");
+
+			toUserIdTermsFilter.addValue(
+				String.valueOf(contextUser.getUserId()));
+
+			booleanFilter.add(toUserIdTermsFilter, BooleanClauseOccur.SHOULD);
+		};
+	}
+
+	private SharedAsset _toSharedAsset(SharingEntry sharingEntry)
+		throws Exception {
+
+		return _sharedAssetDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
+				_dtoConverterRegistry, sharingEntry.getSharingEntryId(),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			sharingEntry);
+	}
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.admin.user.internal.dto.v1_0.converter.SharedAssetDTOConverter)"
+	)
+	private DTOConverter<SharingEntry, SharedAsset> _sharedAssetDTOConverter;
+
+	@Reference
+	private SharingEntryService _sharingEntryService;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
+
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SharedAssetResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/factory/SharedAssetResourceFactoryImpl.java
@@ -1,0 +1,331 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.internal.resource.v1_0.factory;
+
+import com.liferay.headless.admin.user.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-admin-user/v1.0/SharedAsset",
+	service = SharedAssetResource.Factory.class
+)
+@Generated("")
+public class SharedAssetResourceFactoryImpl
+	implements SharedAssetResource.Factory {
+
+	@Override
+	public SharedAssetResource.Builder create() {
+		return new SharedAssetResource.Builder() {
+
+			@Override
+			public SharedAssetResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, SharedAssetResource>
+					sharedAssetResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_sharedAssetResourceProxyProviderFunction;
+
+				return sharedAssetResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public SharedAssetResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public SharedAssetResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public SharedAssetResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public SharedAssetResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public SharedAssetResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public SharedAssetResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, SharedAssetResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			SharedAssetResource.class.getClassLoader(),
+			SharedAssetResource.class);
+
+		try {
+			Constructor<SharedAssetResource> constructor =
+				(Constructor<SharedAssetResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		SharedAssetResource sharedAssetResource =
+			_componentServiceObjects.getService();
+
+		sharedAssetResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		sharedAssetResource.setContextCompany(company);
+
+		sharedAssetResource.setContextHttpServletRequest(httpServletRequest);
+		sharedAssetResource.setContextHttpServletResponse(httpServletResponse);
+		sharedAssetResource.setContextUriInfo(uriInfo);
+		sharedAssetResource.setContextUser(user);
+		sharedAssetResource.setExpressionConvert(_expressionConvert);
+		sharedAssetResource.setFilterParserProvider(_filterParserProvider);
+		sharedAssetResource.setGroupLocalService(_groupLocalService);
+		sharedAssetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		sharedAssetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		sharedAssetResource.setRoleLocalService(_roleLocalService);
+		sharedAssetResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(sharedAssetResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(sharedAssetResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<SharedAssetResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, SharedAssetResource>
+			_sharedAssetResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shared-asset.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/shared-asset.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.admin.user.dto.v1_0.SharedAsset
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=false
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.headless.admin.user.dto.v1_0.SharedAsset
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-rest-spi")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
@@ -29,5 +30,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:segments:segments-test-util")
+	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
@@ -1,0 +1,2114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.client.http.HttpInvoker;
+import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.pagination.Pagination;
+import com.liferay.headless.admin.user.client.resource.v1_0.SharedAssetResource;
+import com.liferay.headless.admin.user.client.serdes.v1_0.SharedAssetSerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseSharedAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_sharedAssetResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		sharedAssetResource = SharedAssetResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SharedAsset sharedAsset1 = randomSharedAsset();
+
+		String json = objectMapper.writeValueAsString(sharedAsset1);
+
+		SharedAsset sharedAsset2 = SharedAssetSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(sharedAsset1, sharedAsset2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		SharedAsset sharedAsset = randomSharedAsset();
+
+		String json1 = objectMapper.writeValueAsString(sharedAsset);
+		String json2 = SharedAssetSerDes.toJSON(sharedAsset);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		SharedAsset sharedAsset = randomSharedAsset();
+
+		sharedAsset.setAssetType(regex);
+		sharedAsset.setClassName(regex);
+		sharedAsset.setExternalReferenceCode(regex);
+		sharedAsset.setSiteName(regex);
+		sharedAsset.setTitle(regex);
+
+		String json = SharedAssetSerDes.toJSON(sharedAsset);
+
+		Assert.assertFalse(json.contains(regex));
+
+		sharedAsset = SharedAssetSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, sharedAsset.getAssetType());
+		Assert.assertEquals(regex, sharedAsset.getClassName());
+		Assert.assertEquals(regex, sharedAsset.getExternalReferenceCode());
+		Assert.assertEquals(regex, sharedAsset.getSiteName());
+		Assert.assertEquals(regex, sharedAsset.getTitle());
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePage()
+		throws Exception {
+
+		Page<SharedAsset> page =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+				null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		page = sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+			null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(sharedAsset1, (List<SharedAsset>)page.getItems());
+		assertContains(sharedAsset2, (List<SharedAsset>)page.getItems());
+		assertValid(
+			page,
+			testGetMyUserAccountSharedAssetsSharedByMePage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetMyUserAccountSharedAssetsSharedByMePage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 = randomSharedAsset();
+
+		sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				sharedAsset1);
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> page =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null,
+					getFilterString(entityField, "between", sharedAsset1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sharedAsset1),
+				(List<SharedAsset>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithFilter(
+			"eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithFilterStringContains()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithFilterStringEquals()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithFilter(
+			"eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetMyUserAccountSharedAssetsSharedByMePageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> page =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null,
+					getFilterString(entityField, operator, sharedAsset1),
+					Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sharedAsset1),
+				(List<SharedAsset>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithPagination()
+		throws Exception {
+
+		Page<SharedAsset> sharedAssetPage =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+				null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(sharedAssetPage.getTotalCount());
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset3 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				randomSharedAsset());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SharedAsset> page1 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(sharedAsset1, (List<SharedAsset>)page1.getItems());
+
+			Page<SharedAsset> page2 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(sharedAsset2, (List<SharedAsset>)page2.getItems());
+
+			Page<SharedAsset> page3 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit),
+					null);
+
+			assertContains(sharedAsset3, (List<SharedAsset>)page3.getItems());
+		}
+		else {
+			Page<SharedAsset> page1 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null, Pagination.of(1, totalCount + 2), null);
+
+			List<SharedAsset> sharedAssets1 =
+				(List<SharedAsset>)page1.getItems();
+
+			Assert.assertEquals(
+				sharedAssets1.toString(), totalCount + 2, sharedAssets1.size());
+
+			Page<SharedAsset> page2 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null, Pagination.of(2, totalCount + 2), null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SharedAsset> sharedAssets2 =
+				(List<SharedAsset>)page2.getItems();
+
+			Assert.assertEquals(
+				sharedAssets2.toString(), 1, sharedAssets2.size());
+
+			Page<SharedAsset> page3 =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null, Pagination.of(1, (int)totalCount + 3),
+					null);
+
+			assertContains(sharedAsset1, (List<SharedAsset>)page3.getItems());
+			assertContains(sharedAsset2, (List<SharedAsset>)page3.getItems());
+			assertContains(sharedAsset3, (List<SharedAsset>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithSortDateTime()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithSortDouble()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					sharedAsset2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithSortInteger()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					sharedAsset2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedByMePageWithSortString()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedByMePageWithSort(
+			EntityField.Type.STRING,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				Class<?> clazz = sharedAsset1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetMyUserAccountSharedAssetsSharedByMePageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, SharedAsset, SharedAsset, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 = randomSharedAsset();
+		SharedAsset sharedAsset2 = randomSharedAsset();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, sharedAsset1, sharedAsset2);
+		}
+
+		sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				sharedAsset1);
+
+		sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				sharedAsset2);
+
+		Page<SharedAsset> page =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+				null, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> ascPage =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":asc");
+
+			assertContains(sharedAsset1, (List<SharedAsset>)ascPage.getItems());
+			assertContains(sharedAsset2, (List<SharedAsset>)ascPage.getItems());
+
+			Page<SharedAsset> descPage =
+				sharedAssetResource.getMyUserAccountSharedAssetsSharedByMePage(
+					null, null, null,
+					Pagination.of(1, (int)page.getTotalCount() + 1),
+					entityField.getName() + ":desc");
+
+			assertContains(
+				sharedAsset2, (List<SharedAsset>)descPage.getItems());
+			assertContains(
+				sharedAsset1, (List<SharedAsset>)descPage.getItems());
+		}
+	}
+
+	protected SharedAsset
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				SharedAsset sharedAsset)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePage()
+		throws Exception {
+
+		Page<SharedAsset> page =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedWithMePage(
+				null, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		page = sharedAssetResource.getMyUserAccountSharedAssetsSharedWithMePage(
+			null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(sharedAsset1, (List<SharedAsset>)page.getItems());
+		assertContains(sharedAsset2, (List<SharedAsset>)page.getItems());
+		assertValid(
+			page,
+			testGetMyUserAccountSharedAssetsSharedWithMePage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetMyUserAccountSharedAssetsSharedWithMePage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 = randomSharedAsset();
+
+		sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				sharedAsset1);
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null,
+						getFilterString(entityField, "between", sharedAsset1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sharedAsset1),
+				(List<SharedAsset>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithFilter(
+			"eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilterStringContains()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilterStringEquals()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithFilter(
+			"eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetMyUserAccountSharedAssetsSharedWithMePageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null,
+						getFilterString(entityField, operator, sharedAsset1),
+						Pagination.of(1, 2), null);
+
+			assertEquals(
+				Collections.singletonList(sharedAsset1),
+				(List<SharedAsset>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithPagination()
+		throws Exception {
+
+		Page<SharedAsset> sharedAssetPage =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedWithMePage(
+				null, null, null, null, null);
+
+		int totalCount = GetterUtil.getInteger(sharedAssetPage.getTotalCount());
+
+		SharedAsset sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		SharedAsset sharedAsset3 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SharedAsset> page1 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+							pageSizeLimit),
+						null);
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(sharedAsset1, (List<SharedAsset>)page1.getItems());
+
+			Page<SharedAsset> page2 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+							pageSizeLimit),
+						null);
+
+			assertContains(sharedAsset2, (List<SharedAsset>)page2.getItems());
+
+			Page<SharedAsset> page3 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+							pageSizeLimit),
+						null);
+
+			assertContains(sharedAsset3, (List<SharedAsset>)page3.getItems());
+		}
+		else {
+			Page<SharedAsset> page1 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null, Pagination.of(1, totalCount + 2),
+						null);
+
+			List<SharedAsset> sharedAssets1 =
+				(List<SharedAsset>)page1.getItems();
+
+			Assert.assertEquals(
+				sharedAssets1.toString(), totalCount + 2, sharedAssets1.size());
+
+			Page<SharedAsset> page2 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null, Pagination.of(2, totalCount + 2),
+						null);
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SharedAsset> sharedAssets2 =
+				(List<SharedAsset>)page2.getItems();
+
+			Assert.assertEquals(
+				sharedAssets2.toString(), 1, sharedAssets2.size());
+
+			Page<SharedAsset> page3 =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null, Pagination.of(1, (int)totalCount + 3),
+						null);
+
+			assertContains(sharedAsset1, (List<SharedAsset>)page3.getItems());
+			assertContains(sharedAsset2, (List<SharedAsset>)page3.getItems());
+			assertContains(sharedAsset3, (List<SharedAsset>)page3.getItems());
+		}
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithSortDateTime()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithSort(
+			EntityField.Type.DATE_TIME,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(),
+					new Date(System.currentTimeMillis() - (2 * Time.MINUTE)));
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithSortDouble()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithSort(
+			EntityField.Type.DOUBLE,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(), 0.1);
+				BeanTestUtil.setProperty(
+					sharedAsset2, entityField.getName(), 0.5);
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithSortInteger()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithSort(
+			EntityField.Type.INTEGER,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				BeanTestUtil.setProperty(
+					sharedAsset1, entityField.getName(), 0);
+				BeanTestUtil.setProperty(
+					sharedAsset2, entityField.getName(), 1);
+			});
+	}
+
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePageWithSortString()
+		throws Exception {
+
+		testGetMyUserAccountSharedAssetsSharedWithMePageWithSort(
+			EntityField.Type.STRING,
+			(entityField, sharedAsset1, sharedAsset2) -> {
+				Class<?> clazz = sharedAsset1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()) +
+									"@liferay.com");
+				}
+				else {
+					BeanTestUtil.setProperty(
+						sharedAsset1, entityFieldName,
+						"aaa" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+					BeanTestUtil.setProperty(
+						sharedAsset2, entityFieldName,
+						"bbb" +
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()));
+				}
+			});
+	}
+
+	protected void testGetMyUserAccountSharedAssetsSharedWithMePageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer<EntityField, SharedAsset, SharedAsset, Exception>
+				unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		SharedAsset sharedAsset1 = randomSharedAsset();
+		SharedAsset sharedAsset2 = randomSharedAsset();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(entityField, sharedAsset1, sharedAsset2);
+		}
+
+		sharedAsset1 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				sharedAsset1);
+
+		sharedAsset2 =
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				sharedAsset2);
+
+		Page<SharedAsset> page =
+			sharedAssetResource.getMyUserAccountSharedAssetsSharedWithMePage(
+				null, null, null, null, null);
+
+		for (EntityField entityField : entityFields) {
+			Page<SharedAsset> ascPage =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null,
+						Pagination.of(1, (int)page.getTotalCount() + 1),
+						entityField.getName() + ":asc");
+
+			assertContains(sharedAsset1, (List<SharedAsset>)ascPage.getItems());
+			assertContains(sharedAsset2, (List<SharedAsset>)ascPage.getItems());
+
+			Page<SharedAsset> descPage =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null,
+						Pagination.of(1, (int)page.getTotalCount() + 1),
+						entityField.getName() + ":desc");
+
+			assertContains(
+				sharedAsset2, (List<SharedAsset>)descPage.getItems());
+			assertContains(
+				sharedAsset1, (List<SharedAsset>)descPage.getItems());
+		}
+	}
+
+	protected SharedAsset
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				SharedAsset sharedAsset)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	protected SharedAsset testGraphQLSharedAsset_addSharedAsset()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(
+		SharedAsset sharedAsset, List<SharedAsset> sharedAssets) {
+
+		boolean contains = false;
+
+		for (SharedAsset item : sharedAssets) {
+			if (equals(sharedAsset, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			sharedAssets + " does not contain " + sharedAsset, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		SharedAsset sharedAsset1, SharedAsset sharedAsset2) {
+
+		Assert.assertTrue(
+			sharedAsset1 + " does not equal " + sharedAsset2,
+			equals(sharedAsset1, sharedAsset2));
+	}
+
+	protected void assertEquals(
+		List<SharedAsset> sharedAssets1, List<SharedAsset> sharedAssets2) {
+
+		Assert.assertEquals(sharedAssets1.size(), sharedAssets2.size());
+
+		for (int i = 0; i < sharedAssets1.size(); i++) {
+			SharedAsset sharedAsset1 = sharedAssets1.get(i);
+			SharedAsset sharedAsset2 = sharedAssets2.get(i);
+
+			assertEquals(sharedAsset1, sharedAsset2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<SharedAsset> sharedAssets1, List<SharedAsset> sharedAssets2) {
+
+		Assert.assertEquals(sharedAssets1.size(), sharedAssets2.size());
+
+		for (SharedAsset sharedAsset1 : sharedAssets1) {
+			boolean contains = false;
+
+			for (SharedAsset sharedAsset2 : sharedAssets2) {
+				if (equals(sharedAsset1, sharedAsset2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				sharedAssets2 + " does not contain " + sharedAsset1, contains);
+		}
+	}
+
+	protected void assertValid(SharedAsset sharedAsset) throws Exception {
+		boolean valid = true;
+
+		if (sharedAsset.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (sharedAsset.getDateModified() == null) {
+			valid = false;
+		}
+
+		if (sharedAsset.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actionIds", additionalAssertFieldName)) {
+				if (sharedAsset.getActionIds() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (sharedAsset.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetType", additionalAssertFieldName)) {
+				if (sharedAsset.getAssetType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("className", additionalAssertFieldName)) {
+				if (sharedAsset.getClassName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (sharedAsset.getClassPK() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (sharedAsset.getCreator() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (sharedAsset.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("shareable", additionalAssertFieldName)) {
+				if (sharedAsset.getShareable() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("siteName", additionalAssertFieldName)) {
+				if (sharedAsset.getSiteName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (sharedAsset.getTitle() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<SharedAsset> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<SharedAsset> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<SharedAsset> sharedAssets = page.getItems();
+
+		int size = sharedAssets.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.admin.user.dto.v1_0.SharedAsset.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		SharedAsset sharedAsset1, SharedAsset sharedAsset2) {
+
+		if (sharedAsset1 == sharedAsset2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actionIds", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getActionIds(),
+						sharedAsset2.getActionIds())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)sharedAsset1.getActions(),
+						(Map)sharedAsset2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("assetType", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getAssetType(),
+						sharedAsset2.getAssetType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("className", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getClassName(),
+						sharedAsset2.getClassName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("classPK", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getClassPK(), sharedAsset2.getClassPK())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getCreator(), sharedAsset2.getCreator())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getDateCreated(),
+						sharedAsset2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateModified", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getDateModified(),
+						sharedAsset2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						sharedAsset1.getExternalReferenceCode(),
+						sharedAsset2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getId(), sharedAsset2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("shareable", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getShareable(),
+						sharedAsset2.getShareable())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("siteName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getSiteName(),
+						sharedAsset2.getSiteName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getTitle(), sharedAsset2.getTitle())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_sharedAssetResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_sharedAssetResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, SharedAsset sharedAsset) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("actionIds")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("assetType")) {
+			Object object = sharedAsset.getAssetType();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("className")) {
+			Object object = sharedAsset.getClassName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("classPK")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("creator")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				Date date = sharedAsset.getDateCreated();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(sharedAsset.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateModified")) {
+			if (operator.equals("between")) {
+				Date date = sharedAsset.getDateModified();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(sharedAsset.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = sharedAsset.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("shareable")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("siteName")) {
+			Object object = sharedAsset.getSiteName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("title")) {
+			Object object = sharedAsset.getTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected SharedAsset randomSharedAsset() throws Exception {
+		return new SharedAsset() {
+			{
+				assetType = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				className = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				classPK = RandomTestUtil.randomLong();
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
+				shareable = RandomTestUtil.randomBoolean();
+				siteName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected SharedAsset randomIrrelevantSharedAsset() throws Exception {
+		SharedAsset randomIrrelevantSharedAsset = randomSharedAsset();
+
+		return randomIrrelevantSharedAsset;
+	}
+
+	protected SharedAsset randomPatchSharedAsset() throws Exception {
+		return randomSharedAsset();
+	}
+
+	protected SharedAssetResource sharedAssetResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseSharedAssetResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.admin.user.resource.v1_0.SharedAssetResource
+		_sharedAssetResource;
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -6,14 +6,215 @@
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.sharing.interpreter.SharingEntryInterpreter;
+import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 
-import org.junit.Ignore;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 /**
  * @author Javier Gamarra
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_objectDefinition = _getObjectDefinition();
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+
+		_userLocalService.deleteUser(_user);
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"actionIds", "assetType", "externalReferenceCode", "id", "title"
+		};
+	}
+
+	@Override
+	protected SharedAsset
+			testGetMyUserAccountSharedAssetsSharedByMePage_addSharedAsset(
+				SharedAsset sharedAsset)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				testGroup.getGroupId(), TestPropsValues.getUserId());
+
+		_objectEntry = _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), testGroup.getGroupId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", sharedAsset.getTitle()
+			).build(),
+			serviceContext);
+
+		return _toSharedAsset(
+			sharedAsset,
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), 0, _user.getUserId(),
+				_classNameLocalService.getClassNameId(
+					_objectDefinition.getClassName()),
+				_objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
+	}
+
+	@Override
+	protected SharedAsset
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				SharedAsset sharedAsset)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				testGroup.getGroupId(), _user.getUserId());
+
+		_objectEntry = _objectEntryLocalService.addObjectEntry(
+			_user.getUserId(), testGroup.getGroupId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", sharedAsset.getTitle()
+			).build(),
+			serviceContext);
+
+		return _toSharedAsset(
+			sharedAsset,
+			_sharingEntryLocalService.addSharingEntry(
+				null, _user.getUserId(), 0, TestPropsValues.getUserId(),
+				_classNameLocalService.getClassNameId(
+					_objectDefinition.getClassName()),
+				_objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
+	}
+
+	private static ObjectDefinition _getObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				true, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexed(
+						true
+					).indexedAsKeyword(
+						true
+					).name(
+						"title"
+					).localized(
+						false
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE,
+				TestPropsValues.getUserId());
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectDefinition.getObjectDefinitionId(), "title");
+
+		objectDefinition.setTitleObjectFieldId(objectField.getObjectFieldId());
+
+		return _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+	}
+
+	private String _getAssetType(SharingEntry sharingEntry) throws Exception {
+		SharingEntryInterpreter sharingEntryInterpreter =
+			_sharingEntryInterpreterProvider.getSharingEntryInterpreter(
+				sharingEntry);
+
+		if (sharingEntryInterpreter == null) {
+			return null;
+		}
+
+		return sharingEntryInterpreter.getAssetTypeTitle(
+			sharingEntry, LocaleUtil.US);
+	}
+
+	private SharedAsset _toSharedAsset(
+			SharedAsset sharedAsset, SharingEntry sharingEntry)
+		throws Exception {
+
+		return new SharedAsset() {
+			{
+				actionIds = TransformUtil.transformToArray(
+					SharingEntryAction.getSharingEntryActions(
+						sharingEntry.getActionIds()),
+					SharingEntryAction::getActionId, String.class);
+				assetType = _getAssetType(sharingEntry);
+				dateCreated = sharingEntry.getCreateDate();
+				dateModified = sharingEntry.getModifiedDate();
+				externalReferenceCode = sharingEntry.getExternalReferenceCode();
+				id = sharingEntry.getSharingEntryId();
+				title = sharedAsset.getTitle();
+			}
+		};
+	}
+
+	private static ObjectDefinition _objectDefinition;
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private static ObjectFieldLocalService _objectFieldLocalService;
+
+	private static User _user;
+
+	@Inject
+	private static UserLocalService _userLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.user.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Gamarra
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -522,13 +522,13 @@ public class ObjectEntryLocalServiceImpl
 				externalReferenceCode, user.getCompanyId(), objectDefinitionId);
 
 			if (objectEntry != null) {
-				return updateObjectEntry(
+				return objectEntryLocalService.updateObjectEntry(
 					userId, objectEntry.getObjectEntryId(), values,
 					serviceContext);
 			}
 		}
 
-		objectEntry = addObjectEntry(
+		objectEntry = objectEntryLocalService.addObjectEntry(
 			userId, groupId, objectDefinitionId, objectEntryFolderId, null,
 			values, serviceContext);
 
@@ -4996,7 +4996,7 @@ public class ObjectEntryLocalServiceImpl
 				nodeObjectEntry.setRootObjectEntryId(
 					parentObjectEntry.getRootObjectEntryId());
 
-				updateObjectEntry(nodeObjectEntry);
+				objectEntryLocalService.updateObjectEntry(nodeObjectEntry);
 			}
 		}
 

--- a/modules/apps/sharing/sharing-api/bnd.bnd
+++ b/modules/apps/sharing/sharing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Sharing API
 Bundle-SymbolicName: com.liferay.sharing.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.sharing.configuration,\
 	com.liferay.sharing.constants,\

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/interpreter/SharingEntryInterpreter.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/interpreter/SharingEntryInterpreter.java
@@ -27,6 +27,8 @@ public interface SharingEntryInterpreter {
 
 	public String getTitle(SharingEntry sharingEntry);
 
+	public String getTitle(SharingEntry sharingEntry, Locale locale);
+
 	public Map<Locale, String> getTitleMap(SharingEntry sharingEntry);
 
 	public boolean isVisible(SharingEntry sharingEntry) throws PortalException;

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
@@ -120,6 +120,10 @@ public interface SharingEntryService extends BaseService {
 	public String getOSGiServiceIdentifier();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public SharingEntry getSharingEntry(long sharingEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SharingEntry getSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException;

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
@@ -133,6 +133,12 @@ public class SharingEntryServiceUtil {
 		return getService().getOSGiServiceIdentifier();
 	}
 
+	public static SharingEntry getSharingEntry(long sharingEntryId)
+		throws PortalException {
+
+		return getService().getSharingEntry(sharingEntryId);
+	}
+
 	public static SharingEntry getSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
@@ -139,6 +139,14 @@ public class SharingEntryServiceWrapper
 	}
 
 	@Override
+	public com.liferay.sharing.model.SharingEntry getSharingEntry(
+			long sharingEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.getSharingEntry(sharingEntryId);
+	}
+
+	@Override
 	public com.liferay.sharing.model.SharingEntry
 			getSharingEntryByExternalReferenceCode(
 				String externalReferenceCode, long groupId)

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/interpreter/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/interpreter/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/sharing/sharing-search/build.gradle
+++ b/modules/apps/sharing/sharing-search/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.search.internal.service;
+
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalServiceWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = ServiceWrapper.class)
+public class SharingEntryObjectEntryFolderServiceWrapper
+	extends ObjectEntryFolderLocalServiceWrapper {
+
+	@Override
+	public ObjectEntryFolder updateObjectEntryFolder(
+			long userId, long objectEntryFolderId,
+			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
+			String name)
+		throws PortalException {
+
+		ObjectEntryFolder objectEntryFolder = super.updateObjectEntryFolder(
+			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
+			name);
+
+		return _reindexSharingEntries(objectEntryFolder);
+	}
+
+	@Override
+	public ObjectEntryFolder updateObjectEntryFolder(
+		ObjectEntryFolder objectEntryFolder) {
+
+		return _reindexSharingEntries(
+			super.updateObjectEntryFolder(objectEntryFolder));
+	}
+
+	private ObjectEntryFolder _reindexSharingEntries(
+		ObjectEntryFolder objectEntryFolder) {
+
+		ClassName className = _classNameLocalService.fetchClassName(
+			ObjectEntryFolder.class.getName());
+
+		if (className == null) {
+			return objectEntryFolder;
+		}
+
+		Indexer<Object> indexer = _indexerRegistry.getIndexer(
+			className.getValue());
+
+		if (indexer == null) {
+			return objectEntryFolder;
+		}
+
+		List<SharingEntry> sharingEntryList =
+			_sharingEntryLocalService.getSharingEntries(
+				className.getClassNameId(),
+				objectEntryFolder.getObjectEntryFolderId());
+
+		sharingEntryList.forEach(
+			sharingEntry -> {
+				try {
+					indexer.reindex(sharingEntry);
+				}
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(exception);
+					}
+				}
+			});
+
+		return objectEntryFolder;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SharingEntryObjectEntryFolderServiceWrapper.class);
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryLocalServiceWrapper.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.search.internal.service;
+
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalServiceWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(service = ServiceWrapper.class)
+public class SharingEntryObjectEntryLocalServiceWrapper
+	extends ObjectEntryLocalServiceWrapper {
+
+	@Override
+	public ObjectEntry updateObjectEntry(
+			long userId, long objectEntryId, Map<String, Serializable> values,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _reindexSharingEntries(
+			super.updateObjectEntry(
+				userId, objectEntryId, values, serviceContext));
+	}
+
+	@Override
+	public ObjectEntry updateObjectEntry(ObjectEntry objectEntry) {
+		return _reindexSharingEntries(super.updateObjectEntry(objectEntry));
+	}
+
+	private ObjectEntry _reindexSharingEntries(ObjectEntry objectEntry) {
+		ClassName className = _classNameLocalService.fetchClassName(
+			objectEntry.getModelClassName());
+
+		if (className == null) {
+			return objectEntry;
+		}
+
+		Indexer<Object> indexer = _indexerRegistry.getIndexer(
+			className.getValue());
+
+		if (indexer == null) {
+			return objectEntry;
+		}
+
+		List<SharingEntry> sharingEntryList =
+			_sharingEntryLocalService.getSharingEntries(
+				className.getClassNameId(), objectEntry.getObjectEntryId());
+
+		sharingEntryList.forEach(
+			sharingEntry -> {
+				try {
+					indexer.reindex(sharingEntry);
+				}
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(exception);
+					}
+				}
+			});
+
+		return objectEntry;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SharingEntryObjectEntryLocalServiceWrapper.class);
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
@@ -267,6 +267,46 @@ public class SharingEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.sharing.model.SharingEntry getSharingEntry(
+			HttpPrincipal httpPrincipal, long sharingEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "getSharingEntry",
+				_getSharingEntryParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, sharingEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.sharing.model.SharingEntry
 			getSharingEntryByExternalReferenceCode(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
@@ -277,7 +317,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"getSharingEntryByExternalReferenceCode",
-				_getSharingEntryByExternalReferenceCodeParameterTypes5);
+				_getSharingEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -322,7 +362,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "updateSharingEntry",
-				_updateSharingEntryParameterTypes6);
+				_updateSharingEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, sharingEntryActions, shareable,
@@ -384,11 +424,13 @@ public class SharingEntryServiceHttp {
 		_fetchSharingEntryByExternalReferenceCodeParameterTypes4 = new Class[] {
 			String.class, long.class
 		};
+	private static final Class<?>[] _getSharingEntryParameterTypes5 =
+		new Class[] {long.class};
 	private static final Class<?>[]
-		_getSharingEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+		_getSharingEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _updateSharingEntryParameterTypes6 =
+	private static final Class<?>[] _updateSharingEntryParameterTypes7 =
 		new Class[] {
 			long.class, java.util.Collection.class, boolean.class,
 			java.util.Date.class,

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -205,7 +206,13 @@ public class SharingEntryLocalServiceImpl
 	 */
 	@Override
 	public void deleteExpiredEntries() {
-		sharingEntryPersistence.removeByLtExpirationDate(DateUtil.newDate());
+		for (SharingEntry sharingEntry :
+				sharingEntryPersistence.findByLtExpirationDate(
+					DateUtil.newDate(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+		}
 	}
 
 	/**
@@ -250,7 +257,8 @@ public class SharingEntryLocalServiceImpl
 	public SharingEntry deleteSharingEntry(long sharingEntryId)
 		throws PortalException {
 
-		return sharingEntryLocalService.deleteSharingEntry(getSharingEntry(sharingEntryId));
+		return sharingEntryLocalService.deleteSharingEntry(
+			getSharingEntry(sharingEntryId));
 	}
 
 	/**

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryLocalServiceImpl.java
@@ -219,7 +219,7 @@ public class SharingEntryLocalServiceImpl
 			sharingEntryPersistence.findByGroupId(groupId);
 
 		for (SharingEntry sharingEntry : sharingEntries) {
-			deleteSharingEntry(sharingEntry);
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 		}
 	}
 
@@ -236,7 +236,7 @@ public class SharingEntryLocalServiceImpl
 			classNameId, classPK);
 
 		for (SharingEntry sharingEntry : sharingEntries) {
-			deleteSharingEntry(sharingEntry);
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 		}
 	}
 
@@ -250,7 +250,7 @@ public class SharingEntryLocalServiceImpl
 	public SharingEntry deleteSharingEntry(long sharingEntryId)
 		throws PortalException {
 
-		return deleteSharingEntry(getSharingEntry(sharingEntryId));
+		return sharingEntryLocalService.deleteSharingEntry(getSharingEntry(sharingEntryId));
 	}
 
 	/**
@@ -271,7 +271,7 @@ public class SharingEntryLocalServiceImpl
 		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
 			0, toUserId, classNameId, classPK);
 
-		return deleteSharingEntry(sharingEntry);
+		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 	}
 
 	/**
@@ -330,7 +330,7 @@ public class SharingEntryLocalServiceImpl
 			sharingEntryPersistence.findByToUserId(toUserId);
 
 		for (SharingEntry sharingEntry : sharingEntries) {
-			deleteSharingEntry(sharingEntry);
+			sharingEntryLocalService.deleteSharingEntry(sharingEntry);
 		}
 	}
 
@@ -660,7 +660,7 @@ public class SharingEntryLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		return updateSharingEntry(
+		return sharingEntryLocalService.updateSharingEntry(
 			serviceContext.getUserId(), sharingEntryId, sharingEntryActions,
 			shareable, expirationDate, serviceContext);
 	}

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -170,6 +170,21 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 	}
 
 	@Override
+	public SharingEntry getSharingEntry(long sharingEntryId)
+		throws PortalException {
+
+		SharingEntry sharingEntry = sharingEntryLocalService.getSharingEntry(
+			sharingEntryId);
+
+		sharingPermission.check(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId(),
+			Collections.singletonList(SharingEntryAction.VIEW));
+
+		return sharingEntry;
+	}
+
+	@Override
 	public SharingEntry getSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {

--- a/modules/apps/sharing/sharing-test/build.gradle
+++ b/modules/apps/sharing/sharing-test/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
+	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/interpreter/test/AssetRendererSharingEntryInterpreterTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/interpreter/test/AssetRendererSharingEntryInterpreterTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.sharing.web.internal.interpreter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.sharing.interpreter.SharingEntryInterpreter;
+import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlags("LPD-17564")
+@RunWith(Arquillian.class)
+public class AssetRendererSharingEntryInterpreterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetTitle() throws Exception {
+		ObjectDefinition objectDefinition = _getObjectDefinition();
+
+		User user = UserTestUtil.addUser();
+
+		try {
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId());
+
+			String title = RandomTestUtil.randomString();
+
+			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				objectDefinition.getObjectDefinitionId(), 0, null,
+				HashMapBuilder.<String, Serializable>put(
+					"title", title
+				).build(),
+				serviceContext);
+
+			SharingEntry sharingEntry =
+				_sharingEntryLocalService.addSharingEntry(
+					null, TestPropsValues.getUserId(), 0, user.getUserId(),
+					_classNameLocalService.getClassNameId(
+						objectDefinition.getClassName()),
+					objectEntry.getObjectEntryId(), _group.getGroupId(), true,
+					Arrays.asList(SharingEntryAction.VIEW), null,
+					serviceContext);
+
+			SharingEntryInterpreter sharingEntryInterpreter =
+				_getSharingEntryInterpreter(sharingEntry);
+
+			Assert.assertEquals(
+				title,
+				sharingEntryInterpreter.getTitle(sharingEntry, LocaleUtil.US));
+		}
+		catch (Exception exception) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+			_userLocalService.deleteUser(user);
+		}
+	}
+
+	private ObjectDefinition _getObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				true, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).indexed(
+						true
+					).indexedAsKeyword(
+						true
+					).name(
+						"title"
+					).localized(
+						false
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE,
+				TestPropsValues.getUserId());
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectDefinition.getObjectDefinitionId(), "title");
+
+		objectDefinition.setTitleObjectFieldId(objectField.getObjectFieldId());
+
+		return _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+	}
+
+	private SharingEntryInterpreter _getSharingEntryInterpreter(
+		SharingEntry sharingEntry) {
+
+		SharingEntryInterpreter sharingEntryInterpreter =
+			_sharingEntryInterpreterProvider.getSharingEntryInterpreter(
+				sharingEntry);
+
+		Assert.assertNotNull(sharingEntryInterpreter);
+
+		return sharingEntryInterpreter;
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/interpreter/AssetRendererSharingEntryInterpreter.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/interpreter/AssetRendererSharingEntryInterpreter.java
@@ -84,6 +84,17 @@ public class AssetRendererSharingEntryInterpreter
 	}
 
 	@Override
+	public String getTitle(SharingEntry sharingEntry, Locale locale) {
+		AssetEntry assetEntry = _getAssetEntry(sharingEntry);
+
+		if (assetEntry == null) {
+			return StringPool.BLANK;
+		}
+
+		return assetEntry.getTitle(locale);
+	}
+
+	@Override
 	public Map<Locale, String> getTitleMap(SharingEntry sharingEntry) {
 		AssetEntry assetEntry = _getAssetEntry(sharingEntry);
 


### PR DESCRIPTION
**Note: only review commits from LPD-49727, I put this on hold until LPD-51800  LPD-51094 are on master.**

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-49727

# How am I fixing it?

Add headless apis to have the data to show the shared by me and shared with me user interfaces. The only thing that is not included on this PR is the sub type of the asset, that is to say the extension for the files and so on in order to show the icon that you can see on the figma screens : https://www.figma.com/design/Pfcjoa2vMlr2JYB93ZEnjk/LPD-32645-Content-Sharing?node-id=4-5219&p=f&t=vUla2nrX7LNeqv3x-0.

# How can you verify that it works?

Run included tests