### PR TITLE
LPD-53397 Remove cache before running tests and restore afterwards

### DIFF
--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/info/item/provider/test/DisplayPageInfoItemFieldSetProviderTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/info/item/provider/test/DisplayPageInfoItemFieldSetProviderTest.java
@@ -11,6 +11,7 @@ import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldValue;
@@ -31,6 +32,9 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -117,11 +121,14 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 		_layout = _layoutLocalService.getLayout(
 			assetDisplayPageEntry.getPlid());
 
+		_removePortalCache();
 		_setUpThemeDisplay();
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		_portalCache.put(TestPropsValues.getCompanyId(), _jsonObject);
+
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
@@ -289,6 +296,16 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 			});
 	}
 
+	private void _removePortalCache() throws Exception {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+
+		_jsonObject = _portalCache.get(TestPropsValues.getCompanyId());
+
+		_portalCache.remove(TestPropsValues.getCompanyId());
+	}
+
 	private void _setUpThemeDisplay() throws Exception {
 		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()),
@@ -336,6 +353,7 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 	private Group _group;
 
 	private JournalArticle _journalArticle;
+	private JSONObject _jsonObject;
 	private Layout _layout;
 
 	@Inject(
@@ -354,8 +372,12 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 		_layoutPageTemplateEntryLocalService;
 
 	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
 	private Portal _portal;
 
+	private PortalCache<Long, JSONObject> _portalCache;
 	private ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
@@ -7,10 +7,14 @@ package com.liferay.layout.portlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LayoutFriendlyURLSeparatorComposite;
@@ -19,6 +23,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -55,10 +60,14 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_removePortalCache();
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		_portalCache.put(TestPropsValues.getCompanyId(), _jsonObject);
+
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
@@ -125,10 +134,27 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 			layoutFriendlyURLSeparatorComposite.getURLSeparator());
 	}
 
+	private void _removePortalCache() throws Exception {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+
+		_jsonObject = _portalCache.get(TestPropsValues.getCompanyId());
+
+		_portalCache.remove(TestPropsValues.getCompanyId());
+	}
+
 	@DeleteAfterTestRun
 	private Group _group;
 
+	private JSONObject _jsonObject;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
 	@Inject
 	private Portal _portal;
+
+	private PortalCache<Long, JSONObject> _portalCache;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
@@ -11,6 +11,7 @@ import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.provider.FriendlyURLSeparatorProvider;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
@@ -22,7 +23,10 @@ import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -45,6 +49,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -97,8 +102,14 @@ public class AssetDisplayPageFriendlyURLProviderImplTest {
 				layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
 				AssetDisplayPageConstants.TYPE_SPECIFIC, serviceContext);
 
+		_removePortalCache();
 		_setUpThemeDisplay(
 			_layoutLocalService.getLayout(assetDisplayPageEntry.getPlid()));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_portalCache.put(TestPropsValues.getCompanyId(), _jsonObject);
 	}
 
 	@Test
@@ -146,6 +157,16 @@ public class AssetDisplayPageFriendlyURLProviderImplTest {
 				LocaleUtil.getSiteDefault(), _themeDisplay));
 	}
 
+	private void _removePortalCache() throws Exception {
+		_portalCache =
+			(PortalCache<Long, JSONObject>)_multiVMPool.getPortalCache(
+				FriendlyURLSeparatorProvider.class.getName());
+
+		_jsonObject = _portalCache.get(TestPropsValues.getCompanyId());
+
+		_portalCache.remove(TestPropsValues.getCompanyId());
+	}
+
 	private void _setUpThemeDisplay(Layout layout) throws Exception {
 		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
 			_companyLocalService.getCompany(_group.getCompanyId()), _group,
@@ -173,13 +194,18 @@ public class AssetDisplayPageFriendlyURLProviderImplTest {
 	private Group _group;
 
 	private JournalArticle _journalArticle;
+	private JSONObject _jsonObject;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
 
 	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
 	private Portal _portal;
 
+	private PortalCache<Long, JSONObject> _portalCache;
 	private ThemeDisplay _themeDisplay;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-53395

We now have a cache in place, so remove the cache first before executing the tests and then restore it

How to test that this works:

Run:

- DisplayPageInfoItemFieldSetProviderTest
- LayoutFriendlyURLSeparatorCompositeTest
- AssetDisplayPageFriendlyURLProviderImplTest
