### PR TITLE
LPD-53490 Technical Task | Expose file URL's in headless API's for file previews

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -98,6 +98,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -789,9 +790,14 @@ public class BatchEngineBrokerTest {
 
 		String template = StreamUtil.toString(_getInputStream(templateName));
 
+		FileEntry fileEntry = _dlAppService.getFileEntry(
+			dlFileEntry.getFileEntryId());
+
 		Link link = LinkUtil.toLink(
-			_dlAppService, dlFileEntry, _dlURLHelper, objectDefinitionERC,
-			objectEntryERC, _portal);
+			dlFileEntry.getFileName(), true, true, objectDefinitionERC,
+			objectEntryERC, _portal,
+			_dlURLHelper.getDownloadURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK));
 
 		template = StringUtil.replace(
 			template,
@@ -918,9 +924,14 @@ public class BatchEngineBrokerTest {
 			Long groupId, long id, Date modifiedDate)
 		throws Exception {
 
+		FileEntry fileEntry = _dlAppService.getFileEntry(
+			dlFileEntry.getFileEntryId());
+
 		Link link = LinkUtil.toLink(
-			_dlAppService, dlFileEntry, _dlURLHelper, objectDefinitionERC,
-			objectEntryERC, _portal);
+			dlFileEntry.getFileName(), true, true, objectDefinitionERC,
+			objectEntryERC, _portal,
+			_dlURLHelper.getDownloadURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK));
 
 		String scopeKey = null;
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -53,8 +53,14 @@
 					"name": {
 						"type": "string"
 					},
+					"previewLink": {
+						"$ref": "#/components/schemas/Link"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"thumbnailLink": {
+						"$ref": "#/components/schemas/Link"
 					},
 					"x-class-name": {
 						"default": "com.liferay.object.rest.dto.v1_0.FileEntry",

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 20.0.1
+Bundle-Version: 21.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -339,6 +339,52 @@ public class FileEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _nameSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "optional field that specifies the preview url of the file, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewLink`)"
+	)
+	@Valid
+	public Link getPreviewLink() {
+		if (_previewLinkSupplier != null) {
+			previewLink = _previewLinkSupplier.get();
+
+			_previewLinkSupplier = null;
+		}
+
+		return previewLink;
+	}
+
+	public void setPreviewLink(Link previewLink) {
+		this.previewLink = previewLink;
+
+		_previewLinkSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPreviewLink(
+		UnsafeSupplier<Link, Exception> previewLinkUnsafeSupplier) {
+
+		_previewLinkSupplier = () -> {
+			try {
+				return previewLinkUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "optional field that specifies the preview url of the file, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewLink`)"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Link previewLink;
+
+	@JsonIgnore
+	private Supplier<Link> _previewLinkSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public Scope getScope() {
@@ -504,6 +550,18 @@ public class FileEntry implements Serializable {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		Link previewLink = getPreviewLink();
+
+		if (previewLink != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"previewLink\": ");
+
+			sb.append(String.valueOf(previewLink));
 		}
 
 		Scope scope = getScope();

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -339,9 +339,7 @@ public class FileEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _nameSupplier;
 
-	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "optional field that specifies the preview url of the file, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewLink`)"
-	)
+	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public Link getPreviewLink() {
 		if (_previewLinkSupplier != null) {
@@ -376,9 +374,7 @@ public class FileEntry implements Serializable {
 		};
 	}
 
-	@GraphQLField(
-		description = "optional field that specifies the preview url of the file, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewLink`)"
-	)
+	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Link previewLink;
 

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -425,6 +425,48 @@ public class FileEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<Scope> _scopeSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Link getThumbnailLink() {
+		if (_thumbnailLinkSupplier != null) {
+			thumbnailLink = _thumbnailLinkSupplier.get();
+
+			_thumbnailLinkSupplier = null;
+		}
+
+		return thumbnailLink;
+	}
+
+	public void setThumbnailLink(Link thumbnailLink) {
+		this.thumbnailLink = thumbnailLink;
+
+		_thumbnailLinkSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setThumbnailLink(
+		UnsafeSupplier<Link, Exception> thumbnailLinkUnsafeSupplier) {
+
+		_thumbnailLinkSupplier = () -> {
+			try {
+				return thumbnailLinkUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Link thumbnailLink;
+
+	@JsonIgnore
+	private Supplier<Link> _thumbnailLinkSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -574,6 +616,18 @@ public class FileEntry implements Serializable {
 			sb.append("\"scope\": ");
 
 			sb.append(String.valueOf(scope));
+		}
+
+		Link thumbnailLink = getThumbnailLink();
+
+		if (thumbnailLink != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"thumbnailLink\": ");
+
+			sb.append(String.valueOf(thumbnailLink));
 		}
 
 		sb.append("}");

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
@@ -64,6 +64,48 @@ public class LinkUtil {
 		};
 	}
 
+	public static Link toPreviewLink(
+		DLAppService dlAppService, DLFileEntry dlFileEntry,
+		DLURLHelper dlURLHelper, String objectDefinitionExternalReferenceCode,
+		String objectEntryExternalReferenceCode, Portal portal) {
+
+		return new Link() {
+			{
+				setHref(
+					() -> {
+						try {
+							FileEntry fileEntry = dlAppService.getFileEntry(
+								dlFileEntry.getFileEntryId());
+
+							String previewURL = dlURLHelper.getPreviewURL(
+								fileEntry, fileEntry.getFileVersion(), null,
+								StringPool.BLANK);
+
+							previewURL = HttpComponentsUtil.addParameter(
+								previewURL,
+								"objectDefinitionExternalReferenceCode",
+								objectDefinitionExternalReferenceCode);
+							previewURL = HttpComponentsUtil.addParameter(
+								previewURL, "objectEntryExternalReferenceCode",
+								objectEntryExternalReferenceCode);
+
+							return previewURL;
+						}
+						catch (Exception exception) {
+							if (_log.isWarnEnabled()) {
+								_log.warn(exception);
+							}
+						}
+
+						return StringBundler.concat(
+							portal.getPathContext(), portal.getPathMain(),
+							"/portal/login");
+					});
+				setLabel(dlFileEntry::getFileName);
+			}
+		};
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(LinkUtil.class);
 
 }

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
@@ -5,15 +5,10 @@
 
 package com.liferay.object.rest.dto.v1_0.util;
 
-import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.service.DLAppService;
-import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.object.rest.dto.v1_0.Link;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -23,31 +18,32 @@ import com.liferay.portal.kernel.util.Portal;
 public class LinkUtil {
 
 	public static Link toLink(
-		DLAppService dlAppService, DLFileEntry dlFileEntry,
-		DLURLHelper dlURLHelper, String objectDefinitionExternalReferenceCode,
-		String objectEntryExternalReferenceCode, Portal portal) {
+		String fileName, boolean includeObjectDefinitionExternalReferenceCode,
+		boolean includeObjectEntryExternalReferenceCode,
+		String objectDefinitionExternalReferenceCode,
+		String objectEntryExternalReferenceCode, Portal portal, String url) {
 
 		return new Link() {
 			{
 				setHref(
 					() -> {
 						try {
-							FileEntry fileEntry = dlAppService.getFileEntry(
-								dlFileEntry.getFileEntryId());
+							String href = url;
 
-							String downloadURL = dlURLHelper.getDownloadURL(
-								fileEntry, fileEntry.getFileVersion(), null,
-								StringPool.BLANK);
+							if (includeObjectDefinitionExternalReferenceCode) {
+								href = HttpComponentsUtil.addParameter(
+									url,
+									"objectDefinitionExternalReferenceCode",
+									objectDefinitionExternalReferenceCode);
+							}
 
-							downloadURL = HttpComponentsUtil.addParameter(
-								downloadURL,
-								"objectDefinitionExternalReferenceCode",
-								objectDefinitionExternalReferenceCode);
-							downloadURL = HttpComponentsUtil.addParameter(
-								downloadURL, "objectEntryExternalReferenceCode",
-								objectEntryExternalReferenceCode);
+							if (includeObjectEntryExternalReferenceCode) {
+								href = HttpComponentsUtil.addParameter(
+									href, "objectEntryExternalReferenceCode",
+									objectEntryExternalReferenceCode);
+							}
 
-							return downloadURL;
+							return href;
 						}
 						catch (Exception exception) {
 							if (_log.isWarnEnabled()) {
@@ -59,49 +55,7 @@ public class LinkUtil {
 							portal.getPathContext(), portal.getPathMain(),
 							"/portal/login");
 					});
-				setLabel(dlFileEntry::getFileName);
-			}
-		};
-	}
-
-	public static Link toPreviewLink(
-		DLAppService dlAppService, DLFileEntry dlFileEntry,
-		DLURLHelper dlURLHelper, String objectDefinitionExternalReferenceCode,
-		String objectEntryExternalReferenceCode, Portal portal) {
-
-		return new Link() {
-			{
-				setHref(
-					() -> {
-						try {
-							FileEntry fileEntry = dlAppService.getFileEntry(
-								dlFileEntry.getFileEntryId());
-
-							String previewURL = dlURLHelper.getPreviewURL(
-								fileEntry, fileEntry.getFileVersion(), null,
-								StringPool.BLANK);
-
-							previewURL = HttpComponentsUtil.addParameter(
-								previewURL,
-								"objectDefinitionExternalReferenceCode",
-								objectDefinitionExternalReferenceCode);
-							previewURL = HttpComponentsUtil.addParameter(
-								previewURL, "objectEntryExternalReferenceCode",
-								objectEntryExternalReferenceCode);
-
-							return previewURL;
-						}
-						catch (Exception exception) {
-							if (_log.isWarnEnabled()) {
-								_log.warn(exception);
-							}
-						}
-
-						return StringBundler.concat(
-							portal.getPathContext(), portal.getPathMain(),
-							"/portal/login");
-					});
-				setLabel(dlFileEntry::getFileName);
+				setLabel(() -> fileName);
 			}
 		};
 	}

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 3.0.0

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -52,6 +52,13 @@ components:
                     readOnly: true
                 name:
                     type: string
+                previewLink:
+                    $ref: "#/components/schemas/Link"
+                    # @review
+                    description:
+                        optional field that specifies the preview url of the file, can be embedded with nestedFields
+                        (the format of the nested field must be `<attachment field name>.previewLink`)
+                    readOnly: true
                 scope:
                     $ref: "#/components/schemas/Scope"
             type: object

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -61,6 +61,9 @@ components:
                     readOnly: true
                 scope:
                     $ref: "#/components/schemas/Scope"
+                thumbnailLink:
+                    $ref: "#/components/schemas/Link"
+                    readOnly: true
             type: object
         Folder:
             properties:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -54,10 +54,6 @@ components:
                     type: string
                 previewLink:
                     $ref: "#/components/schemas/Link"
-                    # @review
-                    description:
-                        optional field that specifies the preview url of the file, can be embedded with nestedFields
-                        (the format of the nested field must be `<attachment field name>.previewLink`)
                     readOnly: true
                 scope:
                     $ref: "#/components/schemas/Scope"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -639,6 +639,14 @@ public class ObjectEntryDTOConverter
 				objectDefinition.getExternalReferenceCode(),
 				objectEntry.getExternalReferenceCode(), _portal));
 		fileEntry.setName(dlFileEntry::getFileName);
+		fileEntry.setPreviewLink(
+			() -> NestedFieldsSupplier.supply(
+				objectFieldName + ".previewLink",
+				fieldName -> LinkUtil.toPreviewLink(
+					_dlAppService, dlFileEntry, _dlURLHelper,
+					objectDefinition.getExternalReferenceCode(),
+					objectEntry.getExternalReferenceCode(), _portal))
+		);
 		fileEntry.setScope(
 			() -> {
 				if ((objectEntry.getGroupId() == dlFileEntry.getGroupId()) &&

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -10,7 +10,6 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.list.type.model.ListTypeEntry;
@@ -87,6 +86,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.language.LanguageResources;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -633,20 +633,29 @@ public class ObjectEntryDTOConverter
 				}));
 
 		fileEntry.setId(dlFileEntry::getFileEntryId);
+
+		LiferayFileEntry liferayFileEntry = new LiferayFileEntry(dlFileEntry);
+
 		fileEntry.setLink(
 			() -> LinkUtil.toLink(
-				_dlAppService, dlFileEntry, _dlURLHelper,
+				dlFileEntry.getFileName(), true, true,
 				objectDefinition.getExternalReferenceCode(),
-				objectEntry.getExternalReferenceCode(), _portal));
+				objectEntry.getExternalReferenceCode(), _portal,
+				_dlURLHelper.getDownloadURL(
+					liferayFileEntry, liferayFileEntry.getFileVersion(), null,
+					StringPool.BLANK)));
+
 		fileEntry.setName(dlFileEntry::getFileName);
 		fileEntry.setPreviewLink(
 			() -> NestedFieldsSupplier.supply(
 				objectFieldName + ".previewLink",
-				fieldName -> LinkUtil.toPreviewLink(
-					_dlAppService, dlFileEntry, _dlURLHelper,
+				fieldName -> LinkUtil.toLink(
+					dlFileEntry.getFileName(), true, true,
 					objectDefinition.getExternalReferenceCode(),
-					objectEntry.getExternalReferenceCode(), _portal))
-		);
+					objectEntry.getExternalReferenceCode(), _portal,
+					_dlURLHelper.getPreviewURL(
+						liferayFileEntry, liferayFileEntry.getFileVersion(),
+						null, StringPool.BLANK, false, false))));
 		fileEntry.setScope(
 			() -> {
 				if ((objectEntry.getGroupId() == dlFileEntry.getGroupId()) &&
@@ -1237,9 +1246,6 @@ public class ObjectEntryDTOConverter
 
 	@Reference
 	private AuditEventLocalService _auditEventLocalService;
-
-	@Reference
-	private DLAppService _dlAppService;
 
 	@Reference
 	private DLFileEntryLocalService _dLFileEntryLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -683,6 +683,16 @@ public class ObjectEntryDTOConverter
 
 				return scope;
 			});
+		fileEntry.setThumbnailLink(
+			() -> NestedFieldsSupplier.supply(
+				objectFieldName + ".thumbnailLink",
+				fieldName -> LinkUtil.toLink(
+					dlFileEntry.getFileName(), false, false,
+					objectDefinition.getExternalReferenceCode(),
+					objectEntry.getExternalReferenceCode(), _portal,
+					_dlURLHelper.getThumbnailSrc(
+						liferayFileEntry, liferayFileEntry.getFileVersion(),
+						null))));
 
 		return fileEntry;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -184,8 +184,14 @@
 					"name": {
 						"type": "string"
 					},
+					"previewLink": {
+						"$ref": "#/components/schemas/Link"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"thumbnailLink": {
+						"$ref": "#/components/schemas/Link"
 					},
 					"x-class-name": {
 						"default": "com.liferay.object.rest.dto.v1_0.FileEntry",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -184,8 +184,14 @@
 					"name": {
 						"type": "string"
 					},
+					"previewLink": {
+						"$ref": "#/components/schemas/Link"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"thumbnailLink": {
+						"$ref": "#/components/schemas/Link"
 					},
 					"x-class-name": {
 						"default": "com.liferay.object.rest.dto.v1_0.FileEntry",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -184,8 +184,14 @@
 					"name": {
 						"type": "string"
 					},
+					"previewLink": {
+						"$ref": "#/components/schemas/Link"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"thumbnailLink": {
+						"$ref": "#/components/schemas/Link"
 					},
 					"x-class-name": {
 						"default": "com.liferay.object.rest.dto.v1_0.FileEntry",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -184,8 +184,14 @@
 					"name": {
 						"type": "string"
 					},
+					"previewLink": {
+						"$ref": "#/components/schemas/Link"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"thumbnailLink": {
+						"$ref": "#/components/schemas/Link"
 					},
 					"x-class-name": {
 						"default": "com.liferay.object.rest.dto.v1_0.FileEntry",


### PR DESCRIPTION
LPD-53490 Technical Task | Expose file URL's in headless API's for file previews

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52833

In order to support file previews we’ll need file URL information computed in the backend and the information available via API.

# How am I fixing it?

Expose file URL's in headless API's for file previews with a nested field.

# How can you verify that it works?


1. Go to CMS and create a Basic document with a File.
2. Edit again and copy the last number of the navigation bar (ie. http://localhost:8080/web/cms/e/basic-document/XXXXX/{basicDocumentId})
3. go to http://localhost:8080/o/api?endpoint=http://localhost:8080/o/cms/basic-documents/openapi.json
4. Fill the field basicDocumentId with the id of 2.
5. On the field "nestedFields" put file.previewLink



# Commits

- **LPD-53490 add previewLink to the FileEntry object**
- **LPD-53490 buildRest**
- **LPD-52833 create method to obtain the previewLink for the file of an object entry**
- **LPD-52833 refactor to do not have 2 different methods to obtain the Link**
