### PR TITLE
[playwright] LPD-54158 Fix playwright test failures in Content Management modules due to LPD-51577 pagination update

### DIFF
--- a/modules/test/playwright/tests/account-admin-web/main/accountPermissions.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/main/accountPermissions.spec.ts
@@ -730,7 +730,7 @@ test(
 			}
 		}
 
-		await setItemsPerPage(page, '40');
+		await setItemsPerPage(page, 40);
 
 		for (const account of accounts) {
 			await expect(

--- a/modules/test/playwright/tests/document-library-web/main/dmHistory.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/dmHistory.spec.ts
@@ -34,7 +34,7 @@ test(
 						)
 					);
 
-				for (let i = 0; i < 11; i++) {
+				for (let i = 0; i < 20; i++) {
 					await apiHelpers.headlessDelivery.patchDocument({
 						document: {
 							description: '' + i,
@@ -49,14 +49,14 @@ test(
 		await documentLibraryPage.goto(site.friendlyUrlPath);
 		await documentLibraryPage.goToViewHistoryFileEntry(fileEntryTitle);
 
-		await setItemsPerPage(page, 8);
+		await setItemsPerPage(page, 20);
 
 		await expect(
-			page.getByText('Showing 1 to 8 of 12 entries.', {exact: true})
+			page.getByText('Showing 1 to 20 of 21 entries.', {exact: true})
 		).toBeVisible();
 
 		await expect(page.locator('td.lfr-version-column').nth(0)).toHaveText(
-			'1.11'
+			'1.20'
 		);
 	}
 );

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -509,7 +509,7 @@ baseTest(
 		const contentStructureId =
 			await getBasicWebContentStructureId(apiHelpers);
 
-		for (let i = 0; i < 10; i++) {
+		for (let i = 0; i < 42; i++) {
 			await apiHelpers.jsonWebServicesJournal.addWebContent({
 				ddmStructureId: contentStructureId,
 				groupId: site.id,
@@ -518,7 +518,7 @@ baseTest(
 
 		await journalPage.goto(site.friendlyUrlPath);
 
-		await setItemsPerPage(page, 4);
+		await setItemsPerPage(page, 20);
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
 		await page.getByTestId('row').nth(1).getByRole('checkbox').check();
@@ -526,7 +526,7 @@ baseTest(
 		await nextPage(page);
 
 		await expect(
-			page.getByText('Showing 5 to 8 of 10 entries.')
+			page.getByText('Showing 21 to 40 of 42 entries.')
 		).toBeVisible();
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
@@ -535,7 +535,7 @@ baseTest(
 		await nextPage(page);
 
 		await expect(
-			page.getByText('Showing 9 to 10 of 10 entries.')
+			page.getByText('Showing 41 to 42 of 42 entries.')
 		).toBeVisible();
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();

--- a/modules/test/playwright/tests/message-boards-web/main/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/main/message-boards-web.spec.ts
@@ -12,7 +12,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {messageBoardsPagesTest} from '../../../fixtures/messageBoardsTest';
 import {workflowPagesTest} from '../../../fixtures/workflowPagesTest';
 import getRandomString from '../../../utils/getRandomString';
-import {gotoPage, setItemsPerPage} from '../../../utils/pagination';
+import {nextPage, setItemsPerPage} from '../../../utils/pagination';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -191,7 +191,7 @@ test(
 		const threadsLinks = page.getByRole('link', {
 			name: /Thread with headline #\d+/,
 		});
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 21; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
 				headline: 'Thread with headline #' + i,
@@ -201,14 +201,14 @@ test(
 
 		await messageBoardsPage.goto(site.friendlyUrlPath);
 
-		await setItemsPerPage(page, 4);
-		await expect(threadsLinks).toHaveCount(4);
+		await setItemsPerPage(page, 20);
+		await expect(threadsLinks).toHaveCount(20);
 
-		await gotoPage(page, 2);
+		await nextPage(page);
 		await expect(threadsLinks).toHaveCount(1);
 
-		await setItemsPerPage(page, 8);
-		await expect(threadsLinks).toHaveCount(5);
+		await setItemsPerPage(page, 40);
+		await expect(threadsLinks).toHaveCount(21);
 	}
 );
 
@@ -219,7 +219,7 @@ test(
 		const threadsLinks = page.getByRole('link', {
 			name: /Thread with headline #\d+/,
 		});
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 21; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
 				headline: 'Thread with headline #' + i,
@@ -228,13 +228,13 @@ test(
 		}
 		await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
 
-		await setItemsPerPage(page, 4);
-		await expect(threadsLinks).toHaveCount(4);
+		await setItemsPerPage(page, 20);
+		await expect(threadsLinks).toHaveCount(20);
 
-		await gotoPage(page, 2);
+		await nextPage(page);
 		await expect(threadsLinks).toHaveCount(1);
 
-		await setItemsPerPage(page, 8);
-		await expect(threadsLinks).toHaveCount(5);
+		await setItemsPerPage(page, 40);
+		await expect(threadsLinks).toHaveCount(21);
 	}
 );

--- a/modules/test/playwright/utils/pagination.ts
+++ b/modules/test/playwright/utils/pagination.ts
@@ -17,13 +17,13 @@ export async function nextPage(page) {
 	await getPaginator(page).getByTitle('next page').click();
 }
 
-export async function gotoPage(page, pageNumber: number | string) {
+export async function gotoPage(page, pageNumber: number) {
 	await getPaginator(page)
 		.getByRole('link', {name: `Page ${pageNumber}`})
 		.click();
 }
 
-export async function setItemsPerPage(page, limit: number | string) {
+export async function setItemsPerPage(page, limit: 20 | 40 | 60) {
 	const timeout = 300;
 	const option = getPaginator(page).getByRole('option', {
 		name: `${limit} Entries per Page`,


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54158

This PR addresses test failures in Content Management Playwright tests that started happening after the pagination logic was updated in [LPD-51577](https://liferay.atlassian.net/browse/LPD-51577). 

# How am I fixing it?

I’ve updated the pagination utility to restrict the allowed delta values to those supported by the portal. The portal now only supports a fixed set of delta values: `5, 10, 20, 40, 60`.
This prevents future inconsistencies or silent failures when using unsupported deltas.

>[!CAUTION]
> However, this change makes the tests significantly more expensive to run, as we now need to create more items in order to trigger the pagination.
> To try to reduce the cost, I attempted to override the default deltas in the search container configuration using these properties:
> - `modules/test/playwright/env/portal-ext.properties`
> - `modules/test/playwright/tests/message-boards-web/env/portal-ext.properties`
>
> **Unfortunately, they seem to have no effect.**

# How can you verify that it works?

Run the playwright affected tests.

```sh
npm run playwright -- test -g "@LPD-52628|@LPD-19384|@LPD-37727|@LPD-39570"
```

# Tested locally

### ✅ Sometimes it passes.
![image](https://github.com/user-attachments/assets/807470cb-7139-40a8-b313-feb39044abca)

### ❌ Other times it still fails due to variability in the number of created items and timing issues.
![image](https://github.com/user-attachments/assets/bb356581-db9a-420f-a879-484fa1b9000d)
