### PR TITLE
LPD-54293 Webcontent are not visible in the Related asset window

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -338,7 +338,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 
 		if (_infoItemItemSelectorCriterion.isMultiSelection()) {
 			JournalRowChecker journalRowChecker = new JournalRowChecker(
-				JournalArticleLocalServiceUtil.fetchJournalArticle(
+				JournalArticleLocalServiceUtil.fetchLatestArticle(
 					_infoItemItemSelectorCriterion.getRefererClassPK()),
 				_portletResponse);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -50,7 +50,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 			%>
 
 			<c:choose>
-				<c:when test="<%= (curArticle != null) && !journalArticleItemSelectorViewDisplayContext.isRefererArticle(curArticle) %>">
+				<c:when test="<%= curArticle != null %>">
 
 					<%
 					row.setCssClass("articles " + row.getCssClass());

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -241,3 +241,49 @@ test(
 		await expect(page.getByRole('button', {name: 'Delete'})).toBeDisabled();
 	}
 );
+
+test(
+	'Current item checkbox is disabled in Related Assets',
+	{
+		tag: '@LPD-54293',
+	},
+	async ({apiHelpers, journalEditArticlePage, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		const webContentTitles = [
+			'First Web Content',
+			'Second Web Content',
+			'Third Web Content',
+		];
+
+		for (const title of webContentTitles) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: title},
+			});
+		}
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('link', {name: 'First Web Content'}).click();
+
+		await journalEditArticlePage.openRelatedAsset('Basic Web Content');
+
+		await journalEditArticlePage.changeViewInRelatedAssetPopUp(
+			'Basic Web Content',
+			'list'
+		);
+
+		const relatedAssetsFrame = page.frameLocator(
+			`iframe[title="Select Basic Web Content"]`
+		);
+
+		const relatedAssetItems = relatedAssetsFrame.locator(
+			'dd:has(input[type="checkbox"]:not([disabled]))'
+		);
+
+		await expect(relatedAssetItems).toHaveCount(2);
+	}
+);

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -85,6 +85,7 @@ export class JournalEditArticlePage {
 				.frameLocator(`iframe[title="Select ${assetType}"]`)
 				.getByLabel('Not Visible to Guest Users')
 				.locator('use')
+				.first()
 		).toBeVisible({timeout: 1000});
 	}
 


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-54293
An additional empty block was appearing in the Related Assets section of Web Content, caused by the current web content article being included in the list of related items. 

### **How am I fixing it?**
The current journal article is now excluded from the list of items (folders and articles) displayed in the related assets search container.

### **How can you verify that it works?**

1. Start the Liferay instance.
2. Create two Web Content articles.
3. Open the Related Assets panel for one of the articles.
4. Expected Result: Only the other web content article is displayed in the list—no extra empty block appears.