### PR TITLE
LPD-46294 cache the values of the configuration to do not check the configuration every time

### DIFF
--- a/modules/apps/friendly-url/friendly-url-api/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL API
 Bundle-SymbolicName: com.liferay.friendly.url.api
-Bundle-Version: 10.2.1
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.friendly.url.configuration,\
 	com.liferay.friendly.url.configuration.manager,\

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/configuration/manager/FriendlyURLSeparatorConfigurationManager.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/configuration/manager/FriendlyURLSeparatorConfigurationManager.java
@@ -5,18 +5,19 @@
 
 package com.liferay.friendly.url.configuration.manager;
 
-import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
 
 /**
  * @author Mikel Lorza
  */
 public interface FriendlyURLSeparatorConfigurationManager {
 
-	public String getFriendlyURLSeparatorsJSON(long companyId)
-		throws ConfigurationException;
+	public JSONObject getFriendlyURLSeparatorsJSONObject(long companyId)
+		throws PortalException;
 
 	public void updateFriendlyURLSeparatorCompanyConfiguration(
 			long companyId, String friendlyURLSeparatorsJSON)
-		throws ConfigurationException;
+		throws PortalException;
 
 }

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/configuration/manager/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/configuration/manager/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
@@ -16,7 +16,11 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -30,14 +34,25 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 	public JSONObject getFriendlyURLSeparatorsJSONObject(long companyId)
 		throws PortalException {
 
+		JSONObject jsonObject = _portalCache.get(companyId);
+
+		if (jsonObject != null) {
+			return jsonObject;
+		}
+
 		FriendlyURLSeparatorCompanyConfiguration
 			friendlyURLSeparatorCompanyConfiguration =
 				_configurationProvider.getCompanyConfiguration(
 					FriendlyURLSeparatorCompanyConfiguration.class, companyId);
 
-		return _jsonFactory.createJSONObject(
-			friendlyURLSeparatorCompanyConfiguration.
-				friendlyURLSeparatorsJSON());
+		JSONObject friendlyURLSeparatorsJSONObject =
+			_jsonFactory.createJSONObject(
+				friendlyURLSeparatorCompanyConfiguration.
+					friendlyURLSeparatorsJSON());
+
+		_portalCache.put(companyId, friendlyURLSeparatorsJSONObject);
+
+		return friendlyURLSeparatorsJSONObject;
 	}
 
 	@Override
@@ -45,11 +60,11 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 			long companyId, String friendlyURLSeparatorsJSON)
 		throws PortalException {
 
-		PortalCache<Long, JSONObject> portalCache =
+		_portalCache =
 			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
 				FriendlyURLSeparatorProvider.class.getName());
 
-		portalCache.remove(companyId);
+		_portalCache.remove(companyId);
 
 		_configurationProvider.saveCompanyConfiguration(
 			FriendlyURLSeparatorCompanyConfiguration.class, companyId,
@@ -57,9 +72,22 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 				"friendlyURLSeparatorsJSON", friendlyURLSeparatorsJSON
 			).build());
 
-		portalCache.put(
+		_portalCache.put(
 			companyId,
 			_jsonFactory.createJSONObject(friendlyURLSeparatorsJSON));
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(
+			FriendlyURLSeparatorProvider.class.getName());
 	}
 
 	@Reference
@@ -70,5 +98,7 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 
 	@Reference
 	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, JSONObject> _portalCache;
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
@@ -27,7 +27,7 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 	implements FriendlyURLSeparatorConfigurationManager {
 
 	@Override
-	public JSONObject getFriendlyURLSeparatorsJSON(long companyId)
+	public JSONObject getFriendlyURLSeparatorsJSONObject(long companyId)
 		throws PortalException {
 
 		FriendlyURLSeparatorCompanyConfiguration

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
@@ -35,8 +35,9 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 				_configurationProvider.getCompanyConfiguration(
 					FriendlyURLSeparatorCompanyConfiguration.class, companyId);
 
-		return _jsonFactory.createJSONObject(friendlyURLSeparatorCompanyConfiguration.
-			friendlyURLSeparatorsJSON());
+		return _jsonFactory.createJSONObject(
+			friendlyURLSeparatorCompanyConfiguration.
+				friendlyURLSeparatorsJSON());
 	}
 
 	@Override

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
@@ -11,10 +11,9 @@ import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,22 +27,22 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 	implements FriendlyURLSeparatorConfigurationManager {
 
 	@Override
-	public String getFriendlyURLSeparatorsJSON(long companyId)
-		throws ConfigurationException {
+	public JSONObject getFriendlyURLSeparatorsJSON(long companyId)
+		throws PortalException {
 
 		FriendlyURLSeparatorCompanyConfiguration
 			friendlyURLSeparatorCompanyConfiguration =
 				_configurationProvider.getCompanyConfiguration(
 					FriendlyURLSeparatorCompanyConfiguration.class, companyId);
 
-		return friendlyURLSeparatorCompanyConfiguration.
-			friendlyURLSeparatorsJSON();
+		return _jsonFactory.createJSONObject(friendlyURLSeparatorCompanyConfiguration.
+			friendlyURLSeparatorsJSON());
 	}
 
 	@Override
 	public void updateFriendlyURLSeparatorCompanyConfiguration(
 			long companyId, String friendlyURLSeparatorsJSON)
-		throws ConfigurationException {
+		throws PortalException {
 
 		PortalCache<Long, JSONObject> portalCache =
 			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
@@ -57,14 +56,9 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 				"friendlyURLSeparatorsJSON", friendlyURLSeparatorsJSON
 			).build());
 
-		try {
-			portalCache.put(
-				companyId,
-				_jsonFactory.createJSONObject(friendlyURLSeparatorsJSON));
-		}
-		catch (JSONException jsonException) {
-			throw new ConfigurationException(jsonException);
-		}
+		portalCache.put(
+			companyId,
+			_jsonFactory.createJSONObject(friendlyURLSeparatorsJSON));
 	}
 
 	@Reference

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/configuration/manager/FriendlyURLSeparatorConfigurationManagerImpl.java
@@ -7,7 +7,13 @@ package com.liferay.friendly.url.internal.configuration.manager;
 
 import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
 import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfigurationManager;
+import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
@@ -39,14 +45,35 @@ public class FriendlyURLSeparatorConfigurationManagerImpl
 			long companyId, String friendlyURLSeparatorsJSON)
 		throws ConfigurationException {
 
+		PortalCache<Long, JSONObject> portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+
+		portalCache.remove(companyId);
+
 		_configurationProvider.saveCompanyConfiguration(
 			FriendlyURLSeparatorCompanyConfiguration.class, companyId,
 			HashMapDictionaryBuilder.<String, Object>put(
 				"friendlyURLSeparatorsJSON", friendlyURLSeparatorsJSON
 			).build());
+
+		try {
+			portalCache.put(
+				companyId,
+				_jsonFactory.createJSONObject(friendlyURLSeparatorsJSON));
+		}
+		catch (JSONException jsonException) {
+			throw new ConfigurationException(jsonException);
+		}
 	}
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
@@ -9,7 +9,6 @@ import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfig
 import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -38,9 +37,8 @@ public class FriendlyURLSeparatorProviderImpl
 			}
 
 			JSONObject friendlyURLSeparatorsJSONObject =
-				_jsonFactory.createJSONObject(
-					_friendlyURLSeparatorConfigurationManager.
-						getFriendlyURLSeparatorsJSON(companyId));
+				_friendlyURLSeparatorConfigurationManager.
+					getFriendlyURLSeparatorsJSONObject(companyId);
 
 			_portalCache.put(companyId, friendlyURLSeparatorsJSONObject);
 
@@ -74,9 +72,6 @@ public class FriendlyURLSeparatorProviderImpl
 	@Reference
 	private FriendlyURLSeparatorConfigurationManager
 		_friendlyURLSeparatorConfigurationManager;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private MultiVMPool _multiVMPool;

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
@@ -7,17 +7,11 @@ package com.liferay.friendly.url.internal.provider;
 
 import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfigurationManager;
 import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
-import com.liferay.portal.kernel.cache.MultiVMPool;
-import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
-import java.util.Map;
-
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -30,17 +24,9 @@ public class FriendlyURLSeparatorProviderImpl
 	@Override
 	public String getFriendlyURLSeparator(long companyId, String key) {
 		try {
-			JSONObject jsonObject = _portalCache.get(companyId);
-
-			if (jsonObject != null) {
-				return jsonObject.getString(key);
-			}
-
 			JSONObject friendlyURLSeparatorsJSONObject =
 				_friendlyURLSeparatorConfigurationManager.
 					getFriendlyURLSeparatorsJSONObject(companyId);
-
-			_portalCache.put(companyId, friendlyURLSeparatorsJSONObject);
 
 			return friendlyURLSeparatorsJSONObject.getString(key);
 		}
@@ -53,29 +39,11 @@ public class FriendlyURLSeparatorProviderImpl
 		return null;
 	}
 
-	@Activate
-	protected void activate(Map<String, Object> properties) {
-		_portalCache =
-			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
-				FriendlyURLSeparatorProvider.class.getName());
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		_multiVMPool.removePortalCache(
-			FriendlyURLSeparatorProvider.class.getName());
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		FriendlyURLSeparatorProviderImpl.class.getName());
 
 	@Reference
 	private FriendlyURLSeparatorConfigurationManager
 		_friendlyURLSeparatorConfigurationManager;
-
-	@Reference
-	private MultiVMPool _multiVMPool;
-
-	private PortalCache<Long, JSONObject> _portalCache;
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/provider/FriendlyURLSeparatorProviderImpl.java
@@ -7,12 +7,18 @@ package com.liferay.friendly.url.internal.provider;
 
 import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfigurationManager;
 import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -25,10 +31,18 @@ public class FriendlyURLSeparatorProviderImpl
 	@Override
 	public String getFriendlyURLSeparator(long companyId, String key) {
 		try {
+			JSONObject jsonObject = _portalCache.get(companyId);
+
+			if (jsonObject != null) {
+				return jsonObject.getString(key);
+			}
+
 			JSONObject friendlyURLSeparatorsJSONObject =
 				_jsonFactory.createJSONObject(
 					_friendlyURLSeparatorConfigurationManager.
 						getFriendlyURLSeparatorsJSON(companyId));
+
+			_portalCache.put(companyId, friendlyURLSeparatorsJSONObject);
 
 			return friendlyURLSeparatorsJSONObject.getString(key);
 		}
@@ -41,6 +55,19 @@ public class FriendlyURLSeparatorProviderImpl
 		return null;
 	}
 
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(
+			FriendlyURLSeparatorProvider.class.getName());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		FriendlyURLSeparatorProviderImpl.class.getName());
 
@@ -50,5 +77,10 @@ public class FriendlyURLSeparatorProviderImpl
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, JSONObject> _portalCache;
 
 }

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/configuration/manager/test/FriendlyURLSeparatorConfigurationManagerTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/configuration/manager/test/FriendlyURLSeparatorConfigurationManagerTest.java
@@ -63,20 +63,20 @@ public class FriendlyURLSeparatorConfigurationManagerTest {
 
 	@Test
 	public void testGetEmptyFriendlyURLSeparatorsJSON() throws Exception {
-		String friendlyURLSeparatorsJSON =
+		JSONObject friendlyURLSeparatorsJSONObject =
 			_friendlyURLSeparatorConfigurationManager.
-				getFriendlyURLSeparatorsJSON(_companyId);
+				getFriendlyURLSeparatorsJSONObject(_companyId);
 
-		Assert.assertNotNull(friendlyURLSeparatorsJSON);
+		Assert.assertNotNull(friendlyURLSeparatorsJSONObject);
 		Assert.assertEquals(
 			_jsonFactory.createJSONObject(
 			).toString(),
-			friendlyURLSeparatorsJSON);
+			friendlyURLSeparatorsJSONObject.toString());
 	}
 
 	@Test
 	public void testGetFriendlyURLSeparatorsJSON() throws Exception {
-		JSONObject friendlyURLSeparatorsJSONObject = JSONUtil.put(
+		JSONObject originalFriendlyURLSeparatorsJSONObject = JSONUtil.put(
 			JournalArticle.class.getName(), "/test1/");
 
 		try (CompanyConfigurationTemporarySwapper
@@ -87,17 +87,17 @@ public class FriendlyURLSeparatorConfigurationManagerTest {
 							getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
 							"friendlyURLSeparatorsJSON",
-							friendlyURLSeparatorsJSONObject.toString()
+							originalFriendlyURLSeparatorsJSONObject.toString()
 						).build())) {
 
-			String friendlyURLSeparatorsJSON =
+			JSONObject friendlyURLSeparatorsJSONObject =
 				_friendlyURLSeparatorConfigurationManager.
-					getFriendlyURLSeparatorsJSON(_companyId);
+					getFriendlyURLSeparatorsJSONObject(_companyId);
 
-			Assert.assertNotNull(friendlyURLSeparatorsJSON);
+			Assert.assertNotNull(friendlyURLSeparatorsJSONObject);
 			Assert.assertEquals(
-				friendlyURLSeparatorsJSONObject.toString(),
-				friendlyURLSeparatorsJSON);
+				originalFriendlyURLSeparatorsJSONObject.toString(),
+				friendlyURLSeparatorsJSONObject.toString());
 		}
 	}
 

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/web/internal/portlet/action/test/FriendlyURLSeparatorSaveCompanyConfigurationMVCActionCommandTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/web/internal/portlet/action/test/FriendlyURLSeparatorSaveCompanyConfigurationMVCActionCommandTest.java
@@ -431,9 +431,9 @@ public class FriendlyURLSeparatorSaveCompanyConfigurationMVCActionCommandTest {
 			Map<String, String> friendlyURLSeparators)
 		throws Exception {
 
-		String originalFriendlyURLSeparatorsJSON =
+		JSONObject originalFriendlyURLSeparatorsJSONObject =
 			_friendlyURLSeparatorConfigurationManager.
-				getFriendlyURLSeparatorsJSON(_company.getCompanyId());
+				getFriendlyURLSeparatorsJSONObject(_company.getCompanyId());
 
 		try {
 			ConfigurationTestUtil.updateConfiguration(
@@ -453,9 +453,9 @@ public class FriendlyURLSeparatorSaveCompanyConfigurationMVCActionCommandTest {
 					configuration.update();
 				});
 
-			JSONObject jsonObject = _jsonFactory.createJSONObject(
+			JSONObject jsonObject =
 				_friendlyURLSeparatorConfigurationManager.
-					getFriendlyURLSeparatorsJSON(_company.getCompanyId()));
+					getFriendlyURLSeparatorsJSONObject(_company.getCompanyId());
 
 			for (Map.Entry<String, String> friendlyURLSeparator :
 					friendlyURLSeparators.entrySet()) {
@@ -473,7 +473,8 @@ public class FriendlyURLSeparatorSaveCompanyConfigurationMVCActionCommandTest {
 		finally {
 			_friendlyURLSeparatorConfigurationManager.
 				updateFriendlyURLSeparatorCompanyConfiguration(
-					_company.getCompanyId(), originalFriendlyURLSeparatorsJSON);
+					_company.getCompanyId(),
+					originalFriendlyURLSeparatorsJSONObject.toString());
 		}
 	}
 

--- a/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContext.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/main/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContext.java
@@ -158,9 +158,9 @@ public class FriendlyURLSeparatorCompanyConfigurationDisplayContext {
 
 	private JSONObject _getConfiguredFriendlyURLSeparatorsJSONObject() {
 		try {
-			return _jsonFactory.createJSONObject(
-				_friendlyURLSeparatorConfigurationManager.
-					getFriendlyURLSeparatorsJSON(_themeDisplay.getCompanyId()));
+			return _friendlyURLSeparatorConfigurationManager.
+				getFriendlyURLSeparatorsJSONObject(
+					_themeDisplay.getCompanyId());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
@@ -79,9 +79,9 @@ public class FriendlyURLSeparatorCompanyConfigurationDisplayContextTest {
 
 		Mockito.when(
 			_friendlyURLSeparatorConfigurationManager.
-				getFriendlyURLSeparatorsJSON(Mockito.anyLong())
+				getFriendlyURLSeparatorsJSONObject(Mockito.anyLong())
 		).thenReturn(
-			StringPool.BLANK
+			_jsonFactory.createJSONObject()
 		);
 
 		_jsonFactory = Mockito.mock(JSONFactory.class);

--- a/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
+++ b/modules/apps/friendly-url/friendly-url-web/src/test/java/com/liferay/friendly/url/web/internal/display/context/FriendlyURLSeparatorCompanyConfigurationDisplayContextTest.java
@@ -77,17 +77,11 @@ public class FriendlyURLSeparatorCompanyConfigurationDisplayContextTest {
 		_friendlyURLSeparatorConfigurationManager = Mockito.mock(
 			FriendlyURLSeparatorConfigurationManager.class);
 
-		Mockito.when(
-			_friendlyURLSeparatorConfigurationManager.
-				getFriendlyURLSeparatorsJSONObject(Mockito.anyLong())
-		).thenReturn(
-			_jsonFactory.createJSONObject()
-		);
-
 		_jsonFactory = Mockito.mock(JSONFactory.class);
 
 		Mockito.when(
-			_jsonFactory.createJSONObject(Mockito.anyString())
+			_friendlyURLSeparatorConfigurationManager.
+				getFriendlyURLSeparatorsJSONObject(Mockito.anyLong())
 		).thenReturn(
 			JSONUtil.put(
 				_SIMPLE_CLASS_NAME_BLOGS_ENTRY, "blog-test1"


### PR DESCRIPTION
PR sent after : https://github.com/liferay-core-infra/liferay-portal/pull/8229
and https://github.com/liferay-core-infra/liferay-portal/pull/8235


LPD-46294 Portal performance decreased after removing FF LPD-11147

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46294

After removing this FF LPD-11147, the portal's performance regressed

# How am I fixing it?

There is severals calls to FriendlyURLSeparatorProvider:getFriendlyURLSeparator and each call is looking at the configuration. So we want to mitigate the performance adding a cache.


# Why doesn't this include any test?

It is a performance improvement, not a functional change.


# Commits
- **LPD-46294 generate a cache to store the JSONObject for each company for the FriendlyURLSeparatorCompanyConfiguration**
- **LPD-46294 when updating the FriendlyURLSeparatorCompanyConfiguration, remove the cache for that company and then update it.**
- **LPD-46294 change getFriendlyURLSeparatorsJSON method to return a JSONObject**
- **LPD-46294 rename**
- **LPD-46294 buildService**
- **LPD-46294 change to new methods**
- **LPD-46294 move cache to FriendlyURLSeparatorConfigurationManager**
