### PR TITLE
LPD-52707 use ObjectEntryFolderId or ExternalReferenceCode instead ParentObjectEntryFolderBrief for the parent folder data

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
+++ b/modules/apps/headless/headless-object/headless-object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Object API
 Bundle-SymbolicName: com.liferay.headless.object.api
-Bundle-Version: 1.0.2
+Bundle-Version: 2.0.0
 Export-Package:\
 	com.liferay.headless.object.dto.v1_0,\
 	com.liferay.headless.object.resource.v1_0

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/ObjectEntryFolder.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/ObjectEntryFolder.java
@@ -50,7 +50,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @io.swagger.v3.oas.annotations.media.Schema(
 	description = "Represents a object entry folder that contains objects entries and other object entry folders.",
-	requiredProperties = {"name"}
+	requiredProperties = {"title"}
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "ObjectEntryFolder")
@@ -416,48 +416,6 @@ public class ObjectEntryFolder implements Serializable {
 	private Supplier<Map<String, String>> _label_i18nSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The object entry folder's main title/name."
-	)
-	public String getName() {
-		if (_nameSupplier != null) {
-			name = _nameSupplier.get();
-
-			_nameSupplier = null;
-		}
-
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-
-		_nameSupplier = null;
-	}
-
-	@JsonIgnore
-	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
-		_nameSupplier = () -> {
-			try {
-				return nameUnsafeSupplier.get();
-			}
-			catch (RuntimeException runtimeException) {
-				throw runtimeException;
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		};
-	}
-
-	@GraphQLField(description = "The object entry folder's main title/name.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	@NotEmpty
-	protected String name;
-
-	@JsonIgnore
-	private Supplier<String> _nameSupplier;
-
-	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The number of object entries in this object entry folder."
 	)
 	public Integer getNumberOfObjectEntries() {
@@ -596,7 +554,7 @@ public class ObjectEntryFolder implements Serializable {
 	@GraphQLField(
 		description = "The object entry folder's parent, if it exists."
 	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ParentObjectEntryFolderBrief parentObjectEntryFolderBrief;
 
 	@JsonIgnore
@@ -744,6 +702,50 @@ public class ObjectEntryFolder implements Serializable {
 
 	@JsonIgnore
 	private Supplier<String> _scopeKeySupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The object entry folder's main title/name."
+	)
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The object entry folder's main title/name.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotEmpty
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "A write-only property that specifies the object entry folder's default permissions."
@@ -945,22 +947,6 @@ public class ObjectEntryFolder implements Serializable {
 			sb.append(_toJSON(label_i18n));
 		}
 
-		String name = getName();
-
-		if (name != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"name\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(name));
-
-			sb.append("\"");
-		}
-
 		Integer numberOfObjectEntries = getNumberOfObjectEntries();
 
 		if (numberOfObjectEntries != null) {
@@ -1039,6 +1025,22 @@ public class ObjectEntryFolder implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(scopeKey));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/ParentObjectEntryFolderBrief.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/ParentObjectEntryFolderBrief.java
@@ -232,27 +232,29 @@ public class ParentObjectEntryFolderBrief implements Serializable {
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The parent object entry folder's main title/name."
 	)
-	public String getName() {
-		if (_nameSupplier != null) {
-			name = _nameSupplier.get();
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
 
-			_nameSupplier = null;
+			_titleSupplier = null;
 		}
 
-		return name;
+		return title;
 	}
 
-	public void setName(String name) {
-		this.name = name;
+	public void setTitle(String title) {
+		this.title = title;
 
-		_nameSupplier = null;
+		_titleSupplier = null;
 	}
 
 	@JsonIgnore
-	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
-		_nameSupplier = () -> {
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
 			try {
-				return nameUnsafeSupplier.get();
+				return titleUnsafeSupplier.get();
 			}
 			catch (RuntimeException runtimeException) {
 				throw runtimeException;
@@ -267,10 +269,10 @@ public class ParentObjectEntryFolderBrief implements Serializable {
 		description = "The parent object entry folder's main title/name."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected String name;
+	protected String title;
 
 	@JsonIgnore
-	private Supplier<String> _nameSupplier;
+	private Supplier<String> _titleSupplier;
 
 	@Override
 	public boolean equals(Object object) {
@@ -357,18 +359,18 @@ public class ParentObjectEntryFolderBrief implements Serializable {
 			sb.append(_toJSON(label_i18n));
 		}
 
-		String name = getName();
+		String title = getTitle();
 
-		if (name != null) {
+		if (title != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"name\": ");
+			sb.append("\"title\": ");
 
 			sb.append("\"");
 
-			sb.append(_escape(name));
+			sb.append(_escape(title));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/ObjectEntryFolder.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/ObjectEntryFolder.java
@@ -195,25 +195,6 @@ public class ObjectEntryFolder implements Cloneable, Serializable {
 
 	protected Map<String, String> label_i18n;
 
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
-		try {
-			name = nameUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected String name;
-
 	public Integer getNumberOfObjectEntries() {
 		return numberOfObjectEntries;
 	}
@@ -356,6 +337,27 @@ public class ObjectEntryFolder implements Cloneable, Serializable {
 	}
 
 	protected String scopeKey;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
 
 	public ViewableBy getViewableBy() {
 		return viewableBy;

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/ParentObjectEntryFolderBrief.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/ParentObjectEntryFolderBrief.java
@@ -109,24 +109,26 @@ public class ParentObjectEntryFolderBrief implements Cloneable, Serializable {
 
 	protected Map<String, String> label_i18n;
 
-	public String getName() {
-		return name;
+	public String getTitle() {
+		return title;
 	}
 
-	public void setName(String name) {
-		this.name = name;
+	public void setTitle(String title) {
+		this.title = title;
 	}
 
-	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
 		try {
-			name = nameUnsafeSupplier.get();
+			title = titleUnsafeSupplier.get();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	protected String name;
+	protected String title;
 
 	@Override
 	public ParentObjectEntryFolderBrief clone()

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/ObjectEntryFolderSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/ObjectEntryFolderSerDes.java
@@ -152,20 +152,6 @@ public class ObjectEntryFolderSerDes {
 			sb.append(_toJSON(objectEntryFolder.getLabel_i18n()));
 		}
 
-		if (objectEntryFolder.getName() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"name\": ");
-
-			sb.append("\"");
-
-			sb.append(_escape(objectEntryFolder.getName()));
-
-			sb.append("\"");
-		}
-
 		if (objectEntryFolder.getNumberOfObjectEntries() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -237,6 +223,20 @@ public class ObjectEntryFolderSerDes {
 			sb.append("\"");
 
 			sb.append(_escape(objectEntryFolder.getScopeKey()));
+
+			sb.append("\"");
+		}
+
+		if (objectEntryFolder.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectEntryFolder.getTitle()));
 
 			sb.append("\"");
 		}
@@ -345,13 +345,6 @@ public class ObjectEntryFolderSerDes {
 				String.valueOf(objectEntryFolder.getLabel_i18n()));
 		}
 
-		if (objectEntryFolder.getName() == null) {
-			map.put("name", null);
-		}
-		else {
-			map.put("name", String.valueOf(objectEntryFolder.getName()));
-		}
-
 		if (objectEntryFolder.getNumberOfObjectEntries() == null) {
 			map.put("numberOfObjectEntries", null);
 		}
@@ -412,6 +405,13 @@ public class ObjectEntryFolderSerDes {
 				"scopeKey", String.valueOf(objectEntryFolder.getScopeKey()));
 		}
 
+		if (objectEntryFolder.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(objectEntryFolder.getTitle()));
+		}
+
 		if (objectEntryFolder.getViewableBy() == null) {
 			map.put("viewableBy", null);
 		}
@@ -465,9 +465,6 @@ public class ObjectEntryFolderSerDes {
 			else if (Objects.equals(jsonParserFieldName, "label_i18n")) {
 				return true;
 			}
-			else if (Objects.equals(jsonParserFieldName, "name")) {
-				return false;
-			}
 			else if (Objects.equals(
 						jsonParserFieldName, "numberOfObjectEntries")) {
 
@@ -495,6 +492,9 @@ public class ObjectEntryFolderSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "scopeKey")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "viewableBy")) {
@@ -558,11 +558,6 @@ public class ObjectEntryFolderSerDes {
 						(Map<String, String>)jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "name")) {
-				if (jsonParserFieldValue != null) {
-					objectEntryFolder.setName((String)jsonParserFieldValue);
-				}
-			}
 			else if (Objects.equals(
 						jsonParserFieldName, "numberOfObjectEntries")) {
 
@@ -609,6 +604,11 @@ public class ObjectEntryFolderSerDes {
 			else if (Objects.equals(jsonParserFieldName, "scopeKey")) {
 				if (jsonParserFieldValue != null) {
 					objectEntryFolder.setScopeKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					objectEntryFolder.setTitle((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "viewableBy")) {

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/ParentObjectEntryFolderBriefSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/ParentObjectEntryFolderBriefSerDes.java
@@ -100,16 +100,16 @@ public class ParentObjectEntryFolderBriefSerDes {
 			sb.append(_toJSON(parentObjectEntryFolderBrief.getLabel_i18n()));
 		}
 
-		if (parentObjectEntryFolderBrief.getName() != null) {
+		if (parentObjectEntryFolderBrief.getTitle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"name\": ");
+			sb.append("\"title\": ");
 
 			sb.append("\"");
 
-			sb.append(_escape(parentObjectEntryFolderBrief.getName()));
+			sb.append(_escape(parentObjectEntryFolderBrief.getTitle()));
 
 			sb.append("\"");
 		}
@@ -171,12 +171,13 @@ public class ParentObjectEntryFolderBriefSerDes {
 				String.valueOf(parentObjectEntryFolderBrief.getLabel_i18n()));
 		}
 
-		if (parentObjectEntryFolderBrief.getName() == null) {
-			map.put("name", null);
+		if (parentObjectEntryFolderBrief.getTitle() == null) {
+			map.put("title", null);
 		}
 		else {
 			map.put(
-				"name", String.valueOf(parentObjectEntryFolderBrief.getName()));
+				"title",
+				String.valueOf(parentObjectEntryFolderBrief.getTitle()));
 		}
 
 		return map;
@@ -209,7 +210,7 @@ public class ParentObjectEntryFolderBriefSerDes {
 			else if (Objects.equals(jsonParserFieldName, "label_i18n")) {
 				return true;
 			}
-			else if (Objects.equals(jsonParserFieldName, "name")) {
+			else if (Objects.equals(jsonParserFieldName, "title")) {
 				return false;
 			}
 
@@ -245,9 +246,9 @@ public class ParentObjectEntryFolderBriefSerDes {
 						(Map<String, String>)jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "name")) {
+			else if (Objects.equals(jsonParserFieldName, "title")) {
 				if (jsonParserFieldValue != null) {
-					parentObjectEntryFolderBrief.setName(
+					parentObjectEntryFolderBrief.setTitle(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -71,6 +71,7 @@ components:
                     # @review
                     description:
                         The object entry folder's parent, if it exists.
+                    readOnly: true
                 parentObjectEntryFolderExternalReferenceCode:
                     # @review
                     description:

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -52,10 +52,6 @@ components:
                     description:
                         The localized object entry folder's label.
                     type: object
-                title:
-                    description:
-                        The object entry folder's main title/name.
-                    type: string
                 numberOfObjectEntries:
                     description:
                         The number of object entries in this object entry folder.
@@ -88,6 +84,10 @@ components:
                     description:
                         The scope key of the object entry folder.
                     readOnly: true
+                    type: string
+                title:
+                    description:
+                        The object entry folder's main title/name.
                     type: string
                 viewableBy:
                     description:

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -52,7 +52,7 @@ components:
                     description:
                         The localized object entry folder's label.
                     type: object
-                name:
+                title:
                     description:
                         The object entry folder's main title/name.
                     type: string
@@ -96,7 +96,7 @@ components:
                     type: string
                     writeOnly: true
             required:
-                -   name
+                -   title
             type: object
         ParentObjectEntryFolderBrief:
             description:
@@ -122,7 +122,7 @@ components:
                     description:
                         The localized parent object entry folder's label.
                     type: object
-                name:
+                title:
                     description:
                         The parent object entry folder's main title/name.
                     type: string

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
@@ -66,7 +66,6 @@ public class ObjectEntryFolderDTOConverter
 				setLabel_i18n(
 					() -> LocalizedMapUtil.getLanguageIdMap(
 						objectEntryFolder.getLabelMap()));
-				setName(objectEntryFolder::getName);
 				setNumberOfObjectEntries(
 					() -> NestedFieldsSupplier.supply(
 						"numberOfObjectEntries",
@@ -111,6 +110,7 @@ public class ObjectEntryFolderDTOConverter
 					});
 				setScopeKey(
 					() -> String.valueOf(objectEntryFolder.getGroupId()));
+				setTitle(objectEntryFolder::getName);
 			}
 		};
 	}
@@ -147,7 +147,7 @@ public class ObjectEntryFolderDTOConverter
 				setLabel_i18n(
 					() -> LocalizedMapUtil.getLanguageIdMap(
 						parentObjectEntryFolder.getLabelMap()));
-				setName(parentObjectEntryFolder::getName);
+				setTitle(parentObjectEntryFolder::getName);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/ObjectEntryFolderDTOConverter.java
@@ -10,6 +10,8 @@ import com.liferay.headless.object.dto.v1_0.ObjectEntryFolder;
 import com.liferay.headless.object.dto.v1_0.ParentObjectEntryFolderBrief;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -109,7 +111,17 @@ public class ObjectEntryFolderDTOConverter
 						return null;
 					});
 				setScopeKey(
-					() -> String.valueOf(objectEntryFolder.getGroupId()));
+					() -> {
+						Group group = _groupLocalService.fetchGroup(
+							objectEntryFolder.getGroupId());
+
+						if (group == null) {
+							return String.valueOf(
+								objectEntryFolder.getGroupId());
+						}
+
+						return group.getGroupKey();
+					});
 				setTitle(objectEntryFolder::getName);
 			}
 		};
@@ -151,6 +163,9 @@ public class ObjectEntryFolderDTOConverter
 			}
 		};
 	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
@@ -51,7 +51,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolder(objectEntryFolderId: ___){actions, creator, dateCreated, dateModified, externalReferenceCode, id, label, label_i18n, name, numberOfObjectEntries, numberOfObjectEntryFolders, parentObjectEntryFolderBrief, parentObjectEntryFolderExternalReferenceCode, parentObjectEntryFolderId, scopeKey, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolder(objectEntryFolderId: ___){actions, creator, dateCreated, dateModified, externalReferenceCode, id, label, label_i18n, numberOfObjectEntries, numberOfObjectEntryFolders, parentObjectEntryFolderBrief, parentObjectEntryFolderExternalReferenceCode, parentObjectEntryFolderId, scopeKey, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the object entry folder.")
 	public ObjectEntryFolder objectEntryFolder(
@@ -69,7 +69,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCode(externalReferenceCode: ___, scopeKey: ___){actions, creator, dateCreated, dateModified, externalReferenceCode, id, label, label_i18n, name, numberOfObjectEntries, numberOfObjectEntryFolders, parentObjectEntryFolderBrief, parentObjectEntryFolderExternalReferenceCode, parentObjectEntryFolderId, scopeKey, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCode(externalReferenceCode: ___, scopeKey: ___){actions, creator, dateCreated, dateModified, externalReferenceCode, id, label, label_i18n, numberOfObjectEntries, numberOfObjectEntryFolders, parentObjectEntryFolderBrief, parentObjectEntryFolderExternalReferenceCode, parentObjectEntryFolderId, scopeKey, title, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public ObjectEntryFolder

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderNameExceptionMapper.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderNameExceptionMapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+package com.liferay.headless.object.internal.jaxrs.exception.mapper;
 
 import com.liferay.object.exception.ObjectEntryFolderNameException;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
@@ -22,9 +22,9 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Object)",
 		"osgi.jaxrs.extension=true",
-		"osgi.jaxrs.name=Liferay.Headless.Delivery.ObjectEntryFolderNameExceptionMapper"
+		"osgi.jaxrs.name=Liferay.Headless.Object.ObjectEntryFolderNameExceptionMapper"
 	},
 	service = ExceptionMapper.class
 )

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderScopeExceptionMapper.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderScopeExceptionMapper.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+package com.liferay.headless.object.internal.jaxrs.exception.mapper;
 
 import com.liferay.object.exception.ObjectEntryFolderScopeException;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
@@ -21,9 +21,9 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Object)",
 		"osgi.jaxrs.extension=true",
-		"osgi.jaxrs.name=Liferay.Headless.Delivery.ObjectEntryFolderScopeExceptionMapper"
+		"osgi.jaxrs.name=Liferay.Headless.Object.ObjectEntryFolderScopeExceptionMapper"
 	},
 	service = ExceptionMapper.class
 )

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/odata/entity/v1_0/ObjectEntryFolderEntityModel.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/odata/entity/v1_0/ObjectEntryFolderEntityModel.java
@@ -43,7 +43,7 @@ public class ObjectEntryFolderEntityModel implements EntityModel {
 					return sortableFieldName.concat(".keyword_lowercase");
 				}),
 			new StringEntityField(
-				"name", locale -> Field.getSortableFieldName(Field.NAME)));
+				"title", locale -> Field.getSortableFieldName(Field.NAME)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseObjectEntryFolderResourceImpl.java
@@ -379,7 +379,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderBrief": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "title": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -416,7 +416,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderBrief": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "title": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -473,10 +473,6 @@ public abstract class BaseObjectEntryFolderResourceImpl
 				objectEntryFolder.getLabel_i18n());
 		}
 
-		if (objectEntryFolder.getName() != null) {
-			existingObjectEntryFolder.setName(objectEntryFolder.getName());
-		}
-
 		if (objectEntryFolder.
 				getParentObjectEntryFolderExternalReferenceCode() != null) {
 
@@ -489,6 +485,10 @@ public abstract class BaseObjectEntryFolderResourceImpl
 		if (objectEntryFolder.getParentObjectEntryFolderId() != null) {
 			existingObjectEntryFolder.setParentObjectEntryFolderId(
 				objectEntryFolder.getParentObjectEntryFolderId());
+		}
+
+		if (objectEntryFolder.getTitle() != null) {
+			existingObjectEntryFolder.setTitle(objectEntryFolder.getTitle());
 		}
 
 		if (objectEntryFolder.getViewableBy() != null) {
@@ -505,7 +505,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderBrief": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "title": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -539,7 +539,7 @@ public abstract class BaseObjectEntryFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "name": ___, "parentObjectEntryFolderBrief": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "label": ___, "label_i18n": ___, "parentObjectEntryFolderExternalReferenceCode": ___, "parentObjectEntryFolderId": ___, "title": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -274,7 +274,7 @@ public class ObjectEntryFolderResourceImpl
 					contextAcceptLanguage.getPreferredLocale(),
 					objectEntryFolder.getLabel(),
 					objectEntryFolder.getLabel_i18n()),
-				objectEntryFolder.getName(),
+				objectEntryFolder.getTitle(),
 				ServiceContextBuilder.create(
 					groupId, contextHttpServletRequest, null
 				).build()));
@@ -293,7 +293,7 @@ public class ObjectEntryFolderResourceImpl
 					contextAcceptLanguage.getPreferredLocale(),
 					objectEntryFolder.getLabel(),
 					objectEntryFolder.getLabel_i18n()),
-				objectEntryFolder.getName(),
+				objectEntryFolder.getTitle(),
 				ServiceContextBuilder.create(
 					groupId, contextHttpServletRequest,
 					objectEntryFolder.getViewableByAsString()
@@ -411,7 +411,7 @@ public class ObjectEntryFolderResourceImpl
 						persistedObjectEntryFolder.getLabel()),
 					labelMap),
 				GetterUtil.getString(
-					objectEntryFolder.getName(),
+					objectEntryFolder.getTitle(),
 					persistedObjectEntryFolder.getName()),
 				ServiceContextBuilder.create(
 					persistedObjectEntryFolder.getGroupId(),

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -12,13 +12,12 @@ import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsUtil;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.object.dto.v1_0.ObjectEntryFolder;
-import com.liferay.headless.object.dto.v1_0.ParentObjectEntryFolderBrief;
 import com.liferay.headless.object.internal.odata.entity.v1_0.ObjectEntryFolderEntityModel;
 import com.liferay.headless.object.resource.v1_0.ObjectEntryFolderResource;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.exception.NoSuchObjectEntryFolderException;
 import com.liferay.object.service.ObjectEntryFolderService;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
-import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
@@ -238,9 +237,7 @@ public class ObjectEntryFolderResourceImpl
 
 		return _addObjectEntryFolder(
 			groupId,
-			_getParentObjectEntryFolderId(
-				false, objectEntryFolder.getParentObjectEntryFolderBrief(),
-				groupId),
+			_getParentObjectEntryFolderId(false, objectEntryFolder, groupId),
 			objectEntryFolder);
 	}
 
@@ -265,18 +262,14 @@ public class ObjectEntryFolderResourceImpl
 		if (persistedObjectEntryFolder == null) {
 			return _addObjectEntryFolder(
 				groupId,
-				_getParentObjectEntryFolderId(
-					true, objectEntryFolder.getParentObjectEntryFolderBrief(),
-					groupId),
+				_getParentObjectEntryFolderId(true, objectEntryFolder, groupId),
 				objectEntryFolder);
 		}
 
 		return _toObjectEntryFolder(
 			_objectEntryFolderService.updateObjectEntryFolder(
 				persistedObjectEntryFolder.getObjectEntryFolderId(),
-				_getParentObjectEntryFolderId(
-					true, objectEntryFolder.getParentObjectEntryFolderBrief(),
-					groupId),
+				_getParentObjectEntryFolderId(true, objectEntryFolder, groupId),
 				LocalizedMapUtil.getLocalizedMap(
 					contextAcceptLanguage.getPreferredLocale(),
 					objectEntryFolder.getLabel(),
@@ -323,61 +316,64 @@ public class ObjectEntryFolderResourceImpl
 	}
 
 	private long _getParentObjectEntryFolderId(
-			boolean addObjectEntryFolder,
-			ParentObjectEntryFolderBrief parentObjectEntryFolderBrief,
+			boolean addObjectEntryFolder, ObjectEntryFolder objectEntryFolder,
 			long groupId)
 		throws Exception {
 
-		long parentObjectEntryFolderId = 0;
+		String parentObjectEntryFolderExternalReferenceCode =
+			objectEntryFolder.getParentObjectEntryFolderExternalReferenceCode();
 
-		if (parentObjectEntryFolderBrief == null) {
-			return parentObjectEntryFolderId;
-		}
+		Long parentObjectEntryFolderId =
+			objectEntryFolder.getParentObjectEntryFolderId();
 
-		parentObjectEntryFolderId = GetterUtil.getLong(
-			parentObjectEntryFolderBrief.getId());
-
-		if (parentObjectEntryFolderId > 0) {
-			return parentObjectEntryFolderId;
-		}
-
-		if (Validator.isNotNull(
-				parentObjectEntryFolderBrief.getExternalReferenceCode())) {
-
-			com.liferay.object.model.ObjectEntryFolder
-				objectEntryFolderPersistence =
-					_objectEntryFolderService.
-						fetchObjectEntryFolderByExternalReferenceCode(
-							parentObjectEntryFolderBrief.
-								getExternalReferenceCode(),
-							groupId, contextUser.getCompanyId());
-
-			if (objectEntryFolderPersistence != null) {
-				return objectEntryFolderPersistence.getObjectEntryFolderId();
+		if (Validator.isNull(parentObjectEntryFolderExternalReferenceCode)) {
+			if (parentObjectEntryFolderId == null) {
+				return ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT;
 			}
 
+			if (parentObjectEntryFolderId > ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
+				_objectEntryFolderService.getObjectEntryFolder(
+					parentObjectEntryFolderId);
+			}
+
+			return parentObjectEntryFolderId;
+		}
+
+		com.liferay.object.model.ObjectEntryFolder
+			objectEntryFolderPersistence =
+				_objectEntryFolderService.
+					fetchObjectEntryFolderByExternalReferenceCode(
+						parentObjectEntryFolderExternalReferenceCode, groupId,
+						contextUser.getCompanyId());
+
+		if ((parentObjectEntryFolderId != null) &&
+			((objectEntryFolderPersistence == null) ||
+			 (objectEntryFolderPersistence.getObjectEntryFolderId() !=
+				 parentObjectEntryFolderId))) {
+
+			throw new NoSuchObjectEntryFolderException();
+		}
+
+		if (objectEntryFolderPersistence == null) {
 			if (!addObjectEntryFolder) {
-				throw new NoSuchModelException();
+				throw new NoSuchObjectEntryFolderException();
 			}
 
 			objectEntryFolderPersistence =
 				_objectEntryFolderService.addObjectEntryFolder(
-					parentObjectEntryFolderBrief.getExternalReferenceCode(),
-					groupId, 0,
-					LocalizedMapUtil.getLocalizedMap(
-						contextAcceptLanguage.getPreferredLocale(),
-						parentObjectEntryFolderBrief.getLabel(),
-						parentObjectEntryFolderBrief.getLabel_i18n()),
-					parentObjectEntryFolderBrief.getName(),
+					parentObjectEntryFolderExternalReferenceCode, groupId,
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null, parentObjectEntryFolderExternalReferenceCode,
 					ServiceContextBuilder.create(
 						groupId, contextHttpServletRequest, null
 					).build());
-
-			parentObjectEntryFolderId =
-				objectEntryFolderPersistence.getObjectEntryFolderId();
 		}
 
-		return parentObjectEntryFolderId;
+		return objectEntryFolderPersistence.getObjectEntryFolderId();
 	}
 
 	private ObjectEntryFolder _patchObjectEntryFolder(
@@ -394,10 +390,12 @@ public class ObjectEntryFolderResourceImpl
 		}
 
 		long parentObjectEntryFolderId = _getParentObjectEntryFolderId(
-			false, objectEntryFolder.getParentObjectEntryFolderBrief(),
-			persistedObjectEntryFolder.getGroupId());
+			false, objectEntryFolder, persistedObjectEntryFolder.getGroupId());
 
-		if (parentObjectEntryFolderId == 0) {
+		if (parentObjectEntryFolderId ==
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+
 			parentObjectEntryFolderId =
 				persistedObjectEntryFolder.getObjectEntryFolderId();
 		}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseObjectEntryFolderResourceTestCase.java
@@ -211,10 +211,10 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 
 		objectEntryFolder.setExternalReferenceCode(regex);
 		objectEntryFolder.setLabel(regex);
-		objectEntryFolder.setName(regex);
 		objectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
 			regex);
 		objectEntryFolder.setScopeKey(regex);
+		objectEntryFolder.setTitle(regex);
 
 		String json = ObjectEntryFolderSerDes.toJSON(objectEntryFolder);
 
@@ -225,12 +225,12 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 		Assert.assertEquals(
 			regex, objectEntryFolder.getExternalReferenceCode());
 		Assert.assertEquals(regex, objectEntryFolder.getLabel());
-		Assert.assertEquals(regex, objectEntryFolder.getName());
 		Assert.assertEquals(
 			regex,
 			objectEntryFolder.
 				getParentObjectEntryFolderExternalReferenceCode());
 		Assert.assertEquals(regex, objectEntryFolder.getScopeKey());
+		Assert.assertEquals(regex, objectEntryFolder.getTitle());
 	}
 
 	@Test
@@ -1723,14 +1723,6 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("name", additionalAssertFieldName)) {
-				if (objectEntryFolder.getName() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals(
 					"numberOfObjectEntries", additionalAssertFieldName)) {
 
@@ -1790,6 +1782,14 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 
 			if (Objects.equals("scopeKey", additionalAssertFieldName)) {
 				if (objectEntryFolder.getScopeKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (objectEntryFolder.getTitle() == null) {
 					valid = false;
 				}
 
@@ -2015,17 +2015,6 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("name", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						objectEntryFolder1.getName(),
-						objectEntryFolder2.getName())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
 			if (Objects.equals(
 					"numberOfObjectEntries", additionalAssertFieldName)) {
 
@@ -2099,6 +2088,17 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				if (!Objects.deepEquals(
 						objectEntryFolder1.getScopeKey(),
 						objectEntryFolder2.getScopeKey())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("title", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						objectEntryFolder1.getTitle(),
+						objectEntryFolder2.getTitle())) {
 
 					return false;
 				}
@@ -2395,52 +2395,6 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
-		if (entityFieldName.equals("name")) {
-			Object object = objectEntryFolder.getName();
-
-			String value = String.valueOf(object);
-
-			if (operator.equals("contains")) {
-				sb = new StringBundler();
-
-				sb.append("contains(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 2)) {
-					sb.append(value.substring(1, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else if (operator.equals("startswith")) {
-				sb = new StringBundler();
-
-				sb.append("startswith(");
-				sb.append(entityFieldName);
-				sb.append(",'");
-
-				if ((object != null) && (value.length() > 1)) {
-					sb.append(value.substring(0, value.length() - 1));
-				}
-				else {
-					sb.append(value);
-				}
-
-				sb.append("')");
-			}
-			else {
-				sb.append("'");
-				sb.append(value);
-				sb.append("'");
-			}
-
-			return sb.toString();
-		}
-
 		if (entityFieldName.equals("numberOfObjectEntries")) {
 			sb.append(
 				String.valueOf(objectEntryFolder.getNumberOfObjectEntries()));
@@ -2562,6 +2516,52 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("title")) {
+			Object object = objectEntryFolder.getTitle();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("viewableBy")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2618,7 +2618,6 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				label = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				numberOfObjectEntries = RandomTestUtil.randomInt();
 				numberOfObjectEntryFolders = RandomTestUtil.randomInt();
 				parentObjectEntryFolderExternalReferenceCode =
@@ -2626,6 +2625,7 @@ public abstract class BaseObjectEntryFolderResourceTestCase {
 				parentObjectEntryFolderId = RandomTestUtil.randomLong();
 				scopeKey = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
 	}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -83,8 +83,8 @@ public class ObjectEntryFolderResourceTest
 			testGetScopeScopeKeyObjectEntryFoldersPage_addObjectEntryFolder(
 				scopeKey, objectEntryFolder1);
 
-		EntityField nameEntityField = new StringEntityField(
-			"name", locale -> Field.getSortableFieldName(Field.NAME));
+		EntityField titleEntityField = new StringEntityField(
+			"title", locale -> Field.getSortableFieldName(Field.TITLE));
 
 		for (EntityField entityField : entityFields) {
 			Page<ObjectEntryFolder> page =
@@ -96,7 +96,7 @@ public class ObjectEntryFolderResourceTest
 								entityField, "between", objectEntryFolder1),
 							" and ",
 							getFilterString(
-								nameEntityField, "contains",
+								titleEntityField, "contains",
 								objectEntryFolder1)),
 						Pagination.of(1, 2), null);
 
@@ -144,7 +144,7 @@ public class ObjectEntryFolderResourceTest
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"label", "name"};
+		return new String[] {"label", "title"};
 	}
 
 	@Override
@@ -157,9 +157,9 @@ public class ObjectEntryFolderResourceTest
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				label = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				numberOfObjectEntries = RandomTestUtil.randomInt();
 				numberOfObjectEntryFolders = RandomTestUtil.randomInt();
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
 	}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.object.client.dto.v1_0.ObjectEntryFolder;
-import com.liferay.headless.object.client.dto.v1_0.ParentObjectEntryFolderBrief;
 import com.liferay.headless.object.client.pagination.Page;
 import com.liferay.headless.object.client.pagination.Pagination;
 import com.liferay.headless.object.client.problem.Problem;
@@ -144,7 +143,6 @@ public class ObjectEntryFolderResourceTest
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				numberOfObjectEntries = RandomTestUtil.randomInt();
 				numberOfObjectEntryFolders = RandomTestUtil.randomInt();
-				parentObjectEntryFolderId = 0L;
 			}
 		};
 	}
@@ -266,20 +264,6 @@ public class ObjectEntryFolderResourceTest
 		return objectEntryFolder;
 	}
 
-	private ParentObjectEntryFolderBrief _randomParentObjectEntryFolderBrief(
-			String parentExternalReferenceCode, long parentObjectEntryFolderId)
-		throws Exception {
-
-		return new ParentObjectEntryFolderBrief() {
-			{
-				externalReferenceCode = parentExternalReferenceCode;
-				id = parentObjectEntryFolderId;
-				label = StringUtil.toLowerCase(RandomTestUtil.randomString());
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
-			}
-		};
-	}
-
 	private void _testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithGroupKey()
 		throws Exception {
 
@@ -321,9 +305,8 @@ public class ObjectEntryFolderResourceTest
 			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
 				randomObjectEntryFolder());
 
-		randomObjectEntryFolder.setParentObjectEntryFolderBrief(
-			_randomParentObjectEntryFolderBrief(
-				parentObjectEntryFolder.getExternalReferenceCode(), 0L));
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			parentObjectEntryFolder.getExternalReferenceCode());
 
 		ObjectEntryFolder postObjectEntryFolder =
 			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
@@ -346,9 +329,8 @@ public class ObjectEntryFolderResourceTest
 
 		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
 
-		randomObjectEntryFolder.setParentObjectEntryFolderBrief(
-			_randomParentObjectEntryFolderBrief(
-				StringUtil.toLowerCase(RandomTestUtil.randomString()), 0L));
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			RandomTestUtil.randomString());
 
 		try {
 			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -121,8 +121,25 @@ public class ObjectEntryFolderResourceTest
 	public void testPostScopeScopeKeyObjectEntryFolder() throws Exception {
 		super.testPostScopeScopeKeyObjectEntryFolder();
 
-		_testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolder();
-		_testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolder();
+		_testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderByExternalReferenceCode();
+		_testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderByObjectEntryFolderId();
+		_testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderDataMismatch();
+		_testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolderByExternalReferenceCode();
+		_testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolderByObjectEntryFolderId();
+	}
+
+	@Override
+	@Test
+	public void testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode()
+		throws Exception {
+
+		super.testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode();
+
+		_testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderByExternalReferenceCode();
+		_testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderByObjectEntryFolderId();
+		_testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderDataMismatch();
+		_testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithNonexistentParentObjectEntryFolderByExternalReferenceCode();
+		_testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithNonexistentParentObjectEntryFolderByObjectEntryFolderId();
 	}
 
 	@Override
@@ -296,7 +313,7 @@ public class ObjectEntryFolderResourceTest
 		assertValid(getObjectEntryFolder);
 	}
 
-	private void _testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolder()
+	private void _testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderByExternalReferenceCode()
 		throws Exception {
 
 		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
@@ -324,7 +341,64 @@ public class ObjectEntryFolderResourceTest
 			parentObjectEntryFolder.getId());
 	}
 
-	private void _testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolder()
+	private void _testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderByObjectEntryFolderId()
+		throws Exception {
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			parentObjectEntryFolder.getId());
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, postObjectEntryFolder);
+		assertValid(postObjectEntryFolder);
+
+		Assert.assertEquals(
+			postObjectEntryFolder.
+				getParentObjectEntryFolderExternalReferenceCode(),
+			parentObjectEntryFolder.getExternalReferenceCode());
+		Assert.assertEquals(
+			postObjectEntryFolder.getParentObjectEntryFolderId(),
+			parentObjectEntryFolder.getId());
+	}
+
+	private void _testPostScopeScopeKeyObjectEntryFolderWithExistingParentObjectEntryFolderDataMismatch()
+		throws Exception {
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			parentObjectEntryFolder.getExternalReferenceCode());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			RandomTestUtil.randomLong());
+
+		try {
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
+	private void _testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolderByExternalReferenceCode()
 		throws Exception {
 
 		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
@@ -335,6 +409,197 @@ public class ObjectEntryFolderResourceTest
 		try {
 			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
 				randomObjectEntryFolder);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
+	private void _testPostScopeScopeKeyObjectEntryFolderWithNonexistentParentObjectEntryFolderByObjectEntryFolderId()
+		throws Exception {
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			RandomTestUtil.randomLong());
+
+		try {
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
+	private void _testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderByExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			parentObjectEntryFolder.getExternalReferenceCode());
+
+		ObjectEntryFolder putObjectEntryFolder =
+			objectEntryFolderResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						postObjectEntryFolder),
+					postObjectEntryFolder.getExternalReferenceCode(),
+					randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, putObjectEntryFolder);
+		Assert.assertEquals(
+			parentObjectEntryFolder.getExternalReferenceCode(),
+			putObjectEntryFolder.
+				getParentObjectEntryFolderExternalReferenceCode());
+		assertValid(putObjectEntryFolder);
+	}
+
+	private void _testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderByObjectEntryFolderId()
+		throws Exception {
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			parentObjectEntryFolder.getId());
+
+		ObjectEntryFolder putObjectEntryFolder =
+			objectEntryFolderResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						postObjectEntryFolder),
+					postObjectEntryFolder.getExternalReferenceCode(),
+					randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, putObjectEntryFolder);
+		Assert.assertEquals(
+			parentObjectEntryFolder.getExternalReferenceCode(),
+			putObjectEntryFolder.
+				getParentObjectEntryFolderExternalReferenceCode());
+		assertValid(putObjectEntryFolder);
+	}
+
+	private void _testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithExistingParentObjectEntryFolderDataMismatch()
+		throws Exception {
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			testPostScopeScopeKeyObjectEntryFolder_addObjectEntryFolder(
+				randomObjectEntryFolder());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			parentObjectEntryFolder.getExternalReferenceCode());
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			RandomTestUtil.randomLong());
+
+		try {
+			objectEntryFolderResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						postObjectEntryFolder),
+					postObjectEntryFolder.getExternalReferenceCode(),
+					randomObjectEntryFolder);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
+	private void _testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithNonexistentParentObjectEntryFolderByExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		String parentObjectEntryFolderExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		randomObjectEntryFolder.setParentObjectEntryFolderExternalReferenceCode(
+			parentObjectEntryFolderExternalReferenceCode);
+
+		ObjectEntryFolder putObjectEntryFolder =
+			objectEntryFolderResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						postObjectEntryFolder),
+					postObjectEntryFolder.getExternalReferenceCode(),
+					randomObjectEntryFolder);
+
+		assertEquals(randomObjectEntryFolder, putObjectEntryFolder);
+		Assert.assertEquals(
+			parentObjectEntryFolderExternalReferenceCode,
+			putObjectEntryFolder.
+				getParentObjectEntryFolderExternalReferenceCode());
+		assertValid(putObjectEntryFolder);
+
+		ObjectEntryFolder parentObjectEntryFolder =
+			objectEntryFolderResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						putObjectEntryFolder),
+					parentObjectEntryFolderExternalReferenceCode);
+
+		Assert.assertEquals(
+			parentObjectEntryFolderExternalReferenceCode,
+			parentObjectEntryFolder.getExternalReferenceCode());
+		assertValid(parentObjectEntryFolder);
+	}
+
+	private void _testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithNonexistentParentObjectEntryFolderByObjectEntryFolderId()
+		throws Exception {
+
+		ObjectEntryFolder postObjectEntryFolder =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_addObjectEntryFolder();
+
+		ObjectEntryFolder randomObjectEntryFolder = randomObjectEntryFolder();
+
+		randomObjectEntryFolder.setParentObjectEntryFolderId(
+			RandomTestUtil.randomLong());
+
+		try {
+			objectEntryFolderResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCode(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCode_getScopeKey(
+						postObjectEntryFolder),
+					postObjectEntryFolder.getExternalReferenceCode(),
+					randomObjectEntryFolder);
 
 			Assert.fail();
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryFolderModelDocumentContributor.java
@@ -35,6 +35,7 @@ public class ObjectEntryFolderModelDocumentContributor
 		document.addKeyword(
 			Field.FOLDER_ID, objectEntryFolder.getParentObjectEntryFolderId());
 		document.addText(Field.NAME, objectEntryFolder.getName());
+		document.addText(Field.TITLE, objectEntryFolder.getName());
 
 		String[] parts = StringUtil.split(
 			objectEntryFolder.getTreePath(), CharPool.SLASH);


### PR DESCRIPTION
LPD-52707 Fix create entry folder api

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-42840 [https://liferay.atlassian.net/browse/LPD-52707]

As an Content Creator, I want to be able to create folders as objects so that I can classify and group assets by different criteria.
Actually the Parent Object Entry folder comes from the parentObjectEntryFolderBrief. but other fields are better suited for it.

# How am I fixing it?

do not use ParentObjectEntryFolderBrief. We should use ObjectEntryFolderId or ExternalReferenceCode for the parent folder.

# How can you verify that it works?

Run the included automated tests.

# Commits


- **LPD-52707 parentObjectEntryFolderBrief should be readOnly**
- **LPD-52707 buildRest**
- **LPD-52707 do not use ParentObjectEntryFolderBrief. We should use ObjectEntryFolderId or ExternalReferenceCode for the parent folder.**
- **LPD-52707 adapt existing test with new behaviour**
- **LPD-52707 add new tests to check the behavior**
