### PR TITLE
LPD-39034 UI shows Article ID to be editable when it is not

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -93,34 +93,43 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 
 <c:choose>
 	<c:when test="<%= !journalWebConfiguration.journalArticleForceAutogenerateId() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
-		<div class="article-id">
-			<label for="<portlet:namespace />newArticleId"><liferay-ui:message key="id" /></label>
 
-			<aui:input label="" name="newArticleId" type="text" value="<%= (article != null) ? article.getArticleId() : StringPool.BLANK %>" wrapperCssClass="mb-1" />
+		<%
+		boolean newArticle = (article != null) && !article.isNew();
+		%>
+
+		<div class="article-id">
+			<label for="<portlet:namespace />newArticleId">
+				<liferay-ui:message key="id" />
+			</label>
+
+			<aui:input disabled="<%= newArticle %>" label="" name="newArticleId" type="text" value="<%= (article != null) ? article.getArticleId() : StringPool.BLANK %>" wrapperCssClass="mb-1" />
 
 			<%
 			String taglibOnChange = "Liferay.Util.toggleDisabled('#" + liferayPortletResponse.getNamespace() + "newArticleId', event.target.checked);";
 			%>
 
-			<aui:input checked="<%= false %>" label="autogenerate-id" name="autoArticleId" onChange="<%= taglibOnChange %>" type="checkbox" value="<%= false %>" wrapperCssClass="mb-3" />
+			<aui:input checked="<%= false %>" disabled="<%= newArticle %>" label="autogenerate-id" name="autoArticleId" onChange="<%= taglibOnChange %>" type="checkbox" value="<%= false %>" wrapperCssClass="mb-3" />
 		</div>
 
-		<aui:script>
-			var autoArticleInput = document.getElementById(
-				'<portlet:namespace />autoArticleId'
-			);
-			var newArticleInput = document.getElementById(
-				'<portlet:namespace />newArticleId'
-			);
+		<c:if test="<%= !newArticle %>">
+			<aui:script>
+				var autoArticleInput = document.getElementById(
+					'<portlet:namespace />autoArticleId'
+				);
+				var newArticleInput = document.getElementById(
+					'<portlet:namespace />newArticleId'
+				);
 
-			if (autoArticleInput && newArticleInput) {
-				newArticleInput.disabled = autoArticleInput.checked;
+				if (autoArticleInput && newArticleInput) {
+					newArticleInput.disabled = autoArticleInput.checked;
 
-				autoArticleInput.addEventListener('click', () => {
-					Liferay.Util.toggleDisabled(newArticleInput, !newArticleInput.disabled);
-				});
-			}
-		</aui:script>
+					autoArticleInput.addEventListener('click', () => {
+						Liferay.Util.toggleDisabled(newArticleInput, !newArticleInput.disabled);
+					});
+				}
+			</aui:script>
+		</c:if>
 	</c:when>
 	<c:otherwise>
 		<aui:input name="newArticleId" type="hidden" />

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -13,8 +13,10 @@ import {loginTest} from '../../fixtures/loginTest';
 import {pageViewModePagesTest} from '../../fixtures/pageViewModePagesTest';
 import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import {SystemSettingsPage} from '../../pages/configuration-admin-web/SystemSettingsPage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
+import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import {openFieldset} from '../../utils/openFieldset';
 import {nextPage, setItemsPerPage} from '../../utils/pagination';
@@ -1813,5 +1815,69 @@ translationAndAutosaveTest(
 				'[id="_com_liferay_journal_web_portlet_JournalPortlet_articles_1"] span.label-item'
 			)
 		).toHaveText('Approved');
+	}
+);
+
+baseTest(
+	'Verify Journal Article ID field is not editable after assignment',
+	{
+		tag: '@LPD-39034',
+	},
+	async ({journalEditArticlePage, page, site}) => {
+		const systemSettingsPage = new SystemSettingsPage(page);
+		const articleTitle = 'Test Article';
+
+		try {
+			await systemSettingsPage.goToSystemSetting(
+				'Web Content',
+				'Administration'
+			);
+
+			const toggle = page.getByLabel(
+				'Journal Article Force Autogenerate ID'
+			);
+
+			await toggle.uncheck();
+
+			await page.getByRole('button', {name: /save|update/i}).click();
+
+			await waitForAlert(page);
+
+			await journalEditArticlePage.createArticleWithCustomArticleId(
+				page,
+				site,
+				String(getRandomInt()),
+				articleTitle
+			);
+
+			await journalEditArticlePage.editArticle(articleTitle);
+
+			await expect(
+				page.locator(
+					'input[name="_com_liferay_journal_web_portlet_JournalPortlet_newArticleId"]'
+				)
+			).toBeDisabled();
+
+			await expect(
+				page.locator(
+					'input[name="_com_liferay_journal_web_portlet_JournalPortlet_autoArticleId"]'
+				)
+			).toBeDisabled();
+		}
+		finally {
+			await systemSettingsPage.goToSystemSetting(
+				'Web Content',
+				'Administration'
+			);
+
+			const toggle = page.getByLabel(
+				'Journal Article Force Autogenerate ID'
+			);
+			await toggle.check();
+
+			await page.getByRole('button', {name: /save|update/i}).click();
+
+			await waitForAlert(page);
+		}
 	}
 );

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -8,6 +8,7 @@ import {Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
+import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -183,6 +184,24 @@ export class JournalEditArticlePage {
 			this.page,
 			`Success:${title} was created successfully.`
 		);
+	}
+
+	async createArticleWithCustomArticleId(
+		page: Page,
+		site: Site,
+		articleId: string,
+		title?: string
+	) {
+		await this.goto({siteUrl: site.friendlyUrlPath});
+
+		await this.fillTitle(title || getRandomString());
+
+		const articleIdInput = page.locator(
+			'input[name="_com_liferay_journal_web_portlet_JournalPortlet_newArticleId"]'
+		);
+		await articleIdInput.fill(articleId || String(getRandomInt()));
+
+		await this.publishArticle();
 	}
 
 	async createArticleWithDuplicatedField(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-39034

The article ID field is editable after an ID is assigned to the article, on disabling Journal Article Force Autogenerate ID

# How am I fixing it?

check if it is a new article, if not deactivate the fields

# How can you verify that it works?

Run the included automated tests.
