### PR TITLE
LPD-54305 Technical Task | External Reference Code Adoption for categories/vocabularies on ObjectEntry

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -911,7 +911,7 @@ public class ObjectEntry implements Serializable {
 	@GraphQLField(
 		description = "The categories associated with this object entry."
 	)
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected TaxonomyCategoryBrief[] taxonomyCategoryBriefs;
 
 	@JsonIgnore

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ParentTaxonomyCategory.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ParentTaxonomyCategory.java
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "The category's parent category.",
+	value = "ParentTaxonomyCategory"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ParentTaxonomyCategory")
+public class ParentTaxonomyCategory implements Serializable {
+
+	public static ParentTaxonomyCategory toDTO(String json) {
+		return ObjectMapperUtil.readValue(ParentTaxonomyCategory.class, json);
+	}
+
+	public static ParentTaxonomyCategory unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			ParentTaxonomyCategory.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The parent taxonomy category's external reference code."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The parent taxonomy category's external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ParentTaxonomyCategory)) {
+			return false;
+		}
+
+		ParentTaxonomyCategory parentTaxonomyCategory =
+			(ParentTaxonomyCategory)object;
+
+		return Objects.equals(toString(), parentTaxonomyCategory.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ParentTaxonomyVocabulary.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ParentTaxonomyVocabulary.java
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "The parent category's `TaxonomyVocabulary`.",
+	value = "ParentTaxonomyVocabulary"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ParentTaxonomyVocabulary")
+public class ParentTaxonomyVocabulary implements Serializable {
+
+	public static ParentTaxonomyVocabulary toDTO(String json) {
+		return ObjectMapperUtil.readValue(ParentTaxonomyVocabulary.class, json);
+	}
+
+	public static ParentTaxonomyVocabulary unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			ParentTaxonomyVocabulary.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The parent category's `TaxonomyVocabulary` external reference code."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The parent category's `TaxonomyVocabulary` external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ParentTaxonomyVocabulary)) {
+			return false;
+		}
+
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			(ParentTaxonomyVocabulary)object;
+
+		return Objects.equals(toString(), parentTaxonomyVocabulary.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/TaxonomyCategoryBrief.java
@@ -98,6 +98,190 @@ public class TaxonomyCategoryBrief implements Serializable {
 	private Supplier<Object> _embeddedTaxonomyCategorySupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The category's parent category."
+	)
+	@Valid
+	public ParentTaxonomyCategory getParentTaxonomyCategory() {
+		if (_parentTaxonomyCategorySupplier != null) {
+			parentTaxonomyCategory = _parentTaxonomyCategorySupplier.get();
+
+			_parentTaxonomyCategorySupplier = null;
+		}
+
+		return parentTaxonomyCategory;
+	}
+
+	public void setParentTaxonomyCategory(
+		ParentTaxonomyCategory parentTaxonomyCategory) {
+
+		this.parentTaxonomyCategory = parentTaxonomyCategory;
+
+		_parentTaxonomyCategorySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setParentTaxonomyCategory(
+		UnsafeSupplier<ParentTaxonomyCategory, Exception>
+			parentTaxonomyCategoryUnsafeSupplier) {
+
+		_parentTaxonomyCategorySupplier = () -> {
+			try {
+				return parentTaxonomyCategoryUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The category's parent category.")
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	protected ParentTaxonomyCategory parentTaxonomyCategory;
+
+	@JsonIgnore
+	private Supplier<ParentTaxonomyCategory> _parentTaxonomyCategorySupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The parent category's `TaxonomyVocabulary`."
+	)
+	@Valid
+	public ParentTaxonomyVocabulary getParentTaxonomyVocabulary() {
+		if (_parentTaxonomyVocabularySupplier != null) {
+			parentTaxonomyVocabulary = _parentTaxonomyVocabularySupplier.get();
+
+			_parentTaxonomyVocabularySupplier = null;
+		}
+
+		return parentTaxonomyVocabulary;
+	}
+
+	public void setParentTaxonomyVocabulary(
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary) {
+
+		this.parentTaxonomyVocabulary = parentTaxonomyVocabulary;
+
+		_parentTaxonomyVocabularySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setParentTaxonomyVocabulary(
+		UnsafeSupplier<ParentTaxonomyVocabulary, Exception>
+			parentTaxonomyVocabularyUnsafeSupplier) {
+
+		_parentTaxonomyVocabularySupplier = () -> {
+			try {
+				return parentTaxonomyVocabularyUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The parent category's `TaxonomyVocabulary`.")
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	protected ParentTaxonomyVocabulary parentTaxonomyVocabulary;
+
+	@JsonIgnore
+	private Supplier<ParentTaxonomyVocabulary>
+		_parentTaxonomyVocabularySupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Scope getScope() {
+		if (_scopeSupplier != null) {
+			scope = _scopeSupplier.get();
+
+			_scopeSupplier = null;
+		}
+
+		return scope;
+	}
+
+	public void setScope(Scope scope) {
+		this.scope = scope;
+
+		_scopeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setScope(UnsafeSupplier<Scope, Exception> scopeUnsafeSupplier) {
+		_scopeSupplier = () -> {
+			try {
+				return scopeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Scope scope;
+
+	@JsonIgnore
+	private Supplier<Scope> _scopeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The category's external reference code."
+	)
+	public String getTaxonomyCategoryExternalReferenceCode() {
+		if (_taxonomyCategoryExternalReferenceCodeSupplier != null) {
+			taxonomyCategoryExternalReferenceCode =
+				_taxonomyCategoryExternalReferenceCodeSupplier.get();
+
+			_taxonomyCategoryExternalReferenceCodeSupplier = null;
+		}
+
+		return taxonomyCategoryExternalReferenceCode;
+	}
+
+	public void setTaxonomyCategoryExternalReferenceCode(
+		String taxonomyCategoryExternalReferenceCode) {
+
+		this.taxonomyCategoryExternalReferenceCode =
+			taxonomyCategoryExternalReferenceCode;
+
+		_taxonomyCategoryExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTaxonomyCategoryExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			taxonomyCategoryExternalReferenceCodeUnsafeSupplier) {
+
+		_taxonomyCategoryExternalReferenceCodeSupplier = () -> {
+			try {
+				return taxonomyCategoryExternalReferenceCodeUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The category's external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String taxonomyCategoryExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _taxonomyCategoryExternalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API."
 	)
 	public Long getTaxonomyCategoryId() {
@@ -283,6 +467,61 @@ public class TaxonomyCategoryBrief implements Serializable {
 			else {
 				sb.append(embeddedTaxonomyCategory);
 			}
+		}
+
+		ParentTaxonomyCategory parentTaxonomyCategory =
+			getParentTaxonomyCategory();
+
+		if (parentTaxonomyCategory != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentTaxonomyCategory\": ");
+
+			sb.append(String.valueOf(parentTaxonomyCategory));
+		}
+
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			getParentTaxonomyVocabulary();
+
+		if (parentTaxonomyVocabulary != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentTaxonomyVocabulary\": ");
+
+			sb.append(String.valueOf(parentTaxonomyVocabulary));
+		}
+
+		Scope scope = getScope();
+
+		if (scope != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"scope\": ");
+
+			sb.append(String.valueOf(scope));
+		}
+
+		String taxonomyCategoryExternalReferenceCode =
+			getTaxonomyCategoryExternalReferenceCode();
+
+		if (taxonomyCategoryExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"taxonomyCategoryExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(taxonomyCategoryExternalReferenceCode));
+
+			sb.append("\"");
 		}
 
 		Long taxonomyCategoryId = getTaxonomyCategoryId();

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -215,6 +215,36 @@ components:
                         Optional field with the embedded taxonomy category, can be embedded with nestedFields
                     readOnly: true
                     type: object
+                parentTaxonomyCategory:
+                    description:
+                        The category's parent category.
+                    properties:
+                        externalReferenceCode:
+                            # @review
+                            description:
+                                The parent taxonomy category's external reference code.
+                            type: string
+                    type: object
+                    writeOnly: true
+                parentTaxonomyVocabulary:
+                    description:
+                        The parent category's `TaxonomyVocabulary`.
+                    properties:
+                        externalReferenceCode:
+                            # @review
+                            description:
+                                The parent category's `TaxonomyVocabulary` external reference code.
+                            type: string
+                    type: object
+                    writeOnly: true
+                scope:
+                    $ref: "#/components/schemas/Scope"
+                taxonomyCategoryExternalReferenceCode:
+                    # @review
+                    description:
+                        The category's external reference code.
+                    type:
+                        string
                 taxonomyCategoryId:
                     description:
                         The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -170,7 +170,6 @@ components:
                         The categories associated with this object entry.
                     items:
                         $ref: "#/components/schemas/TaxonomyCategoryBrief"
-                    readOnly: true
                     type: array
                 taxonomyCategoryIds:
                     # @review

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/util/TaxonomyCategoryBriefUtil.java
@@ -34,6 +34,8 @@ public class TaxonomyCategoryBriefUtil {
 				setEmbeddedTaxonomyCategory(
 					() -> _toTaxonomyCategory(
 						assetCategory.getCategoryId(), dtoConverterContext));
+				setTaxonomyCategoryExternalReferenceCode(
+					assetCategory::getExternalReferenceCode);
 				setTaxonomyCategoryId(assetCategory::getCategoryId);
 				setTaxonomyCategoryName(
 					() -> assetCategory.getTitle(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7248,12 +7248,18 @@ public class ObjectEntryResourceTest {
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
 				JSONUtil.put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory1.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory1.getId())
 				).put(
 					"taxonomyCategoryName", taxonomyCategory1.getName()
 				),
 				JSONUtil.put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory2.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory2.getId())
 				).put(
@@ -7297,6 +7303,9 @@ public class ObjectEntryResourceTest {
 					"embeddedTaxonomyCategory",
 					_toEmbeddedTaxonomyCategoryJSONObject(taxonomyCategory1)
 				).put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory1.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory1.getId())
 				).put(
@@ -7305,6 +7314,9 @@ public class ObjectEntryResourceTest {
 				JSONUtil.put(
 					"embeddedTaxonomyCategory",
 					_toEmbeddedTaxonomyCategoryJSONObject(taxonomyCategory2)
+				).put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory2.getExternalReferenceCode()
 				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory2.getId())
@@ -7683,18 +7695,27 @@ public class ObjectEntryResourceTest {
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
 				JSONUtil.put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory1.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory1.getId())
 				).put(
 					"taxonomyCategoryName", taxonomyCategory1.getName()
 				),
 				JSONUtil.put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory2.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory2.getId())
 				).put(
 					"taxonomyCategoryName", taxonomyCategory2.getName()
 				),
 				JSONUtil.put(
+					"taxonomyCategoryExternalReferenceCode",
+					taxonomyCategory3.getExternalReferenceCode()
+				).put(
 					"taxonomyCategoryId",
 					Long.valueOf(taxonomyCategory3.getId())
 				).put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -478,7 +478,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -824,7 +823,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -1227,6 +1225,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -1312,6 +1348,19 @@
 						"description": "Optional field with the embedded taxonomy category, can be embedded with nestedFields",
 						"readOnly": true,
 						"type": "object"
+					},
+					"parentTaxonomyCategory": {
+						"$ref": "#/components/schemas/ParentTaxonomyCategory"
+					},
+					"parentTaxonomyVocabulary": {
+						"$ref": "#/components/schemas/ParentTaxonomyVocabulary"
+					},
+					"scope": {
+						"$ref": "#/components/schemas/Scope"
+					},
+					"taxonomyCategoryExternalReferenceCode": {
+						"description": "The category's external reference code.",
+						"type": "string"
 					},
 					"taxonomyCategoryId": {
 						"description": "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -492,7 +492,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -771,6 +770,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -856,6 +893,19 @@
 						"description": "Optional field with the embedded taxonomy category, can be embedded with nestedFields",
 						"readOnly": true,
 						"type": "object"
+					},
+					"parentTaxonomyCategory": {
+						"$ref": "#/components/schemas/ParentTaxonomyCategory"
+					},
+					"parentTaxonomyVocabulary": {
+						"$ref": "#/components/schemas/ParentTaxonomyVocabulary"
+					},
+					"scope": {
+						"$ref": "#/components/schemas/Scope"
+					},
+					"taxonomyCategoryExternalReferenceCode": {
+						"description": "The category's external reference code.",
+						"type": "string"
 					},
 					"taxonomyCategoryId": {
 						"description": "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -504,7 +504,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -795,6 +794,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -880,6 +917,19 @@
 						"description": "Optional field with the embedded taxonomy category, can be embedded with nestedFields",
 						"readOnly": true,
 						"type": "object"
+					},
+					"parentTaxonomyCategory": {
+						"$ref": "#/components/schemas/ParentTaxonomyCategory"
+					},
+					"parentTaxonomyVocabulary": {
+						"$ref": "#/components/schemas/ParentTaxonomyVocabulary"
+					},
+					"scope": {
+						"$ref": "#/components/schemas/Scope"
+					},
+					"taxonomyCategoryExternalReferenceCode": {
+						"description": "The category's external reference code.",
+						"type": "string"
 					},
 					"taxonomyCategoryId": {
 						"description": "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -490,6 +490,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -513,6 +551,31 @@
 				],
 				"xml": {
 					"name": "Permission"
+				}
+			},
+			"Scope": {
+				"properties": {
+					"externalReferenceCode": {
+						"type": "string"
+					},
+					"type": {
+						"enum": [
+							"AssetLibrary",
+							"Site"
+						],
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.Scope",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "Scope"
 				}
 			},
 			"Status": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -479,7 +479,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -824,7 +823,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -1189,7 +1187,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -1663,6 +1660,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -1748,6 +1783,19 @@
 						"description": "Optional field with the embedded taxonomy category, can be embedded with nestedFields",
 						"readOnly": true,
 						"type": "object"
+					},
+					"parentTaxonomyCategory": {
+						"$ref": "#/components/schemas/ParentTaxonomyCategory"
+					},
+					"parentTaxonomyVocabulary": {
+						"$ref": "#/components/schemas/ParentTaxonomyVocabulary"
+					},
+					"scope": {
+						"$ref": "#/components/schemas/Scope"
+					},
+					"taxonomyCategoryExternalReferenceCode": {
+						"description": "The category's external reference code.",
+						"type": "string"
 					},
 					"taxonomyCategoryId": {
 						"description": "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -338,7 +338,6 @@
 						"items": {
 							"$ref": "#/components/schemas/TaxonomyCategoryBrief"
 						},
-						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
@@ -517,6 +516,44 @@
 				"x-filterable": [
 				]
 			},
+			"ParentTaxonomyCategory": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent taxonomy category's external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyCategory",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyCategory"
+				}
+			},
+			"ParentTaxonomyVocabulary": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The parent category's `TaxonomyVocabulary` external reference code.",
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ParentTaxonomyVocabulary",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ParentTaxonomyVocabulary"
+				}
+			},
 			"Permission": {
 				"properties": {
 					"actionIds": {
@@ -540,6 +577,31 @@
 				],
 				"xml": {
 					"name": "Permission"
+				}
+			},
+			"Scope": {
+				"properties": {
+					"externalReferenceCode": {
+						"type": "string"
+					},
+					"type": {
+						"enum": [
+							"AssetLibrary",
+							"Site"
+						],
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.Scope",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "Scope"
 				}
 			},
 			"Status": {
@@ -577,6 +639,19 @@
 						"description": "Optional field with the embedded taxonomy category, can be embedded with nestedFields",
 						"readOnly": true,
 						"type": "object"
+					},
+					"parentTaxonomyCategory": {
+						"$ref": "#/components/schemas/ParentTaxonomyCategory"
+					},
+					"parentTaxonomyVocabulary": {
+						"$ref": "#/components/schemas/ParentTaxonomyVocabulary"
+					},
+					"scope": {
+						"$ref": "#/components/schemas/Scope"
+					},
+					"taxonomyCategoryExternalReferenceCode": {
+						"description": "The category's external reference code.",
+						"type": "string"
 					},
 					"taxonomyCategoryId": {
 						"description": "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API.",


### PR DESCRIPTION
LPD-54305 Technical Task | External Reference Code Adoption for categories/vocabularies on ObjectEntry

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46893

If an Object Entry is being imported and its Category does not exist in the destination environment, the import will still succeed and the category/vocabulary created.

# How am I fixing it?

On this first task, I will modify the structure of the TaxonomyCategoryBrief to add taxonomyCategoryExternalReferenceCode, scope, parentTaxonomyCategory and parentTaxonomyVocabulary, to allow to know the data to create it. This should only modify the schema and the data shown after adding a category(ies) to a object entry

# How can you verify that it works?

Run the included automated tests.



# Commits


- **LPD-54305 add taxonomyCategoryExternalReferenceCode, parentTaxonomyCategory and parentTaxonomyVocabulary to TaxonomyCategoryBrief to allow lazy references loading. parentTaxonomyCategory and parentTaxonomyVocabulary will be write only**
- **LPD-54305 we need TaxonomyCategoryBrief not to be read only**
- **LPD-54305 show the TaxonomyCategoryExternalReferenceCode field on the TaxonomyCategoryBrief**
- **LPD-54305 buildRest**
- **LPD-54305 baseline**
- **LPD-54305 fix test**
