### PR TITLE
LPD-54529 Add parenthesis to OData filter expressions

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
@@ -13,7 +13,6 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -65,14 +64,22 @@ public class ContentsSectionDisplayContextTest
 
 		Assert.assertTrue(apiURL.contains("emptySearch=true"));
 
-		StringBundler sb = new StringBundler(3);
+		int start = apiURL.indexOf("filter=");
 
-		sb.append("filter=objectFolderExternalReferenceCode in ('");
-		sb.append(
-			StringUtil.merge(_getObjectFolderExternalReferenceCodes(), "','"));
-		sb.append("')");
+		int end = apiURL.indexOf("&", start);
 
-		Assert.assertTrue(apiURL.contains(sb.toString()));
+		String filterExpression = apiURL.substring(start + 7, end);
+
+		String objectFolderExternalReferenceCodesString = StringUtil.merge(
+			_getObjectFolderExternalReferenceCodes(), "','");
+
+		Assert.assertTrue(
+			filterExpression.startsWith(
+				"(objectFolderExternalReferenceCode in ('" +
+					objectFolderExternalReferenceCodesString + "')"));
+
+		Assert.assertTrue(
+			filterExpression.endsWith(StringPool.CLOSE_PARENTHESIS));
 	}
 
 	@Ignore

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -85,7 +85,7 @@ public abstract class BaseSectionDisplayContext {
 		StringBundler sb = new StringBundler(9);
 
 		sb.append("/o/search/v1.0/search?emptySearch=true&");
-		sb.append("filter=objectFolderExternalReferenceCode in ('");
+		sb.append("filter=(objectFolderExternalReferenceCode in ('");
 		sb.append(StringUtil.merge(objectFolderExternalReferenceCodes, "','"));
 		sb.append("')");
 
@@ -101,7 +101,7 @@ public abstract class BaseSectionDisplayContext {
 			sb.append(_objectEntryFolder.getObjectEntryFolderId());
 		}
 
-		sb.append("&nestedFields=embedded");
+		sb.append(")&nestedFields=embedded");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/PicklistBuilderDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/PicklistBuilderDisplayContext.java
@@ -39,7 +39,7 @@ public class PicklistBuilderDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public Map<String, Object> getProps() throws Exception {
+	public Map<String, Object> getProps() {
 		return HashMapBuilder.<String, Object>put(
 			"learnResources",
 			LearnMessageUtil.getReactDataJSONObject("site-cms-site-initializer")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureBuilderDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureBuilderDisplayContext.java
@@ -40,7 +40,7 @@ public class StructureBuilderDisplayContext {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public Map<String, Object> getProps() throws Exception {
+	public Map<String, Object> getProps() {
 		return HashMapBuilder.<String, Object>put(
 			"config",
 			JSONUtil.put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureUsagesDisplayContext.java
@@ -43,9 +43,9 @@ public class StructureUsagesDisplayContext {
 		StringBundler sb = new StringBundler(4);
 
 		sb.append("/o/search/v1.0/search?emptySearch=true&");
-		sb.append("filter=objectDefinitionId eq ");
+		sb.append("filter=(objectDefinitionId eq ");
 		sb.append(ParamUtil.getLong(_httpServletRequest, "objectDefinitionId"));
-		sb.append("&nestedFields=embedded");
+		sb.append(")&nestedFields=embedded");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContext.java
@@ -51,12 +51,12 @@ public class StructuresSectionDisplayContext {
 		StringBundler sb = new StringBundler(6);
 
 		sb.append("/o/object-admin/v1.0/object-definitions?filter=");
-		sb.append("objectFolderExternalReferenceCode eq '");
+		sb.append("(objectFolderExternalReferenceCode eq '");
 		sb.append(
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
 		sb.append("' or objectFolderExternalReferenceCode eq '");
 		sb.append(ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
-		sb.append("'");
+		sb.append("')");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
@@ -14,7 +14,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenuBuilder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -43,13 +42,12 @@ public class ViewCategoriesDisplayContext {
 
 	public ViewCategoriesDisplayContext(
 		AssetVocabularyLocalService assetVocabularyLocalService,
-		HttpServletRequest httpServletRequest, JSONFactory jsonFactory,
+		HttpServletRequest httpServletRequest,
 		LayoutLocalService layoutLocalService, Language language,
 		Portal portal) {
 
 		_assetVocabularyLocalService = assetVocabularyLocalService;
 		_httpServletRequest = httpServletRequest;
-		_jsonFactory = jsonFactory;
 		_layoutLocalService = layoutLocalService;
 		_language = language;
 		_portal = portal;
@@ -181,7 +179,6 @@ public class ViewCategoriesDisplayContext {
 
 	private final AssetVocabularyLocalService _assetVocabularyLocalService;
 	private final HttpServletRequest _httpServletRequest;
-	private final JSONFactory _jsonFactory;
 	private final Language _language;
 	private final LayoutLocalService _layoutLocalService;
 	private final Portal _portal;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagsDisplayContext.java
@@ -14,17 +14,12 @@ import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializ
 
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-
 /**
  * @author Noor Najjar
  */
 public class ViewTagsDisplayContext {
 
-	public ViewTagsDisplayContext(
-		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
-
-		_httpServletRequest = httpServletRequest;
+	public ViewTagsDisplayContext(ThemeDisplay themeDisplay) {
 		_themeDisplay = themeDisplay;
 	}
 
@@ -48,7 +43,6 @@ public class ViewTagsDisplayContext {
 		).build();
 	}
 
-	private final HttpServletRequest _httpServletRequest;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategoriesFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategoriesFragmentRenderer.java
@@ -9,7 +9,6 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
@@ -59,7 +58,7 @@ public class ViewCategoriesFragmentRenderer
 				ViewCategoriesDisplayContext.class.getName(),
 				new ViewCategoriesDisplayContext(
 					_assetVocabularyLocalService, httpServletRequest,
-					_jsonFactory, _layoutLocalService, _language, _portal));
+					_layoutLocalService, _language, _portal));
 
 			requestDispatcher.include(httpServletRequest, httpServletResponse);
 		}
@@ -70,9 +69,6 @@ public class ViewCategoriesFragmentRenderer
 
 	@Reference
 	private AssetVocabularyLocalService _assetVocabularyLocalService;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewTagsFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewTagsFragmentRenderer.java
@@ -54,7 +54,6 @@ public class ViewTagsFragmentRenderer extends BaseSectionFragmentRenderer {
 			httpServletRequest.setAttribute(
 				ViewTagsDisplayContext.class.getName(),
 				new ViewTagsDisplayContext(
-					httpServletRequest,
 					(ThemeDisplay)httpServletRequest.getAttribute(
 						WebKeys.THEME_DISPLAY)));
 

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureUsagesDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureUsagesDisplayContextTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class StructureUsagesDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetAPIURL() {
+		String apiURL = _structureUsagesDisplayContext.getAPIURL();
+
+		int start = apiURL.indexOf("filter=");
+
+		int end = apiURL.indexOf("&", start);
+
+		String filterExpression = apiURL.substring(start + 7, end);
+
+		Assert.assertTrue(
+			filterExpression.startsWith(StringPool.OPEN_PARENTHESIS));
+		Assert.assertTrue(
+			filterExpression.endsWith(StringPool.CLOSE_PARENTHESIS));
+	}
+
+	private final StructureUsagesDisplayContext _structureUsagesDisplayContext =
+		new StructureUsagesDisplayContext(new MockHttpServletRequest(), null);
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/display/context/StructuresSectionDisplayContextTest.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class StructuresSectionDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetAPIURL() {
+		String apiURL = _structuresSectionDisplayContext.getAPIURL();
+
+		int start = apiURL.indexOf("filter=");
+
+		String filterExpression = apiURL.substring(start + 7);
+
+		Assert.assertTrue(
+			filterExpression.startsWith(StringPool.OPEN_PARENTHESIS));
+		Assert.assertTrue(
+			filterExpression.endsWith(StringPool.CLOSE_PARENTHESIS));
+	}
+
+	private final StructuresSectionDisplayContext
+		_structuresSectionDisplayContext = new StructuresSectionDisplayContext(
+			new MockHttpServletRequest());
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54529

To avoid precedence problems when the FDS appends filter expressions, surround the initial OData expression in parenthesis.