### PR TITLE
LPD-50998 Move iFrame Sanitizer tests to Content Management on Testray

### DIFF
--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/test.properties
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Content Management System

--- a/modules/apps/portal-security/portal-security-iframe-sanitizer/test.properties
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Content Management System

--- a/test.properties
+++ b/test.properties
@@ -3287,6 +3287,7 @@
         **/knowledge-base/**/*Test.java,\
         **/mentions/**/*Test.java,\
         **/message-boards/**/*Test.java,\
+        **/portal-security-iframe-sanitizer*/**/*Test.java,\
         **/ratings-test/**/*Test.java,\
         **/reading-time/**/*Test.java,\
         **/repository/**/*Test.java,\


### PR DESCRIPTION
Related issue: [LPD-50998](https://liferay.atlassian.net/browse/LPD-50998)

Hello team!

I'm sending this PR for you to review since it is related to the iFrame Sanitizer. These modules were assigned to the "Security" component on Testray but they're actually not owned by AppSec.

I've created a [slack thread](https://liferay.slack.com/archives/CLD39UKM5/p1743428086203509) to check the ownership of this and it was confirmed to be from Content Management. I've also added the tests to the content management test suite, but we can drop this change if it's unnecessary to you.

I've moved the component to "Content Management System" but I'm not sure if this should be the right one. Let me know if we should change it.

Please let me know if you have any questions :)

The main PR is being worked here: https://github.com/liferay-appsec/liferay-portal/pull/2268