### PR TITLE
LPD-54298 Duplicate Web Content Articles are created if "Publish" is clicked more than once

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -108,6 +108,7 @@ export default function PublishModal({
 								}
 								else {
 									onPublishButtonClick(actionButton);
+									onClose();
 								}
 							}}
 							type={


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-54298)

**How did I fix it**

I have tried to "disable" the button on the onclick function (like @jkappler did), but this is triggered before the submit action, so the submit is never reached then. 

The only alternative I see is to close the modal once it is submitted, and this action is done asynchronously. First it reached the [DDMFormValid](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js#L446) and then the form is submitted. 

**How to test it**

Follow the steps on the issue (use throttling in your browser). I don't think this case need a unit or functional test. 