### PR TITLE
LPD-54298 Duplicate Web Content Articles are created if "Publish" is clicked more than once

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -40,8 +40,13 @@ export default function PublishModal({
 	const [displayDate, setDisplayDate] = useState(defaultDisplayDate);
 	const [dateError, setDateError] = useState('');
 	const [showErrorAlert, setShowErrorAlert] = useState(false);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const handleButtonClick = () => {
+		if (isSubmitting) {
+			return;
+		}
+
 		if (!displayDate && actionButton === 'schedule') {
 			setDateError(Liferay.Language.get('please-enter-a-valid-date'));
 			setShowErrorAlert(true);
@@ -55,6 +60,7 @@ export default function PublishModal({
 			return;
 		}
 
+		setIsSubmitting(true);
 		onPublishButtonClick(actionButton);
 	};
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -41,6 +41,19 @@ export default function PublishModal({
 	const [dateError, setDateError] = useState('');
 	const [showErrorAlert, setShowErrorAlert] = useState(false);
 
+	const handleButtonClick = () => {
+		if (!displayDate && actionButton === 'schedule') {
+			setDateError(Liferay.Language.get('please-enter-a-valid-date'));
+			setShowErrorAlert(true);
+		}
+		else if (dateError) {
+			setShowErrorAlert(true);
+		}
+		else {
+			onPublishButtonClick(actionButton);
+		}
+	};
+
 	return (
 		<ClayModal className="m-0" observer={observer} size="md">
 			<ClayModal.Header>{heading}</ClayModal.Header>
@@ -91,25 +104,7 @@ export default function PublishModal({
 						<ClayButton
 							displayType="primary"
 							form={formId}
-							onClick={() => {
-								if (
-									!displayDate &&
-									actionButton === 'schedule'
-								) {
-									setDateError(
-										Liferay.Language.get(
-											'please-enter-a-valid-date'
-										)
-									);
-									setShowErrorAlert(true);
-								}
-								else if (dateError) {
-									setShowErrorAlert(true);
-								}
-								else {
-									onPublishButtonClick(actionButton);
-								}
-							}}
+							onClick={handleButtonClick}
 							type={
 								dateError ||
 								(!displayDate && actionButton === 'schedule')

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/PublishModal.js
@@ -45,13 +45,17 @@ export default function PublishModal({
 		if (!displayDate && actionButton === 'schedule') {
 			setDateError(Liferay.Language.get('please-enter-a-valid-date'));
 			setShowErrorAlert(true);
+
+			return;
 		}
-		else if (dateError) {
+
+		if (dateError) {
 			setShowErrorAlert(true);
+
+			return;
 		}
-		else {
-			onPublishButtonClick(actionButton);
-		}
+
+		onPublishButtonClick(actionButton);
 	};
 
 	return (


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-54298)

# How did I fix it

I have tried to "disable" the button on the onclick function (like @jkappler did), but this is triggered before the submit action, so the submit is never reached then. 

The only alternative I see is to control manually that the callback is only called once (but not disabling the button)

# How to test it

Follow the steps on the issue (use throttling in your browser). I don't think this case need a unit or functional test. 