### PR TITLE
LPD-47341 Edit folder fragment renderer + display page template

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-edit/display-page-template.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-edit/display-page-template.json
@@ -1,0 +1,7 @@
+{
+	"contentType": {
+		"className": "com.liferay.object.model.ObjectEntryFolder"
+	},
+	"defaultTemplate": true,
+	"name": "Edit Folder"
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-edit/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-edit/page-definition.json
@@ -1,0 +1,34 @@
+{
+	"pageElement": {
+		"id": "40f19ab4-0c8b-e614-2956-9e9c01c76e1f",
+		"pageElements": [
+			{
+				"definition": {
+					"indexed": true,
+					"layout": {
+					}
+				},
+				"id": "d82ed0d0-ba20-6e54-4e52-610b97e9223c",
+				"pageElements": [
+					{
+						"definition": {
+							"fragment": {
+								"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.EditFolderFragmentRenderer"
+							},
+							"fragmentConfig": {
+							},
+							"fragmentFields": [
+							],
+							"indexed": true
+						},
+						"id": "d656e0c8-f755-a3a4-a2d2-7289b48b5fb0",
+						"type": "Fragment"
+					}
+				],
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"version": 1.1
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/display-page-template.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/display-page-template.json
@@ -1,0 +1,7 @@
+{
+	"contentType": {
+		"className": "com.liferay.object.model.ObjectEntryFolder"
+	},
+	"defaultTemplate": true,
+	"name": "View Folder"
+}

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/display-page-templates/folder-view/page-definition.json
@@ -1,0 +1,14 @@
+{
+	"pageElement": {
+		"id": "e516faca-6284-cfd8-4ce1-33fc578c0da7",
+		"pageElements": [
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"masterPage": {
+			"key": "cms-master"
+		}
+	},
+	"version": 1.1
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderFragmentRenderer.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.frontend.taglib.react.servlet.taglib.ComponentTag;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.taglib.servlet.PageContextFactoryUtil;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Locale;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Ambrín Chaudhary
+ */
+@Component(service = FragmentRenderer.class)
+public class EditFolderFragmentRenderer extends BaseSectionFragmentRenderer {
+
+	@Override
+	public String getCollectionKey() {
+		return "sections";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "edit-folder");
+	}
+
+	@Override
+	public void render(
+			FragmentRendererContext fragmentRendererContext,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		try {
+			PrintWriter printWriter = httpServletResponse.getWriter();
+
+			printWriter.write("<div><span aria-hidden=\"true\" class=\"");
+			printWriter.write("loading-animation\"></span>");
+
+			ComponentTag componentTag = new ComponentTag();
+
+			componentTag.setModule(
+				"{EditFolder} from site-cms-site-initializer");
+			componentTag.setPageContext(
+				PageContextFactoryUtil.create(
+					httpServletRequest, httpServletResponse));
+
+			componentTag.setProps(
+				HashMapBuilder.<String, Object>put(
+					"description", "description"
+				).put(
+					"name", "name"
+				).put(
+					"space", "space 1"
+				).build());
+
+			componentTag.setServletContext(_servletContext);
+
+			componentTag.doStartTag();
+
+			componentTag.doEndTag();
+
+			printWriter.write("</div>");
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	@Reference
+	private Language _language;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.site.cms.site.initializer)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/EditFolderFragmentRenderer.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.frontend.taglib.react.servlet.taglib.ComponentTag;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.taglib.servlet.PageContextFactoryUtil;
 
 import java.io.IOException;
@@ -63,6 +64,9 @@ public class EditFolderFragmentRenderer extends BaseSectionFragmentRenderer {
 
 			componentTag.setProps(
 				HashMapBuilder.<String, Object>put(
+					"backURL",
+					ParamUtil.getString(httpServletRequest, "backURL")
+				).put(
 					"description", "description"
 				).put(
 					"name", "name"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -14,6 +14,7 @@ export {default as CategorizationToolbar} from './main/categorization/Categoriza
 export {default as ViewTags} from './main/categorization/tags/ViewTags';
 export {default as EditVocabulary} from './main/categorization/vocabularies/EditVocabulary';
 export {default as SpacesSticker} from './main/components/SpaceSticker';
+export {default as EditFolder} from './main/components/folders/EditFolder';
 export {default as ViewDashboard} from './main/dashboard/ViewDashboard';
 export {default as SpacesNavigation} from './main/spaces_navigation/SpacesNavigation';
 export {default as StructureBuilder} from './structure_builder/components/StructureBuilder';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+interface EditFolderProps {
+	description?: string;
+	name: string;
+	space: string;
+}
+
+const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
+	return (
+		<h1>
+			{' '}
+
+			Edit Folder Page {name} {description} {space}{' '}
+		</h1>
+	);
+};
+
+export default EditFolder;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -4,8 +4,11 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayForm from '@clayui/form';
 import ClayToolbar from '@clayui/toolbar';
 import React from 'react';
+
+import {FieldText} from '../forms';
 
 interface EditFolderProps {
 	description?: string;
@@ -54,7 +57,37 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 				</ClayToolbar.Nav>
 			</ClayToolbar>
 
-			Edit Folder Page {name} {description} {space}
+			<div className="container-fluid container-fluid-max-md mt-4">
+				<ClayForm>
+					<h3 className="font-weight-semi-bold mb-4 text-6">
+						{Liferay.Language.get('basic-info')}
+					</h3>
+
+					<FieldText
+						label={Liferay.Language.get('name')}
+						name="folderName"
+						required
+						type="input"
+						value={name}
+					/>
+
+					<FieldText
+						disabled
+						label={Liferay.Language.get('space')}
+						name="folderSpace"
+						required
+						type="input"
+						value={space}
+					/>
+
+					<FieldText
+						label={Liferay.Language.get('description')}
+						name="folderDescription"
+						type="textarea"
+						value={description}
+					/>
+				</ClayForm>
+			</div>
 		</div>
 	);
 };

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -22,7 +22,7 @@ interface EditFolderProps {
 const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 	const spaceItems: Item[] = [{label: space, value: space}];
 
-	const {errors, handleChange, values} = useFormik({
+	const {errors, handleChange, handleSubmit, values} = useFormik({
 		initialValues: {
 			folderDescription: description || '',
 			folderName: name,
@@ -71,7 +71,12 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 					</ClayToolbar.Item>
 
 					<ClayToolbar.Item>
-						<ClayButton displayType="primary" size="sm">
+						<ClayButton
+							displayType="primary"
+							form="formEditFolder"
+							size="sm"
+							type="submit"
+						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 					</ClayToolbar.Item>
@@ -79,7 +84,7 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 			</ClayToolbar>
 
 			<div className="container-fluid container-fluid-max-md mt-4">
-				<ClayForm>
+				<ClayForm id="formEditFolder" onSubmit={handleSubmit}>
 					<h3 className="font-weight-semi-bold mb-4 text-6">
 						{Liferay.Language.get('basic-info')}
 					</h3>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -5,10 +5,12 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
+import {Item} from '@clayui/multi-select/lib/types';
 import ClayToolbar from '@clayui/toolbar';
 import React from 'react';
 
-import {FieldText} from '../forms';
+import {FieldPicker, FieldText} from '../forms';
+import {required, validate} from '../forms/validations';
 
 interface EditFolderProps {
 	description?: string;
@@ -17,6 +19,8 @@ interface EditFolderProps {
 }
 
 const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
+	const spaceItems: Item[] = [{label: space, value: space}];
+
 	return (
 		<div className="edit-folder">
 			<ClayToolbar className="container-fluid" light>
@@ -71,13 +75,13 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 						value={name}
 					/>
 
-					<FieldText
+					<FieldPicker
 						disabled
+						items={spaceItems}
 						label={Liferay.Language.get('space')}
 						name="folderSpace"
 						required
-						type="input"
-						value={space}
+						selectedKey={space}
 					/>
 
 					<FieldText

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -7,6 +7,7 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
 import {Item} from '@clayui/multi-select/lib/types';
 import ClayToolbar from '@clayui/toolbar';
+import {useFormik} from 'formik';
 import React from 'react';
 
 import {FieldPicker, FieldText} from '../forms';
@@ -20,6 +21,22 @@ interface EditFolderProps {
 
 const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 	const spaceItems: Item[] = [{label: space, value: space}];
+
+	const {errors, handleChange, values} = useFormik({
+		initialValues: {
+			folderDescription: description || '',
+			folderName: name,
+			folderSpace: space,
+		},
+		onSubmit: () => {},
+		validate: (values) =>
+			validate(
+				{
+					folderName: [required],
+				},
+				values
+			),
+	});
 
 	return (
 		<div className="edit-folder">
@@ -68,11 +85,13 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 					</h3>
 
 					<FieldText
+						errorMessage={errors.folderName}
 						label={Liferay.Language.get('name')}
 						name="folderName"
+						onChange={handleChange}
 						required
 						type="input"
-						value={name}
+						value={values.folderName}
 					/>
 
 					<FieldPicker
@@ -81,14 +100,15 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 						label={Liferay.Language.get('space')}
 						name="folderSpace"
 						required
-						selectedKey={space}
+						selectedKey={values.folderSpace}
 					/>
 
 					<FieldText
 						label={Liferay.Language.get('description')}
 						name="folderDescription"
+						onChange={handleChange}
 						type="textarea"
-						value={description}
+						value={values.folderDescription}
 					/>
 				</ClayForm>
 			</div>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayToolbar from '@clayui/toolbar';
 import React from 'react';
 
 interface EditFolderProps {
@@ -13,11 +15,47 @@ interface EditFolderProps {
 
 const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 	return (
-		<h1>
-			{' '}
+		<div className="edit-folder">
+			<ClayToolbar className="container-fluid" light>
+				<ClayToolbar.Nav>
+					<ClayToolbar.Item>
+						<ClayButtonWithIcon
+							aria-label={Liferay.Language.get('back')}
+							borderless
+							displayType="secondary"
+							monospaced
+							size="sm"
+							symbol="angle-left"
+							title={Liferay.Language.get('back')}
+						/>
+					</ClayToolbar.Item>
 
-			Edit Folder Page {name} {description} {space}{' '}
-		</h1>
+					<ClayToolbar.Item className="text-left" expand>
+						<h2 className="font-weight-semi-bold m-0 text-5">
+							{name}
+						</h2>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButton
+							borderless
+							displayType="secondary"
+							size="sm"
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayToolbar.Item>
+
+					<ClayToolbar.Item>
+						<ClayButton displayType="primary" size="sm">
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayToolbar.Item>
+				</ClayToolbar.Nav>
+			</ClayToolbar>
+
+			Edit Folder Page {name} {description} {space}
+		</div>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -8,18 +8,25 @@ import ClayForm from '@clayui/form';
 import {Item} from '@clayui/multi-select/lib/types';
 import ClayToolbar from '@clayui/toolbar';
 import {useFormik} from 'formik';
+import {navigate} from 'frontend-js-web';
 import React from 'react';
 
 import {FieldPicker, FieldText} from '../forms';
 import {required, validate} from '../forms/validations';
 
 interface EditFolderProps {
+	backURL: string;
 	description?: string;
 	name: string;
 	space: string;
 }
 
-const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
+const EditFolder: React.FC<EditFolderProps> = ({
+	backURL,
+	description,
+	name,
+	space,
+}) => {
 	const spaceItems: Item[] = [{label: space, value: space}];
 
 	const {errors, handleChange, handleSubmit, values} = useFormik({
@@ -48,6 +55,7 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 							borderless
 							displayType="secondary"
 							monospaced
+							onClick={() => navigate(backURL)}
 							size="sm"
 							symbol="angle-left"
 							title={Liferay.Language.get('back')}
@@ -64,6 +72,7 @@ const EditFolder: React.FC<EditFolderProps> = ({description, name, space}) => {
 						<ClayButton
 							borderless
 							displayType="secondary"
+							onClick={() => navigate(backURL)}
 							size="sm"
 						>
 							{Liferay.Language.get('cancel')}


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-47341)
[Parent story](https://liferay.atlassian.net/browse/LPD-42841)

The aim of the story is to create a page (`/edit-folder`) that renders a custom fragment renderer (`EditFolder.tsx`) to display the edit folder page as it is designed in https://liferay.atlassian.net/browse/LPD-42841

In following subtasks, the page will be [linked to a Edit](https://liferay.atlassian.net/browse/LPD-54027) action for each folder and the [save button](https://liferay.atlassian.net/browse/LPD-54028) will be handled. 

**How to test it**: access to http://localhost:8080/web/cms/edit-folder

Frontend part has already been reviewed by @boton in https://github.com/liferay/liferay-portal/pull/6250

![Screenshot 2025-04-24 at 13 25 24](https://github.com/user-attachments/assets/0e243522-2889-44ad-a1cc-9147da6fd56d)

