### PR TITLE
LPD-51619 Technical Task | Create CMS Consumer role

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 7.1.1
+Bundle-Version: 7.2.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
@@ -23,4 +23,6 @@ public class DepotRolesConstants {
 
 	public static final String ASSET_LIBRARY_OWNER = "Asset Library Owner";
 
+	public static final String CMS_CONSUMER = "CMS Consumer";
+
 }

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
@@ -91,7 +91,8 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 				role.getName(),
 				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
 			Objects.equals(
-				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER)) {
+				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER) ||
+			Objects.equals(role.getName(), DepotRolesConstants.CMS_CONSUMER)) {
 
 			return false;
 		}
@@ -105,7 +106,8 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 				role.getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER) ||
 			Objects.equals(
 				role.getName(),
-				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER)) {
+				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
+			Objects.equals(role.getName(), DepotRolesConstants.CMS_CONSUMER)) {
 
 			return true;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
@@ -46,36 +46,41 @@ public class DepotRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
-			if (!group.isDepot()) {
-				return;
-			}
+			if (group.isDepot()) {
+				UserBag userBag = roleCollection.getUserBag();
 
-			UserBag userBag = roleCollection.getUserBag();
-
-			if (userBag.hasUserGroup(group) ||
-				_hasInheritedMemberships(group.getGroupId(), userBag)) {
-
-				_addRoleId(
-					roleCollection, DepotRolesConstants.ASSET_LIBRARY_MEMBER);
-			}
-
-			List<DepotEntryGroupRel> depotEntryGroupRels =
-				_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-					_depotEntryLocalService.getGroupDepotEntry(
-						group.getGroupId()));
-
-			for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
-				if (userBag.hasUserGroup(
-						_groupLocalService.getGroup(
-							depotEntryGroupRel.getToGroupId()))) {
+				if (userBag.hasUserGroup(group) ||
+					_hasInheritedMemberships(group.getGroupId(), userBag)) {
 
 					_addRoleId(
 						roleCollection,
-						DepotRolesConstants.
-							ASSET_LIBRARY_CONNECTED_SITE_MEMBER);
-
-					break;
+						DepotRolesConstants.ASSET_LIBRARY_MEMBER);
 				}
+
+				List<DepotEntryGroupRel> depotEntryGroupRels =
+					_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+						_depotEntryLocalService.getGroupDepotEntry(
+							group.getGroupId()));
+
+				for (DepotEntryGroupRel depotEntryGroupRel :
+						depotEntryGroupRels) {
+
+					if (userBag.hasUserGroup(
+							_groupLocalService.getGroup(
+								depotEntryGroupRel.getToGroupId()))) {
+
+						_addRoleId(
+							roleCollection,
+							DepotRolesConstants.
+								ASSET_LIBRARY_CONNECTED_SITE_MEMBER);
+
+						break;
+					}
+				}
+			}
+
+			if (group.isCMS()) {
+				_addRoleId(roleCollection, DepotRolesConstants.CMS_CONSUMER);
 			}
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
@@ -10,6 +10,7 @@ import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -79,7 +80,10 @@ public class DepotRoleContributor implements RoleContributor {
 				}
 			}
 
-			if (group.isCMS()) {
+			if (FeatureFlagManagerUtil.isEnabled(
+					group.getCompanyId(), "LPD-17564") &&
+				group.isCMS()) {
+
 				_addRoleId(roleCollection, DepotRolesConstants.CMS_CONSUMER);
 			}
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -126,11 +127,16 @@ public class DepotRoleUtil {
 	}
 
 	private static String _getTitle(Locale locale, String name) {
+		String title = _titleKeys.get(name);
+
+		if (Validator.isNull(title)) {
+			return name;
+		}
+
 		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
 			locale, DepotRolesPortalInstanceLifecycleListener.class);
 
-		return ResourceBundleUtil.getString(
-			resourceBundle, _titleKeys.get(name));
+		return ResourceBundleUtil.getString(resourceBundle, title);
 	}
 
 	private static final Map<String, String> _titleKeys;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
@@ -29,7 +29,8 @@ public class DepotRoleUtil {
 		DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER,
 		DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
 		DepotRolesConstants.ASSET_LIBRARY_MEMBER,
-		DepotRolesConstants.ASSET_LIBRARY_OWNER
+		DepotRolesConstants.ASSET_LIBRARY_OWNER,
+		DepotRolesConstants.CMS_CONSUMER
 	};
 
 	public static Map<Locale, String> getDescriptionMap(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -56,6 +57,7 @@ public class DepotRoleContributorTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
+	@FeatureFlags("LPD-17564")
 	@Test
 	public void testCMSConsumerRoleAssignment() throws Exception {
 		Group group = GroupTestUtil.addGroup(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -12,6 +12,7 @@ import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.test.util.DepotTestUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -52,6 +54,29 @@ public class DepotRoleContributorTest {
 		_depotEntry = _addDepotEntry();
 
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testCMSConsumerRoleAssignment() throws Exception {
+		Group group = GroupTestUtil.addGroup(
+			_group.getCompanyId(), TestPropsValues.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+
+		DepotTestUtil.withSiteMember(
+			group,
+			user -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				long[] roleIds = permissionChecker.getRoleIds(
+					user.getUserId(), group.getGroupId());
+
+				Role role = _roleLocalService.getRole(
+					_group.getCompanyId(), DepotRolesConstants.CMS_CONSUMER);
+
+				Assert.assertTrue(
+					ArrayUtil.contains(roleIds, role.getRoleId()));
+			});
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/test/util/DepotTestUtil.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/test/util/DepotTestUtil.java
@@ -139,7 +139,7 @@ public class DepotTestUtil {
 			group.getGroupId(), RoleConstants.SITE_MEMBER, unsafeConsumer);
 	}
 
-	private static boolean _isAsignableRole(String roleName) {
+	private static boolean _isAssignableRole(String roleName) {
 		if (roleName.equals(DepotRolesConstants.ASSET_LIBRARY_MEMBER) ||
 			roleName.equals(RoleConstants.SITE_MEMBER)) {
 
@@ -159,7 +159,7 @@ public class DepotTestUtil {
 
 		User user = UserTestUtil.addUser();
 
-		if (_isAsignableRole(roleName)) {
+		if (_isAssignableRole(roleName)) {
 			UserGroupRoleLocalServiceUtil.addUserGroupRoles(
 				user.getUserId(), groupId, new long[] {role.getRoleId()});
 		}
@@ -167,7 +167,7 @@ public class DepotTestUtil {
 		UserLocalServiceUtil.addGroupUsers(
 			groupId, new long[] {user.getUserId()});
 
-		if (_isAsignableRole(roleName)) {
+		if (_isAssignableRole(roleName)) {
 			UserLocalServiceUtil.addRoleUser(role.getRoleId(), user);
 		}
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
@@ -378,7 +378,9 @@ public class DepotAdminSelectRoleDisplayContext {
 							role.getName()) &&
 						!Objects.equals(
 							DepotRolesConstants.ASSET_LIBRARY_MEMBER,
-							role.getName()));
+							role.getName()) &&
+						!Objects.equals(
+							DepotRolesConstants.CMS_CONSUMER, role.getName()));
 			}
 
 			if (!GroupPermissionUtil.contains(
@@ -402,6 +404,8 @@ public class DepotAdminSelectRoleDisplayContext {
 					!Objects.equals(
 						DepotRolesConstants.ASSET_LIBRARY_OWNER,
 						role.getName()) &&
+					!Objects.equals(
+						DepotRolesConstants.CMS_CONSUMER, role.getName()) &&
 					RolePermissionUtil.contains(
 						permissionChecker, _group.getGroupId(),
 						role.getRoleId(), ActionKeys.ASSIGN_MEMBERS));


### PR DESCRIPTION
LPD-51619 Technical Task | Create CMS Consumer role

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40060

As a Role Administrator I want to be able to have an out-of-the-box CMS Consumer role so that I don’t need to create them from scratch

# How am I fixing it?

Creating the role on the asset library section (soon Space) and adding a little functionality to see it.

# How can you verify that it works?

Run the included automated tests.


# Commits


- **LPD-51619 add new role for CMS Consumer**
- **LPD-51619 new role is automatically assigned**
- **LPD-51619 add role if group is cms**
- **LPD-51619 add new role on the list with the asset library / space roles**
- **LPD-51619 if there is no title returns the name as before**
- **LPD-51619 DepotRoleContributor.java**
- **LPD-51619 baseline**
- **LPD-51619 do not show the new role on the selector of asset/library roles of the user**
- **LPD-51619 add simple test to check that if the group is cms the role is automatically added.**
