### PR TITLE
LPD-52521 Auto translated non-html fields output remain unescaped.

### DIFF
--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/Translate.js
@@ -192,18 +192,10 @@ const Translate = ({
 					dispatch({
 						payload: Object.entries(fields).reduce(
 							(acc, [id, content]) => {
-								let contentData;
-								if (
-									html &&
-									sourceFields[id].html === html[id]
-								) {
-									contentData = content;
-								}
-								else {
-									contentData = unescapeHTML(content);
-								}
 								acc[id] = {
-									content: contentData,
+									content: html?.[id]
+										? content
+										: unescapeHTML(content),
 								};
 
 								return acc;
@@ -257,20 +249,13 @@ const Translate = ({
 					throw error;
 				}
 
-				let contentData;
-
-				if (html && sourceFields[fieldId].html === html[fieldId]) {
-					contentData = fields[fieldId];
-				}
-				else {
-					contentData = unescapeHTML(fields[fieldId]);
-				}
-
 				if (isMounted()) {
 					dispatch({
 						payload: {
 							field: {
-								content: contentData,
+								content: html?.[fieldId]
+									? fields[fieldId]
+									: unescapeHTML(fields[fieldId]),
 								message:
 									Liferay.Language.get('field-translated'),
 								status: FETCH_STATUS.SUCCESS,

--- a/modules/apps/translation/translation-web/test/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/test/js/translate/Translate.js
@@ -45,6 +45,18 @@ const baseProps = {
 					targetContentDir: 'ltr',
 					targetLanguageId: 'es_ES',
 				},
+				{
+					editorConfiguration: null,
+					html: false,
+					id: 'infoField--text--',
+					label: 'Text',
+					multiline: false,
+					sourceContent: ['mock text'],
+					sourceContentDir: 'ltr',
+					targetContent: ['mock text'],
+					targetContentDir: 'ltr',
+					targetLanguageId: 'es_ES',
+				},
 			],
 			legend: 'Basic Information',
 		},
@@ -199,6 +211,8 @@ describe('Translate', () => {
 							'<p>campo repetible de fuente simulada 2</p>',
 						'infoField--repeteableContent--2':
 							'<p>campo repetible de fuente simulada 3</p>',
+						'infoField--text--0':
+							'Esto es un &quot;texto de ejemplo&quot;',
 						'infoField--title--0': 'título simulado&#39;',
 					},
 					sourceLanguageId: 'en_US',
@@ -250,11 +264,21 @@ describe('Translate', () => {
 
 			// LPS-133164
 
-			it('updates the input with the translated message with HTML unescaped character', () => {
+			it('updates the input of a non-html field with the translated message with unescaped characters', () => {
 				const {getByDisplayValue} = result;
 
 				expect(
 					getByDisplayValue("título simulado'")
+				).toBeInTheDocument();
+			});
+
+			// LPD-52521
+
+			it('updates the input with the translated message with HTML unescaped character', () => {
+				const {getByDisplayValue} = result;
+
+				expect(
+					getByDisplayValue('Esto es un "texto de ejemplo"')
 				).toBeInTheDocument();
 			});
 

--- a/modules/apps/translation/translation-web/test/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/test/js/translate/Translate.js
@@ -45,18 +45,6 @@ const baseProps = {
 					targetContentDir: 'ltr',
 					targetLanguageId: 'es_ES',
 				},
-				{
-					editorConfiguration: null,
-					html: false,
-					id: 'infoField--text--',
-					label: 'Text',
-					multiline: false,
-					sourceContent: ['mock text'],
-					sourceContentDir: 'ltr',
-					targetContent: ['mock text'],
-					targetContentDir: 'ltr',
-					targetLanguageId: 'es_ES',
-				},
 			],
 			legend: 'Basic Information',
 		},
@@ -91,6 +79,18 @@ const baseProps = {
 						'<p>mock target repeteable field 2</p>',
 						'<p>mock target repeteable field 3</p>',
 					],
+					targetContentDir: 'ltr',
+					targetLanguageId: 'es_ES',
+				},
+				{
+					editorConfiguration: null,
+					html: false,
+					id: 'infoField--text--',
+					label: 'Text',
+					multiline: false,
+					sourceContent: ['mock text'],
+					sourceContentDir: 'ltr',
+					targetContent: ['mock text'],
 					targetContentDir: 'ltr',
 					targetLanguageId: 'es_ES',
 				},
@@ -264,21 +264,11 @@ describe('Translate', () => {
 
 			// LPS-133164
 
-			it('updates the input of a non-html field with the translated message with unescaped characters', () => {
+			it('updates the `Title` input of a non-html field with the translated message with unescaped characters', () => {
 				const {getByDisplayValue} = result;
 
 				expect(
 					getByDisplayValue("título simulado'")
-				).toBeInTheDocument();
-			});
-
-			// LPD-52521
-
-			it('updates the input with the translated message with HTML unescaped character', () => {
-				const {getByDisplayValue} = result;
-
-				expect(
-					getByDisplayValue('Esto es un "texto de ejemplo"')
 				).toBeInTheDocument();
 			});
 
@@ -303,11 +293,23 @@ describe('Translate', () => {
 				});
 			});
 
-			it('updates the input with the translated message with HTML unescaped character', () => {
+			// LPS-133164
+
+			it('updates the `Title` input with a translated message containing unescaped HTML characters', () => {
 				const {getByDisplayValue} = result;
 
 				expect(
 					getByDisplayValue("título simulado'")
+				).toBeInTheDocument();
+			});
+
+			// LPD-52521
+
+			it('updates the `Text` input with a translated message containing unescaped HTML characters', () => {
+				const {getByDisplayValue} = result;
+
+				expect(
+					getByDisplayValue('Esto es un "texto de ejemplo"')
 				).toBeInTheDocument();
 			});
 

--- a/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
+++ b/modules/apps/translation/translation-web/test/js/translate/__snapshots__/Translate.js.snap
@@ -55,7 +55,7 @@ exports[`Translate renders with auto-translate disabled 1`] = `
                   class="dropdown"
                 >
                   <button
-                    aria-controls="clay-dropdown-menu-21"
+                    aria-controls="clay-dropdown-menu-23"
                     aria-expanded="false"
                     aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
@@ -93,7 +93,7 @@ exports[`Translate renders with auto-translate disabled 1`] = `
                   class="dropdown"
                 >
                   <button
-                    aria-controls="clay-dropdown-menu-22"
+                    aria-controls="clay-dropdown-menu-24"
                     aria-expanded="false"
                     aria-haspopup="true"
                     class="dropdown-toggle btn btn-monospaced btn-sm btn-secondary"
@@ -555,6 +555,60 @@ exports[`Translate renders with auto-translate disabled 1`] = `
                 name="_mock_TranslationPortlet_infoField--repeteableContent--"
                 type="hidden"
                 value="<p>mock target repeteable field 3</p>"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="row"
+        >
+          <div
+            class="col-md-6"
+          >
+            <div
+              class="form-group"
+            >
+              <label
+                class="control-label"
+              >
+                Text
+              </label>
+              <input
+                class="form-control"
+                dir="ltr"
+                readonly=""
+                type="text"
+                value="mock text"
+              />
+            </div>
+          </div>
+          <div
+            class="col-md-6"
+          >
+            <div
+              class="form-group"
+            >
+              <div
+                class="row"
+              >
+                <div
+                  class="autofit-col autofit-col-expand"
+                >
+                  <label
+                    class="control-label"
+                    for="_mock_TranslationPortlet_infoField--text--0"
+                  >
+                    Text
+                  </label>
+                </div>
+              </div>
+              <input
+                class="form-control"
+                dir="ltr"
+                id="_mock_TranslationPortlet_infoField--text--0"
+                name="_mock_TranslationPortlet_infoField--text--"
+                type="text"
+                value="mock text"
               />
             </div>
           </div>
@@ -1327,6 +1381,91 @@ exports[`Translate renders with auto-translate enabled 1`] = `
                 class="sr-only"
               >
                 auto-translate-Content-field
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="row"
+        >
+          <div
+            class="col-autotranslate-content autofit-col autofit-col-expand"
+          >
+            <div
+              class="row"
+            >
+              <div
+                class="col-md-6"
+              >
+                <div
+                  class="form-group"
+                >
+                  <label
+                    class="control-label"
+                  >
+                    Text
+                  </label>
+                  <input
+                    class="form-control"
+                    dir="ltr"
+                    readonly=""
+                    type="text"
+                    value="mock text"
+                  />
+                </div>
+              </div>
+              <div
+                class="col-md-6"
+              >
+                <div
+                  class="form-group"
+                >
+                  <div
+                    class="row"
+                  >
+                    <div
+                      class="autofit-col autofit-col-expand"
+                    >
+                      <label
+                        class="control-label"
+                        for="_mock_TranslationPortlet_infoField--text--0"
+                      >
+                        Text
+                      </label>
+                    </div>
+                  </div>
+                  <input
+                    class="form-control"
+                    dir="ltr"
+                    id="_mock_TranslationPortlet_infoField--text--0"
+                    name="_mock_TranslationPortlet_infoField--text--"
+                    type="text"
+                    value="mock text"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="align-self-top col-autotranslate-button autofit-col"
+          >
+            <button
+              class="btn btn-monospaced btn-secondary"
+              title="auto-translate-Text-field"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-automatic-translate"
+                role="presentation"
+              >
+                <use
+                  href="#automatic-translate"
+                />
+              </svg>
+              <span
+                class="sr-only"
+              >
+                auto-translate-Text-field
               </span>
             </button>
           </div>
@@ -2136,6 +2275,91 @@ exports[`Translate renders with experiences selector 1`] = `
                 class="sr-only"
               >
                 auto-translate-Content-field
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="row"
+        >
+          <div
+            class="col-autotranslate-content autofit-col autofit-col-expand"
+          >
+            <div
+              class="row"
+            >
+              <div
+                class="col-md-6"
+              >
+                <div
+                  class="form-group"
+                >
+                  <label
+                    class="control-label"
+                  >
+                    Text
+                  </label>
+                  <input
+                    class="form-control"
+                    dir="ltr"
+                    readonly=""
+                    type="text"
+                    value="mock text"
+                  />
+                </div>
+              </div>
+              <div
+                class="col-md-6"
+              >
+                <div
+                  class="form-group"
+                >
+                  <div
+                    class="row"
+                  >
+                    <div
+                      class="autofit-col autofit-col-expand"
+                    >
+                      <label
+                        class="control-label"
+                        for="_mock_TranslationPortlet_infoField--text--0"
+                      >
+                        Text
+                      </label>
+                    </div>
+                  </div>
+                  <input
+                    class="form-control"
+                    dir="ltr"
+                    id="_mock_TranslationPortlet_infoField--text--0"
+                    name="_mock_TranslationPortlet_infoField--text--"
+                    type="text"
+                    value="mock text"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="align-self-top col-autotranslate-button autofit-col"
+          >
+            <button
+              class="btn btn-monospaced btn-secondary"
+              title="auto-translate-Text-field"
+              type="button"
+            >
+              <svg
+                class="lexicon-icon lexicon-icon-automatic-translate"
+                role="presentation"
+              >
+                <use
+                  href="#automatic-translate"
+                />
+              </svg>
+              <span
+                class="sr-only"
+              >
+                auto-translate-Text-field
               </span>
             </button>
           </div>


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-52521   Auto translated non-html fields output remain unescaped.
### How am I fixing it?
Fixing the existing condition that avoided text fields to be unescaped as other fields do.
### How can you verify that it works?
1. Running the test