### PR TITLE
LPD-52521 Auto translated non-html fields output remain unescaped.

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -192,18 +192,10 @@ const Translate = ({
 					dispatch({
 						payload: Object.entries(fields).reduce(
 							(acc, [id, content]) => {
-								let contentData;
-								if (
-									html &&
-									sourceFields[id].html === html[id]
-								) {
-									contentData = content;
-								}
-								else {
-									contentData = unescapeHTML(content);
-								}
 								acc[id] = {
-									content: contentData,
+									content: html?.[id]
+										? content
+										: unescapeHTML(content),
 								};
 
 								return acc;
@@ -257,20 +249,13 @@ const Translate = ({
 					throw error;
 				}
 
-				let contentData;
-
-				if (html && sourceFields[fieldId].html === html[fieldId]) {
-					contentData = fields[fieldId];
-				}
-				else {
-					contentData = unescapeHTML(fields[fieldId]);
-				}
-
 				if (isMounted()) {
 					dispatch({
 						payload: {
 							field: {
-								content: contentData,
+								content: html?.[fieldId]
+									? fields[fieldId]
+									: unescapeHTML(fields[fieldId]),
 								message:
 									Liferay.Language.get('field-translated'),
 								status: FETCH_STATUS.SUCCESS,

--- a/modules/apps/translation/translation-web/test/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/test/js/translate/Translate.js
@@ -45,6 +45,18 @@ const baseProps = {
 					targetContentDir: 'ltr',
 					targetLanguageId: 'es_ES',
 				},
+				{
+					targetContentDir: 'ltr',
+					targetContent: ['mock text'],
+					sourceContent: ['mock text'],
+					multiline: false,
+					html: false,
+					editorConfiguration: null,
+					id: 'infoField--text--',
+					label: 'Text',
+					sourceContentDir: 'ltr',
+					targetLanguageId: 'es_ES',
+				},
 			],
 			legend: 'Basic Information',
 		},
@@ -199,6 +211,8 @@ describe('Translate', () => {
 							'<p>campo repetible de fuente simulada 2</p>',
 						'infoField--repeteableContent--2':
 							'<p>campo repetible de fuente simulada 3</p>',
+						'infoField--text--0':
+							'Esto es un &quot;texto de ejemplo&quot;',
 						'infoField--title--0': 'título simulado&#39;',
 					},
 					sourceLanguageId: 'en_US',
@@ -250,11 +264,21 @@ describe('Translate', () => {
 
 			// LPS-133164
 
-			it('updates the input with the translated message with HTML unescaped character', () => {
+			it.only('updates the input of a non-html field with the translated message with unescaped characters', () => {
 				const {getByDisplayValue} = result;
 
 				expect(
 					getByDisplayValue("título simulado'")
+				).toBeInTheDocument();
+			});
+
+			// LPD-52521
+
+			it.only('updates the input with the translated message with HTML unescaped character', () => {
+				const {getByDisplayValue} = result;
+
+				expect(
+					getByDisplayValue('Esto es un "texto de ejemplo"')
 				).toBeInTheDocument();
 			});
 


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-52521   Auto translated non-html fields output remain unescaped.
### How am I fixing it?
Fixing the existing condition that avoided text fields to be unescaped as other fields do.
### How can you verify that it works?
1. Running the test