### PR TITLE
LPD-49762 Use real API in create folder

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
@@ -38,6 +39,13 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 			objectDefinitionSettingLocalService);
 
 		_depotEntryLocalService = depotEntryLocalService;
+	}
+
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"parentObjectEntryFolderExternalReferenceCode",
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS
+		).build();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
@@ -39,6 +40,13 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 			objectDefinitionSettingLocalService);
 
 		_depotEntryLocalService = depotEntryLocalService;
+	}
+
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"parentObjectEntryFolderExternalReferenceCode",
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES
+		).build();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/all_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/all_section.jsp
@@ -20,7 +20,7 @@ AllSectionDisplayContext allSectionDisplayContext = (AllSectionDisplayContext)re
 		fdsActionDropdownItems="<%= allSectionDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.ALL_SECTION %>"
-		itemsPerPage="<%= 10 %>"
+		itemsPerPage="<%= 20 %>"
 		propsTransformer="{AllFDSPropsTransformer} from site-cms-site-initializer"
 		selectedItemsKey="id"
 		selectionType="multiple"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
@@ -13,6 +13,7 @@ ContentsSectionDisplayContext contentsSectionDisplayContext = (ContentsSectionDi
 
 <div class="cms-section custom-empty-state">
 	<frontend-data-set:headless-display
+		additionalProps="<%= contentsSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= contentsSectionDisplayContext.getAPIURL() %>"
 		bulkActionDropdownItems="<%= contentsSectionDisplayContext.getBulkActionDropdownItems() %>"
 		creationMenu="<%= contentsSectionDisplayContext.getCreationMenu() %>"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/contents_section.jsp
@@ -20,7 +20,7 @@ ContentsSectionDisplayContext contentsSectionDisplayContext = (ContentsSectionDi
 		fdsActionDropdownItems="<%= contentsSectionDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.CONTENTS_SECTION %>"
-		itemsPerPage="<%= 10 %>"
+		itemsPerPage="<%= 20 %>"
 		propsTransformer="{ContentsFDSPropsTransformer} from site-cms-site-initializer"
 		selectedItemsKey="id"
 		selectionType="multiple"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
@@ -13,6 +13,7 @@ FilesSectionDisplayContext filesSectionDisplayContext = (FilesSectionDisplayCont
 
 <div class="cms-section custom-empty-state">
 	<frontend-data-set:headless-display
+		additionalProps="<%= filesSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= filesSectionDisplayContext.getAPIURL() %>"
 		bulkActionDropdownItems="<%= filesSectionDisplayContext.getBulkActionDropdownItems() %>"
 		creationMenu="<%= filesSectionDisplayContext.getCreationMenu() %>"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/files_section.jsp
@@ -20,7 +20,7 @@ FilesSectionDisplayContext filesSectionDisplayContext = (FilesSectionDisplayCont
 		fdsActionDropdownItems="<%= filesSectionDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.FILES_SECTION %>"
-		itemsPerPage="<%= 10 %>"
+		itemsPerPage="<%= 20 %>"
 		propsTransformer="{FilesFDSPropsTransformer} from site-cms-site-initializer"
 		selectedItemsKey="id"
 		selectionType="multiple"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
@@ -3,19 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {API as objectAPI} from '@liferay/object-js-components-web';
 import {fetch} from 'frontend-js-web';
-
-export const {save: saveObject} = objectAPI;
 
 const UNEXPECTED_ERROR_MESSAGE = Liferay.Language.get(
 	'an-unexpected-error-occurred'
 );
-
-type PostFormDataResult = {
-	errorMessage?: string | undefined;
-	success: boolean;
-};
 
 type RequestHandlerResult<T> = {
 	data?: T;
@@ -72,27 +64,13 @@ export async function handleRequest<T>(
 	}
 }
 
-export async function postFormData(
-	formData: FormData,
-	url: string
-): Promise<PostFormDataResult> {
-	try {
-		await saveObject({
-			item: formData,
+export async function postFormData(formData: FormData, url: string) {
+	return handleRequest(() =>
+		fetch(url, {
+			body: formData,
 			method: 'POST',
-			url,
-		});
-
-		return {
-			success: true,
-		};
-	}
-	catch (error) {
-		return {
-			errorMessage: (error as Error).message || UNEXPECTED_ERROR_MESSAGE,
-			success: false,
-		};
-	}
+		})
+	);
 }
 
 const headers = new Headers({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
@@ -87,7 +87,7 @@ export async function fetchJSON<T>(input: RequestInfo, init?: RequestInit) {
 
 export async function postScopeScopeKeyObjectEntryFolder(
 	scopeKey: string,
-	name: string,
+	title: string,
 	parentObjectEntryFolderExternalReferenceCode: string
 ) {
 	return await handleRequest(() =>
@@ -95,8 +95,8 @@ export async function postScopeScopeKeyObjectEntryFolder(
 			`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
 			{
 				body: JSON.stringify({
-					name,
 					parentObjectEntryFolderExternalReferenceCode,
+					title,
 				}),
 				headers,
 				method: 'POST',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
@@ -17,6 +17,61 @@ type PostFormDataResult = {
 	success: boolean;
 };
 
+type RequestHandlerResult<T> = {
+	data?: T;
+	errorMessage?: string;
+	success: boolean;
+};
+
+export async function handleRequest<T>(
+	fetcher: () => Promise<Response>,
+	{returnValue = false}: {returnValue?: boolean} = {}
+): Promise<RequestHandlerResult<T>> {
+	try {
+		const response = await fetcher();
+
+		if (response.status === 401) {
+			window.location.reload();
+		}
+
+		if (!response.ok) {
+			let errorMessage = UNEXPECTED_ERROR_MESSAGE;
+
+			try {
+				const {message, title} = await response.json();
+
+				errorMessage = title ?? message ?? UNEXPECTED_ERROR_MESSAGE;
+
+				if (Array.isArray(errorMessage)) {
+					errorMessage = JSON.stringify(errorMessage);
+				}
+			}
+			catch (error) {
+				throw new Error(UNEXPECTED_ERROR_MESSAGE);
+			}
+
+			throw new Error(errorMessage);
+		}
+
+		let data: T | undefined;
+
+		if (returnValue) {
+			data = await response.json();
+		}
+
+		return {
+			data,
+			success: true,
+		};
+	}
+	catch (error) {
+		return {
+			errorMessage: (error as Error).message || UNEXPECTED_ERROR_MESSAGE,
+			success: false,
+		};
+	}
+}
+
 export async function postFormData(
 	formData: FormData,
 	url: string
@@ -57,15 +112,17 @@ export async function postScopeScopeKeyObjectEntryFolder(
 	name: string,
 	parentObjectEntryFolderExternalReferenceCode: string
 ) {
-	return await fetch(
-		`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
-		{
-			body: JSON.stringify({
-				name,
-				parentObjectEntryFolderExternalReferenceCode,
-			}),
-			headers,
-			method: 'POST',
-		}
+	return await handleRequest(() =>
+		fetch(
+			`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
+			{
+				body: JSON.stringify({
+					name,
+					parentObjectEntryFolderExternalReferenceCode,
+				}),
+				headers,
+				method: 'POST',
+			}
+		)
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/api/api.ts
@@ -51,3 +51,21 @@ export async function fetchJSON<T>(input: RequestInfo, init?: RequestInit) {
 
 	return (await result.json()) as T;
 }
+
+export async function postScopeScopeKeyObjectEntryFolder(
+	scopeKey: string,
+	name: string,
+	parentObjectEntryFolderExternalReferenceCode: string
+) {
+	return await fetch(
+		`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
+		{
+			body: JSON.stringify({
+				name,
+				parentObjectEntryFolderExternalReferenceCode,
+			}),
+			headers,
+			method: 'POST',
+		}
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
@@ -19,9 +19,11 @@ const ACTIONS = {
 };
 
 export default function ContentFDSPropsTransformer({
+	additionalProps,
 	creationMenu,
 	...otherProps
 }: {
+	additionalProps: any;
 	creationMenu: any;
 	otherProps: any;
 }) {
@@ -31,7 +33,8 @@ export default function ContentFDSPropsTransformer({
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(
 				creationMenu.primaryItems,
-				ACTIONS
+				ACTIONS,
+				additionalProps
 			),
 		},
 		customRenderers: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
@@ -19,9 +19,11 @@ const ACTIONS = {
 };
 
 export default function FilesFDSPropsTransformer({
+	additionalProps,
 	creationMenu,
 	...otherProps
 }: {
+	additionalProps: any;
 	creationMenu: any;
 	otherProps: any;
 }) {
@@ -31,7 +33,8 @@ export default function FilesFDSPropsTransformer({
 			...creationMenu,
 			primaryItems: addOnClickToCreationMenuItems(
 				creationMenu.primaryItems,
-				ACTIONS
+				ACTIONS,
+				additionalProps
 			),
 		},
 		customRenderers: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createAssetAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createAssetAction.ts
@@ -7,12 +7,12 @@ import {openModal} from 'frontend-js-components-web';
 import {navigate} from 'frontend-js-web';
 
 import CreationModalContent, {
-	AssetLibray,
+	AssetLibrary,
 } from '../../components/modal/CreationModalContent';
 
 export type AssetData = {
 	action: 'createAsset';
-	assetLibraries: AssetLibray[];
+	assetLibraries: AssetLibrary[];
 	redirect: string;
 	title: string;
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-components-web';
+import {openModal, openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
+import {postScopeScopeKeyObjectEntryFolder} from '../../../api/api';
 import CreationModalContent, {
 	AssetLibray,
 } from '../../components/modal/CreationModalContent';
@@ -14,13 +16,53 @@ export type FolderData = {
 	assetLibraries: AssetLibray[];
 };
 
-export default function createFolderAction(data: FolderData) {
+export default function createFolderAction(
+	data: FolderData,
+	additionalProps: {parentObjectEntryFolderExternalReferenceCode: string}
+) {
 	openModal({
 		center: true,
 		contentComponent: ({closeModal}: {closeModal: () => void}) =>
 			CreationModalContent({
 				...data,
 				closeModal,
+				onSubmit: async ({groupId, name}) => {
+					const response = await postScopeScopeKeyObjectEntryFolder(
+						groupId,
+						name,
+						additionalProps.parentObjectEntryFolderExternalReferenceCode
+					);
+
+					if (response.ok) {
+						closeModal();
+
+						openToast({
+							message: sub(
+								Liferay.Language.get(
+									'x-was-created-successfully'
+								),
+								`<strong>${name}</strong>`
+							),
+							type: 'success',
+						});
+					}
+					else {
+						const {
+							message,
+						}: {
+							message?: string;
+						} = await response.json();
+
+						openToast({
+							message:
+								message ||
+								Liferay.Language.get(
+									'an-unexpected-error-occurred'
+								),
+							type: 'danger',
+						});
+					}
+				},
 				title: Liferay.Language.get('new-folder'),
 			}),
 		size: 'sm',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -43,6 +43,9 @@ export default function createFolderAction(
 								),
 								`<strong>${name}</strong>`
 							),
+							onClose: () => {
+								window.location.reload();
+							},
 							type: 'success',
 						});
 					}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -8,12 +8,12 @@ import {sub} from 'frontend-js-web';
 
 import {postScopeScopeKeyObjectEntryFolder} from '../../../api/api';
 import CreationModalContent, {
-	AssetLibray,
+	AssetLibrary,
 } from '../../components/modal/CreationModalContent';
 
 export type FolderData = {
 	action: 'createFolder';
-	assetLibraries: AssetLibray[];
+	assetLibraries: AssetLibrary[];
 };
 
 export default function createFolderAction(
@@ -27,11 +27,11 @@ export default function createFolderAction(
 			CreationModalContent({
 				...data,
 				closeModal,
-				onSubmit: async ({groupId, name}) => {
+				onSubmit: async ({groupId, name: title}) => {
 					const {errorMessage, success} =
 						await postScopeScopeKeyObjectEntryFolder(
 							groupId,
-							name,
+							title,
 							additionalProps.parentObjectEntryFolderExternalReferenceCode
 						);
 
@@ -45,7 +45,7 @@ export default function createFolderAction(
 								Liferay.Language.get(
 									'x-was-created-successfully'
 								),
-								`<strong>${name}</strong>`
+								`<strong>${title}</strong>`
 							),
 							type: 'success',
 						});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -27,16 +27,17 @@ export default function createFolderAction(
 			CreationModalContent({
 				...data,
 				closeModal,
-				onSubmit: async ({name, groupId}) => {
-					const response = await postScopeScopeKeyObjectEntryFolder(
-						groupId,
-						name,
-						additionalProps.parentObjectEntryFolderExternalReferenceCode
-					);
+				onSubmit: async ({groupId, name}) => {
+					const {errorMessage, success} =
+						await postScopeScopeKeyObjectEntryFolder(
+							groupId,
+							name,
+							additionalProps.parentObjectEntryFolderExternalReferenceCode
+						);
 
-					if (response.ok) {
+					if (success) {
 						loadData?.();
-						
+
 						closeModal();
 
 						openToast({
@@ -50,18 +51,8 @@ export default function createFolderAction(
 						});
 					}
 					else {
-						const {
-							message,
-						}: {
-							message?: string;
-						} = await response.json();
-
 						openToast({
-							message:
-								message ||
-								Liferay.Language.get(
-									'an-unexpected-error-occurred'
-								),
+							message: errorMessage,
 							type: 'danger',
 						});
 					}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/actions/createFolderAction.ts
@@ -18,7 +18,8 @@ export type FolderData = {
 
 export default function createFolderAction(
 	data: FolderData,
-	additionalProps: {parentObjectEntryFolderExternalReferenceCode: string}
+	additionalProps: {parentObjectEntryFolderExternalReferenceCode: string},
+	loadData?: () => {}
 ) {
 	openModal({
 		center: true,
@@ -26,7 +27,7 @@ export default function createFolderAction(
 			CreationModalContent({
 				...data,
 				closeModal,
-				onSubmit: async ({groupId, name}) => {
+				onSubmit: async ({name, groupId}) => {
 					const response = await postScopeScopeKeyObjectEntryFolder(
 						groupId,
 						name,
@@ -34,6 +35,8 @@ export default function createFolderAction(
 					);
 
 					if (response.ok) {
+						loadData?.();
+						
 						closeModal();
 
 						openToast({
@@ -43,9 +46,6 @@ export default function createFolderAction(
 								),
 								`<strong>${name}</strong>`
 							),
-							onClose: () => {
-								window.location.reload();
-							},
 							type: 'success',
 						});
 					}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
@@ -5,7 +5,8 @@
 
 export default function addOnClickToCreationMenuItems(
 	items: {data: {action: string}}[],
-	actions: Record<string, (data: any) => void>
+	actions: Record<string, (data: any, additionalProps?: any) => void>,
+	additionalProps?: any
 ) {
 	return items.map((item: {data?: {action?: string}}) => {
 		return {
@@ -14,7 +15,7 @@ export default function addOnClickToCreationMenuItems(
 				const action = item?.data?.action;
 
 				if (action) {
-					actions[action](item.data);
+					actions[action](item.data, additionalProps);
 				}
 			},
 		};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/utils/addOnClickToCreationMenuItems.ts
@@ -5,17 +5,20 @@
 
 export default function addOnClickToCreationMenuItems(
 	items: {data: {action: string}}[],
-	actions: Record<string, (data: any, additionalProps?: any) => void>,
+	actions: Record<
+		string,
+		(data: any, additionalProps?: any, loadData?: () => {}) => void
+	>,
 	additionalProps?: any
 ) {
 	return items.map((item: {data?: {action?: string}}) => {
 		return {
 			...item,
-			onClick() {
+			onClick({loadData}: {loadData?: () => {}}) {
 				const action = item?.data?.action;
 
 				if (action) {
-					actions[action](item.data, additionalProps);
+					actions[action](item.data, additionalProps, loadData);
 				}
 			},
 		};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
@@ -15,14 +15,14 @@ import {SpaceData} from '../../FDSPropsTransformer/actions/createSpaceAction';
 import {FieldPicker, FieldText} from '../forms';
 import {required, validate} from '../forms/validations';
 
-export type AssetLibray = {
+export type AssetLibrary = {
 	groupId: string;
 	name: string;
 };
 
 type Props = {
 	action: AssetData['action'] | FolderData['action'] | SpaceData['action'];
-	assetLibraries: AssetLibray[];
+	assetLibraries: AssetLibrary[];
 	closeModal: () => void;
 	onSubmit?: (
 		values: {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent.tsx
@@ -5,7 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {useFormik} from 'formik';
+import {FormikHelpers, useFormik} from 'formik';
 import {navigate, sub} from 'frontend-js-web';
 import React from 'react';
 
@@ -24,6 +24,16 @@ type Props = {
 	action: AssetData['action'] | FolderData['action'] | SpaceData['action'];
 	assetLibraries: AssetLibray[];
 	closeModal: () => void;
+	onSubmit?: (
+		values: {
+			groupId: string;
+			name: string;
+		},
+		formikHelpers: FormikHelpers<{
+			groupId: string;
+			name: string;
+		}>
+	) => Promise<any> | void;
 	redirect?: string;
 	title: string;
 };
@@ -32,6 +42,7 @@ export default function CreationModalContent({
 	action,
 	assetLibraries,
 	closeModal,
+	onSubmit,
 	redirect,
 	title,
 }: Props) {
@@ -44,7 +55,7 @@ export default function CreationModalContent({
 						: '',
 				name: '',
 			},
-			onSubmit: (values) => {
+			onSubmit: async (values, formikHelpers) => {
 				if (redirect) {
 					const {groupId, name} = values;
 
@@ -54,9 +65,12 @@ export default function CreationModalContent({
 					url.searchParams.set('groupId', groupId);
 
 					navigate(url.pathname + url.search);
+
+					return;
 				}
-				else {
-					alert(JSON.stringify(values, null, 4));
+
+				if (onSubmit) {
+					await onSubmit(values, formikHelpers);
 				}
 			},
 			validate: (values) =>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/structure_usages.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/structure_usages.jsp
@@ -18,7 +18,7 @@ StructureUsagesDisplayContext structureUsagesDisplayContext = (StructureUsagesDi
 		fdsActionDropdownItems="<%= structureUsagesDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.STRUCTURE_USAGES %>"
-		itemsPerPage="<%= 10 %>"
+		itemsPerPage="<%= 20 %>"
 		propsTransformer="{StructureUsagesFDSPropsTransformer} from site-cms-site-initializer"
 		selectedItemsKey="id"
 		selectionType="multiple"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/structures_section.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/structures_section.jsp
@@ -19,7 +19,7 @@ StructuresSectionDisplayContext structuresSectionDisplayContext = (StructuresSec
 		fdsActionDropdownItems="<%= structuresSectionDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.STRUCTURES_SECTION %>"
-		itemsPerPage="<%= 10 %>"
+		itemsPerPage="<%= 20 %>"
 		propsTransformer="{StructuresFDSPropsTransformer} from site-cms-site-initializer"
 		selectedItemsKey="id"
 		selectionType="multiple"

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
@@ -5,11 +5,14 @@
 
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
 
 import CreationModalContent from '../../../../../src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent';
+
+const mockOnSubmit = jest.fn();
 
 const defaultProps = {
 	action: 'createFolder' as const,
@@ -18,11 +21,15 @@ const defaultProps = {
 		{groupId: '456', name: 'Space 2'},
 	],
 	closeModal: () => {},
-	onSubmit: () => {},
+	onSubmit: mockOnSubmit,
 	title: 'Create Folder',
 };
 
 describe('CreationModalContent', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	test('renders the modal title in the header', () => {
 		render(<CreationModalContent {...defaultProps} />);
 		expect(screen.getByText('Create Folder')).toBeInTheDocument();
@@ -49,5 +56,25 @@ describe('CreationModalContent', () => {
 			/>
 		);
 		expect(screen.queryByLabelText(/space/i)).not.toBeInTheDocument();
+	});
+
+	test('calls onSubmit when form is submitted and there is no redirect', async () => {
+		render(<CreationModalContent {...defaultProps} />);
+
+		await userEvent.type(screen.getByLabelText(/name/i), 'Folder Name');
+		await userEvent.click(screen.getByText('select-a-space'));
+		await userEvent.click(screen.getByText('Space 1'));
+		await userEvent.click(screen.getByText('save'));
+
+		expect(mockOnSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				groupId: '123',
+				name: 'Folder Name',
+			}),
+			expect.objectContaining({
+				setErrors: expect.any(Function),
+				setFieldError: expect.any(Function),
+			})
+		);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import CreationModalContent from '../../../../../src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent';
+
+const defaultProps = {
+	action: 'createFolder' as const,
+	assetLibraries: [
+		{groupId: '123', name: 'Space 1'},
+		{groupId: '456', name: 'Space 2'},
+	],
+	closeModal: () => {},
+	onSubmit: () => {},
+	title: 'Create Folder',
+};
+
+describe('CreationModalContent', () => {
+	test('renders the modal title in the header', () => {
+		render(<CreationModalContent {...defaultProps} />);
+		expect(screen.getByText('Create Folder')).toBeInTheDocument();
+	});
+
+	test('shows the name field only when action is "createFolder"', () => {
+		const {rerender} = render(<CreationModalContent {...defaultProps} />);
+		expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+
+		rerender(
+			<CreationModalContent {...defaultProps} action="createAsset" />
+		);
+		expect(screen.queryByLabelText('name')).not.toBeInTheDocument();
+	});
+
+	test('shows the space picker only when there are multiple asset libraries', () => {
+		const {rerender} = render(<CreationModalContent {...defaultProps} />);
+		expect(screen.getByLabelText(/space/i)).toBeInTheDocument();
+
+		rerender(
+			<CreationModalContent
+				{...defaultProps}
+				assetLibraries={[{groupId: '123', name: 'Only One Space'}]}
+			/>
+		);
+		expect(screen.queryByLabelText(/space/i)).not.toBeInTheDocument();
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/components/modal/CreationModalContent.test.tsx
@@ -13,6 +13,12 @@ import '@testing-library/jest-dom/extend-expect';
 import CreationModalContent from '../../../../../src/main/resources/META-INF/resources/js/main/components/modal/CreationModalContent';
 
 const mockOnSubmit = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock('frontend-js-web', () => ({
+	...(jest.requireActual('frontend-js-web') ?? {}),
+	navigate: (url: string) => mockNavigate(url),
+}));
 
 const defaultProps = {
 	action: 'createFolder' as const,
@@ -76,5 +82,42 @@ describe('CreationModalContent', () => {
 				setFieldError: expect.any(Function),
 			})
 		);
+	});
+
+	test('navigates with correct parameters when form is submitted and redirect is provided', async () => {
+		const originalURL = window.URL;
+
+		try {
+			window.URL = class extends URL {
+				constructor(path: string, base = 'http://localhost:8080') {
+					super(path, base);
+				}
+			} as typeof URL;
+
+			render(
+				<CreationModalContent
+					{...defaultProps}
+					redirect="/target-page"
+				/>
+			);
+
+			await userEvent.type(screen.getByLabelText(/name/i), 'Folder Name');
+			await userEvent.click(screen.getByText('select-a-space'));
+			await userEvent.click(screen.getByText('Space 1'));
+			await userEvent.click(screen.getByText('save'));
+
+			expect(mockNavigate).toHaveBeenCalledWith(
+				expect.stringContaining('/target-page?')
+			);
+			expect(mockNavigate).toHaveBeenCalledWith(
+				expect.stringContaining('name=Folder+Name')
+			);
+			expect(mockNavigate).toHaveBeenCalledWith(
+				expect.stringContaining('groupId=123')
+			);
+		}
+		finally {
+			window.URL = originalURL;
+		}
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-49762

Send a real request to the API to create a new folder.
How am I implementing it?

1. Pass parentObjectEntryFolderExternalReferenceCode as additionalProps
2. Add a new onSubmit prop to the CreationModalContent to be used in addition to the redirect
3. Create a new API request: postScopeScopeKeyObjectEntryFolder
4. Add a requestHandler to manage errors similarly to postForm

> [!NOTE]
> All FDS are initialized with `20` items per page because `10` isn't currently supported by the FDS paginator.

# How can you verify that it works?

> [!WARNING]
> You need to deploy https://github.com/liferay-content-management/liferay-portal/pull/6543 to have the API available.

Then, go to the CMS Files or Contents section and click on [ + ] > Create new > Folder, and fill in the name / Space (if needed).



# ~~Why doesn't this include any test?~~

~~I created a separate task to add Jest (unit) tests https://liferay.atlassian.net/browse/LPD-53480, but we can’t add Playwright tests yet until folder names are properly rendered in the FDS.~~

# ✅ Tests added

They can be executed locally by running:

```sh
yarn test
```

inside the `site-cms-site-initializer` module.

Here’s a screenshot of the tests running successfully on my local machine:
![image](https://github.com/user-attachments/assets/a84c8e5f-eda1-40dd-ba92-bf3993c5dd8c)