### PR TITLE
LPD-52303 Add test to delete action for structures when they contain references and without references

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structures.spec.ts
@@ -5,12 +5,11 @@
 
 import {
 	ObjectDefinition,
-	ObjectDefinitionAPI,
 	ObjectRelationshipAPI,
 } from '@liferay/object-admin-rest-client-js';
 import {expect, mergeTests} from '@playwright/test';
 
-import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {getRandomInt} from '../../utils/getRandomInt';
@@ -19,7 +18,7 @@ import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
 	cmsPagesTest,
-	apiHelpersTest,
+	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-11232': {enabled: true},
 		'LPD-17564': {enabled: true},
@@ -93,12 +92,20 @@ test(
 				objectFolderExternalReferenceCode: 'L_CMS_FILE_TYPES',
 				status: {code: 0},
 			})) as ObjectDefinition;
+		apiHelpers.data.push({
+			id: objectDefinition1.id,
+			type: 'objectDefinition',
+		});
 
 		const objectDefinition2 =
 			(await apiHelpers.objectAdmin.postRandomObjectDefinition({
 				objectFolderExternalReferenceCode: 'L_CMS_FILE_TYPES',
 				status: {code: 0},
 			})) as ObjectDefinition;
+		apiHelpers.data.push({
+			id: objectDefinition2.id,
+			type: 'objectDefinition',
+		});
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
@@ -127,44 +134,28 @@ test(
 					type: 'oneToMany',
 				}
 			);
+		apiHelpers.data.push({
+			id: objectRelationship.id,
+			type: 'objectRelationship',
+		});
 
-		try {
-			await structuresPage.goto();
+		await structuresPage.goto();
 
-			await structuresPage.execItemAction({
-				action: 'Delete',
-				filter: objectDefinition1.name,
-			});
+		await structuresPage.execItemAction({
+			action: 'Delete',
+			filter: objectDefinition1.name,
+		});
+		await expect(
+			page.getByRole('heading', {name: 'Deletion Not Allowed'})
+		).toBeVisible();
+		await page.getByRole('button', {name: 'OK'}).click();
 
-			await expect(
-				page.getByRole('heading', {name: 'Deletion Not Allowed'})
-			).toBeVisible();
-
-			await page.getByRole('button', {name: 'OK'}).click();
-
-			await structuresPage.execItemAction({
-				action: 'Delete',
-				filter: objectDefinition2.name,
-			});
-
-			await expect(
-				page.getByRole('heading', {name: 'Deletion Not Allowed'})
-			).toBeVisible();
-		}
-		finally {
-			await objectRelationshipApiClient.deleteObjectRelationship(
-				objectRelationship.id
-			);
-
-			const objectDefinitionAPIClient =
-				await apiHelpers.buildRestClient(ObjectDefinitionAPI);
-
-			await objectDefinitionAPIClient.deleteObjectDefinition(
-				objectDefinition1.id
-			);
-			await objectDefinitionAPIClient.deleteObjectDefinition(
-				objectDefinition2.id
-			);
-		}
+		await structuresPage.execItemAction({
+			action: 'Delete',
+			filter: objectDefinition2.name,
+		});
+		await expect(
+			page.getByRole('heading', {name: 'Deletion Not Allowed'})
+		).toBeVisible();
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52303

This is a follow-up to the previous PR #6529 / https://github.com/brianchandotcom/liferay-portal/pull/160525 to improve the cleanup process.

# How am I fixing it?

Using dataApiHelpersTest and its clearData method to handle cleanup, avoiding manual cleanup.

# How can you verify that it works?

1. Go to `modules/test/playwright` 
2. run `npm install`
3. ```sh 
    npm run playwright -- test -g LPD-51516
    ```

# Run tests locally
![image](https://github.com/user-attachments/assets/ad4126dd-98d3-4083-b079-8a4eecfc67ed)

Clean structures after 10 runs
![image](https://github.com/user-attachments/assets/6ac95f9e-d772-47a5-91ad-3e94644fa8e9)
