### PR TITLE
LPD-52625 When uploading a file too close to the upload limit, the page loads forever

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.kernel.exception.FileSizeException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
 import com.liferay.document.library.workflow.WorkflowHandlerInvocationCounter;
 import com.liferay.petra.lang.SafeCloseable;
@@ -42,6 +43,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProviderUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -211,6 +213,24 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		Assert.assertNull(fileEntry.getDisplayDate());
 		Assert.assertNull(fileEntry.getExpirationDate());
 		Assert.assertEquals(reviewDate, fileEntry.getReviewDate());
+	}
+
+	@Test
+	public void testFileEntryShouldUploadFileWithMaxUploadSizeFromServletRequest()
+		throws Exception {
+
+		String fileName = "test.pdf";
+
+		int maxSize =
+			(int)UploadServletRequestConfigurationProviderUtil.getMaxSize();
+
+		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
+			null, group.getGroupId(), parentFolder.getFolderId(), fileName,
+			ContentTypes.APPLICATION_OCTET_STREAM, fileName, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, new byte[maxSize], null, null,
+			null, ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertNotNull(fileEntry);
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/ServletFileUploadImpl.java
+++ b/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/ServletFileUploadImpl.java
@@ -43,8 +43,11 @@ public class ServletFileUploadImpl implements ServletFileUpload {
 						new File(location), fileSizeThreshold,
 						httpServletRequest.getCharacterEncoding()));
 
+		// LPD-52625 Added Padding for Metadata Handling
+
 		long fileMaxSize =
-			UploadServletRequestConfigurationProviderUtil.getMaxSize();
+			UploadServletRequestConfigurationProviderUtil.getMaxSize() +
+				_UPLOAD_MAX_SIZE_PADDING;
 
 		servletFileUpload.setFileSizeMax(fileMaxSize);
 		servletFileUpload.setSizeMax(fileMaxSize);
@@ -76,5 +79,7 @@ public class ServletFileUploadImpl implements ServletFileUpload {
 			throw uploadException;
 		}
 	}
+
+	private static final long _UPLOAD_MAX_SIZE_PADDING = 10000;
 
 }

--- a/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java
@@ -86,8 +86,13 @@ public class UploadServletRequestImpl
 			liferayServletRequest.setFinishedReadingOriginalStream(true);
 
 			int contentLength = httpServletRequest.getContentLength();
+
+			// LPD-52625 Added Padding for Metadata Handling
+
 			long uploadServletRequestImplMaxSize =
-				UploadServletRequestConfigurationProviderUtil.getMaxSize();
+				UploadServletRequestConfigurationProviderUtil.getMaxSize() +
+					_UPLOAD_MAX_SIZE_PADDING;
+
 			long uploadServletRequestImplSize = 0;
 
 			if ((uploadServletRequestImplMaxSize > 0) &&
@@ -585,6 +590,8 @@ public class UploadServletRequestImpl
 
 		return sortedFileItems;
 	}
+
+	private static final long _UPLOAD_MAX_SIZE_PADDING = 10000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UploadServletRequestImpl.class);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-52625
When a file is uploaded with a size exactly equal to the upload servlet request limit, the upload fails with an error. This happens because metadata and multipart headers consume additional bytes beyond the raw file size.
### **How am I fixing it?**
A buffer of 10KB has been added to the maximum allowed file size to account for metadata and multipart overhead during file uploads. This ensures that files with a size equal to the servlet limit can be uploaded successfully.
### **How can you verify that it works?**

1. Start the Liferay instance.
2. Navigate to Documents and Media.
3. Upload a document whose size is exactly equal to the Upload Servlet Request Max Size.
4. The file should upload successfully without any errors.

