### PR TITLE
LPD-52764 Add file type in order to show the icon type

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SharedAsset.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/SharedAsset.java
@@ -441,6 +441,92 @@ public class SharedAsset implements Serializable {
 	private Supplier<String> _externalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset file type icon."
+	)
+	public String getFileTypeIcon() {
+		if (_fileTypeIconSupplier != null) {
+			fileTypeIcon = _fileTypeIconSupplier.get();
+
+			_fileTypeIconSupplier = null;
+		}
+
+		return fileTypeIcon;
+	}
+
+	public void setFileTypeIcon(String fileTypeIcon) {
+		this.fileTypeIcon = fileTypeIcon;
+
+		_fileTypeIconSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFileTypeIcon(
+		UnsafeSupplier<String, Exception> fileTypeIconUnsafeSupplier) {
+
+		_fileTypeIconSupplier = () -> {
+			try {
+				return fileTypeIconUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset file type icon.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String fileTypeIcon;
+
+	@JsonIgnore
+	private Supplier<String> _fileTypeIconSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The shared asset file type icon color."
+	)
+	public String getFileTypeIconColor() {
+		if (_fileTypeIconColorSupplier != null) {
+			fileTypeIconColor = _fileTypeIconColorSupplier.get();
+
+			_fileTypeIconColorSupplier = null;
+		}
+
+		return fileTypeIconColor;
+	}
+
+	public void setFileTypeIconColor(String fileTypeIconColor) {
+		this.fileTypeIconColor = fileTypeIconColor;
+
+		_fileTypeIconColorSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFileTypeIconColor(
+		UnsafeSupplier<String, Exception> fileTypeIconColorUnsafeSupplier) {
+
+		_fileTypeIconColorSupplier = () -> {
+			try {
+				return fileTypeIconColorUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The shared asset file type icon color.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String fileTypeIconColor;
+
+	@JsonIgnore
+	private Supplier<String> _fileTypeIconColorSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The shared asset ID."
 	)
 	public Long getId() {
@@ -780,6 +866,38 @@ public class SharedAsset implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String fileTypeIcon = getFileTypeIcon();
+
+		if (fileTypeIcon != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileTypeIcon\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fileTypeIcon));
+
+			sb.append("\"");
+		}
+
+		String fileTypeIconColor = getFileTypeIconColor();
+
+		if (fileTypeIconColor != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileTypeIconColor\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fileTypeIconColor));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/SharedAsset.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/SharedAsset.java
@@ -217,6 +217,48 @@ public class SharedAsset implements Cloneable, Serializable {
 
 	protected String externalReferenceCode;
 
+	public String getFileTypeIcon() {
+		return fileTypeIcon;
+	}
+
+	public void setFileTypeIcon(String fileTypeIcon) {
+		this.fileTypeIcon = fileTypeIcon;
+	}
+
+	public void setFileTypeIcon(
+		UnsafeSupplier<String, Exception> fileTypeIconUnsafeSupplier) {
+
+		try {
+			fileTypeIcon = fileTypeIconUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fileTypeIcon;
+
+	public String getFileTypeIconColor() {
+		return fileTypeIconColor;
+	}
+
+	public void setFileTypeIconColor(String fileTypeIconColor) {
+		this.fileTypeIconColor = fileTypeIconColor;
+	}
+
+	public void setFileTypeIconColor(
+		UnsafeSupplier<String, Exception> fileTypeIconColorUnsafeSupplier) {
+
+		try {
+			fileTypeIconColor = fileTypeIconColorUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fileTypeIconColor;
+
 	public Long getId() {
 		return id;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SharedAssetSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SharedAssetSerDes.java
@@ -174,6 +174,34 @@ public class SharedAssetSerDes {
 			sb.append("\"");
 		}
 
+		if (sharedAsset.getFileTypeIcon() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileTypeIcon\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getFileTypeIcon()));
+
+			sb.append("\"");
+		}
+
+		if (sharedAsset.getFileTypeIconColor() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileTypeIconColor\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(sharedAsset.getFileTypeIconColor()));
+
+			sb.append("\"");
+		}
+
 		if (sharedAsset.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -313,6 +341,23 @@ public class SharedAssetSerDes {
 				String.valueOf(sharedAsset.getExternalReferenceCode()));
 		}
 
+		if (sharedAsset.getFileTypeIcon() == null) {
+			map.put("fileTypeIcon", null);
+		}
+		else {
+			map.put(
+				"fileTypeIcon", String.valueOf(sharedAsset.getFileTypeIcon()));
+		}
+
+		if (sharedAsset.getFileTypeIconColor() == null) {
+			map.put("fileTypeIconColor", null);
+		}
+		else {
+			map.put(
+				"fileTypeIconColor",
+				String.valueOf(sharedAsset.getFileTypeIconColor()));
+		}
+
 		if (sharedAsset.getId() == null) {
 			map.put("id", null);
 		}
@@ -388,6 +433,12 @@ public class SharedAssetSerDes {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "fileTypeIcon")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "fileTypeIconColor")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
@@ -460,6 +511,17 @@ public class SharedAssetSerDes {
 
 				if (jsonParserFieldValue != null) {
 					sharedAsset.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fileTypeIcon")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setFileTypeIcon((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fileTypeIconColor")) {
+				if (jsonParserFieldValue != null) {
+					sharedAsset.setFileTypeIconColor(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/build.gradle
@@ -13,8 +13,10 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:account:account-api")
 	compileOnly project(":apps:captcha:captcha-api")
+	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	compileOnly project(":apps:headless:headless-common-spi")
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1089,6 +1089,16 @@ components:
                         The shared asset external reference code.
                     readOnly: true
                     type: string
+                fileTypeIcon:
+                    description:
+                        The shared asset file type icon.
+                    readOnly: true
+                    type: string
+                fileTypeIconColor:
+                    description:
+                        The shared asset file type icon color.
+                    readOnly: true
+                    type: string
                 id:
                     description:
                         The shared asset ID.

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -5,19 +5,38 @@
 
 package com.liferay.headless.admin.user.internal.dto.v1_0.converter;
 
+import com.liferay.document.library.display.context.DLMimeTypeDisplayContext;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.headless.admin.user.dto.v1_0.SharedAsset;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.CreatorUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.sharing.interpreter.SharingEntryInterpreter;
 import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
+
+import java.io.Serializable;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,6 +64,8 @@ public class SharedAssetDTOConverter
 			_sharingEntryInterpreterProvider.getSharingEntryInterpreter(
 				sharingEntry);
 
+		String mimeType = _getMimeType(sharingEntry);
+
 		return new SharedAsset() {
 			{
 				setActionIds(
@@ -71,6 +92,38 @@ public class SharedAssetDTOConverter
 				setDateModified(sharingEntry::getModifiedDate);
 				setExternalReferenceCode(
 					sharingEntry::getExternalReferenceCode);
+				setFileTypeIcon(
+					() -> {
+						if (StringUtil.equals(
+								ObjectEntryFolder.class.getName(),
+								sharingEntry.getClassName())) {
+
+							return "folder";
+						}
+
+						if (Validator.isNull(mimeType)) {
+							return null;
+						}
+
+						return _dlMimeTypeDisplayContext.getIconFileMimeType(
+							mimeType);
+					});
+				setFileTypeIconColor(
+					() -> {
+						if (StringUtil.equals(
+								ObjectEntryFolder.class.getName(),
+								sharingEntry.getClassName())) {
+
+							return "folder";
+						}
+
+						if (Validator.isNull(mimeType)) {
+							return null;
+						}
+
+						return _dlMimeTypeDisplayContext.
+							getCssClassFileMimeType(mimeType);
+					});
 				setId(sharingEntry::getSharingEntryId);
 				setShareable(sharingEntry::isShareable);
 				setSiteName(
@@ -93,8 +146,80 @@ public class SharedAssetDTOConverter
 		};
 	}
 
+	private String _getMimeType(SharingEntry sharingEntry) {
+		if (StringUtil.equals(
+				ObjectEntryFolder.class.getName(),
+				sharingEntry.getClassName())) {
+
+			return null;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				sharingEntry.getCompanyId(), sharingEntry.getClassName());
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), "file");
+
+		if (objectField == null) {
+			return null;
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			sharingEntry.getClassPK());
+
+		if (objectEntry == null) {
+			return null;
+		}
+
+		Map<String, Serializable> objectEntryValues = objectEntry.getValues();
+
+		long file = (long)objectEntryValues.get("file");
+
+		if (file == 0) {
+			return null;
+		}
+
+		FileEntry fileEntry = null;
+
+		try {
+			fileEntry = _dlAppLocalService.getFileEntry(file);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return null;
+		}
+
+		return fileEntry.getMimeType();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SharedAssetDTOConverter.class);
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private DLMimeTypeDisplayContext _dlMimeTypeDisplayContext;
+
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSharedAssetResourceTestCase.java
@@ -173,6 +173,8 @@ public abstract class BaseSharedAssetResourceTestCase {
 		sharedAsset.setAssetType(regex);
 		sharedAsset.setClassName(regex);
 		sharedAsset.setExternalReferenceCode(regex);
+		sharedAsset.setFileTypeIcon(regex);
+		sharedAsset.setFileTypeIconColor(regex);
 		sharedAsset.setSiteName(regex);
 		sharedAsset.setTitle(regex);
 
@@ -185,6 +187,8 @@ public abstract class BaseSharedAssetResourceTestCase {
 		Assert.assertEquals(regex, sharedAsset.getAssetType());
 		Assert.assertEquals(regex, sharedAsset.getClassName());
 		Assert.assertEquals(regex, sharedAsset.getExternalReferenceCode());
+		Assert.assertEquals(regex, sharedAsset.getFileTypeIcon());
+		Assert.assertEquals(regex, sharedAsset.getFileTypeIconColor());
 		Assert.assertEquals(regex, sharedAsset.getSiteName());
 		Assert.assertEquals(regex, sharedAsset.getTitle());
 	}
@@ -1120,6 +1124,24 @@ public abstract class BaseSharedAssetResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("fileTypeIcon", additionalAssertFieldName)) {
+				if (sharedAsset.getFileTypeIcon() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fileTypeIconColor", additionalAssertFieldName)) {
+
+				if (sharedAsset.getFileTypeIconColor() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("shareable", additionalAssertFieldName)) {
 				if (sharedAsset.getShareable() == null) {
 					valid = false;
@@ -1355,6 +1377,30 @@ public abstract class BaseSharedAssetResourceTestCase {
 				if (!Objects.deepEquals(
 						sharedAsset1.getExternalReferenceCode(),
 						sharedAsset2.getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("fileTypeIcon", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sharedAsset1.getFileTypeIcon(),
+						sharedAsset2.getFileTypeIcon())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fileTypeIconColor", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						sharedAsset1.getFileTypeIconColor(),
+						sharedAsset2.getFileTypeIconColor())) {
 
 					return false;
 				}
@@ -1727,6 +1773,98 @@ public abstract class BaseSharedAssetResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("fileTypeIcon")) {
+			Object object = sharedAsset.getFileTypeIcon();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("fileTypeIconColor")) {
+			Object object = sharedAsset.getFileTypeIconColor();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1882,6 +2020,10 @@ public abstract class BaseSharedAssetResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fileTypeIcon = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fileTypeIconColor = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				shareable = RandomTestUtil.randomBoolean();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -64,6 +65,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
+@FeatureFlags("LPD-17564")
 @RunWith(Arquillian.class)
 public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -6,42 +6,59 @@
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.sharing.interpreter.SharingEntryInterpreter;
-import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -49,6 +66,13 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -67,7 +91,8 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"actionIds", "assetType", "externalReferenceCode", "id", "title"
+			"actionIds", "assetType", "externalReferenceCode", "fileTypeIcon",
+			"fileTypeIconColor", "id", "title"
 		};
 	}
 
@@ -81,21 +106,25 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				testGroup.getGroupId(), TestPropsValues.getUserId());
 
-		_objectEntry = _objectEntryLocalService.addObjectEntry(
-			TestPropsValues.getUserId(), testGroup.getGroupId(),
-			_objectDefinition.getObjectDefinitionId(), 0, null,
-			HashMapBuilder.<String, Serializable>put(
-				"title", sharedAsset.getTitle()
-			).build(),
-			serviceContext);
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				null, TestPropsValues.getUserId(), testGroup.getGroupId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.put(
+					LocaleUtil.US, sharedAsset.getTitle()
+				).build(),
+				sharedAsset.getTitle(), new ServiceContext());
 
-		return _toSharedAsset(
+		return _toObjectEntryFolderSharedAsset(
 			sharedAsset,
 			_sharingEntryLocalService.addSharingEntry(
-				null, TestPropsValues.getUserId(), 0, _user.getUserId(),
+				sharedAsset.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), 0, _user.getUserId(),
 				_classNameLocalService.getClassNameId(
-					_objectDefinition.getClassName()),
-				_objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
+					ObjectEntryFolder.class.getName()),
+				objectEntryFolder.getObjectEntryFolderId(),
+				testGroup.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
 	}
 
@@ -109,29 +138,61 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 			ServiceContextTestUtil.getServiceContext(
 				testGroup.getGroupId(), _user.getUserId());
 
-		_objectEntry = _objectEntryLocalService.addObjectEntry(
+		DLFileEntry dlFileEntry = _addDLFileEntry(
+			testGroup.getGroupId(), TestPropsValues.getUserId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			_user.getUserId(), testGroup.getGroupId(),
 			_objectDefinition.getObjectDefinitionId(), 0, null,
 			HashMapBuilder.<String, Serializable>put(
+				"file", dlFileEntry.getFileEntryId()
+			).put(
 				"title", sharedAsset.getTitle()
 			).build(),
 			serviceContext);
 
-		return _toSharedAsset(
-			sharedAsset,
+		return _toObjectEntrySharedAsset(
+			objectEntry, sharedAsset,
 			_sharingEntryLocalService.addSharingEntry(
-				null, _user.getUserId(), 0, TestPropsValues.getUserId(),
+				sharedAsset.getExternalReferenceCode(), _user.getUserId(), 0,
+				TestPropsValues.getUserId(),
 				_classNameLocalService.getClassNameId(
 					_objectDefinition.getClassName()),
-				_objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
+				objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
 				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
+	}
+
+	private static ObjectFieldSetting _createObjectFieldSetting(
+		String name, String value) {
+
+		ObjectFieldSetting objectFieldSetting =
+			_objectFieldSettingLocalService.createObjectFieldSetting(0);
+
+		objectFieldSetting.setName(name);
+		objectFieldSetting.setValue(value);
+
+		return objectFieldSetting;
 	}
 
 	private static ObjectDefinition _getObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				true, ObjectDefinitionTestUtil.getRandomName(),
-				Collections.singletonList(
+				Arrays.asList(
+					new AttachmentObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"file"
+					).objectFieldSettings(
+						Arrays.asList(
+							_createObjectFieldSetting(
+								"acceptedFileExtensions", "txt"),
+							_createObjectFieldSetting(
+								"fileSource", "documentsAndMedia"),
+							_createObjectFieldSetting("maximumFileSize", "100"))
+					).build(),
 					new TextObjectFieldBuilder(
 					).labelMap(
 						LocalizedMapUtil.getLocalizedMap(
@@ -157,22 +218,26 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 			objectDefinition);
 	}
 
-	private String _getAssetTypeTitle(SharingEntry sharingEntry)
+	private DLFileEntry _addDLFileEntry(long groupId, long userId)
 		throws Exception {
 
-		SharingEntryInterpreter sharingEntryInterpreter =
-			_sharingEntryInterpreterProvider.getSharingEntryInterpreter(
-				sharingEntry);
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
 
-		if (sharingEntryInterpreter == null) {
-			return null;
-		}
+		InputStream inputStream = new ByteArrayInputStream(bytes);
 
-		return sharingEntryInterpreter.getAssetTypeTitle(
-			sharingEntry, LocaleUtil.US);
+		return _dlFileEntryLocalService.addFileEntry(
+			null, userId, groupId, groupId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".txt",
+			MimeTypesUtil.getExtensionContentType("txt"),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, inputStream, bytes.length, null, null, null,
+			ServiceContextTestUtil.getServiceContext(groupId));
 	}
 
-	private SharedAsset _toSharedAsset(
+	private SharedAsset _toObjectEntryFolderSharedAsset(
 			SharedAsset sharedAsset, SharingEntry sharingEntry)
 		throws Exception {
 
@@ -182,12 +247,37 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 					SharingEntryAction.getSharingEntryActions(
 						sharingEntry.getActionIds()),
 					SharingEntryAction::getActionId, String.class);
-				assetType = _getAssetTypeTitle(sharingEntry);
+				assetType = "Object Entry Folder";
 				dateCreated = sharingEntry.getCreateDate();
 				dateModified = sharingEntry.getModifiedDate();
-				externalReferenceCode = sharingEntry.getExternalReferenceCode();
+				externalReferenceCode = sharedAsset.getExternalReferenceCode();
+				fileTypeIcon = "folder";
+				fileTypeIconColor = "folder";
 				id = sharingEntry.getSharingEntryId();
 				title = sharedAsset.getTitle();
+			}
+		};
+	}
+
+	private SharedAsset _toObjectEntrySharedAsset(
+			ObjectEntry objectEntry, SharedAsset sharedAsset,
+			SharingEntry sharingEntry)
+		throws Exception {
+
+		return new SharedAsset() {
+			{
+				actionIds = TransformUtil.transformToArray(
+					SharingEntryAction.getSharingEntryActions(
+						sharingEntry.getActionIds()),
+					SharingEntryAction::getActionId, String.class);
+				assetType = _objectDefinition.getLabel(LocaleUtil.US);
+				dateCreated = sharingEntry.getCreateDate();
+				dateModified = sharingEntry.getModifiedDate();
+				externalReferenceCode = sharedAsset.getExternalReferenceCode();
+				fileTypeIcon = "document-text";
+				fileTypeIconColor = "file-icon-color-6";
+				id = sharingEntry.getSharingEntryId();
+				title = objectEntry.getTitleValue();
 			}
 		};
 	}
@@ -200,6 +290,10 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 	@Inject
 	private static ObjectFieldLocalService _objectFieldLocalService;
 
+	@Inject
+	private static ObjectFieldSettingLocalService
+		_objectFieldSettingLocalService;
+
 	private static User _user;
 
 	@Inject
@@ -208,13 +302,14 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
-	private ObjectEntry _objectEntry;
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;
 
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -281,7 +281,10 @@ public class ObjectEntryFolderResourceImpl
 					contextAcceptLanguage.getPreferredLocale(),
 					objectEntryFolder.getLabel(),
 					objectEntryFolder.getLabel_i18n()),
-				objectEntryFolder.getName()));
+				objectEntryFolder.getName(),
+				ServiceContextBuilder.create(
+					groupId, contextHttpServletRequest, null
+				).build()));
 	}
 
 	private ObjectEntryFolder _addObjectEntryFolder(
@@ -411,7 +414,11 @@ public class ObjectEntryFolderResourceImpl
 					labelMap),
 				GetterUtil.getString(
 					objectEntryFolder.getName(),
-					persistedObjectEntryFolder.getName())));
+					persistedObjectEntryFolder.getName()),
+				ServiceContextBuilder.create(
+					persistedObjectEntryFolder.getGroupId(),
+					contextHttpServletRequest, null
+				).build()));
 	}
 
 	private ObjectEntryFolder _toObjectEntryFolder(

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 103.1.0
+Bundle-Version: 104.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalService.java
@@ -341,7 +341,7 @@ public interface ObjectEntryFolderLocalService
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceUtil.java
@@ -409,12 +409,13 @@ public class ObjectEntryFolderLocalServiceUtil {
 	public static ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId,
-			Map<java.util.Locale, String> labelMap, String name)
+			Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderLocalServiceWrapper.java
@@ -463,12 +463,13 @@ public class ObjectEntryFolderLocalServiceWrapper
 	public com.liferay.object.model.ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId,
-			java.util.Map<java.util.Locale, String> labelMap, String name)
+			java.util.Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryFolderLocalService.updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderService.java
@@ -92,7 +92,8 @@ public interface ObjectEntryFolderService extends BaseService {
 
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<Locale, String> labelMap, String name)
+			Map<Locale, String> labelMap, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceUtil.java
@@ -111,11 +111,13 @@ public class ObjectEntryFolderServiceUtil {
 
 	public static ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<java.util.Locale, String> labelMap, String name)
+			Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateObjectEntryFolder(
-			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name);
+			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name,
+			serviceContext);
 	}
 
 	public static ObjectEntryFolderService getService() {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryFolderServiceWrapper.java
@@ -125,11 +125,13 @@ public class ObjectEntryFolderServiceWrapper
 	@Override
 	public com.liferay.object.model.ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			java.util.Map<java.util.Locale, String> labelMap, String name)
+			java.util.Map<java.util.Locale, String> labelMap, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryFolderService.updateObjectEntryFolder(
-			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name);
+			objectEntryFolderId, parentObjectEntryFolderId, labelMap, name,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 70.0.0
+version 71.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/ObjectEntryFolderSharingPermissionChecker.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/ObjectEntryFolderSharingPermissionChecker.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.security.permission;
+
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.security.permission.SharingPermissionChecker;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mikel Lorza
+ */
+@Component(
+	property = "model.class.name=com.liferay.object.model.ObjectEntryFolder",
+	service = SharingPermissionChecker.class
+)
+public class ObjectEntryFolderSharingPermissionChecker
+	implements SharingPermissionChecker {
+
+	@Override
+	public boolean hasPermission(
+			PermissionChecker permissionChecker, long classPK, long groupId,
+			Collection<SharingEntryAction> sharingEntryActions)
+		throws PortalException {
+
+		for (SharingEntryAction sharingEntryAction : sharingEntryActions) {
+			if (!_actionKeysSet.contains(sharingEntryAction) ||
+				!_objectEntryFolderModelResourcePermission.contains(
+					permissionChecker, classPK,
+					sharingEntryAction.getActionId())) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static final Set<SharingEntryAction> _actionKeysSet = new HashSet<>(
+		Arrays.asList(
+			SharingEntryAction.ADD_DISCUSSION, SharingEntryAction.UPDATE,
+			SharingEntryAction.VIEW));
+
+	@Reference(
+		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
+	)
+	private ModelResourcePermission<ObjectEntryFolder>
+		_objectEntryFolderModelResourcePermission;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryFolderServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryFolderServiceHttp.java
@@ -387,7 +387,8 @@ public class ObjectEntryFolderServiceHttp {
 			updateObjectEntryFolder(
 				HttpPrincipal httpPrincipal, long objectEntryFolderId,
 				long parentObjectEntryFolderId,
-				java.util.Map<java.util.Locale, String> labelMap, String name)
+				java.util.Map<java.util.Locale, String> labelMap, String name,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -397,7 +398,7 @@ public class ObjectEntryFolderServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, objectEntryFolderId, parentObjectEntryFolderId,
-				labelMap, name);
+				labelMap, name, serviceContext);
 
 			Object returnObj = null;
 
@@ -453,6 +454,9 @@ public class ObjectEntryFolderServiceHttp {
 	private static final Class<?>[] _getObjectEntryFoldersCountParameterTypes7 =
 		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _updateObjectEntryFolderParameterTypes8 =
-		new Class[] {long.class, long.class, java.util.Map.class, String.class};
+		new Class[] {
+			long.class, long.class, java.util.Map.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -246,7 +246,7 @@ public class ObjectEntryFolderLocalServiceImpl
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException {
 
 		ObjectEntryFolder objectEntryFolder =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.service.impl;
 
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.entry.folder.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
@@ -85,6 +86,8 @@ public class ObjectEntryFolderLocalServiceImpl
 
 		objectEntryFolder = objectEntryFolderPersistence.update(
 			objectEntryFolder);
+
+		_updateAsset(objectEntryFolder, serviceContext);
 
 		if (serviceContext.isAddGroupPermissions() ||
 			serviceContext.isAddGuestPermissions()) {
@@ -187,6 +190,10 @@ public class ObjectEntryFolderLocalServiceImpl
 
 		actionableDynamicQuery.performActions();
 
+		_assetEntryLocalService.deleteEntry(
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId());
+
 		objectEntryFolderPersistence.removeByG_C_LikeT(
 			objectEntryFolder.getGroupId(), objectEntryFolder.getCompanyId(),
 			objectEntryFolder.getTreePath() + "%");
@@ -264,7 +271,12 @@ public class ObjectEntryFolderLocalServiceImpl
 		objectEntryFolder.setName(name);
 		objectEntryFolder.setTreePath(objectEntryFolder.buildTreePath());
 
-		return objectEntryFolderPersistence.update(objectEntryFolder);
+		objectEntryFolder = objectEntryFolderPersistence.update(
+			objectEntryFolder);
+
+		_updateAsset(objectEntryFolder, serviceContext);
+
+		return objectEntryFolder;
 	}
 
 	private Map<Locale, String> _getLabelMap(
@@ -281,6 +293,23 @@ public class ObjectEntryFolderLocalServiceImpl
 		}
 
 		return labelMap;
+	}
+
+	private void _updateAsset(
+			ObjectEntryFolder objectEntryFolder, ServiceContext serviceContext)
+		throws PortalException {
+
+		_assetEntryLocalService.updateEntry(
+			serviceContext.getUserId(), objectEntryFolder.getGroupId(),
+			objectEntryFolder.getCreateDate(),
+			objectEntryFolder.getModifiedDate(),
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId(),
+			objectEntryFolder.getUuid(), 0,
+			serviceContext.getAssetCategoryIds(),
+			serviceContext.getAssetTagNames(), true, true, null, null,
+			objectEntryFolder.getCreateDate(), null, null,
+			objectEntryFolder.getName(), null, null, null, null, 0, 0, null);
 	}
 
 	private void _validateExternalReferenceCode(
@@ -342,6 +371,9 @@ public class ObjectEntryFolderLocalServiceImpl
 					objectEntryFolder.getGroupId()));
 		}
 	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderServiceImpl.java
@@ -163,7 +163,8 @@ public class ObjectEntryFolderServiceImpl
 	@Override
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long objectEntryFolderId, long parentObjectEntryFolderId,
-			Map<Locale, String> labelMap, String name)
+			Map<Locale, String> labelMap, String name,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_modelResourcePermission.check(
@@ -171,7 +172,7 @@ public class ObjectEntryFolderServiceImpl
 
 		return objectEntryFolderLocalService.updateObjectEntryFolder(
 			getUserId(), objectEntryFolderId, parentObjectEntryFolderId,
-			labelMap, name);
+			labelMap, name, serviceContext);
 	}
 
 	@Reference(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -24,6 +24,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -251,7 +252,8 @@ public class ObjectEntryFolderLocalServiceTest {
 					TestPropsValues.getUserId(),
 					objectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getParentObjectEntryFolderId(),
-					objectEntryFolder.getLabelMap(), name);
+					objectEntryFolder.getLabelMap(), name,
+					new ServiceContext());
 			});
 
 		AssertUtils.assertFailure(
@@ -267,7 +269,8 @@ public class ObjectEntryFolderLocalServiceTest {
 					TestPropsValues.getUserId(),
 					objectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getParentObjectEntryFolderId(),
-					objectEntryFolder.getLabelMap(), null);
+					objectEntryFolder.getLabelMap(), null,
+					new ServiceContext());
 			});
 		AssertUtils.assertFailure(
 			ObjectEntryFolderScopeException.class,
@@ -294,7 +297,7 @@ public class ObjectEntryFolderLocalServiceTest {
 					objectEntryFolder.getObjectEntryFolderId(),
 					parentObjectEntryFolder.getObjectEntryFolderId(),
 					objectEntryFolder.getLabelMap(),
-					objectEntryFolder.getName());
+					objectEntryFolder.getName(), new ServiceContext());
 			});
 
 		ObjectEntryFolder objectEntryFolder1 = _addObjectEntryFolder(
@@ -312,7 +315,7 @@ public class ObjectEntryFolderLocalServiceTest {
 				objectEntryFolder1.getObjectEntryFolderId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null, objectEntryFolder1.getName());
+				null, objectEntryFolder1.getName(), new ServiceContext());
 
 		AssertUtils.assertEquals(
 			HashMapBuilder.put(

--- a/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
+++ b/modules/apps/sharing/sharing-search/src/main/java/com/liferay/sharing/search/internal/service/SharingEntryObjectEntryFolderServiceWrapper.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.service.SharingEntryLocalService;
@@ -36,12 +37,12 @@ public class SharingEntryObjectEntryFolderServiceWrapper
 	public ObjectEntryFolder updateObjectEntryFolder(
 			long userId, long objectEntryFolderId,
 			long parentObjectEntryFolderId, Map<Locale, String> labelMap,
-			String name)
+			String name, ServiceContext serviceContext)
 		throws PortalException {
 
 		ObjectEntryFolder objectEntryFolder = super.updateObjectEntryFolder(
 			userId, objectEntryFolderId, parentObjectEntryFolderId, labelMap,
-			name);
+			name, serviceContext);
 
 		return _reindexSharingEntries(objectEntryFolder);
 	}


### PR DESCRIPTION
**Note: only review commits from LPD-52764, this PR is a continuation of the following one: https://github.com/liferay-content-management/liferay-portal/pull/6522**.  Commits from LPD-49727 has been merged into brian.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52764

# How am I fixing it?

Add fileTypeIcon and fileTypeIconColor in order to show the icons that it can be seen in the figma : https://www.figma.com/design/Pfcjoa2vMlr2JYB93ZEnjk/LPD-32645-Content-Sharing?node-id=149-6839&p=f&t=ug74378hoLsCRINT-0

# How can you verify that it works?

Run included tests