### PR TITLE
LPD-53830 | We Content is not saved when Time Zone in Account Display Setting is set to certain zones

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1151,7 +1151,7 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"showPublishModal", _isShowPublishModal()
 		).put(
-			"timeZone", getTimeZoneName()
+			"timeZone", getTimeZone()
 		).put(
 			"workflowEnabled", () -> _isWorkflowEnabled()
 		).build();
@@ -1322,6 +1322,16 @@ public class JournalEditArticleDisplayContext {
 						requestBackedPortletURLFactory, "selectDDMTemplate",
 						ddmTemplateItemSelectorCriterion));
 			}
+		).build();
+	}
+
+	public Map<String, Object> getTimeZone() {
+		TimeZone timeZone = _themeDisplay.getTimeZone();
+
+		return HashMapBuilder.<String, Object>put(
+			"id", timeZone.getID()
+		).put(
+			"name", timeZone.getDisplayName(false, TimeZone.SHORT)
 		).build();
 	}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -33,7 +33,8 @@ export default function ScheduleOptions({
 			const date = new Date(displayDate);
 
 			if (
-				date <= new Date(new Date().toLocaleString('en-US', {timeZone}))
+				date <=
+				new Date(new Date().toLocaleString('en-US', timeZone.id))
 			) {
 				setError(
 					Liferay.Language.get('the-date-entered-is-in-the-past')
@@ -67,7 +68,7 @@ export default function ScheduleOptions({
 					placeholder="YYYY-MM-DD HH:mm"
 					required
 					time
-					timezone={timeZone}
+					timezone={timeZone.name}
 					value={displayDate || ''}
 					years={{
 						end: 9999,
@@ -90,7 +91,7 @@ export default function ScheduleOptions({
 			</ClayForm.Group>
 
 			<p className="mt-1 text-3 text-secondary">
-				{sub(Liferay.Language.get('time-zone-x'), timeZone)}
+				{sub(Liferay.Language.get('time-zone-x'), timeZone.name)}
 			</p>
 
 			<ClayInput

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContextTest.java
@@ -32,7 +32,9 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -265,6 +267,43 @@ public class JournalEditArticleDisplayContextTest {
 		).get(
 			_httpServletRequest, "home"
 		);
+	}
+
+	@Test
+	public void testGetTimeZone() {
+		TimeZone timeZone = Mockito.mock(TimeZone.class);
+
+		String timeZoneId = RandomTestUtil.randomString();
+		String timeZoneName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			timeZone.getID()
+		).thenReturn(
+			timeZoneId
+		);
+
+		Mockito.when(
+			timeZone.getDisplayName(false, TimeZone.SHORT)
+		).thenReturn(
+			timeZoneName
+		);
+
+		Mockito.when(
+			_themeDisplay.getTimeZone()
+		).thenReturn(
+			timeZone
+		);
+
+		_journalEditArticleDisplayContext =
+			new JournalEditArticleDisplayContext(
+				_httpServletRequest, _liferayPortletResponse, null, null, null,
+				null);
+
+		Map<String, Object> timeZoneMap =
+			_journalEditArticleDisplayContext.getTimeZone();
+
+		Assert.assertEquals(timeZoneId, timeZoneMap.get("id"));
+		Assert.assertEquals(timeZoneName, timeZoneMap.get("name"));
 	}
 
 	@Test


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-53830
### How am I fixing it?
By following the standard used in the conversion method.
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#timezone

### How can you verify that it works?

To test run:
`gw test --tests JournalEditArticleDisplayContextTest.testGetTimeZone`

Or manually test based on the LPD steps