### PR TITLE
LPD-52010 Create batch endpoints to shared an asset to user and user groups and list them using sharing entry component

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
+++ b/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Object API
 Bundle-SymbolicName: com.liferay.headless.object.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.headless.object.dto.v1_0,\
 	com.liferay.headless.object.resource.v1_0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
@@ -1,0 +1,787 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import com.liferay.headless.delivery.dto.v1_0.Creator;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Represents a collaborator for an entry.",
+	value = "Collaborator"
+)
+@io.swagger.v3.oas.annotations.media.Schema(
+	description = "Represents a collaborator for an entry.",
+	requiredProperties = {"actionIds", "externalReferenceCode", "type"}
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Collaborator")
+public class Collaborator implements Serializable {
+
+	public static Collaborator toDTO(String json) {
+		return ObjectMapperUtil.readValue(Collaborator.class, json);
+	}
+
+	public static Collaborator unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Collaborator.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator actions for the shared asset."
+	)
+	public String[] getActionIds() {
+		if (_actionIdsSupplier != null) {
+			actionIds = _actionIdsSupplier.get();
+
+			_actionIdsSupplier = null;
+		}
+
+		return actionIds;
+	}
+
+	public void setActionIds(String[] actionIds) {
+		this.actionIds = actionIds;
+
+		_actionIdsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActionIds(
+		UnsafeSupplier<String[], Exception> actionIdsUnsafeSupplier) {
+
+		_actionIdsSupplier = () -> {
+			try {
+				return actionIdsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The collaborator actions for the shared asset."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
+	protected String[] actionIds;
+
+	@JsonIgnore
+	private Supplier<String[]> _actionIdsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@Valid
+	public Map<String, Object> getActions() {
+		if (_actionsSupplier != null) {
+			actions = _actionsSupplier.get();
+
+			_actionsSupplier = null;
+		}
+
+		return actions;
+	}
+
+	public void setActions(Map<String, Object> actions) {
+		this.actions = actions;
+
+		_actionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Object>, Exception> actionsUnsafeSupplier) {
+
+		_actionsSupplier = () -> {
+			try {
+				return actionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Block of actions allowed by the user making the request."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Object> actions;
+
+	@JsonIgnore
+	private Supplier<Map<String, Object>> _actionsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The object entry folder's creator."
+	)
+	@Valid
+	public Creator getCreator() {
+		if (_creatorSupplier != null) {
+			creator = _creatorSupplier.get();
+
+			_creatorSupplier = null;
+		}
+
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+
+		_creatorSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		_creatorSupplier = () -> {
+			try {
+				return creatorUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The object entry folder's creator.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Creator creator;
+
+	@JsonIgnore
+	private Supplier<Creator> _creatorSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The expiration date to be a collaborator of the asset."
+	)
+	public Date getDateExpired() {
+		if (_dateExpiredSupplier != null) {
+			dateExpired = _dateExpiredSupplier.get();
+
+			_dateExpiredSupplier = null;
+		}
+
+		return dateExpired;
+	}
+
+	public void setDateExpired(Date dateExpired) {
+		this.dateExpired = dateExpired;
+
+		_dateExpiredSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateExpired(
+		UnsafeSupplier<Date, Exception> dateExpiredUnsafeSupplier) {
+
+		_dateExpiredSupplier = () -> {
+			try {
+				return dateExpiredUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The expiration date to be a collaborator of the asset."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateExpired;
+
+	@JsonIgnore
+	private Supplier<Date> _dateExpiredSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator external reference code."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotEmpty
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator name."
+	)
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator name.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator portrait."
+	)
+	public String getPortrait() {
+		if (_portraitSupplier != null) {
+			portrait = _portraitSupplier.get();
+
+			_portraitSupplier = null;
+		}
+
+		return portrait;
+	}
+
+	public void setPortrait(String portrait) {
+		this.portrait = portrait;
+
+		_portraitSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPortrait(
+		UnsafeSupplier<String, Exception> portraitUnsafeSupplier) {
+
+		_portraitSupplier = () -> {
+			try {
+				return portraitUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator portrait.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String portrait;
+
+	@JsonIgnore
+	private Supplier<String> _portraitSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "If the collaborator can share or not the asset."
+	)
+	public Boolean getShare() {
+		if (_shareSupplier != null) {
+			share = _shareSupplier.get();
+
+			_shareSupplier = null;
+		}
+
+		return share;
+	}
+
+	public void setShare(Boolean share) {
+		this.share = share;
+
+		_shareSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setShare(
+		UnsafeSupplier<Boolean, Exception> shareUnsafeSupplier) {
+
+		_shareSupplier = () -> {
+			try {
+				return shareUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "If the collaborator can share or not the asset."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean share;
+
+	@JsonIgnore
+	private Supplier<Boolean> _shareSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator type.", example = "User"
+	)
+	@JsonGetter("type")
+	@Valid
+	public Type getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
+
+			_typeSupplier = null;
+		}
+
+		return type;
+	}
+
+	@JsonIgnore
+	public String getTypeAsString() {
+		Type type = getType();
+
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+
+		_typeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
+			try {
+				return typeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator type.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
+	protected Type type;
+
+	@JsonIgnore
+	private Supplier<Type> _typeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Collaborator)) {
+			return false;
+		}
+
+		Collaborator collaborator = (Collaborator)object;
+
+		return Objects.equals(toString(), collaborator.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		String[] actionIds = getActionIds();
+
+		if (actionIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < actionIds.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(actionIds[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < actionIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Map<String, Object> actions = getActions();
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
+
+		Creator creator = getCreator();
+
+		if (creator != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(creator);
+		}
+
+		Date dateExpired = getDateExpired();
+
+		if (dateExpired != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateExpired\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateExpired));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String portrait = getPortrait();
+
+		if (portrait != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"portrait\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(portrait));
+
+			sb.append("\"");
+		}
+
+		Boolean share = getShare();
+
+		if (share != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"share\": ");
+
+			sb.append(share);
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.object.dto.v1_0.Collaborator",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	@GraphQLName("Type")
+	public static enum Type {
+
+		USER("User"), USER_GROUP("UserGroup");
+
+		@JsonCreator
+		public static Type create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value)) {
+					return type;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.resource.v1_0;
+
+import com.liferay.headless.object.dto.v1_0.Collaborator;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-object/v1.0
+ *
+ * @author Alicia García
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface CollaboratorResource {
+
+	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Page<Collaborator>
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception;
+
+	public Page<Collaborator> postObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Collaborator[] collaborators)
+		throws Exception;
+
+	public Response postObjectEntryFolderCollaboratorsPageExportBatch(
+			Long objectEntryFolderId, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public Page<Collaborator>
+			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public CollaboratorResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
@@ -1,0 +1,287 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.client.dto.v1_0;
+
+import com.liferay.headless.object.client.function.UnsafeSupplier;
+import com.liferay.headless.object.client.serdes.v1_0.CollaboratorSerDes;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+public class Collaborator implements Cloneable, Serializable {
+
+	public static Collaborator toDTO(String json) {
+		return CollaboratorSerDes.toDTO(json);
+	}
+
+	public String[] getActionIds() {
+		return actionIds;
+	}
+
+	public void setActionIds(String[] actionIds) {
+		this.actionIds = actionIds;
+	}
+
+	public void setActionIds(
+		UnsafeSupplier<String[], Exception> actionIdsUnsafeSupplier) {
+
+		try {
+			actionIds = actionIdsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] actionIds;
+
+	public Map<String, Object> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Object> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Object>, Exception> actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Object> actions;
+
+	public Creator getCreator() {
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+	}
+
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		try {
+			creator = creatorUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Creator creator;
+
+	public Date getDateExpired() {
+		return dateExpired;
+	}
+
+	public void setDateExpired(Date dateExpired) {
+		this.dateExpired = dateExpired;
+	}
+
+	public void setDateExpired(
+		UnsafeSupplier<Date, Exception> dateExpiredUnsafeSupplier) {
+
+		try {
+			dateExpired = dateExpiredUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateExpired;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getPortrait() {
+		return portrait;
+	}
+
+	public void setPortrait(String portrait) {
+		this.portrait = portrait;
+	}
+
+	public void setPortrait(
+		UnsafeSupplier<String, Exception> portraitUnsafeSupplier) {
+
+		try {
+			portrait = portraitUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String portrait;
+
+	public Boolean getShare() {
+		return share;
+	}
+
+	public void setShare(Boolean share) {
+		this.share = share;
+	}
+
+	public void setShare(
+		UnsafeSupplier<Boolean, Exception> shareUnsafeSupplier) {
+
+		try {
+			share = shareUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean share;
+
+	public Type getType() {
+		return type;
+	}
+
+	public String getTypeAsString() {
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Type type;
+
+	@Override
+	public Collaborator clone() throws CloneNotSupportedException {
+		return (Collaborator)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Collaborator)) {
+			return false;
+		}
+
+		Collaborator collaborator = (Collaborator)object;
+
+		return Objects.equals(toString(), collaborator.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return CollaboratorSerDes.toJSON(this);
+	}
+
+	public static enum Type {
+
+		USER("User"), USER_GROUP("UserGroup");
+
+		public static Type create(String value) {
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value) ||
+					Objects.equals(type.name(), value)) {
+
+					return type;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
@@ -1,0 +1,797 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.client.resource.v1_0;
+
+import com.liferay.headless.object.client.dto.v1_0.Collaborator;
+import com.liferay.headless.object.client.http.HttpInvoker;
+import com.liferay.headless.object.client.pagination.Page;
+import com.liferay.headless.object.client.pagination.Pagination;
+import com.liferay.headless.object.client.problem.Problem;
+import com.liferay.headless.object.client.serdes.v1_0.CollaboratorSerDes;
+
+import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+public interface CollaboratorResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getObjectEntryFolderCollaboratorsPageHttpResponse(
+				Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Page<Collaborator>
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception;
+
+	public Page<Collaborator> postObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Collaborator[] collaborators)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postObjectEntryFolderCollaboratorsPageHttpResponse(
+				Long objectEntryFolderId, Collaborator[] collaborators)
+		throws Exception;
+
+	public void postObjectEntryFolderCollaboratorsPageExportBatch(
+			Long objectEntryFolderId, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postObjectEntryFolderCollaboratorsPageExportBatchHttpResponse(
+				Long objectEntryFolderId, String callbackURL,
+				String contentType, String fieldNames)
+		throws Exception;
+
+	public Page<Collaborator>
+			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+				String scopeKey, String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public CollaboratorResource build() {
+			return new CollaboratorResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class CollaboratorResourceImpl
+		implements CollaboratorResource {
+
+		public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
+				Long objectEntryFolderId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectEntryFolderCollaboratorsPageHttpResponse(
+					objectEntryFolderId, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, CollaboratorSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getObjectEntryFolderCollaboratorsPageHttpResponse(
+					Long objectEntryFolderId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Collaborator>
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					String scopeKey, String externalReferenceCode,
+					Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+					scopeKey, externalReferenceCode, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, CollaboratorSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+					String scopeKey, String externalReferenceCode,
+					Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Collaborator> postObjectEntryFolderCollaboratorsPage(
+				Long objectEntryFolderId, Collaborator[] collaborators)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postObjectEntryFolderCollaboratorsPageHttpResponse(
+					objectEntryFolderId, collaborators);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, CollaboratorSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postObjectEntryFolderCollaboratorsPageHttpResponse(
+					Long objectEntryFolderId, Collaborator[] collaborators)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (Collaborator collaboratorValue : collaborators) {
+				values.add(String.valueOf(collaboratorValue));
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postObjectEntryFolderCollaboratorsPageExportBatch(
+				Long objectEntryFolderId, String callbackURL,
+				String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postObjectEntryFolderCollaboratorsPageExportBatchHttpResponse(
+					objectEntryFolderId, callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postObjectEntryFolderCollaboratorsPageExportBatchHttpResponse(
+					Long objectEntryFolderId, String callbackURL,
+					String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/export-batch");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Collaborator>
+				postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					String scopeKey, String externalReferenceCode,
+					Collaborator[] collaborators)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+					scopeKey, externalReferenceCode, collaborators);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, CollaboratorSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
+					String scopeKey, String externalReferenceCode,
+					Collaborator[] collaborators)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (Collaborator collaboratorValue : collaborators) {
+				values.add(String.valueOf(collaboratorValue));
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private CollaboratorResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			CollaboratorResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
@@ -1,0 +1,454 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.client.serdes.v1_0;
+
+import com.liferay.headless.object.client.dto.v1_0.Collaborator;
+import com.liferay.headless.object.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+public class CollaboratorSerDes {
+
+	public static Collaborator toDTO(String json) {
+		CollaboratorJSONParser collaboratorJSONParser =
+			new CollaboratorJSONParser();
+
+		return collaboratorJSONParser.parseToDTO(json);
+	}
+
+	public static Collaborator[] toDTOs(String json) {
+		CollaboratorJSONParser collaboratorJSONParser =
+			new CollaboratorJSONParser();
+
+		return collaboratorJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Collaborator collaborator) {
+		if (collaborator == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (collaborator.getActionIds() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < collaborator.getActionIds().length; i++) {
+				sb.append(_toJSON(collaborator.getActionIds()[i]));
+
+				if ((i + 1) < collaborator.getActionIds().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (collaborator.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(collaborator.getActions()));
+		}
+
+		if (collaborator.getCreator() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(collaborator.getCreator());
+		}
+
+		if (collaborator.getDateExpired() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateExpired\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(collaborator.getDateExpired()));
+
+			sb.append("\"");
+		}
+
+		if (collaborator.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collaborator.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (collaborator.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collaborator.getName()));
+
+			sb.append("\"");
+		}
+
+		if (collaborator.getPortrait() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"portrait\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(collaborator.getPortrait()));
+
+			sb.append("\"");
+		}
+
+		if (collaborator.getShare() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"share\": ");
+
+			sb.append(collaborator.getShare());
+		}
+
+		if (collaborator.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(collaborator.getType());
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		CollaboratorJSONParser collaboratorJSONParser =
+			new CollaboratorJSONParser();
+
+		return collaboratorJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Collaborator collaborator) {
+		if (collaborator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (collaborator.getActionIds() == null) {
+			map.put("actionIds", null);
+		}
+		else {
+			map.put("actionIds", String.valueOf(collaborator.getActionIds()));
+		}
+
+		if (collaborator.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(collaborator.getActions()));
+		}
+
+		if (collaborator.getCreator() == null) {
+			map.put("creator", null);
+		}
+		else {
+			map.put("creator", String.valueOf(collaborator.getCreator()));
+		}
+
+		if (collaborator.getDateExpired() == null) {
+			map.put("dateExpired", null);
+		}
+		else {
+			map.put(
+				"dateExpired",
+				liferayToJSONDateFormat.format(collaborator.getDateExpired()));
+		}
+
+		if (collaborator.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(collaborator.getExternalReferenceCode()));
+		}
+
+		if (collaborator.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(collaborator.getName()));
+		}
+
+		if (collaborator.getPortrait() == null) {
+			map.put("portrait", null);
+		}
+		else {
+			map.put("portrait", String.valueOf(collaborator.getPortrait()));
+		}
+
+		if (collaborator.getShare() == null) {
+			map.put("share", null);
+		}
+		else {
+			map.put("share", String.valueOf(collaborator.getShare()));
+		}
+
+		if (collaborator.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(collaborator.getType()));
+		}
+
+		return map;
+	}
+
+	public static class CollaboratorJSONParser
+		extends BaseJSONParser<Collaborator> {
+
+		@Override
+		protected Collaborator createDTO() {
+			return new Collaborator();
+		}
+
+		@Override
+		protected Collaborator[] createDTOArray(int size) {
+			return new Collaborator[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "actions")) {
+				return true;
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateExpired")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "portrait")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "share")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Collaborator collaborator, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setActionIds(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setActions(
+						(Map<String, Object>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setCreator(
+						CreatorSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateExpired")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setDateExpired(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					collaborator.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "portrait")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setPortrait((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "share")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setShare((Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setType(
+						Collaborator.Type.create((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/build.gradle
+++ b/modules/apps/headless/headless-object/headless-object-impl/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -569,6 +569,7 @@ paths:
         get:
             description:
                 Retrieves the collaborators of an object entry.
+            operationId: getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage
             parameters:
                 -   in: path
                     name: scopeKey
@@ -619,6 +620,7 @@ paths:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
                 included in the request. Send a notification for the new collaborators and those whose permissions are
                 different.
+            operationId: postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage
             parameters:
                 -   in: path
                     name: scopeKey

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -1,5 +1,63 @@
 components:
     schemas:
+        Collaborator:
+            description:
+                Represents a collaborator for an entry.
+            properties:
+                actionIds:
+                    description:
+                        The collaborator actions for the shared asset.
+                    items:
+                        type: string
+                    type: array
+                actions:
+                    additionalProperties:
+                        type: object
+                    # @review
+                    description:
+                        Block of actions allowed by the user making the request.
+                    readOnly: true
+                    type: object
+                creator:
+                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    description:
+                        The object entry folder's creator.
+                    readOnly: true
+                dateExpired:
+                    description:
+                        The expiration date to be a collaborator of the asset.
+                    format: date-time
+                    type: string
+                externalReferenceCode:
+                    # @review
+                    description:
+                        The collaborator external reference code.
+                    type: string
+                name:
+                    description:
+                        The collaborator name.
+                    readOnly: true
+                    type: string
+                portrait:
+                    description:
+                        The collaborator portrait.
+                    readOnly: true
+                    type: string
+                share:
+                    description:
+                        If the collaborator can share or not the asset.
+                    type: boolean
+                type:
+                    description:
+                        The collaborator type.
+                    enum: [User,UserGroup]
+                    example: User
+                    type: string
+            required:
+                -   actionIds
+                -   externalReferenceCode
+                -   type
+            type: object
         ObjectEntryFolder:
             description:
                 Represents a object entry folder that contains objects entries and other object entry folders.
@@ -214,6 +272,91 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntryFolder"
             tags: ["ObjectEntryFolder"]
+    "/object-entry-folders/{objectEntryFolderId}/collaborators":
+        get:
+            description:
+                Retrieves the collaborators of an object entry folder.
+            operationId: getObjectEntryFolderCollaboratorsPage
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+            tags: ["Collaborator"]
+        post:
+            description:
+                Add or update all the collaborators received in the request. Delete existing collaborators that are not
+                included in the request. Send a notification for the new collaborators and those whose permissions are
+                different.
+            operationId: postObjectEntryFolderCollaboratorsPage
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            items:
+                                $ref: "#/components/schemas/Collaborator"
+                            type: array
+                    application/xml:
+                        schema:
+                            items:
+                                $ref: "#/components/schemas/Collaborator"
+                            type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+            tags: ["Collaborator"]
     "/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}":
         delete:
             operationId: deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCode
@@ -422,3 +565,94 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntryFolder"
             tags: ["ObjectEntryFolder"]
+    "/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators":
+        get:
+            description:
+                Retrieves the collaborators of an object entry.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+            tags: ["Collaborator"]
+        post:
+            description:
+                Add or update all the collaborators received in the request. Delete existing collaborators that are not
+                included in the request. Send a notification for the new collaborators and those whose permissions are
+                different.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            items:
+                                $ref: "#/components/schemas/Collaborator"
+                            type: array
+                    application/xml:
+                        schema:
+                            items:
+                                $ref: "#/components/schemas/Collaborator"
+                            type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Collaborator"
+                                type: array
+            tags: ["Collaborator"]

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.dto.v1_0.converter;
+
+import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
+import com.liferay.headless.object.dto.v1_0.Collaborator;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	property = "dto.class.name=com.liferay.headless.object.dto.v1_0.Collaborator",
+	service = DTOConverter.class
+)
+public class CollaboratorDTOConverter
+	implements DTOConverter<SharingEntry, Collaborator> {
+
+	@Override
+	public String getContentType() {
+		return Collaborator.class.getSimpleName();
+	}
+
+	@Override
+	public Collaborator toDTO(
+			DTOConverterContext dtoConverterContext, SharingEntry sharingEntry)
+		throws Exception {
+
+		User user = _getUser(sharingEntry);
+		UserGroup userGroup = _getUserGroup(sharingEntry);
+
+		return new Collaborator() {
+			{
+				setActionIds(
+					() -> TransformUtil.transformToArray(
+						SharingEntryAction.getSharingEntryActions(
+							sharingEntry.getActionIds()),
+						SharingEntryAction::getActionId, String.class));
+				setCreator(
+					() -> CreatorUtil.toCreator(
+						dtoConverterContext, _portal,
+						_userLocalService.getUser(sharingEntry.getUserId())));
+				setDateExpired(sharingEntry::getExpirationDate);
+				setExternalReferenceCode(
+					() -> {
+						if (user != null) {
+							return user.getExternalReferenceCode();
+						}
+
+						return userGroup.getExternalReferenceCode();
+					});
+				setName(
+					() -> {
+						if (user != null) {
+							return user.getFullName();
+						}
+
+						return userGroup.getName();
+					});
+				setPortrait(
+					() -> {
+						if (user != null) {
+							if (user.getPortraitId() == 0) {
+								return null;
+							}
+
+							ThemeDisplay themeDisplay = new ThemeDisplay() {
+								{
+									setPathImage(_portal.getPathImage());
+								}
+							};
+
+							return user.getPortraitURL(themeDisplay);
+						}
+
+						return null;
+					});
+				setShare(sharingEntry::isShareable);
+				setType(
+					() -> {
+						if (user != null) {
+							return Type.USER;
+						}
+
+						return Type.USER_GROUP;
+					});
+			}
+		};
+	}
+
+	private User _getUser(SharingEntry sharingEntry) throws Exception {
+		if (sharingEntry.getToUserId() > 0) {
+			return _userLocalService.getUser(sharingEntry.getToUserId());
+		}
+
+		return null;
+	}
+
+	private UserGroup _getUserGroup(SharingEntry sharingEntry)
+		throws Exception {
+
+		if (sharingEntry.getToUserGroupId() > 0) {
+			return _userGroupLocalService.getUserGroup(
+				sharingEntry.getToUserGroupId());
+		}
+
+		return null;
+	}
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
@@ -5,7 +5,9 @@
 
 package com.liferay.headless.object.internal.graphql.mutation.v1_0;
 
+import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.headless.object.dto.v1_0.ObjectEntryFolder;
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
 import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
@@ -16,6 +18,7 @@ import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTa
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.function.BiFunction;
 
@@ -36,12 +39,83 @@ import org.osgi.service.component.ComponentServiceObjects;
 @Generated("")
 public class Mutation {
 
+	public static void setCollaboratorResourceComponentServiceObjects(
+		ComponentServiceObjects<CollaboratorResource>
+			collaboratorResourceComponentServiceObjects) {
+
+		_collaboratorResourceComponentServiceObjects =
+			collaboratorResourceComponentServiceObjects;
+	}
+
 	public static void setObjectEntryFolderResourceComponentServiceObjects(
 		ComponentServiceObjects<ObjectEntryFolderResource>
 			objectEntryFolderResourceComponentServiceObjects) {
 
 		_objectEntryFolderResourceComponentServiceObjects =
 			objectEntryFolderResourceComponentServiceObjects;
+	}
+
+	@GraphQLField(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
+	)
+	public java.util.Collection<Collaborator>
+			createObjectEntryFolderCollaboratorsPage(
+				@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+				@GraphQLName("collaborators") Collaborator[] collaborators)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource -> {
+				Page paginationPage =
+					collaboratorResource.postObjectEntryFolderCollaboratorsPage(
+						objectEntryFolderId, collaborators);
+
+				return paginationPage.getItems();
+			});
+	}
+
+	@GraphQLField
+	public Response createObjectEntryFolderCollaboratorsPageExportBatch(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					postObjectEntryFolderCollaboratorsPageExportBatch(
+						objectEntryFolderId, callbackURL, contentType,
+						fieldNames));
+	}
+
+	@GraphQLField(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
+	)
+	public java.util.Collection<Collaborator>
+			createScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("collaborators") Collaborator[] collaborators)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource -> {
+				Page paginationPage =
+					collaboratorResource.
+						postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+							scopeKey, externalReferenceCode, collaborators);
+
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField(
@@ -201,6 +275,27 @@ public class Mutation {
 	}
 
 	private void _populateResourceContext(
+			CollaboratorResource collaboratorResource)
+		throws Exception {
+
+		collaboratorResource.setContextAcceptLanguage(_acceptLanguage);
+		collaboratorResource.setContextCompany(_company);
+		collaboratorResource.setContextHttpServletRequest(_httpServletRequest);
+		collaboratorResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		collaboratorResource.setContextUriInfo(_uriInfo);
+		collaboratorResource.setContextUser(_user);
+		collaboratorResource.setGroupLocalService(_groupLocalService);
+		collaboratorResource.setRoleLocalService(_roleLocalService);
+
+		collaboratorResource.setVulcanBatchEngineExportTaskResource(
+			_vulcanBatchEngineExportTaskResource);
+
+		collaboratorResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
+	private void _populateResourceContext(
 			ObjectEntryFolderResource objectEntryFolderResource)
 		throws Exception {
 
@@ -222,6 +317,8 @@ public class Mutation {
 			_vulcanBatchEngineImportTaskResource);
 	}
 
+	private static ComponentServiceObjects<CollaboratorResource>
+		_collaboratorResourceComponentServiceObjects;
 	private static ComponentServiceObjects<ObjectEntryFolderResource>
 		_objectEntryFolderResourceComponentServiceObjects;
 

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
@@ -5,7 +5,9 @@
 
 package com.liferay.headless.object.internal.graphql.query.v1_0;
 
+import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.headless.object.dto.v1_0.ObjectEntryFolder;
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
 import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
@@ -40,12 +42,69 @@ import org.osgi.service.component.ComponentServiceObjects;
 @Generated("")
 public class Query {
 
+	public static void setCollaboratorResourceComponentServiceObjects(
+		ComponentServiceObjects<CollaboratorResource>
+			collaboratorResourceComponentServiceObjects) {
+
+		_collaboratorResourceComponentServiceObjects =
+			collaboratorResourceComponentServiceObjects;
+	}
+
 	public static void setObjectEntryFolderResourceComponentServiceObjects(
 		ComponentServiceObjects<ObjectEntryFolderResource>
 			objectEntryFolderResourceComponentServiceObjects) {
 
 		_objectEntryFolderResourceComponentServiceObjects =
 			objectEntryFolderResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaborators(objectEntryFolderId: ___, page: ___, pageSize: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborators of an object entry folder."
+	)
+	public CollaboratorPage objectEntryFolderCollaborators(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("pageSize") int pageSize,
+			@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource -> new CollaboratorPage(
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId, Pagination.of(page, pageSize))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborators(externalReferenceCode: ___, page: ___, pageSize: ___, scopeKey: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborators of an object entry."
+	)
+	public CollaboratorPage
+			scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborators(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource -> new CollaboratorPage(
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(page, pageSize))));
 	}
 
 	/**
@@ -119,6 +178,74 @@ public class Query {
 						Pagination.of(page, pageSize),
 						_sortsBiFunction.apply(
 							objectEntryFolderResource, sortsString))));
+	}
+
+	@GraphQLTypeExtension(ObjectEntryFolder.class)
+	public class GetObjectEntryFolderCollaboratorsPageTypeExtension {
+
+		public GetObjectEntryFolderCollaboratorsPageTypeExtension(
+			ObjectEntryFolder objectEntryFolder) {
+
+			_objectEntryFolder = objectEntryFolder;
+		}
+
+		@GraphQLField(
+			description = "Retrieves the collaborators of an object entry folder."
+		)
+		public CollaboratorPage collaborators(
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_collaboratorResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				collaboratorResource -> new CollaboratorPage(
+					collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+						_objectEntryFolder.getId(),
+						Pagination.of(page, pageSize))));
+		}
+
+		private ObjectEntryFolder _objectEntryFolder;
+
+	}
+
+	@GraphQLName("CollaboratorPage")
+	public class CollaboratorPage {
+
+		public CollaboratorPage(Page collaboratorPage) {
+			actions = collaboratorPage.getActions();
+
+			facets = collaboratorPage.getFacets();
+
+			items = collaboratorPage.getItems();
+			lastPage = collaboratorPage.getLastPage();
+			page = collaboratorPage.getPage();
+			pageSize = collaboratorPage.getPageSize();
+			totalCount = collaboratorPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected List<Facet> facets;
+
+		@GraphQLField
+		protected java.util.Collection<Collaborator> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
 	}
 
 	@GraphQLName("ObjectEntryFolderPage")
@@ -206,6 +333,21 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			CollaboratorResource collaboratorResource)
+		throws Exception {
+
+		collaboratorResource.setContextAcceptLanguage(_acceptLanguage);
+		collaboratorResource.setContextCompany(_company);
+		collaboratorResource.setContextHttpServletRequest(_httpServletRequest);
+		collaboratorResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		collaboratorResource.setContextUriInfo(_uriInfo);
+		collaboratorResource.setContextUser(_user);
+		collaboratorResource.setGroupLocalService(_groupLocalService);
+		collaboratorResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private void _populateResourceContext(
 			ObjectEntryFolderResource objectEntryFolderResource)
 		throws Exception {
 
@@ -221,6 +363,8 @@ public class Query {
 		objectEntryFolderResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private static ComponentServiceObjects<CollaboratorResource>
+		_collaboratorResourceComponentServiceObjects;
 	private static ComponentServiceObjects<ObjectEntryFolderResource>
 		_objectEntryFolderResourceComponentServiceObjects;
 

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -7,7 +7,9 @@ package com.liferay.headless.object.internal.graphql.servlet.v1_0;
 
 import com.liferay.headless.object.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.headless.object.internal.graphql.query.v1_0.Query;
+import com.liferay.headless.object.internal.resource.v1_0.CollaboratorResourceImpl;
 import com.liferay.headless.object.internal.resource.v1_0.ObjectEntryFolderResourceImpl;
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
 import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
@@ -34,9 +36,13 @@ public class ServletDataImpl implements ServletData {
 
 	@Activate
 	public void activate(BundleContext bundleContext) {
+		Mutation.setCollaboratorResourceComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects);
 		Mutation.setObjectEntryFolderResourceComponentServiceObjects(
 			_objectEntryFolderResourceComponentServiceObjects);
 
+		Query.setCollaboratorResourceComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects);
 		Query.setObjectEntryFolderResourceComponentServiceObjects(
 			_objectEntryFolderResourceComponentServiceObjects);
 	}
@@ -76,6 +82,21 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#createObjectEntryFolderCollaboratorsPage",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"postObjectEntryFolderCollaboratorsPage"));
+					put(
+						"mutation#createObjectEntryFolderCollaboratorsPageExportBatch",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"postObjectEntryFolderCollaboratorsPageExportBatch"));
+					put(
+						"mutation#createScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage"));
+					put(
 						"mutation#deleteObjectEntryFolder",
 						new ObjectValuePair<>(
 							ObjectEntryFolderResourceImpl.class,
@@ -112,6 +133,16 @@ public class ServletDataImpl implements ServletData {
 							"putScopeScopeKeyObjectEntryFolderByExternalReferenceCode"));
 
 					put(
+						"query#objectEntryFolderCollaborators",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorsPage"));
+					put(
+						"query#scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborators",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage"));
+					put(
 						"query#objectEntryFolder",
 						new ObjectValuePair<>(
 							ObjectEntryFolderResourceImpl.class,
@@ -128,12 +159,22 @@ public class ServletDataImpl implements ServletData {
 							"getScopeScopeKeyObjectEntryFoldersPage"));
 
 					put(
+						"query#ObjectEntryFolder.collaborators",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorsPage"));
+
+					put(
 						"query#ObjectEntryFolder.parentObjectEntryFolder",
 						new ObjectValuePair<>(
 							ObjectEntryFolderResourceImpl.class,
 							"getObjectEntryFolder"));
 				}
 			};
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<CollaboratorResource>
+		_collaboratorResourceComponentServiceObjects;
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<ObjectEntryFolderResource>

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -1,0 +1,766 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.resource.v1_0;
+
+import com.liferay.headless.object.dto.v1_0.Collaborator;
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/v1.0")
+public abstract class BaseCollaboratorResourceImpl
+	implements CollaboratorResource, EntityModelResource,
+			   VulcanBatchEngineTaskItemDelegate<Collaborator> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborators of an object entry folder."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborators of an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Collaborator>
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Collaborator> postObjectEntryFolderCollaboratorsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			Collaborator[] collaborators)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/export-batch"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postObjectEntryFolderCollaboratorsPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.DefaultValue("JSON")
+			@javax.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				Collaborator.class.getName(), callbackURL, contentType,
+				fieldNames)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Collaborator>
+			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<Collaborator> collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<Collaborator> collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getResourceName() {
+		return "Collaborator";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<Collaborator> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		if (parameters.containsKey("objectEntryFolderId")) {
+			return getObjectEntryFolderCollaboratorsPage(
+				_parseLong((String)parameters.get("objectEntryFolderId")),
+				pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be specified: [objectEntryFolderId]");
+		}
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<Collaborator> collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<Collaborator>,
+			 UnsafeFunction<Collaborator, Collaborator, Exception>, Exception>
+				contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<Collaborator>, UnsafeConsumer<Collaborator, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-object";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<Collaborator>,
+		 UnsafeFunction<Collaborator, Collaborator, Exception>, Exception>
+			contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<Collaborator>, UnsafeConsumer<Collaborator, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseCollaboratorResourceImpl.class);
+
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.resource.v1_0;
+
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Alicia García
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/collaborator.properties",
+	scope = ServiceScope.PROTOTYPE, service = CollaboratorResource.class
+)
+public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -5,9 +5,38 @@
 
 package com.liferay.headless.object.internal.resource.v1_0;
 
+import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+import com.liferay.sharing.service.SharingEntryService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -18,4 +47,229 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = CollaboratorResource.class
 )
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
+
+	@Override
+	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _getObjectEntryFolderCollaboratorsPage(
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId),
+			pagination);
+	}
+
+	@Override
+	public Page<Collaborator>
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _getObjectEntryFolderCollaboratorsPage(
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode, _getGroupId(scopeKey),
+					contextCompany.getCompanyId()),
+			pagination);
+	}
+
+	@Override
+	public Page<Collaborator> postObjectEntryFolderCollaboratorsPage(
+			Long objectEntryFolderId, Collaborator[] collaborators)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _postObjectEntryFolderCollaboratorsPage(
+			collaborators,
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId));
+	}
+
+	@Override
+	public Page<Collaborator>
+			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _postObjectEntryFolderCollaboratorsPage(
+			collaborators,
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode, _getGroupId(scopeKey),
+					contextCompany.getCompanyId()));
+	}
+
+	private SharingEntry _addOrUpdateSharingEntry(
+			long classNameId, long classPK, Collaborator collaborator,
+			long groupId)
+		throws Exception {
+
+		long toUserId = 0;
+		long toUserGroupId = 0;
+
+		if (Objects.equals(Collaborator.Type.USER, collaborator.getType())) {
+			User user = _userLocalService.getUserByExternalReferenceCode(
+				collaborator.getExternalReferenceCode(),
+				contextCompany.getCompanyId());
+
+			toUserId = user.getUserId();
+		}
+		else {
+			UserGroup userGroup =
+				_userGroupLocalService.getUserGroupByExternalReferenceCode(
+					collaborator.getExternalReferenceCode(),
+					contextCompany.getCompanyId());
+
+			toUserGroupId = userGroup.getUserGroupId();
+		}
+
+		boolean shareable = false;
+
+		if (collaborator.getShare() != null) {
+			shareable = collaborator.getShare();
+		}
+
+		return _sharingEntryService.addOrUpdateSharingEntry(
+			null, toUserGroupId, toUserId, classNameId, classPK, groupId,
+			shareable,
+			transformToList(
+				collaborator.getActionIds(),
+				SharingEntryAction::parseFromActionId),
+			collaborator.getDateExpired(), new ServiceContext());
+	}
+
+	private long _getGroupId(String scopeKey) throws Exception {
+		Long groupId = GroupUtil.getGroupId(
+			contextCompany.getCompanyId(), scopeKey, _groupLocalService);
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		if (Objects.equals(scopeKey, "0")) {
+			return 0;
+		}
+
+		throw new NoSuchGroupException();
+	}
+
+	private Page<Collaborator> _getObjectEntryFolderCollaboratorsPage(
+			ObjectEntryFolder objectEntryFolder, Pagination pagination)
+		throws Exception {
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			ObjectEntryFolder.class.getName());
+
+		return Page.of(
+			transform(
+				_sharingEntryService.getSharingEntries(
+					classNameId, objectEntryFolder.getObjectEntryFolderId(),
+					objectEntryFolder.getGroupId(),
+					pagination.getStartPosition(), pagination.getEndPosition()),
+				this::_toCollaborator),
+			pagination,
+			_sharingEntryLocalService.getSharingEntriesCount(
+				classNameId, objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	private Page<Collaborator> _postObjectEntryFolderCollaboratorsPage(
+			Collaborator[] collaborators, ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return _postObjectEntryFolderCollaboratorsPage(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborators,
+			objectEntryFolder.getGroupId());
+	}
+
+	private Page<Collaborator> _postObjectEntryFolderCollaboratorsPage(
+			long classNameId, long classPK, Collaborator[] collaborators,
+			long groupId)
+		throws Exception {
+
+		List<SharingEntry> oldSharingEntries =
+			_sharingEntryService.getSharingEntries(
+				classNameId, classPK, groupId, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		List<SharingEntry> newSharingEntries = new ArrayList<>();
+
+		List<Long> sharingEntriesIds = new ArrayList<>();
+
+		for (Collaborator collaborator : collaborators) {
+			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, groupId);
+
+			newSharingEntries.add(sharingEntry);
+			sharingEntriesIds.add(sharingEntry.getSharingEntryId());
+		}
+
+		for (SharingEntry sharingEntry : oldSharingEntries) {
+			if (!sharingEntriesIds.contains(sharingEntry.getSharingEntryId())) {
+				_sharingEntryService.deleteSharingEntry(sharingEntry);
+			}
+		}
+
+		return Page.of(transform(newSharingEntries, this::_toCollaborator));
+	}
+
+	private Collaborator _toCollaborator(SharingEntry sharingEntry)
+		throws Exception {
+
+		return _collaboratorDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
+				_dtoConverterRegistry, sharingEntry.getSharingEntryId(),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			sharingEntry);
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.object.internal.dto.v1_0.converter.CollaboratorDTOConverter)"
+	)
+	private DTOConverter<SharingEntry, Collaborator> _collaboratorDTOConverter;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private SharingEntryService _sharingEntryService;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
 }

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(CollaboratorResourceImpl.class);
+
 			add(ObjectEntryFolderResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/factory/CollaboratorResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/factory/CollaboratorResourceFactoryImpl.java
@@ -1,0 +1,331 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.resource.v1_0.factory;
+
+import com.liferay.headless.object.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.object.resource.v1_0.CollaboratorResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-object/v1.0/Collaborator",
+	service = CollaboratorResource.Factory.class
+)
+@Generated("")
+public class CollaboratorResourceFactoryImpl
+	implements CollaboratorResource.Factory {
+
+	@Override
+	public CollaboratorResource.Builder create() {
+		return new CollaboratorResource.Builder() {
+
+			@Override
+			public CollaboratorResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, CollaboratorResource>
+					collaboratorResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_collaboratorResourceProxyProviderFunction;
+
+				return collaboratorResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public CollaboratorResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, CollaboratorResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			CollaboratorResource.class.getClassLoader(),
+			CollaboratorResource.class);
+
+		try {
+			Constructor<CollaboratorResource> constructor =
+				(Constructor<CollaboratorResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		CollaboratorResource collaboratorResource =
+			_componentServiceObjects.getService();
+
+		collaboratorResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		collaboratorResource.setContextCompany(company);
+
+		collaboratorResource.setContextHttpServletRequest(httpServletRequest);
+		collaboratorResource.setContextHttpServletResponse(httpServletResponse);
+		collaboratorResource.setContextUriInfo(uriInfo);
+		collaboratorResource.setContextUser(user);
+		collaboratorResource.setExpressionConvert(_expressionConvert);
+		collaboratorResource.setFilterParserProvider(_filterParserProvider);
+		collaboratorResource.setGroupLocalService(_groupLocalService);
+		collaboratorResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		collaboratorResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		collaboratorResource.setRoleLocalService(_roleLocalService);
+		collaboratorResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(collaboratorResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(collaboratorResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<CollaboratorResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, CollaboratorResource>
+			_collaboratorResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collaborator.properties
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collaborator.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.object.dto.v1_0.Collaborator
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.headless.object.dto.v1_0.Collaborator
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Object)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-object/headless-object-test/build.gradle
+++ b/modules/apps/headless/headless-object/headless-object-test/build.gradle
@@ -9,8 +9,11 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-object:headless-object-api")
 	testIntegrationImplementation project(":apps:headless:headless-object:headless-object-client")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
@@ -1,0 +1,1541 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.object.client.dto.v1_0.Collaborator;
+import com.liferay.headless.object.client.http.HttpInvoker;
+import com.liferay.headless.object.client.pagination.Page;
+import com.liferay.headless.object.client.pagination.Pagination;
+import com.liferay.headless.object.client.resource.v1_0.CollaboratorResource;
+import com.liferay.headless.object.client.serdes.v1_0.CollaboratorSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Alicia García
+ * @generated
+ */
+@Generated("")
+public abstract class BaseCollaboratorResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_collaboratorResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		collaboratorResource = CollaboratorResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Collaborator collaborator1 = randomCollaborator();
+
+		String json = objectMapper.writeValueAsString(collaborator1);
+
+		Collaborator collaborator2 = CollaboratorSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(collaborator1, collaborator2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Collaborator collaborator = randomCollaborator();
+
+		String json1 = objectMapper.writeValueAsString(collaborator);
+		String json2 = CollaboratorSerDes.toJSON(collaborator);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Collaborator collaborator = randomCollaborator();
+
+		collaborator.setExternalReferenceCode(regex);
+		collaborator.setName(regex);
+		collaborator.setPortrait(regex);
+
+		String json = CollaboratorSerDes.toJSON(collaborator);
+
+		Assert.assertFalse(json.contains(regex));
+
+		collaborator = CollaboratorSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, collaborator.getExternalReferenceCode());
+		Assert.assertEquals(regex, collaborator.getName());
+		Assert.assertEquals(regex, collaborator.getPortrait());
+	}
+
+	@Test
+	public void testGetObjectEntryFolderCollaboratorsPage() throws Exception {
+		Long objectEntryFolderId =
+			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId();
+		Long irrelevantObjectEntryFolderId =
+			testGetObjectEntryFolderCollaboratorsPage_getIrrelevantObjectEntryFolderId();
+
+		Page<Collaborator> page =
+			collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+				objectEntryFolderId, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantObjectEntryFolderId != null) {
+			Collaborator irrelevantCollaborator =
+				testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+					irrelevantObjectEntryFolderId,
+					randomIrrelevantCollaborator());
+
+			page = collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+				irrelevantObjectEntryFolderId,
+				Pagination.of(1, (int)totalCount + 1));
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantCollaborator, (List<Collaborator>)page.getItems());
+			assertValid(
+				page,
+				testGetObjectEntryFolderCollaboratorsPage_getExpectedActions(
+					irrelevantObjectEntryFolderId));
+		}
+
+		Collaborator collaborator1 =
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				objectEntryFolderId, randomCollaborator());
+
+		Collaborator collaborator2 =
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				objectEntryFolderId, randomCollaborator());
+
+		page = collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+			objectEntryFolderId, Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(collaborator1, (List<Collaborator>)page.getItems());
+		assertContains(collaborator2, (List<Collaborator>)page.getItems());
+		assertValid(
+			page,
+			testGetObjectEntryFolderCollaboratorsPage_getExpectedActions(
+				objectEntryFolderId));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetObjectEntryFolderCollaboratorsPage_getExpectedActions(
+				Long objectEntryFolderId)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetObjectEntryFolderCollaboratorsPageWithPagination()
+		throws Exception {
+
+		Long objectEntryFolderId =
+			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId();
+
+		Page<Collaborator> collaboratorPage =
+			collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+				objectEntryFolderId, null);
+
+		int totalCount = GetterUtil.getInteger(
+			collaboratorPage.getTotalCount());
+
+		Collaborator collaborator1 =
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				objectEntryFolderId, randomCollaborator());
+
+		Collaborator collaborator2 =
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				objectEntryFolderId, randomCollaborator());
+
+		Collaborator collaborator3 =
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				objectEntryFolderId, randomCollaborator());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<Collaborator> page1 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(collaborator1, (List<Collaborator>)page1.getItems());
+
+			Page<Collaborator> page2 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(collaborator2, (List<Collaborator>)page2.getItems());
+
+			Page<Collaborator> page3 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(collaborator3, (List<Collaborator>)page3.getItems());
+		}
+		else {
+			Page<Collaborator> page1 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId, Pagination.of(1, totalCount + 2));
+
+			List<Collaborator> collaborators1 =
+				(List<Collaborator>)page1.getItems();
+
+			Assert.assertEquals(
+				collaborators1.toString(), totalCount + 2,
+				collaborators1.size());
+
+			Page<Collaborator> page2 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId, Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<Collaborator> collaborators2 =
+				(List<Collaborator>)page2.getItems();
+
+			Assert.assertEquals(
+				collaborators2.toString(), 1, collaborators2.size());
+
+			Page<Collaborator> page3 =
+				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
+					objectEntryFolderId, Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(collaborator1, (List<Collaborator>)page3.getItems());
+			assertContains(collaborator2, (List<Collaborator>)page3.getItems());
+			assertContains(collaborator3, (List<Collaborator>)page3.getItems());
+		}
+	}
+
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				Long objectEntryFolderId, Collaborator collaborator)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testGetObjectEntryFolderCollaboratorsPage_getIrrelevantObjectEntryFolderId()
+		throws Exception {
+
+		return null;
+	}
+
+	@Test
+	public void testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage()
+		throws Exception {
+
+		String scopeKey =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getScopeKey();
+		String irrelevantScopeKey =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getIrrelevantScopeKey();
+		String externalReferenceCode =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExternalReferenceCode();
+		String irrelevantExternalReferenceCode =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getIrrelevantExternalReferenceCode();
+
+		Page<Collaborator> page =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					scopeKey, externalReferenceCode, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		if ((irrelevantScopeKey != null) &&
+			(irrelevantExternalReferenceCode != null)) {
+
+			Collaborator irrelevantCollaborator =
+				testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+					irrelevantScopeKey, irrelevantExternalReferenceCode,
+					randomIrrelevantCollaborator());
+
+			page =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						irrelevantScopeKey, irrelevantExternalReferenceCode,
+						Pagination.of(1, (int)totalCount + 1));
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantCollaborator, (List<Collaborator>)page.getItems());
+			assertValid(
+				page,
+				testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExpectedActions(
+					irrelevantScopeKey, irrelevantExternalReferenceCode));
+		}
+
+		Collaborator collaborator1 =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				scopeKey, externalReferenceCode, randomCollaborator());
+
+		Collaborator collaborator2 =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				scopeKey, externalReferenceCode, randomCollaborator());
+
+		page =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					scopeKey, externalReferenceCode, Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(collaborator1, (List<Collaborator>)page.getItems());
+		assertContains(collaborator2, (List<Collaborator>)page.getItems());
+		assertValid(
+			page,
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExpectedActions(
+				scopeKey, externalReferenceCode));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExpectedActions(
+				String scopeKey, String externalReferenceCode)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageWithPagination()
+		throws Exception {
+
+		String scopeKey =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getScopeKey();
+		String externalReferenceCode =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExternalReferenceCode();
+
+		Page<Collaborator> collaboratorPage =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					scopeKey, externalReferenceCode, null);
+
+		int totalCount = GetterUtil.getInteger(
+			collaboratorPage.getTotalCount());
+
+		Collaborator collaborator1 =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				scopeKey, externalReferenceCode, randomCollaborator());
+
+		Collaborator collaborator2 =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				scopeKey, externalReferenceCode, randomCollaborator());
+
+		Collaborator collaborator3 =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				scopeKey, externalReferenceCode, randomCollaborator());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<Collaborator> page1 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+							pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(collaborator1, (List<Collaborator>)page1.getItems());
+
+			Page<Collaborator> page2 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+							pageSizeLimit));
+
+			assertContains(collaborator2, (List<Collaborator>)page2.getItems());
+
+			Page<Collaborator> page3 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(
+							(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+							pageSizeLimit));
+
+			assertContains(collaborator3, (List<Collaborator>)page3.getItems());
+		}
+		else {
+			Page<Collaborator> page1 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(1, totalCount + 2));
+
+			List<Collaborator> collaborators1 =
+				(List<Collaborator>)page1.getItems();
+
+			Assert.assertEquals(
+				collaborators1.toString(), totalCount + 2,
+				collaborators1.size());
+
+			Page<Collaborator> page2 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<Collaborator> collaborators2 =
+				(List<Collaborator>)page2.getItems();
+
+			Assert.assertEquals(
+				collaborators2.toString(), 1, collaborators2.size());
+
+			Page<Collaborator> page3 =
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+						scopeKey, externalReferenceCode,
+						Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(collaborator1, (List<Collaborator>)page3.getItems());
+			assertContains(collaborator2, (List<Collaborator>)page3.getItems());
+			assertContains(collaborator3, (List<Collaborator>)page3.getItems());
+		}
+	}
+
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				String scopeKey, String externalReferenceCode,
+				Collaborator collaborator)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getIrrelevantScopeKey()
+		throws Exception {
+
+		return null;
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getIrrelevantExternalReferenceCode()
+		throws Exception {
+
+		return null;
+	}
+
+	@Test
+	public void testPostObjectEntryFolderCollaboratorsPage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testPostScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage()
+		throws Exception {
+
+		Assert.assertTrue(false);
+	}
+
+	protected void assertContains(
+		Collaborator collaborator, List<Collaborator> collaborators) {
+
+		boolean contains = false;
+
+		for (Collaborator item : collaborators) {
+			if (equals(collaborator, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			collaborators + " does not contain " + collaborator, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		Collaborator collaborator1, Collaborator collaborator2) {
+
+		Assert.assertTrue(
+			collaborator1 + " does not equal " + collaborator2,
+			equals(collaborator1, collaborator2));
+	}
+
+	protected void assertEquals(
+		List<Collaborator> collaborators1, List<Collaborator> collaborators2) {
+
+		Assert.assertEquals(collaborators1.size(), collaborators2.size());
+
+		for (int i = 0; i < collaborators1.size(); i++) {
+			Collaborator collaborator1 = collaborators1.get(i);
+			Collaborator collaborator2 = collaborators2.get(i);
+
+			assertEquals(collaborator1, collaborator2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Collaborator> collaborators1, List<Collaborator> collaborators2) {
+
+		Assert.assertEquals(collaborators1.size(), collaborators2.size());
+
+		for (Collaborator collaborator1 : collaborators1) {
+			boolean contains = false;
+
+			for (Collaborator collaborator2 : collaborators2) {
+				if (equals(collaborator1, collaborator2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				collaborators2 + " does not contain " + collaborator1,
+				contains);
+		}
+	}
+
+	protected void assertValid(Collaborator collaborator) throws Exception {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actionIds", additionalAssertFieldName)) {
+				if (collaborator.getActionIds() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (collaborator.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (collaborator.getCreator() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateExpired", additionalAssertFieldName)) {
+				if (collaborator.getDateExpired() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (collaborator.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (collaborator.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("portrait", additionalAssertFieldName)) {
+				if (collaborator.getPortrait() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("share", additionalAssertFieldName)) {
+				if (collaborator.getShare() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (collaborator.getType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Collaborator> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<Collaborator> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<Collaborator> collaborators = page.getItems();
+
+		int size = collaborators.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.object.dto.v1_0.Collaborator.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		Collaborator collaborator1, Collaborator collaborator2) {
+
+		if (collaborator1 == collaborator2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actionIds", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getActionIds(),
+						collaborator2.getActionIds())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)collaborator1.getActions(),
+						(Map)collaborator2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getCreator(),
+						collaborator2.getCreator())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateExpired", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getDateExpired(),
+						collaborator2.getDateExpired())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						collaborator1.getExternalReferenceCode(),
+						collaborator2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getName(), collaborator2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("portrait", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getPortrait(),
+						collaborator2.getPortrait())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("share", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getShare(), collaborator2.getShare())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getType(), collaborator2.getType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_collaboratorResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_collaboratorResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Collaborator collaborator) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("actionIds")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("creator")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dateExpired")) {
+			if (operator.equals("between")) {
+				Date date = collaborator.getDateExpired();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(_format.format(collaborator.getDateExpired()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = collaborator.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("name")) {
+			Object object = collaborator.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("portrait")) {
+			Object object = collaborator.getPortrait();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("share")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("type")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected Collaborator randomCollaborator() throws Exception {
+		return new Collaborator() {
+			{
+				dateExpired = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				portrait = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				share = RandomTestUtil.randomBoolean();
+			}
+		};
+	}
+
+	protected Collaborator randomIrrelevantCollaborator() throws Exception {
+		Collaborator randomIrrelevantCollaborator = randomCollaborator();
+
+		return randomIrrelevantCollaborator;
+	}
+
+	protected Collaborator randomPatchCollaborator() throws Exception {
+		return randomCollaborator();
+	}
+
+	protected CollaboratorResource collaboratorResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseCollaboratorResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.object.resource.v1_0.CollaboratorResource
+		_collaboratorResource;
+
+}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -6,14 +6,380 @@
 package com.liferay.headless.object.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.object.client.dto.v1_0.Collaborator;
+import com.liferay.headless.object.client.pagination.Page;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 
-import org.junit.Ignore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Alicia García
  */
-@Ignore
+@FeatureFlags("LPD-17564")
 @RunWith(Arquillian.class)
 public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		_users.clear();
+		_userGroups.clear();
+	}
+
+	@Override
+	@Test
+	public void testPostObjectEntryFolderCollaboratorsPage() throws Exception {
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+
+		_addUserCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Collaborator[] collaborators = {
+			_getUserCollaborator(), _getUserGroupCollaborator(),
+			_getUserGroupCollaborator()
+		};
+
+		Page<Collaborator> collaboratorPage =
+			collaboratorResource.postObjectEntryFolderCollaboratorsPage(
+				objectEntryFolder.getObjectEntryFolderId(), collaborators);
+
+		_assertCollaborators(
+			(List<Collaborator>)collaboratorPage.getItems(), collaborators);
+	}
+
+	@Override
+	@Test
+	public void testPostScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+
+		_addUserCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Collaborator[] collaborators = {
+			_getUserCollaborator(), _getUserGroupCollaborator(),
+			_getUserGroupCollaborator()
+		};
+
+		Page<Collaborator> collaboratorPage =
+			collaboratorResource.
+				postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
+					testGroup.getGroupKey(),
+					objectEntryFolder.getExternalReferenceCode(),
+					collaborators);
+
+		_assertCollaborators(
+			(List<Collaborator>)collaboratorPage.getItems(), collaborators);
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"actionIds", "dateExpired", "externalReferenceCode", "name",
+			"share", "type"
+		};
+	}
+
+	@Override
+	protected Collaborator randomCollaborator() throws Exception {
+		return new Collaborator() {
+			{
+				dateExpired = _randomDatePlusAYear();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				portrait = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				share = RandomTestUtil.randomBoolean();
+				type = Type.USER;
+			}
+		};
+	}
+
+	@Override
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorsPage_addCollaborator(
+				Long objectEntryFolderId, Collaborator collaborator)
+		throws Exception {
+
+		return _addUserGroupCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolderId);
+	}
+
+	@Override
+	protected Long
+			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+
+		return objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_addCollaborator(
+				String scopeKey, String externalReferenceCode,
+				Collaborator collaborator)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode, testGroup.getGroupId(),
+					testCompany.getCompanyId());
+
+		return _addUserCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId());
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+
+		return objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
+	private ObjectEntryFolder _addObjectEntryFolder() throws Exception {
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.put(
+				LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+			).build(),
+			RandomTestUtil.randomString(), new ServiceContext());
+	}
+
+	private Collaborator _addUserCollaborator(long classNameId, long classPK)
+		throws Exception {
+
+		User user = _getUser();
+
+		return _toCollaborator(
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), 0, user.getUserId(),
+				classNameId, classPK, testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private Collaborator _addUserGroupCollaborator(
+			long classNameId, long classPK)
+		throws Exception {
+
+		UserGroup userGroup = _getUserGroup();
+
+		return _toCollaborator(
+			_sharingEntryLocalService.addSharingEntry(
+				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
+				0, classNameId, classPK, testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), null,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _assertCollaborators(
+		List<Collaborator> actualCollaborators,
+		Collaborator[] expectedCollaborators) {
+
+		Assert.assertEquals(
+			actualCollaborators.toString(), expectedCollaborators.length,
+			actualCollaborators.size());
+
+		for (Collaborator expectedCollaborator : expectedCollaborators) {
+			assertContains(expectedCollaborator, actualCollaborators);
+		}
+	}
+
+	private User _getUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private Collaborator _getUserCollaborator() throws Exception {
+		User user = _getUser();
+
+		return new Collaborator() {
+			{
+				actionIds = new String[] {
+					SharingEntryAction.VIEW.getActionId()
+				};
+				dateExpired = _randomDatePlusAYear();
+				externalReferenceCode = user.getExternalReferenceCode();
+				name = user.getFullName();
+				share = true;
+				type = Type.USER;
+			}
+		};
+	}
+
+	private UserGroup _getUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
+	}
+
+	private Collaborator _getUserGroupCollaborator() throws Exception {
+		UserGroup userGroup = _getUserGroup();
+
+		return new Collaborator() {
+			{
+				actionIds = new String[] {
+					SharingEntryAction.VIEW.getActionId()
+				};
+				dateExpired = _randomDatePlusAYear();
+				externalReferenceCode = userGroup.getExternalReferenceCode();
+				name = userGroup.getName();
+				share = true;
+				type = Type.USER_GROUP;
+			}
+		};
+	}
+
+	private Date _randomDatePlusAYear() {
+		Calendar calendar = CalendarFactoryUtil.getCalendar();
+
+		calendar.add(Calendar.YEAR, 1);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		return calendar.getTime();
+	}
+
+	private Collaborator _toCollaborator(SharingEntry sharingEntry)
+		throws Exception {
+
+		if (sharingEntry.getToUserId() > 0) {
+			User user = _userLocalService.getUser(sharingEntry.getToUserId());
+
+			return new Collaborator() {
+				{
+					actionIds = TransformUtil.transformToArray(
+						SharingEntryAction.getSharingEntryActions(
+							sharingEntry.getActionIds()),
+						SharingEntryAction::getActionId, String.class);
+					dateExpired = sharingEntry.getExpirationDate();
+					externalReferenceCode = user.getExternalReferenceCode();
+					name = user.getFullName();
+					share = sharingEntry.isShareable();
+					type = Type.USER;
+				}
+			};
+		}
+
+		UserGroup userGroup = _userGroupLocalService.getUserGroup(
+			sharingEntry.getToUserGroupId());
+
+		return new Collaborator() {
+			{
+				actionIds = TransformUtil.transformToArray(
+					SharingEntryAction.getSharingEntryActions(
+						sharingEntry.getActionIds()),
+					SharingEntryAction::getActionId, String.class);
+				dateExpired = sharingEntry.getExpirationDate();
+				externalReferenceCode = userGroup.getExternalReferenceCode();
+				name = userGroup.getName();
+				share = sharingEntry.isShareable();
+				type = Type.USER_GROUP;
+			}
+		};
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+	@DeleteAfterTestRun
+	private List<UserGroup> _userGroups = new ArrayList<>();
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private List<User> _users = new ArrayList<>();
+
 }

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
+}

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 20.0.1
+Bundle-Version: 20.1.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/build.gradle
+++ b/modules/apps/object/object-rest-api/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
+	compileOnly project(":apps:headless:headless-object:headless-object-api")
 	compileOnly project(":apps:list-type:list-type-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.resource.v1_0;
+
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface CollaboratorResource {
+
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			getObjectEntryCollaboratorsPage(
+				Long objectEntryId, Pagination pagination)
+		throws Exception;
+
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception;
+
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			postObjectEntryCollaboratorsPage(
+				Long objectEntryId,
+				com.liferay.headless.object.dto.v1_0.Collaborator[]
+					collaborators)
+		throws Exception;
+
+	public Response postObjectEntryCollaboratorsPageExportBatch(
+			Long objectEntryId, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			postScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				com.liferay.headless.object.dto.v1_0.Collaborator[]
+					collaborators)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public CollaboratorResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.6.0
+version 3.7.0

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-storage-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-catapult-api")
+	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
+	compileOnly project(":apps:headless:headless-object:headless-object-api")
 	compileOnly project(":apps:list-type:list-type-api")
 	compileOnly project(":apps:object:object-admin-rest-api")
 	compileOnly project(":apps:object:object-api")

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -686,6 +686,97 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
+    "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators":
+        get:
+            description:
+                Retrieves the collaborators of an object entry.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+            tags: ["Collaborator"]
+        post:
+            description:
+                Add or update all the collaborators received in the request. Delete existing collaborators that are not
+                included in the request. Send a notification for the new collaborators and those whose permissions are
+                different.
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            items:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            type: array
+                    application/xml:
+                        schema:
+                            items:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+            tags: ["Collaborator"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/object-actions/{objectActionName}":
         put:
             operationId: putScopeScopeKeyByExternalReferenceCodeObjectActionObjectActionName
@@ -913,6 +1004,90 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
+    "/{objectEntryId}/collaborators":
+        get:
+            description:
+                Retrieves the collaborators of an object entry.
+            operationId: getObjectEntryCollaboratorsPage
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+            tags: ["Collaborator"]
+        post:
+            description:
+                Add or update all the collaborators received in the request. Delete existing collaborators that are not
+                included in the request.
+            operationId: postObjectEntryCollaboratorsPage
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            items:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            type: array
+                    application/xml:
+                        schema:
+                            items:
+                                $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                            type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator"
+                                type: array
+            tags: ["Collaborator"]
     "/{objectEntryId}/object-actions/{objectActionName}":
         put:
             operationId: putObjectEntryObjectActionObjectActionName

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -690,6 +690,7 @@ paths:
         get:
             description:
                 Retrieves the collaborators of an object entry.
+            operationId: getScopeScopeKeyByExternalReferenceCodeCollaboratorsPage
             parameters:
                 -   in: path
                     name: scopeKey
@@ -740,6 +741,7 @@ paths:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
                 included in the request. Send a notification for the new collaborators and those whose permissions are
                 different.
+            operationId: postScopeScopeKeyByExternalReferenceCodeCollaboratorsPage
             parameters:
                 -   in: path
                     name: scopeKey

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.rest.internal.deployer;
 
+import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
@@ -30,6 +31,8 @@ import com.liferay.object.rest.internal.manager.v1_0.SystemObjectEntry1toMObject
 import com.liferay.object.rest.internal.manager.v1_0.SystemObjectEntryMtoMObjectRelationshipElementsParserImpl;
 import com.liferay.object.rest.internal.openapi.v1_0.ObjectEntryOpenAPIResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.BaseObjectEntryResourceImpl;
+import com.liferay.object.rest.internal.resource.v1_0.CollaboratorResourceFactoryImpl;
+import com.liferay.object.rest.internal.resource.v1_0.CollaboratorResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceFactoryImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
@@ -38,6 +41,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParser;
 import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResourceProvider;
+import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
 import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
@@ -63,11 +67,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -82,6 +88,9 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.service.SharingEntryLocalService;
+import com.liferay.sharing.service.SharingEntryService;
 
 import java.lang.reflect.Method;
 
@@ -189,6 +198,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
+	}
+
+	private CollaboratorResourceImpl _createCollaboratorResourceImpl() {
+		return new CollaboratorResourceImpl(
+			_classNameLocalService, _collaboratorDTOConverter,
+			_dtoConverterRegistry, _groupLocalService, _objectEntryLocalService,
+			_sharingEntryService, _sharingEntryLocalService,
+			_userGroupLocalService, _userLocalService);
 	}
 
 	private ObjectEntryResourceImpl _createObjectEntryResourceImpl(
@@ -378,6 +395,57 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			applicationServiceRegistration.setProperties(properties);
 		}
 
+		properties = HashMapDictionaryBuilder.<String, Object>put(
+			"api.version", "v1.0"
+		).put(
+			"companyId", companyIds
+		).put(
+			"entity.class.name", Collaborator.class.getName()
+		).put(
+			"osgi.jaxrs.application.select",
+			"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
+		).put(
+			"osgi.jaxrs.resource", "true"
+		).build();
+
+		_collaboratorResourcePropertiesMap.put(restContextPath, properties);
+
+		ServiceRegistration<CollaboratorResource>
+			collaboratorResourceServiceRegistration =
+				_collaboratorResourceServiceRegistrationsMap.get(
+					restContextPath);
+
+		if (collaboratorResourceServiceRegistration == null) {
+			_collaboratorResourceServiceRegistrationsMap.put(
+				restContextPath,
+				_bundleContext.registerService(
+					CollaboratorResource.class,
+					new PrototypeServiceFactory<CollaboratorResource>() {
+
+						@Override
+						public CollaboratorResource getService(
+							Bundle bundle,
+							ServiceRegistration<CollaboratorResource>
+								serviceRegistration) {
+
+							return _createCollaboratorResourceImpl();
+						}
+
+						@Override
+						public void ungetService(
+							Bundle bundle,
+							ServiceRegistration<CollaboratorResource>
+								serviceRegistration,
+							CollaboratorResource collaboratorResource) {
+						}
+
+					},
+					properties));
+		}
+		else {
+			collaboratorResourceServiceRegistration.setProperties(properties);
+		}
+
 		boolean featureFlagEnabled = FeatureFlagManagerUtil.isEnabled(
 			CompanyConstants.SYSTEM, "LPD-35914");
 
@@ -558,6 +626,21 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			restContextPath,
 			key -> ListUtil.concat(
 				Arrays.asList(
+					_bundleContext.registerService(
+						CollaboratorResource.Factory.class,
+						new CollaboratorResourceFactoryImpl(
+							_companyLocalService,
+							() -> _createCollaboratorResourceImpl(),
+							_defaultPermissionCheckerFactory,
+							_expressionConvert, _filterParserProvider,
+							_groupLocalService, _resourceActionLocalService,
+							_resourcePermissionLocalService, _roleLocalService,
+							_sortParserProvider, _userLocalService),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"resource.locator.key",
+							objectDefinition.getRESTContextPath() + "/" +
+								objectDefinition.getShortName()
+						).build()),
 					_bundleContext.registerService(
 						ContextProvider.class,
 						new ObjectDefinitionContextProvider(this, _portal),
@@ -807,6 +890,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					restContextPath, _applicationPropertiesMap,
 					(Map)_applicationServiceRegistrationsMap);
 				_updateServiceRegistrationProperties(
+					restContextPath, _collaboratorResourcePropertiesMap,
+					(Map)_collaboratorResourceServiceRegistrationsMap);
+				_updateServiceRegistrationProperties(
 					restContextPath, _objectEntryResourcePropertiesMap,
 					(Map)_objectEntryResourceServiceRegistrationsMap);
 			}
@@ -873,6 +959,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		}
 
 		serviceRegistration1 =
+			_collaboratorResourceServiceRegistrationsMap.remove(
+				restContextPath);
+
+		if (serviceRegistration1 != null) {
+			serviceRegistration1.unregister();
+		}
+
+		serviceRegistration1 =
 			_objectEntryResourceServiceRegistrationsMap.remove(restContextPath);
 
 		if (serviceRegistration1 != null) {
@@ -909,6 +1003,19 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private final Map<String, ServiceRegistration<Application>>
 		_applicationServiceRegistrationsMap = new HashMap<>();
 	private BundleContext _bundleContext;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference(
+		target = "(dto.class.name=com.liferay.headless.object.dto.v1_0.Collaborator)"
+	)
+	private DTOConverter<SharingEntry, Collaborator> _collaboratorDTOConverter;
+
+	private final Map<String, Dictionary<String, Object>>
+		_collaboratorResourcePropertiesMap = new HashMap<>();
+	private final Map<String, ServiceRegistration<CollaboratorResource>>
+		_collaboratorResourceServiceRegistrationsMap = new HashMap<>();
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
@@ -1017,11 +1124,20 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_serviceRegistrationsMap = new HashMap<>();
 
 	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private SharingEntryService _sharingEntryService;
+
+	@Reference
 	private SortParserProvider _sortParserProvider;
 
 	@Reference
 	private SystemObjectDefinitionManagerRegistry
 		_systemObjectDefinitionManagerRegistry;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -14,6 +14,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
+import com.liferay.object.rest.internal.resource.v1_0.CollaboratorResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
@@ -432,6 +433,7 @@ public class ObjectEntryOpenAPIResourceImpl
 			openAPISchemaFilter,
 			new HashSet<Class<?>>() {
 				{
+					add(CollaboratorResourceImpl.class);
 					add(ObjectEntryRelatedObjectsResourceImpl.class);
 					add(ObjectEntryResourceImpl.class);
 					add(OpenAPIResourceImpl.class);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -1,0 +1,750 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0;
+
+import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public abstract class BaseCollaboratorResourceImpl
+	implements CollaboratorResource, EntityModelResource,
+			   VulcanBatchEngineTaskItemDelegate
+				   <com.liferay.headless.object.dto.v1_0.Collaborator> {
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborators of an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/{objectEntryId}/collaborators")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			getObjectEntryCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborators of an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/{objectEntryId}/collaborators")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			postObjectEntryCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				com.liferay.headless.object.dto.v1_0.Collaborator[]
+					collaborators)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/{objectEntryId}/collaborators/export-batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postObjectEntryCollaboratorsPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.DefaultValue("JSON")
+			@javax.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				com.liferay.headless.object.dto.v1_0.Collaborator.class.
+					getName(),
+				callbackURL, contentType, fieldNames)
+		).build();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
+			postScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				com.liferay.headless.object.dto.v1_0.Collaborator[]
+					collaborators)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<com.liferay.headless.object.dto.v1_0.Collaborator>
+				collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<com.liferay.headless.object.dto.v1_0.Collaborator>
+				collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getResourceName() {
+		return "Collaborator";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<com.liferay.headless.object.dto.v1_0.Collaborator> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		if (parameters.containsKey("objectEntryId")) {
+			return getObjectEntryCollaboratorsPage(
+				_parseLong((String)parameters.get("objectEntryId")),
+				pagination);
+		}
+		else {
+			throw new NotSupportedException(
+				"One of the following parameters must be specified: [objectEntryId]");
+		}
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<com.liferay.headless.object.dto.v1_0.Collaborator>
+				collaborators,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<com.liferay.headless.object.dto.v1_0.Collaborator>,
+			 UnsafeFunction
+				 <com.liferay.headless.object.dto.v1_0.Collaborator,
+				  com.liferay.headless.object.dto.v1_0.Collaborator, Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<com.liferay.headless.object.dto.v1_0.Collaborator>,
+			 UnsafeConsumer
+				 <com.liferay.headless.object.dto.v1_0.Collaborator, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return null;
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<com.liferay.headless.object.dto.v1_0.Collaborator>,
+		 UnsafeFunction
+			 <com.liferay.headless.object.dto.v1_0.Collaborator,
+			  com.liferay.headless.object.dto.v1_0.Collaborator, Exception>,
+		 Exception> contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<com.liferay.headless.object.dto.v1_0.Collaborator>,
+		 UnsafeConsumer
+			 <com.liferay.headless.object.dto.v1_0.Collaborator, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseCollaboratorResourceImpl.class);
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceFactoryImpl.java
@@ -1,0 +1,321 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0;
+
+import com.liferay.object.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Mikel Lorza
+ */
+public class CollaboratorResourceFactoryImpl
+	implements CollaboratorResource.Factory {
+
+	public CollaboratorResourceFactoryImpl(
+		CompanyLocalService companyLocalService,
+		Supplier<CollaboratorResourceImpl> collaboratorResourceImplSupplier,
+		PermissionCheckerFactory defaultPermissionCheckerFactory,
+		ExpressionConvert<Filter> expressionConvert,
+		FilterParserProvider filterParserProvider,
+		GroupLocalService groupLocalService,
+		ResourceActionLocalService resourceActionLocalService,
+		ResourcePermissionLocalService resourcePermissionLocalService,
+		RoleLocalService roleLocalService,
+		SortParserProvider sortParserProvider,
+		UserLocalService userLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_collaboratorResourceImplSupplier = collaboratorResourceImplSupplier;
+		_defaultPermissionCheckerFactory = defaultPermissionCheckerFactory;
+		_expressionConvert = expressionConvert;
+		_filterParserProvider = filterParserProvider;
+		_groupLocalService = groupLocalService;
+		_resourceActionLocalService = resourceActionLocalService;
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+		_roleLocalService = roleLocalService;
+		_sortParserProvider = sortParserProvider;
+		_userLocalService = userLocalService;
+	}
+
+	@Override
+	public CollaboratorResource.Builder create() {
+		return new CollaboratorResource.Builder() {
+
+			@Override
+			public CollaboratorResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, CollaboratorResource>
+					collaboratorResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_collaboratorResourceProxyProviderFunction;
+
+				return collaboratorResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public CollaboratorResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public CollaboratorResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, CollaboratorResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			CollaboratorResource.class.getClassLoader(),
+			CollaboratorResource.class);
+
+		try {
+			Constructor<CollaboratorResource> constructor =
+				(Constructor<CollaboratorResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		CollaboratorResourceImpl collaboratorResourceImpl =
+			_collaboratorResourceImplSupplier.get();
+
+		collaboratorResourceImpl.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		collaboratorResourceImpl.setContextCompany(
+			_companyLocalService.getCompany(user.getCompanyId()));
+
+		collaboratorResourceImpl.setContextHttpServletRequest(
+			httpServletRequest);
+		collaboratorResourceImpl.setContextHttpServletResponse(
+			httpServletResponse);
+		collaboratorResourceImpl.setContextUriInfo(uriInfo);
+		collaboratorResourceImpl.setContextUser(user);
+		collaboratorResourceImpl.setExpressionConvert(_expressionConvert);
+		collaboratorResourceImpl.setFilterParserProvider(_filterParserProvider);
+		collaboratorResourceImpl.setGroupLocalService(_groupLocalService);
+		collaboratorResourceImpl.setResourceActionLocalService(
+			_resourceActionLocalService);
+		collaboratorResourceImpl.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		collaboratorResourceImpl.setRoleLocalService(_roleLocalService);
+		collaboratorResourceImpl.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(collaboratorResourceImpl, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	private final Supplier<CollaboratorResourceImpl>
+		_collaboratorResourceImplSupplier;
+	private final CompanyLocalService _companyLocalService;
+	private final PermissionCheckerFactory _defaultPermissionCheckerFactory;
+	private final ExpressionConvert<Filter> _expressionConvert;
+	private final FilterParserProvider _filterParserProvider;
+	private final GroupLocalService _groupLocalService;
+	private final ResourceActionLocalService _resourceActionLocalService;
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService;
+	private final RoleLocalService _roleLocalService;
+	private final SortParserProvider _sortParserProvider;
+	private final UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, CollaboratorResource>
+			_collaboratorResourceProxyProviderFunction =
+				_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -44,10 +44,6 @@ import org.osgi.service.component.annotations.ServiceScope;
 /**
  * @author Javier Gamarra
  */
-@Component(
-	properties = "OSGI-INF/liferay/rest/v1_0/collaborator.properties",
-	scope = ServiceScope.PROTOTYPE, service = CollaboratorResource.class
-)
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0;
+
+import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Javier Gamarra
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/collaborator.properties",
+	scope = ServiceScope.PROTOTYPE, service = CollaboratorResource.class
+)
+public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -5,9 +5,40 @@
 
 package com.liferay.object.rest.internal.resource.v1_0;
 
+import com.liferay.headless.object.dto.v1_0.Collaborator;
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
+import com.liferay.sharing.model.SharingEntry;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+import com.liferay.sharing.service.SharingEntryService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -18,4 +49,228 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = CollaboratorResource.class
 )
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
+
+	@Override
+	public Page<Collaborator> getObjectEntryCollaboratorsPage(
+			Long objectEntryId, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _getObjectEntryCollaboratorsPage(
+			_objectEntryLocalService.getObjectEntry(objectEntryId), pagination);
+	}
+
+	@Override
+	public Page<Collaborator>
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _getObjectEntryCollaboratorsPage(
+			_objectEntryLocalService.getObjectEntry(
+				externalReferenceCode, contextCompany.getCompanyId(),
+				_getGroupId(scopeKey)),
+			pagination);
+	}
+
+	@Override
+	public Page<Collaborator> postObjectEntryCollaboratorsPage(
+			Long objectEntryId, Collaborator[] collaborators)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _postObjectEntryCollaboratorsPage(
+			collaborators,
+			_objectEntryLocalService.getObjectEntry(objectEntryId));
+	}
+
+	@Override
+	public Page<Collaborator>
+			postScopeScopeKeyByExternalReferenceCodeCollaboratorsPage(
+				String scopeKey, String externalReferenceCode,
+				Collaborator[] collaborators)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _postObjectEntryCollaboratorsPage(
+			collaborators,
+			_objectEntryLocalService.getObjectEntry(
+				externalReferenceCode, contextCompany.getCompanyId(),
+				_getGroupId(scopeKey)));
+	}
+
+	private SharingEntry _addOrUpdateSharingEntry(
+			long classNameId, long classPK, Collaborator collaborator,
+			long groupId)
+		throws Exception {
+
+		long toUserId = 0;
+		long toUserGroupId = 0;
+
+		if (Objects.equals(Collaborator.Type.USER, collaborator.getType())) {
+			User user = _userLocalService.getUserByExternalReferenceCode(
+				collaborator.getExternalReferenceCode(),
+				contextCompany.getCompanyId());
+
+			toUserId = user.getUserId();
+		}
+		else {
+			UserGroup userGroup =
+				_userGroupLocalService.getUserGroupByExternalReferenceCode(
+					collaborator.getExternalReferenceCode(),
+					contextCompany.getCompanyId());
+
+			toUserGroupId = userGroup.getUserGroupId();
+		}
+
+		boolean shareable = false;
+
+		if (collaborator.getShare() != null) {
+			shareable = collaborator.getShare();
+		}
+
+		return _sharingEntryService.addOrUpdateSharingEntry(
+			null, toUserGroupId, toUserId, classNameId, classPK, groupId,
+			shareable,
+			transformToList(
+				collaborator.getActionIds(),
+				SharingEntryAction::parseFromActionId),
+			collaborator.getDateExpired(), new ServiceContext());
+	}
+
+	private long _getGroupId(String scopeKey) throws Exception {
+		Long groupId = GroupUtil.getGroupId(
+			contextCompany.getCompanyId(), scopeKey, _groupLocalService);
+
+		if (groupId != null) {
+			return groupId;
+		}
+
+		if (Objects.equals(scopeKey, "0")) {
+			return 0;
+		}
+
+		throw new NoSuchGroupException();
+	}
+
+	private Page<Collaborator> _getObjectEntryCollaboratorsPage(
+		ObjectEntry objectEntry, Pagination pagination) {
+
+		long classNameId = _classNameLocalService.getClassNameId(
+			objectEntry.getModelClassName());
+
+		return Page.of(
+			transform(
+				_sharingEntryLocalService.getSharingEntries(
+					classNameId, objectEntry.getObjectEntryId(),
+					pagination.getStartPosition(), pagination.getEndPosition()),
+				this::_toCollaborator),
+			pagination,
+			_sharingEntryLocalService.getSharingEntriesCount(
+				classNameId, objectEntry.getObjectEntryId()));
+	}
+
+	private Page<Collaborator> _postObjectEntryCollaboratorsPage(
+			Collaborator[] collaborators, ObjectEntry objectEntry)
+		throws Exception {
+
+		return _postObjectEntryCollaboratorsPage(
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborators,
+			objectEntry.getGroupId());
+	}
+
+	private Page<Collaborator> _postObjectEntryCollaboratorsPage(
+			long classNameId, long classPK, Collaborator[] collaborators,
+			long groupId)
+		throws Exception {
+
+		List<SharingEntry> oldSharingEntries =
+			_sharingEntryService.getSharingEntries(
+				classNameId, classPK, groupId, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		List<SharingEntry> newSharingEntries = new ArrayList<>();
+
+		List<Long> sharingEntriesIds = new ArrayList<>();
+
+		for (Collaborator collaborator : collaborators) {
+			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, groupId);
+
+			newSharingEntries.add(sharingEntry);
+			sharingEntriesIds.add(sharingEntry.getSharingEntryId());
+		}
+
+		for (SharingEntry sharingEntry : oldSharingEntries) {
+			if (!sharingEntriesIds.contains(sharingEntry.getSharingEntryId())) {
+				_sharingEntryService.deleteSharingEntry(sharingEntry);
+			}
+		}
+
+		return Page.of(transform(newSharingEntries, this::_toCollaborator));
+	}
+
+	private Collaborator _toCollaborator(SharingEntry sharingEntry)
+		throws Exception {
+
+		return _collaboratorDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), new HashMap<>(),
+				_dtoConverterRegistry, sharingEntry.getSharingEntryId(),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			sharingEntry);
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.object.rest.internal.dto.v1_0.converter.CollaboratorDTOConverter)"
+	)
+	private DTOConverter<SharingEntry, Collaborator> _collaboratorDTOConverter;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@Reference
+	private SharingEntryService _sharingEntryService;
+
+	@Reference
+	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -7,10 +7,7 @@ package com.liferay.object.rest.internal.resource.v1_0;
 
 import com.liferay.headless.object.dto.v1_0.Collaborator;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.rest.resource.v1_0.CollaboratorResource;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -37,14 +34,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ServiceScope;
-
 /**
- * @author Javier Gamarra
+ * @author Mikel Lorza
  */
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
+
+	public CollaboratorResourceImpl(
+		ClassNameLocalService classNameLocalService,
+		DTOConverter<SharingEntry, Collaborator> collaboratorDTOConverter,
+		DTOConverterRegistry dtoConverterRegistry,
+		GroupLocalService groupLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
+		SharingEntryService sharingEntryService,
+		SharingEntryLocalService sharingEntryLocalService,
+		UserGroupLocalService userGroupLocalService,
+		UserLocalService userLocalService) {
+
+		_classNameLocalService = classNameLocalService;
+		_collaboratorDTOConverter = collaboratorDTOConverter;
+		_dtoConverterRegistry = dtoConverterRegistry;
+		_groupLocalService = groupLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
+		_sharingEntryService = sharingEntryService;
+		_sharingEntryLocalService = sharingEntryLocalService;
+		_userGroupLocalService = userGroupLocalService;
+		_userLocalService = userLocalService;
+	}
 
 	@Override
 	public Page<Collaborator> getObjectEntryCollaboratorsPage(
@@ -234,39 +249,15 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			sharingEntry);
 	}
 
-	@Reference
-	private ClassNameLocalService _classNameLocalService;
-
-	@Reference(
-		target = "(component.name=com.liferay.object.rest.internal.dto.v1_0.converter.CollaboratorDTOConverter)"
-	)
-	private DTOConverter<SharingEntry, Collaborator> _collaboratorDTOConverter;
-
-	@Reference
-	private DTOConverterRegistry _dtoConverterRegistry;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
-
-	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Reference
-	private ObjectEntryService _objectEntryService;
-
-	@Reference
-	private SharingEntryLocalService _sharingEntryLocalService;
-
-	@Reference
-	private SharingEntryService _sharingEntryService;
-
-	@Reference
-	private UserGroupLocalService _userGroupLocalService;
-
-	@Reference
-	private UserLocalService _userLocalService;
+	private final ClassNameLocalService _classNameLocalService;
+	private final DTOConverter<SharingEntry, Collaborator>
+		_collaboratorDTOConverter;
+	private final DTOConverterRegistry _dtoConverterRegistry;
+	private final GroupLocalService _groupLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final SharingEntryLocalService _sharingEntryLocalService;
+	private final SharingEntryService _sharingEntryService;
+	private final UserGroupLocalService _userGroupLocalService;
+	private final UserLocalService _userLocalService;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collaborator.properties
+++ b/modules/apps/object/object-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/collaborator.properties
@@ -1,0 +1,11 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.headless.object.dto.v1_0.Collaborator
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.headless.object.dto.v1_0.Collaborator
+osgi.jaxrs.resource=true

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -28,5 +28,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationImplementation project(":apps:headless:headless-delivery:headless-delivery-api")
+	testIntegrationImplementation project(":apps:headless:headless-object:headless-object-api")
 	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-api")
 	testIntegrationImplementation project(":apps:object:object-admin-rest-api")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -1,0 +1,395 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@FeatureFlags("LPD-17564")
+@RunWith(Arquillian.class)
+public class CollaboratorResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_objectDefinition = _getObjectDefinition();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_users.clear();
+		_userGroups.clear();
+	}
+
+	@Test
+	public void testGetObjectEntryCollaboratorsPage() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			_getUserCollaboratorJSONObject(),
+			_getUserGroupCollaboratorJSONObject(),
+			_getUserCollaboratorJSONObject());
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonArray.toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), _COLLABORATORS),
+			Http.Method.POST);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), _COLLABORATORS),
+			Http.Method.GET);
+
+		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testGetScopeScopeKeyByExternalReferenceCodeCollaboratorsPage()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			_getUserCollaboratorJSONObject(),
+			_getUserGroupCollaboratorJSONObject());
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonArray.toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), _COLLABORATORS),
+			Http.Method.POST);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), _SCOPES,
+				_group.getGroupId(), _BY_EXTERNAL_REFERENCE_CODE,
+				objectEntry.getExternalReferenceCode(), _COLLABORATORS),
+			Http.Method.GET);
+
+		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testPostObjectEntryCollaboratorsPage() throws Exception {
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			_getUserCollaboratorJSONObject(),
+			_getUserGroupCollaboratorJSONObject(),
+			_getUserCollaboratorJSONObject());
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			jsonArray.toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), _COLLABORATORS),
+			Http.Method.POST);
+
+		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testPostScopeScopeKeyByExternalReferenceCodeCollaboratorsPage()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			_getUserCollaboratorJSONObject(),
+			_getUserGroupCollaboratorJSONObject(),
+			_getUserCollaboratorJSONObject(),
+			_getUserGroupCollaboratorJSONObject());
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			jsonArray.toString(),
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), _SCOPES,
+				_group.getGroupId(), _BY_EXTERNAL_REFERENCE_CODE,
+				objectEntry.getExternalReferenceCode(), _COLLABORATORS),
+			Http.Method.POST);
+
+		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	private static ObjectDefinition _getObjectDefinition() throws Exception {
+		return ObjectDefinitionTestUtil.publishObjectDefinition(
+			true, ObjectDefinitionTestUtil.getRandomName(),
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).indexed(
+					true
+				).indexedAsKeyword(
+					true
+				).name(
+					"title"
+				).localized(
+					false
+				).build()),
+			ObjectDefinitionConstants.SCOPE_SITE, TestPropsValues.getUserId());
+	}
+
+	private ObjectEntry _addObjectEntry() throws Exception {
+		return _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _assertContains(
+		JSONArray actualJSONArray, JSONObject expectedJSONObject) {
+
+		boolean contains = false;
+
+		for (int i = 0; i < actualJSONArray.length(); i++) {
+			JSONObject actualJSONObject = actualJSONArray.getJSONObject(i);
+
+			if (_equals(actualJSONObject, expectedJSONObject)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			actualJSONArray + " does not contain " + expectedJSONObject,
+			contains);
+	}
+
+	private void _assertEquals(
+		JSONArray actualJSONArray, JSONArray expectedJSONArray) {
+
+		Assert.assertEquals(
+			expectedJSONArray.length(), actualJSONArray.length());
+
+		for (int i = 0; i < expectedJSONArray.length(); i++) {
+			_assertContains(
+				actualJSONArray, expectedJSONArray.getJSONObject(i));
+		}
+	}
+
+	private boolean _equals(JSONObject jsonObject1, JSONObject jsonObject2) {
+		for (String assertFieldName : _ASSERT_FIELD_NAMES) {
+			if (Objects.equals(assertFieldName, "actionIds")) {
+				if (!JSONUtil.equals(
+						jsonObject1.getJSONArray("actionIds"),
+						jsonObject2.getJSONArray("actionIds"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(assertFieldName, "externalReferenceCode")) {
+				if (!StringUtil.equals(
+						jsonObject1.getString("externalReferenceCode"),
+						jsonObject2.getString("externalReferenceCode"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(assertFieldName, "name")) {
+				if (!StringUtil.equals(
+						jsonObject1.getString("name"),
+						jsonObject2.getString("name"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(assertFieldName, "share")) {
+				if (!jsonObject1.getBoolean("share") == jsonObject2.getBoolean(
+						"share")) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(assertFieldName, "type") &&
+				!StringUtil.equals(
+					jsonObject1.getString("type"),
+					jsonObject2.getString("type"))) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private User _getUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		_users.add(user);
+
+		return user;
+	}
+
+	private JSONObject _getUserCollaboratorJSONObject() throws Exception {
+		User user = _getUser();
+
+		return JSONUtil.put(
+			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
+		).put(
+			"externalReferenceCode", user.getExternalReferenceCode()
+		).put(
+			"name", user.getFullName()
+		).put(
+			"share", true
+		).put(
+			"type", "User"
+		);
+	}
+
+	private UserGroup _getUserGroup() throws Exception {
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroups.add(userGroup);
+
+		return userGroup;
+	}
+
+	private JSONObject _getUserGroupCollaboratorJSONObject() throws Exception {
+		UserGroup userGroup = _getUserGroup();
+
+		return JSONUtil.put(
+			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
+		).put(
+			"externalReferenceCode", userGroup.getExternalReferenceCode()
+		).put(
+			"name", userGroup.getName()
+		).put(
+			"share", true
+		).put(
+			"type", "UserGroup"
+		);
+	}
+
+	private static final String[] _ASSERT_FIELD_NAMES = {
+		"actionIds", "externalReferenceCode", "name", "share", "type"
+	};
+
+	private static final String _BY_EXTERNAL_REFERENCE_CODE =
+		"/by-external-reference-code/";
+
+	private static final String _COLLABORATORS = "/collaborators";
+
+	private static final String _SCOPES = "/scopes/";
+
+	private static ObjectDefinition _objectDefinition;
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	@DeleteAfterTestRun
+	private List<UserGroup> _userGroups = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private List<User> _users = new ArrayList<>();
+
+}

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
@@ -19,6 +19,7 @@ import com.liferay.sharing.security.permission.SharingEntryAction;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -103,6 +104,9 @@ public interface SharingEntryService extends BaseService {
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException;
 
+	public SharingEntry deleteSharingEntry(SharingEntry sharingEntry)
+		throws PortalException;
+
 	public SharingEntry deleteSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException;
@@ -118,6 +122,11 @@ public interface SharingEntryService extends BaseService {
 	 * @return the OSGi service identifier
 	 */
 	public String getOSGiServiceIdentifier();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<SharingEntry> getSharingEntries(
+			long classNameId, long classPK, long groupId, int start, int end)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SharingEntry getSharingEntry(long sharingEntryId)

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
@@ -9,6 +9,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.sharing.model.SharingEntry;
 
+import java.util.List;
+
 /**
  * Provides the remote service utility for SharingEntry. This utility wraps
  * <code>com.liferay.sharing.service.impl.SharingEntryServiceImpl</code> and is an
@@ -108,6 +110,12 @@ public class SharingEntryServiceUtil {
 		return getService().deleteSharingEntry(sharingEntryId, serviceContext);
 	}
 
+	public static SharingEntry deleteSharingEntry(SharingEntry sharingEntry)
+		throws PortalException {
+
+		return getService().deleteSharingEntry(sharingEntry);
+	}
+
 	public static SharingEntry deleteSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {
@@ -131,6 +139,14 @@ public class SharingEntryServiceUtil {
 	 */
 	public static String getOSGiServiceIdentifier() {
 		return getService().getOSGiServiceIdentifier();
+	}
+
+	public static List<SharingEntry> getSharingEntries(
+			long classNameId, long classPK, long groupId, int start, int end)
+		throws PortalException {
+
+		return getService().getSharingEntries(
+			classNameId, classPK, groupId, start, end);
 	}
 
 	public static SharingEntry getSharingEntry(long sharingEntryId)

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
@@ -109,6 +109,14 @@ public class SharingEntryServiceWrapper
 	}
 
 	@Override
+	public com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			com.liferay.sharing.model.SharingEntry sharingEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.deleteSharingEntry(sharingEntry);
+	}
+
+	@Override
 	public com.liferay.sharing.model.SharingEntry
 			deleteSharingEntryByExternalReferenceCode(
 				String externalReferenceCode, long groupId)
@@ -136,6 +144,17 @@ public class SharingEntryServiceWrapper
 	@Override
 	public String getOSGiServiceIdentifier() {
 		return _sharingEntryService.getOSGiServiceIdentifier();
+	}
+
+	@Override
+	public java.util.List<com.liferay.sharing.model.SharingEntry>
+			getSharingEntries(
+				long classNameId, long classPK, long groupId, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.getSharingEntries(
+			classNameId, classPK, groupId, start, end);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
@@ -181,6 +181,47 @@ public class SharingEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			HttpPrincipal httpPrincipal,
+			com.liferay.sharing.model.SharingEntry sharingEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "deleteSharingEntry",
+				_deleteSharingEntryParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, sharingEntry);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.sharing.model.SharingEntry
 			deleteSharingEntryByExternalReferenceCode(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
@@ -191,7 +232,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"deleteSharingEntryByExternalReferenceCode",
-				_deleteSharingEntryByExternalReferenceCodeParameterTypes3);
+				_deleteSharingEntryByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -234,7 +275,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"fetchSharingEntryByExternalReferenceCode",
-				_fetchSharingEntryByExternalReferenceCodeParameterTypes4);
+				_fetchSharingEntryByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -267,6 +308,49 @@ public class SharingEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.sharing.model.SharingEntry>
+			getSharingEntries(
+				HttpPrincipal httpPrincipal, long classNameId, long classPK,
+				long groupId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "getSharingEntries",
+				_getSharingEntriesParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, classNameId, classPK, groupId, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<com.liferay.sharing.model.SharingEntry>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.sharing.model.SharingEntry getSharingEntry(
 			HttpPrincipal httpPrincipal, long sharingEntryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -274,7 +358,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "getSharingEntry",
-				_getSharingEntryParameterTypes5);
+				_getSharingEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId);
@@ -317,7 +401,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"getSharingEntryByExternalReferenceCode",
-				_getSharingEntryByExternalReferenceCodeParameterTypes6);
+				_getSharingEntryByExternalReferenceCodeParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -362,7 +446,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "updateSharingEntry",
-				_updateSharingEntryParameterTypes7);
+				_updateSharingEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, sharingEntryActions, shareable,
@@ -417,20 +501,24 @@ public class SharingEntryServiceHttp {
 		new Class[] {
 			long.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
+	private static final Class<?>[] _deleteSharingEntryParameterTypes3 =
+		new Class[] {com.liferay.sharing.model.SharingEntry.class};
 	private static final Class<?>[]
-		_deleteSharingEntryByExternalReferenceCodeParameterTypes3 =
+		_deleteSharingEntryByExternalReferenceCodeParameterTypes4 =
 			new Class[] {String.class, long.class};
 	private static final Class<?>[]
-		_fetchSharingEntryByExternalReferenceCodeParameterTypes4 = new Class[] {
+		_fetchSharingEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getSharingEntryParameterTypes5 =
+	private static final Class<?>[] _getSharingEntriesParameterTypes6 =
+		new Class[] {long.class, long.class, long.class, int.class, int.class};
+	private static final Class<?>[] _getSharingEntryParameterTypes7 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getSharingEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
+		_getSharingEntryByExternalReferenceCodeParameterTypes8 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _updateSharingEntryParameterTypes7 =
+	private static final Class<?>[] _updateSharingEntryParameterTypes9 =
 		new Class[] {
 			long.class, java.util.Collection.class, boolean.class,
 			java.util.Date.class,

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.sharing.service.base.SharingEntryServiceBaseImpl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -178,6 +179,18 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 		}
 
 		return sharingEntry;
+	}
+
+	@Override
+	public List<SharingEntry> getSharingEntries(
+			long classNameId, long classPK, long groupId, int start, int end)
+		throws PortalException {
+
+		sharingPermission.checkSharePermission(
+			getPermissionChecker(), classNameId, classPK, groupId);
+
+		return sharingEntryLocalService.getSharingEntries(
+			classNameId, classPK, start, end);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -125,14 +125,8 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
-		SharingEntry sharingEntry = sharingEntryLocalService.getSharingEntry(
-			sharingEntryId);
-
-		sharingPermission.checkManageCollaboratorsPermission(
-			getPermissionChecker(), sharingEntry.getClassNameId(),
-			sharingEntry.getClassPK(), sharingEntry.getGroupId());
-
-		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+		return deleteSharingEntry(
+			sharingEntryLocalService.getSharingEntry(sharingEntryId));
 	}
 
 	@Override
@@ -151,15 +145,9 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
-		SharingEntry sharingEntry =
+		return deleteSharingEntry(
 			sharingEntryLocalService.getSharingEntryByExternalReferenceCode(
-				externalReferenceCode, groupId);
-
-		sharingPermission.checkManageCollaboratorsPermission(
-			getPermissionChecker(), sharingEntry.getClassNameId(),
-			sharingEntry.getClassPK(), sharingEntry.getGroupId());
-
-		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+				externalReferenceCode, groupId));
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -135,6 +135,17 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 	}
 
 	@Override
+	public SharingEntry deleteSharingEntry(SharingEntry sharingEntry)
+		throws PortalException {
+
+		sharingPermission.checkManageCollaboratorsPermission(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId());
+
+		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+	}
+
+	@Override
 	public SharingEntry deleteSharingEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId)
 		throws PortalException {

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/service/test/SharingEntryServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.sharing.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
@@ -42,6 +43,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -499,6 +501,18 @@ public class SharingEntryServiceTest {
 		Assert.assertNull(
 			_sharingEntryLocalService.fetchSharingEntry(
 				sharingEntry.getSharingEntryId()));
+
+		sharingEntry = _sharingEntryLocalService.addSharingEntry(
+			null, _fromUser.getUserId(), 0, _toUser.getUserId(), _classNameId,
+			_group.getGroupId(), _group.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			_serviceContext);
+
+		_sharingEntryService.deleteSharingEntry(sharingEntry);
+
+		Assert.assertNull(
+			_sharingEntryLocalService.fetchSharingEntry(
+				sharingEntry.getSharingEntryId()));
 	}
 
 	@Test
@@ -533,6 +547,40 @@ public class SharingEntryServiceTest {
 
 		_sharingEntryService.deleteSharingEntryByExternalReferenceCode(
 			RandomTestUtil.randomString(), _group.getGroupId());
+	}
+
+	@Test
+	public void testGetSharingEntries() throws Exception {
+		_registerSharingPermissionChecker(SharingEntryAction.VIEW);
+
+		User user1 = UserTestUtil.addUser();
+
+		SharingEntry sharingEntry1 = _sharingEntryLocalService.addSharingEntry(
+			null, _fromUser.getUserId(), 0, user1.getUserId(), _classNameId,
+			_group.getGroupId(), _group.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			_serviceContext);
+
+		User user2 = UserTestUtil.addUser();
+
+		SharingEntry sharingEntry2 = _sharingEntryLocalService.addSharingEntry(
+			null, _fromUser.getUserId(), 0, user2.getUserId(), _classNameId,
+			_group.getGroupId(), _group.getGroupId(), false,
+			Collections.singletonList(SharingEntryAction.VIEW), null,
+			_serviceContext);
+
+		List<SharingEntry> sharingEntries =
+			_sharingEntryService.getSharingEntries(
+				_classNameId, _group.getGroupId(), _group.getGroupId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertEquals(
+			sharingEntries.toString(), 2, sharingEntries.size());
+
+		Assert.assertTrue(
+			sharingEntries.toString(), sharingEntries.contains(sharingEntry1));
+		Assert.assertTrue(
+			sharingEntries.toString(), sharingEntries.contains(sharingEntry2));
 	}
 
 	@Test(expected = PrincipalException.class)


### PR DESCRIPTION
**Note: only review commits from LPD-49727, I put this on hold until LPD-51800  LPD-51094 are on master.**

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52010

# How am I fixing it?

Add headless apis to share an asset to a user or a user groupd and also to list them when the sharing entry component is used. So, this PR contribute the apis to use in the following views: https://www.figma.com/design/Pfcjoa2vMlr2JYB93ZEnjk/LPD-32645-Content-Sharing?node-id=328-5863&p=f&t=eLq0uRoycPf8GJs8-0.

# How can you verify that it works?

Run included tests