### PR TITLE
LPD-53397 Fix integration tests

### DIFF
--- a/modules/apps/friendly-url/friendly-url-test-util/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Friendly URL Test Utilities
 Bundle-SymbolicName: com.liferay.friendly.url.test.util
-Bundle-Version: 1.0.3
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.friendly.url.test.util

--- a/modules/apps/friendly-url/friendly-url-test-util/build.gradle
+++ b/modules/apps/friendly-url/friendly-url-test-util/build.gradle
@@ -2,7 +2,10 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	compileOnly group: "junit", name: "junit", version: "4.13.1"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:friendly-url:friendly-url-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
 
 	liferay {
 		deployDir = file("${liferayHome}/osgi/test")

--- a/modules/apps/friendly-url/friendly-url-test-util/src/main/java/com/liferay/friendly/url/test/util/FriendlyURLSeparatorConfigurationManagerTemporarySwapper.java
+++ b/modules/apps/friendly-url/friendly-url-test-util/src/main/java/com/liferay/friendly/url/test/util/FriendlyURLSeparatorConfigurationManagerTemporarySwapper.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.friendly.url.test.util;
+
+import com.liferay.friendly.url.configuration.manager.FriendlyURLSeparatorConfigurationManager;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class FriendlyURLSeparatorConfigurationManagerTemporarySwapper
+	implements AutoCloseable {
+
+	public FriendlyURLSeparatorConfigurationManagerTemporarySwapper(
+			long companyId, String json)
+		throws PortalException {
+
+		_companyId = companyId;
+
+		FriendlyURLSeparatorConfigurationManager
+			friendlyURLSeparatorConfigurationManager =
+				_serviceTracker.getService();
+
+		_jsonObject =
+			friendlyURLSeparatorConfigurationManager.
+				getFriendlyURLSeparatorsJSONObject(companyId);
+
+		friendlyURLSeparatorConfigurationManager.
+			updateFriendlyURLSeparatorCompanyConfiguration(companyId, json);
+	}
+
+	@Override
+	public void close() throws Exception {
+		FriendlyURLSeparatorConfigurationManager
+			friendlyURLSeparatorConfigurationManager =
+				_serviceTracker.getService();
+
+		friendlyURLSeparatorConfigurationManager.
+			updateFriendlyURLSeparatorCompanyConfiguration(
+				_companyId, _jsonObject.toString());
+	}
+
+	private static final BundleContext _bundleContext;
+	private static final ServiceTracker
+		<FriendlyURLSeparatorConfigurationManager,
+		 FriendlyURLSeparatorConfigurationManager> _serviceTracker;
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(
+			FriendlyURLSeparatorConfigurationManagerTemporarySwapper.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		ServiceTracker
+			<FriendlyURLSeparatorConfigurationManager,
+			 FriendlyURLSeparatorConfigurationManager> serviceTracker =
+				new ServiceTracker<>(
+					bundle.getBundleContext(),
+					FriendlyURLSeparatorConfigurationManager.class, null);
+
+		serviceTracker.open();
+
+		_serviceTracker = serviceTracker;
+	}
+
+	private final long _companyId;
+	private final JSONObject _jsonObject;
+
+}

--- a/modules/apps/friendly-url/friendly-url-test-util/src/main/resources/com/liferay/friendly/url/test/util/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-test-util/src/main/resources/com/liferay/friendly/url/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/layout/layout-page-template-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-test/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")
+	testIntegrationImplementation project(":apps:friendly-url:friendly-url-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-delivery:headless-delivery-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:info:info-list-provider-item-selector-api")

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/info/item/provider/test/DisplayPageInfoItemFieldSetProviderTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/info/item/provider/test/DisplayPageInfoItemFieldSetProviderTest.java
@@ -10,7 +10,7 @@ import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
-import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.test.util.FriendlyURLSeparatorConfigurationManagerTemporarySwapper;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldValue;
@@ -24,13 +24,11 @@ import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.constants.LayoutDisplayPageWebKeys;
 import com.liferay.layout.page.template.info.item.provider.DisplayPageInfoItemFieldSetProvider;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
-import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -47,7 +45,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -137,23 +134,16 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 
 		String customAssetFriendlyURLSeparator = "/custom-asset-test1";
 
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
+		try (FriendlyURLSeparatorConfigurationManagerTemporarySwapper
+				friendlyURLSeparatorConfigurationManagerTemporarySwapper =
+					new FriendlyURLSeparatorConfigurationManagerTemporarySwapper(
 						_group.getCompanyId(),
-						FriendlyURLSeparatorCompanyConfiguration.class.
-							getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"friendlyURLSeparatorsJSON",
-							JSONUtil.put(
-								JournalArticle.class.getName(),
-								"/journal-test1/"
-							).put(
-								"custom-asset-display-page",
-								customAssetFriendlyURLSeparator +
-									StringPool.SLASH
-							)
-						).build())) {
+						JSONUtil.put(
+							JournalArticle.class.getName(), "/journal-test1/"
+						).put(
+							"custom-asset-display-page",
+							customAssetFriendlyURLSeparator + StringPool.SLASH
+						).toString())) {
 
 			_assertInfoFieldValues(customAssetFriendlyURLSeparator);
 		}
@@ -348,10 +338,6 @@ public class DisplayPageInfoItemFieldSetProviderTest {
 	private LayoutLocalService _layoutLocalService;
 
 	private LayoutPageTemplateEntry _layoutPageTemplateEntry;
-
-	@Inject
-	private LayoutPageTemplateEntryLocalService
-		_layoutPageTemplateEntryLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/layout/layout-test/build.gradle
+++ b/modules/apps/layout/layout-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")
+	testIntegrationImplementation project(":apps:friendly-url:friendly-url-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-delivery:headless-delivery-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:info:info-list-provider-item-selector-api")

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/portlet/test/LayoutFriendlyURLSeparatorCompositeTest.java
@@ -6,11 +6,10 @@
 package com.liferay.layout.portlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.test.util.FriendlyURLSeparatorConfigurationManagerTemporarySwapper;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
-import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LayoutFriendlyURLSeparatorComposite;
@@ -20,7 +19,6 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -74,18 +72,14 @@ public class LayoutFriendlyURLSeparatorCompositeTest {
 
 		String journalArticleFriendlyURLSeparator = "/journal-test1/";
 
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
+		try (FriendlyURLSeparatorConfigurationManagerTemporarySwapper
+				friendlyURLSeparatorConfigurationManagerTemporarySwapper =
+					new FriendlyURLSeparatorConfigurationManagerTemporarySwapper(
 						_group.getCompanyId(),
-						FriendlyURLSeparatorCompanyConfiguration.class.
-							getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"friendlyURLSeparatorsJSON",
-							JSONUtil.put(
-								JournalArticle.class.getName(),
-								journalArticleFriendlyURLSeparator)
-						).build())) {
+						JSONUtil.put(
+							JournalArticle.class.getName(),
+							journalArticleFriendlyURLSeparator
+						).toString())) {
 
 			_assertGetLayoutFriendlyURLSeparatorComposite(
 				journalArticleFriendlyURLSeparator);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
 	testIntegrationImplementation project(":apps:friendly-url:friendly-url-api")
+	testIntegrationImplementation project(":apps:friendly-url:friendly-url-test-util")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
@@ -10,7 +10,7 @@ import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
-import com.liferay.friendly.url.configuration.FriendlyURLSeparatorCompanyConfiguration;
+import com.liferay.friendly.url.test.util.FriendlyURLSeparatorConfigurationManagerTemporarySwapper;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
@@ -21,7 +21,6 @@ import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -38,7 +37,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -111,20 +109,16 @@ public class AssetDisplayPageFriendlyURLProviderImplTest {
 	public void testGetFriendlyURLWithConfiguredURLSeparator()
 		throws Exception {
 
-		String journalArticleFriendlyURLSeparator = "/journal-test1/";
+		String journalArticleFriendlyURLSeparator = "/journal-test2/";
 
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
+		try (FriendlyURLSeparatorConfigurationManagerTemporarySwapper
+				friendlyURLSeparatorConfigurationManagerTemporarySwapper =
+					new FriendlyURLSeparatorConfigurationManagerTemporarySwapper(
 						_group.getCompanyId(),
-						FriendlyURLSeparatorCompanyConfiguration.class.
-							getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"friendlyURLSeparatorsJSON",
-							JSONUtil.put(
-								JournalArticle.class.getName(),
-								journalArticleFriendlyURLSeparator)
-						).build())) {
+						JSONUtil.put(
+							JournalArticle.class.getName(),
+							journalArticleFriendlyURLSeparator
+						).toString())) {
 
 			_assertGetFriendlyURL(journalArticleFriendlyURLSeparator);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-53395

We now have a cache in place, so instead of calling the configuration directly, create a swapper for the configuration admin interface and replace it accordingly

How to test that this works:

Run:

- DisplayPageInfoItemFieldSetProviderTest
- LayoutFriendlyURLSeparatorCompositeTest
- AssetDisplayPageFriendlyURLProviderImplTest