### PR TITLE
LPD-52570 Creation of folder with parent reference code is not working

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -349,9 +349,11 @@ public class ObjectEntryFolderResourceImpl
 								getExternalReferenceCode(),
 							groupId, contextUser.getCompanyId());
 
-			if ((objectEntryFolderPersistence == null) &&
-				!addObjectEntryFolder) {
+			if (objectEntryFolderPersistence != null) {
+				return objectEntryFolderPersistence.getObjectEntryFolderId();
+			}
 
+			if (!addObjectEntryFolder) {
 				throw new PortalException();
 			}
 

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -18,7 +18,7 @@ import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
 import com.liferay.object.exception.NoSuchObjectEntryFolderException;
 import com.liferay.object.service.ObjectEntryFolderService;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
-import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
@@ -354,7 +354,7 @@ public class ObjectEntryFolderResourceImpl
 			}
 
 			if (!addObjectEntryFolder) {
-				throw new PortalException();
+				throw new NoSuchModelException();
 			}
 
 			objectEntryFolderPersistence =

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -9,8 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.object.client.dto.v1_0.ObjectEntryFolder;
+import com.liferay.headless.object.client.dto.v1_0.ParentObjectEntryFolderBrief;
 import com.liferay.headless.object.client.pagination.Page;
 import com.liferay.headless.object.client.pagination.Pagination;
+import com.liferay.headless.object.client.problem.Problem;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Field;
@@ -29,6 +31,7 @@ import com.liferay.portal.test.rule.Inject;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -112,6 +115,15 @@ public class ObjectEntryFolderResourceTest
 		super.testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCode();
 
 		_testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithGroupKey();
+	}
+
+	@Override
+	@Test
+	public void testPostScopeScopeKeyObjectEntryFolder() throws Exception {
+		super.testPostScopeScopeKeyObjectEntryFolder();
+
+		_testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolder();
+		_testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolder();
 	}
 
 	@Override
@@ -254,6 +266,20 @@ public class ObjectEntryFolderResourceTest
 		return objectEntryFolder;
 	}
 
+	private ParentObjectEntryFolderBrief _randomParentObjectEntryFolderBrief(
+			String parentExternalReferenceCode, long parentObjectEntryFolderId)
+		throws Exception {
+
+		return new ParentObjectEntryFolderBrief() {
+			{
+				externalReferenceCode = parentExternalReferenceCode;
+				id = parentObjectEntryFolderId;
+				label = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
 	private void _testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithGroupKey()
 		throws Exception {
 
@@ -284,6 +310,63 @@ public class ObjectEntryFolderResourceTest
 
 		assertEquals(expectedPatchObjectEntryFolder, getObjectEntryFolder);
 		assertValid(getObjectEntryFolder);
+	}
+
+	private void _testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolder()
+		throws Exception {
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		ParentObjectEntryFolderBrief parentObjectEntryFolderBrief =
+			_randomParentObjectEntryFolderBrief(
+				parentObjectEntryFolder.getExternalReferenceCode(), 0);
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		randomObjectEntryFolder.setParentObjectEntryFolderBrief(
+			parentObjectEntryFolderBrief);
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, postObjectEntryFolder);
+		assertValid(postObjectEntryFolder);
+
+		Assert.assertEquals(
+			postObjectEntryFolder.
+				getParentObjectEntryFolderExternalReferenceCode(),
+			parentObjectEntryFolder.getExternalReferenceCode());
+		Assert.assertEquals(
+			postObjectEntryFolder.getParentObjectEntryFolderId(),
+			parentObjectEntryFolder.getId());
+	}
+
+	private void _testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolder()
+		throws Exception {
+
+		ParentObjectEntryFolderBrief parentObjectEntryFolderBrief =
+			_randomParentObjectEntryFolderBrief(
+				StringUtil.toLowerCase(RandomTestUtil.randomString()), 0L);
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		randomObjectEntryFolder.setParentObjectEntryFolderBrief(
+			parentObjectEntryFolderBrief);
+
+		try {
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder);
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
 	}
 
 	@Inject


### PR DESCRIPTION
LPD-52570 Creation by parent external reference code is not working

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52570

While developing the https://liferay.atlassian.net/browse/LPD-49762 task, we saw that although the parent folder existed, the system is trying to re-create it, giving an error because it already exists. This wasblocking the creation of the folders inside of other folders


# How am I fixing it?

Returning the id if the parent object entry folder exists

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-52570 return id if exists**
- **LPD-52570 change exception thrown**
- **LPD-52570 add tests to reflect the issue**
