### PR TITLE
LPD-54412 Add item download action in files / all section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSectionDisplayContext.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.service.ObjectDefinitionService;
@@ -16,6 +17,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -59,6 +61,21 @@ public class AllSectionDisplayContext extends BaseSectionDisplayContext {
 		).put(
 			"title", LanguageUtil.get(httpServletRequest, "no-assets-yet")
 		).build();
+	}
+
+	@Override
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			super.getFDSActionDropdownItems();
+
+		fdsActionDropdownItems.add(
+			1,
+			new FDSActionDropdownItem(
+				"{embedded.file.link.href}", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link"));
+
+		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -6,6 +6,7 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -82,6 +84,21 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 		).put(
 			"title", LanguageUtil.get(httpServletRequest, "no-files-yet")
 		).build();
+	}
+
+	@Override
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			super.getFDSActionDropdownItems();
+
+		fdsActionDropdownItems.add(
+			1,
+			new FDSActionDropdownItem(
+				"{embedded.file.link.href}", "download", "download",
+				LanguageUtil.get(httpServletRequest, "download"), "get", null,
+				"link"));
+
+		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/AllFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/AllFDSPropsTransformer.ts
@@ -18,9 +18,11 @@ const ACTIONS = {
 
 export default function AllFDSPropsTransformer({
 	creationMenu,
+	itemsActions = [],
 	...otherProps
 }: {
 	creationMenu: any;
+	itemsActions?: any[];
 	otherProps: any;
 }) {
 	return {
@@ -56,5 +58,16 @@ export default function AllFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
+		itemsActions: itemsActions.map((action) => {
+			if (action?.data?.id === 'download') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(item?.embedded?.file?.link?.href),
+				};
+			}
+
+			return action;
+		}),
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
@@ -21,10 +21,12 @@ const ACTIONS = {
 export default function FilesFDSPropsTransformer({
 	additionalProps,
 	creationMenu,
+	itemsActions = [],
 	...otherProps
 }: {
 	additionalProps: any;
 	creationMenu: any;
+	itemsActions?: any[];
 	otherProps: any;
 }) {
 	return {
@@ -61,5 +63,16 @@ export default function FilesFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
+		itemsActions: itemsActions.map((action) => {
+			if (action?.data?.id === 'download') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(item?.embedded?.file?.link?.href),
+				};
+			}
+
+			return action;
+		}),
 	};
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54412

Add a download action for file type items in the `Files` and `All` sections.

# How am I fixing it?

Added an extra action in the `Files` and `All` display contexts, and included an isVisible method in the `FDSpropsTransformer` to ensure the action is only shown when the file exists.

# How can you verify that it works?

## `Files` section
1. Go to CMS
2. Navigate to the Files section
3. Create a few `Basic Documents`
4. Create a new Folder
5. Create an External Video

### Result
- When clicking the actions menu of a `Basic Document`, the download action appears and works. ✅ 
- For `Folder` or `External Video` items, the download action does not appear. ✅ 

## `All` section
1. Navigate to the Contents section
2. Create a few Basic Web Content items
3. Navigate to the All section

### Result
- When clicking the actions menu of a `File` item, the download action appears and works. ✅ 
- For `Content` items, the download action does not appear. ✅ 

# Why doesn't this include any test?

I've created a separate task for the test.