### PR TITLE
LPD-52287 On updating the Folder, modified by is not updated.

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -124,6 +124,9 @@ public class JournalFolderLocalServiceImpl
 		folder.setTreePath(folder.buildTreePath());
 		folder.setName(name);
 		folder.setDescription(description);
+		folder.setStatusByUserId(user.getUserId());
+		folder.setStatusByUserName(user.getFullName());
+		folder.setStatusDate(serviceContext.getModifiedDate(new Date()));
 		folder.setExpandoBridgeAttributes(serviceContext);
 
 		folder = journalFolderPersistence.update(folder);
@@ -1392,6 +1395,8 @@ public class JournalFolderLocalServiceImpl
 
 		_validateFolder(folderId, folder.getGroupId(), parentFolderId, name);
 
+		User user = _userLocalService.getUser(userId);
+
 		long oldParentFolderId = folder.getParentFolderId();
 
 		if (oldParentFolderId != parentFolderId) {
@@ -1402,6 +1407,9 @@ public class JournalFolderLocalServiceImpl
 		folder.setName(name);
 		folder.setDescription(description);
 		folder.setRestrictionType(restrictionType);
+		folder.setStatusByUserId(user.getUserId());
+		folder.setStatusByUserName(user.getFullName());
+		folder.setStatusDate(serviceContext.getModifiedDate(new Date()));
 		folder.setExpandoBridgeAttributes(serviceContext);
 
 		folder = journalFolderPersistence.update(folder);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderLocalServiceTest.java
@@ -60,53 +60,20 @@ public class JournalFolderLocalServiceTest {
 	public void testAddJournalFolder() throws Exception {
 		User user = UserTestUtil.addGroupAdminUser(_group);
 
-		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
-			_journalFolderLocalService);
+		JournalFolder journalFolder = _addJournalFolder(
+			user.getUserId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-		JournalFolder journalFolder = journalFolderFixture.addFolder(
-			user.getUserId(), _group.getGroupId(),
-			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			RandomTestUtil.randomString());
-
-		_assertFolderStatusByUser(
-			journalFolder, user);
-	}
-
-	@Test
-	public void testUpdateJournalFolder() throws Exception {
-		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
-			_journalFolderLocalService);
-
-		JournalFolder journalFolder = journalFolderFixture.addFolder(
-			_group.getGroupId(), RandomTestUtil.randomString());
-
-		User user = UserTestUtil.addGroupAdminUser(_group);
-
-		journalFolder = _journalFolderLocalService.updateFolder(
-			user.getUserId(), _group.getGroupId(), journalFolder.getFolderId(),
-			journalFolder.getParentFolderId(), journalFolder.getName(),
-			journalFolder.getDescription(), new long[0],
-			JournalFolderConstants.RESTRICTION_TYPE_INHERIT, false,
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), user.getUserId()));
-
-		_assertFolderStatusByUser(
-			journalFolder, user);
+		_assertFolderStatusByUser(journalFolder, user);
 	}
 
 	@Test
 	public void testGetFoldersAndArticlesCount() throws Exception {
-		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
-			_journalFolderLocalService);
-
-		JournalFolder parentJournalFolder = journalFolderFixture.addFolder(
-			_group.getGroupId(), RandomTestUtil.randomString());
+		JournalFolder parentJournalFolder = _addJournalFolder();
 
 		_addApprovedJournalArticle(parentJournalFolder);
 
-		JournalFolder journalFolder = journalFolderFixture.addFolder(
-			_group.getGroupId(), parentJournalFolder.getFolderId(),
-			RandomTestUtil.randomString());
+		JournalFolder journalFolder = _addJournalFolder(
+			TestPropsValues.getUserId(), parentJournalFolder.getFolderId());
 
 		_addExpiredJournalArticle(
 			journalFolder,
@@ -129,14 +96,9 @@ public class JournalFolderLocalServiceTest {
 
 	@Test
 	public void testGetNoAssetFolders() throws Exception {
-		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
-			_journalFolderLocalService);
+		_addJournalFolder();
 
-		journalFolderFixture.addFolder(
-			_group.getGroupId(), RandomTestUtil.randomString());
-
-		JournalFolder folder = journalFolderFixture.addFolder(
-			_group.getGroupId(), RandomTestUtil.randomString());
+		JournalFolder folder = _addJournalFolder();
 
 		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			JournalFolder.class.getName(), folder.getFolderId());
@@ -150,6 +112,23 @@ public class JournalFolderLocalServiceTest {
 
 		Assert.assertEquals(folders.toString(), 1, folders.size());
 		Assert.assertEquals(folders.toString(), folder, folders.get(0));
+	}
+
+	@Test
+	public void testUpdateJournalFolder() throws Exception {
+		JournalFolder journalFolder = _addJournalFolder();
+
+		User user = UserTestUtil.addGroupAdminUser(_group);
+
+		journalFolder = _journalFolderLocalService.updateFolder(
+			user.getUserId(), _group.getGroupId(), journalFolder.getFolderId(),
+			journalFolder.getParentFolderId(), journalFolder.getName(),
+			journalFolder.getDescription(), new long[0],
+			JournalFolderConstants.RESTRICTION_TYPE_INHERIT, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), user.getUserId()));
+
+		_assertFolderStatusByUser(journalFolder, user);
 	}
 
 	private JournalArticle _addApprovedJournalArticle(
@@ -185,6 +164,25 @@ public class JournalFolderLocalServiceTest {
 			TestPropsValues.getUserId(), _group.getGroupId(),
 			journalArticle.getArticleId(), journalArticle.getVersion(), null,
 			serviceContext);
+	}
+
+	private JournalFolder _addJournalFolder() throws Exception {
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			_journalFolderLocalService);
+
+		return journalFolderFixture.addFolder(
+			_group.getGroupId(), RandomTestUtil.randomString());
+	}
+
+	private JournalFolder _addJournalFolder(long userId, long parentFolderId)
+		throws Exception {
+
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			_journalFolderLocalService);
+
+		return journalFolderFixture.addFolder(
+			userId, _group.getGroupId(), parentFolderId,
+			RandomTestUtil.randomString());
 	}
 
 	private void _assertFoldersAndArticlesCount(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalFolderLocalServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.journal.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -15,6 +16,7 @@ import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.test.util.JournalFolderFixture;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -22,6 +24,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -51,6 +54,44 @@ public class JournalFolderLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddJournalFolder() throws Exception {
+		User user = UserTestUtil.addGroupAdminUser(_group);
+
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			_journalFolderLocalService);
+
+		JournalFolder journalFolder = journalFolderFixture.addFolder(
+			user.getUserId(), _group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString());
+
+		_assertFolderStatusByUser(
+			journalFolder, user);
+	}
+
+	@Test
+	public void testUpdateJournalFolder() throws Exception {
+		JournalFolderFixture journalFolderFixture = new JournalFolderFixture(
+			_journalFolderLocalService);
+
+		JournalFolder journalFolder = journalFolderFixture.addFolder(
+			_group.getGroupId(), RandomTestUtil.randomString());
+
+		User user = UserTestUtil.addGroupAdminUser(_group);
+
+		journalFolder = _journalFolderLocalService.updateFolder(
+			user.getUserId(), _group.getGroupId(), journalFolder.getFolderId(),
+			journalFolder.getParentFolderId(), journalFolder.getName(),
+			journalFolder.getDescription(), new long[0],
+			JournalFolderConstants.RESTRICTION_TYPE_INHERIT, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), user.getUserId()));
+
+		_assertFolderStatusByUser(
+			journalFolder, user);
 	}
 
 	@Test
@@ -153,6 +194,15 @@ public class JournalFolderLocalServiceTest {
 			expectedCount,
 			_journalFolderLocalService.getFoldersAndArticlesCount(
 				groupId, folderIds, status));
+	}
+
+	private void _assertFolderStatusByUser(
+		JournalFolder journalFolder, User user) {
+
+		Assert.assertEquals(
+			journalFolder.getStatusByUserId(), user.getUserId());
+		Assert.assertEquals(
+			journalFolder.getStatusByUserName(), user.getFullName());
 	}
 
 	@Inject

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -684,7 +684,7 @@ public class JournalDisplayContext {
 
 		return _getSubtitle(
 			folder.getModifiedDate(), "modified-x-ago-by-x",
-			folder.getUserName());
+			folder.getStatusByUserName());
 	}
 
 	public long getHighlightedDDMStructureId() {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-58266

When updating a web content folder, the "Modified By" user name is not being updated correctly.

# How am I fixing it?

- Display the subtitle based on StatusByUserName.
- Ensure StatusBy is updated when adding and updating a journal folder.

# How can you verify that it works?

Run the included automated tests.

