### PR TITLE
LPD-52628 File Version display is not always ordered correctly

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntryHistoryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntryHistoryDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.util.comparator.FileVersionVersionComparator;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
@@ -118,11 +119,16 @@ public class DLViewEntryHistoryDisplayContext {
 		int status = _getFileEntryStatus();
 
 		searchContainer.setResultsAndTotal(
-			() -> ListUtil.sort(
-				_fileEntry.getFileVersions(
-					status, searchContainer.getStart(),
-					searchContainer.getEnd()),
-				new FileVersionVersionComparator(false)),
+			() -> {
+				List<FileVersion> fileVersions = ListUtil.sort(
+					_fileEntry.getFileVersions(
+						status, QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					new FileVersionVersionComparator(false));
+
+				return fileVersions.subList(
+					searchContainer.getStart(),
+					Math.min(searchContainer.getEnd(), fileVersions.size()));
+			},
 			_fileEntry.getFileVersionsCount(status));
 
 		return searchContainer;

--- a/modules/test/playwright/tests/document-library-web/dmHistory.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmHistory.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import {createReadStream} from 'fs';
+import path from 'path';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {setItemsPerPage} from '../../utils/pagination';
+
+const test = mergeTests(
+	apiHelpersTest,
+	documentLibraryPagesTest,
+	isolatedSiteTest,
+	loginTest()
+);
+
+test(
+	'File Entry History is ordered correctly',
+	{tag: '@LPD-52628'},
+	async ({apiHelpers, documentLibraryPage, page, site}) => {
+		const fileEntryTitle =
+			await test.step('Create a new File Entry with multiple versions', async () => {
+				const fileEntry =
+					await apiHelpers.headlessDelivery.postDocument(
+						site.id,
+						createReadStream(
+							path.join(__dirname, '/dependencies/image1.jpeg')
+						)
+					);
+
+				for (let i = 0; i < 11; i++) {
+					await apiHelpers.headlessDelivery.patchDocument({
+						document: {
+							description: '' + i,
+						},
+						documentId: fileEntry.id,
+					});
+				}
+
+				return fileEntry.title;
+			});
+
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.goToViewHistoryFileEntry(fileEntryTitle);
+
+		await setItemsPerPage(page, 8);
+
+		await expect(
+			page.getByText('Showing 1 to 8 of 12 entries.', {exact: true})
+		).toBeVisible();
+
+		await expect(page.locator('td.lfr-version-column').nth(0)).toHaveText(
+			'1.11'
+		);
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?
[LPD-52628](https://liferay.atlassian.net/browse/LPD-52628)
FileVersions in the database level are ordered as if the version numbers are Strings. But, these versions are actually 2 numbers separated via a dot <majorVersion>.<minorVersion> and a basic String or Number ordering can't deal with Version `1.11` actually being newer than version `1.2`. Because of this ordering, if the requested result window is smaller than the count of versions and either minorVersions or majorVersions have more than 10 entries, the result window will not accurately display versions.

# How am I fixing it?
By moving the sorting mechanism to the business layer.

# How can you verify that it works?
Run the included automated test

Cheers,
Balázs