### PR TITLE
LPD-53188 Non-default Locale Translation Automatically Added to Web Content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress.ts
@@ -40,10 +40,14 @@ export default function useTranslationProgress({
 						`[type="hidden"][data-field-name="${fieldName}"]`
 					)
 				)
-					.filter(
-						(input) =>
-							input.value || input.getAttribute('data-translated')
-					)
+					.filter((input) => {
+						const {value} = input;
+
+						return (
+							input.getAttribute('data-translated') === 'true' ||
+							value?.trim()
+						);
+					})
 					.map(
 						(input) =>
 							input.dataset.languageid as Liferay.Language.Locale

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fieldToTranslations} from '../../../src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress';
+import useTranslationProgress, {
+	fieldToTranslations,
+} from '../../../src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress';
 
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
+import {act, renderHook} from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import TranslationManager from '../../../src/main/resources/META-INF/resources/js/translation_manager/TranslationManager';
+import {TranslationManagerProps} from '../../../src/main/resources/META-INF/resources/js/translation_manager/Types';
 
 const FIELDS = {
 	description: {
@@ -23,7 +27,7 @@ const FIELDS = {
 	},
 };
 
-const DEFAULT_PROPS = {
+const DEFAULT_PROPS: TranslationManagerProps = {
 	defaultLanguageId: 'en_US',
 	fields: FIELDS,
 	locales: [
@@ -118,5 +122,47 @@ describe('TranslationManager', () => {
 				item,
 			}
 		);
+	});
+
+	it('ignores hidden inputs with data-translated=false and no value', () => {
+		Object.keys(DEFAULT_PROPS.fields).forEach((fieldName) => {
+			const ddmField = document.createElement('input');
+			ddmField.type = 'text';
+			ddmField.setAttribute('data-ddm-localizable-field-id', '');
+			ddmField.setAttribute('data-field-name', fieldName);
+			document.body.appendChild(ddmField);
+
+			Object.keys(DEFAULT_PROPS.fields[fieldName]).forEach((langId) => {
+				const input = document.createElement('input');
+				input.type = 'hidden';
+				input.setAttribute('data-field-name', fieldName);
+				input.setAttribute('data-languageid', langId);
+				if (fieldName === 'name' && langId === 'en_US') {
+					input.setAttribute('data-translated', 'false');
+					input.value = '';
+				}
+				else {
+					input.setAttribute('data-translated', 'true');
+					input.value = 'test';
+				}
+				document.body.appendChild(input);
+			});
+		});
+
+		const expectedTranslations = [
+			{fieldName: 'titleMapAsXML', languages: []},
+			{fieldName: 'description', languages: ['ar_SA', 'ca_ES']},
+			{fieldName: 'name', languages: ['ca_ES']},
+		];
+
+		const {result} = renderHook(() =>
+			useTranslationProgress(DEFAULT_PROPS)
+		);
+
+		act(() => {
+			result.current.updateTranslations();
+		});
+
+		expect(result.current.translations).toEqual(expectedTranslations);
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-58361

When creating new web content, if the content's default language doesn't match the default language configured in the structure, a translation progress is automatically added to the structure's default language

# How am I fixing it?

Filter treats "false" as a truthy value because it checks only for the existence of the attribute, not its actual value. Have updated to check if its true and has a value

# How can you verify that it works?

Run the included automated tests.
