### PR TITLE
LPD-53481 Return JournalResultRowSplitter in all display style 

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -939,11 +939,7 @@ public class JournalDisplayContext {
 			return new JournalRecentArticlesResultRowSplitter(_themeDisplay);
 		}
 
-		if (Objects.equals(getDisplayStyle(), "icon")) {
-			return new JournalResultRowSplitter();
-		}
-
-		return null;
+		return new JournalResultRowSplitter();
 	}
 
 	public String getScheduledArticleMessage(JournalArticle journalArticle) {

--- a/modules/test/playwright/tests/journal-web/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalPage.spec.ts
@@ -20,6 +20,43 @@ export const test = mergeTests(
 );
 
 test(
+	'List view displays folders and articles correctly',
+	{
+		tag: '@LPD-53481',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'First Web content'},
+		});
+
+		await apiHelpers.jsonWebServicesJournal.addFolder({
+			groupId: site.id,
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await journalPage.changeView('list');
+
+		await page.pause();
+
+		await expect(
+			page
+				.locator(
+					'[id="_com_liferay_journal_web_portlet_JournalPortlet_articlesSearchContainer"]'
+				)
+				.getByText('Web Content', {exact: true})
+		).toBeVisible();
+
+		await expect(page.getByText('Folders')).toBeVisible();
+	}
+);
+
+test(
 	'Table view displays folders and articles correctly',
 	{
 		tag: '@LPD-42429',
@@ -42,6 +79,7 @@ test(
 
 		await journalPage.changeView('table');
 
+		await page.pause();
 		await expect(page.getByRole('cell', {name: 'Title'})).toBeVisible();
 
 		await expect(
@@ -49,6 +87,14 @@ test(
 		).toBeVisible();
 
 		await expect(page.getByRole('cell', {name: 'Author'})).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Web Content'})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Folders'})
+		).toBeVisible();
 
 		await expect(page.getByRole('cell', {name: 'Status'})).toBeVisible();
 


### PR DESCRIPTION
What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-53481

In table and List view the folders and JA  results are not separated.

How am I fixing it?
It is only returned the Result Row Splitter, if the display was set to icon.  Removed it and letting the list and table view as well to have the result separated by folders and wc.

How can you verify that it works?
Run @LPD-53481 and LPD-42429 playwright tests