### PR TITLE
LPD-54638 Avoid hardcoding CMS url prefix

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -123,7 +123,8 @@ public abstract class BaseSectionDisplayContext {
 			new FDSActionDropdownItem(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					"/cms/edit_content_item?className={entryClassName}&",
+					themeDisplay.getPathCms(),
+					"/edit_content_item?className={entryClassName}&",
 					"objectEntryId={embedded.id}&redirect=",
 					themeDisplay.getURLCurrent()),
 				"pencil", "edit", LanguageUtil.get(httpServletRequest, "edit"),
@@ -177,8 +178,8 @@ public abstract class BaseSectionDisplayContext {
 						StringBundler.concat(
 							themeDisplay.getPortalURL(),
 							themeDisplay.getPathMain(),
-							"/cms/add_structured_content_item?",
-							"objectDefinitionId=",
+							themeDisplay.getPathCms(),
+							"/add_structured_content_item?objectDefinitionId=",
 							objectDefinition.getObjectDefinitionId(), "&plid=",
 							themeDisplay.getPlid()));
 					dropdownItem.putData(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesSectionFragmentRenderer.java
@@ -120,6 +120,11 @@ public class SpacesSectionFragmentRenderer extends BaseSectionFragmentRenderer {
 
 			componentTag.setProps(
 				HashMapBuilder.<String, Object>put(
+					"allSpacesURL",
+					StringBundler.concat(
+						themeDisplay.getPathFriendlyURLPublic(),
+						themeDisplay.getPathCms(), "/all-spaces")
+				).put(
 					"assetLibraries", assetLibrariesJSONArray
 				).put(
 					"assetLibrariesCount", assetLibrariesCount

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
@@ -19,12 +19,14 @@ export interface AssetLibrary {
 }
 
 interface SpacesNavigationProps {
+	allSpacesURL: string;
 	assetLibraries: AssetLibrary[];
 	assetLibrariesCount: number;
 	showAddButton: boolean;
 }
 
 const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
+	allSpacesURL,
 	assetLibraries,
 	assetLibrariesCount,
 	showAddButton,
@@ -73,10 +75,7 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 					))}
 
 					<li className="nav-item" role="none">
-						<ClayLink
-							className="nav-link"
-							href="/web/cms/all-spaces"
-						>
+						<ClayLink className="nav-link" href={allSpacesURL}>
 							<span className="mr-2 sticker">
 								<ClayIcon symbol="box-container" />
 							</span>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54638

Some URLs are hardcoding the CMS url prefix.

# How am I fixing it?

By using `ThemeDisplay#getPathCms` instead of hardcoding the value.

# How can you verify that it works?

All existing tests should pass.