### PR TITLE
LPD-54384 On PUT requests, only the field values corresponding to the specified translation (indicated by the Accept-Language header) are updated

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
@@ -34,6 +35,7 @@ import com.liferay.headless.common.spi.odata.entity.EntityFieldsUtil;
 import com.liferay.headless.common.spi.resource.SPIRatingResource;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.delivery.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.dto.v1_0.ContentFieldValue;
 import com.liferay.headless.delivery.dto.v1_0.Rating;
 import com.liferay.headless.delivery.dto.v1_0.RelatedContent;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
@@ -93,6 +95,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -119,6 +122,8 @@ import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
+
+import java.io.Serializable;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -862,6 +867,45 @@ public class StructuredContentResourceImpl
 					structuredContent)));
 	}
 
+	private boolean _containsI18nMap(ContentField[] contentFields) {
+		if (ArrayUtil.isEmpty(contentFields)) {
+			return false;
+		}
+
+		for (ContentField contentField : contentFields) {
+			if (MapUtil.isNotEmpty(contentField.getContentFieldValue_i18n()) ||
+				_containsI18nMap(contentField.getNestedContentFields())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private Fields _createFieldsWithI18n(
+			Set<Locale> availableLocales, ContentField[] contentFields,
+			DDMStructure ddmStructure, JournalArticle journalArticle,
+			Locale preferredLocale)
+		throws Exception {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		DDMFormValues ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
+			availableLocales, contentFields, ddmStructure.getDDMForm(),
+			_dlAppService, journalArticle.getGroupId(), _journalArticleService,
+			_layoutLocalService, preferredLocale,
+			_getRootDDMFormFields(ddmStructure));
+
+		serviceContext.setAttribute(
+			"ddmFormValues",
+			DDMFormValuesUtil.getContent(
+				_jsonDDMFormValuesSerializer, ddmStructure.getDDMForm(),
+				ddmFormValues.getDDMFormFieldValues()));
+
+		return _ddm.getFields(ddmStructure.getStructureId(), serviceContext);
+	}
+
 	private ServiceContext _createServiceContext(
 			Long[] assetCategoryIds, long[] assetLinkEntryIds,
 			double assetPriority, String[] assetTagNames, long groupId,
@@ -1147,28 +1191,64 @@ public class StructuredContentResourceImpl
 			sorts, this::_toStructuredContent);
 	}
 
+	private void _populateContentFieldMap(
+		ContentField[] contentFields,
+		Map<String, List<ContentField>> contentFieldMap) {
+
+		if (ArrayUtil.isEmpty(contentFields)) {
+			return;
+		}
+
+		for (ContentField contentField : contentFields) {
+			if (contentField.getContentFieldValue() != null) {
+				contentFieldMap.computeIfAbsent(
+					contentField.getName(), key -> new ArrayList<>()
+				).add(
+					contentField
+				);
+			}
+
+			_populateContentFieldMap(
+				contentField.getNestedContentFields(), contentFieldMap);
+		}
+	}
+
 	private Fields _toFields(
 			Set<Locale> availableLocales, ContentField[] contentFields,
 			JournalArticle journalArticle)
 		throws Exception {
 
+		if (ArrayUtil.isEmpty(contentFields)) {
+			return _ddmFormValuesToFieldsConverter.convert(
+				journalArticle.getDDMStructure(),
+				journalArticle.getDDMFormValues());
+		}
+
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+		Locale preferredLocale = contextAcceptLanguage.getPreferredLocale();
 
-		ServiceContext serviceContext = new ServiceContext();
+		if (_containsI18nMap(contentFields)) {
+			return _createFieldsWithI18n(
+				availableLocales, contentFields, ddmStructure, journalArticle,
+				preferredLocale);
+		}
 
-		DDMFormValues ddmFormValues = DDMFormValuesUtil.toDDMFormValues(
-			availableLocales, contentFields, ddmStructure.getDDMForm(),
-			_dlAppService, journalArticle.getGroupId(), _journalArticleService,
-			_layoutLocalService, contextAcceptLanguage.getPreferredLocale(),
-			_getRootDDMFormFields(ddmStructure));
+		Fields fields = _ddmFormValuesToFieldsConverter.convert(
+			ddmStructure, journalArticle.getDDMFormValues());
 
-		serviceContext.setAttribute(
-			"ddmFormValues",
-			DDMFormValuesUtil.getContent(
-				_jsonDDMFormValuesSerializer, ddmStructure.getDDMForm(),
-				ddmFormValues.getDDMFormFieldValues()));
+		Map<String, List<ContentField>> contentFieldMap = new HashMap<>();
 
-		return _ddm.getFields(ddmStructure.getStructureId(), serviceContext);
+		_populateContentFieldMap(contentFields, contentFieldMap);
+
+		if (MapUtil.isNotEmpty(contentFieldMap)) {
+			_updatePreferredLocaleValues(
+				contentFieldMap, fields, preferredLocale);
+		}
+
+		_ddmFormValuesValidator.validate(
+			_fieldsToDDMFormValuesConverter.convert(ddmStructure, fields));
+
+		return fields;
 	}
 
 	private Fields _toPatchedFields(
@@ -1347,6 +1427,46 @@ public class StructuredContentResourceImpl
 				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 				contextUser),
 			journalArticle);
+	}
+
+	private void _updatePreferredLocaleValues(
+			Map<String, List<ContentField>> contentFieldMap, Fields fields,
+			Locale preferredLocale)
+		throws Exception {
+
+		for (Map.Entry<String, List<ContentField>> entry :
+				contentFieldMap.entrySet()) {
+
+			List<ContentField> contentFields = entry.getValue();
+			Field field = fields.get(entry.getKey());
+
+			if (contentFields.isEmpty() || (field == null)) {
+				continue;
+			}
+
+			List<Serializable> valueList = new ArrayList<>(
+				contentFields.size());
+
+			for (ContentField contentField : contentFields) {
+				ContentFieldValue contentFieldValue =
+					contentField.getContentFieldValue();
+
+				if ((contentFieldValue == null) ||
+					(contentFieldValue.getData() == null)) {
+
+					continue;
+				}
+
+				valueList.add(
+					FieldConstants.getSerializable(
+						preferredLocale, LocaleUtil.ROOT, field.getDataType(),
+						contentFieldValue.getData()));
+			}
+
+			if (ListUtil.isNotEmpty(valueList)) {
+				field.setValues(preferredLocale, valueList);
+			}
+		}
 	}
 
 	private StructuredContent _updateStructuredContent(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -109,6 +109,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.junit.After;
@@ -712,6 +713,15 @@ public class StructuredContentResourceTest
 	}
 
 	@Override
+	@Test
+	public void testPutStructuredContent() throws Exception {
+		super.testPutStructuredContent();
+
+		_testPutStructuredContentWithLocalizedValues();
+		_testPutStructuredContentWithoutLocalizedValues();
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
 			"contentStructureId", "description", "priority", "title"
@@ -935,6 +945,15 @@ public class StructuredContentResourceTest
 			_read("test-structured-content-template.vm"), LocaleUtil.US);
 	}
 
+	private void _assertEquals(
+		StructuredContent structuredContent1,
+		StructuredContent structuredContent2) {
+
+		Assert.assertTrue(
+			structuredContent1 + " does not equal " + structuredContent2,
+			_equals(structuredContent1, structuredContent2));
+	}
+
 	private void _assertFilterSiteStructuredContentsPageFilteredByDateField(
 			Locale locale)
 		throws Exception {
@@ -1069,6 +1088,60 @@ public class StructuredContentResourceTest
 				_jsonDDMFormDeserializer.deserialize(builder.build());
 
 		return ddmFormDeserializerDeserializeResponse.getDDMForm();
+	}
+
+	private boolean _equals(
+		StructuredContent structuredContent1,
+		StructuredContent structuredContent2) {
+
+		assertEquals(structuredContent1, structuredContent2);
+
+		if (!Objects.deepEquals(
+				structuredContent1.getDescription(),
+				structuredContent2.getDescription()) ||
+			!equals(
+				(Map)structuredContent1.getDescription_i18n(),
+				(Map)structuredContent2.getDescription_i18n()) ||
+			!Objects.deepEquals(
+				structuredContent1.getFriendlyUrlPath(),
+				structuredContent2.getFriendlyUrlPath()) ||
+			!equals(
+				(Map)structuredContent1.getFriendlyUrlPath_i18n(),
+				(Map)structuredContent2.getFriendlyUrlPath_i18n()) ||
+			!Objects.deepEquals(
+				structuredContent1.getTitle(), structuredContent2.getTitle()) ||
+			!equals(
+				(Map)structuredContent1.getTitle_i18n(),
+				(Map)structuredContent2.getTitle_i18n())) {
+
+			return false;
+		}
+
+		ContentField[] contentFields1 = structuredContent1.getContentFields();
+		ContentField[] contentFields2 = structuredContent1.getContentFields();
+
+		if (contentFields1.length != contentFields2.length) {
+			return false;
+		}
+
+		for (int i = 0; i < contentFields1.length; i++) {
+			ContentField contentField1 = contentFields1[i];
+			ContentField contentField2 = contentFields2[i];
+
+			if (!Objects.equals(
+					contentField1.getName(), contentField2.getName()) ||
+				!Objects.equals(
+					contentField1.getContentFieldValue(),
+					contentField2.getContentFieldValue()) ||
+				!equals(
+					(Map)contentField1.getContentFieldValue_i18n(),
+					(Map)contentField2.getContentFieldValue_i18n())) {
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private String _randomColor() {
@@ -1421,9 +1494,13 @@ public class StructuredContentResourceTest
 		structuredContent.setDescription_i18n(description_i18n);
 
 		Map<String, String> friendlyUrlPath_i18n = HashMapBuilder.put(
-			"en-US", RandomTestUtil.randomString()
+			"en-US",
+			RandomTestUtil.randomString(
+			).toLowerCase()
 		).put(
-			"es-ES", RandomTestUtil.randomString()
+			"es-ES",
+			RandomTestUtil.randomString(
+			).toLowerCase()
 		).build();
 
 		structuredContent.setFriendlyUrlPath(
@@ -2427,6 +2504,106 @@ public class StructuredContentResourceTest
 
 		Assert.assertEquals(1, jsonObject.getLong("processedItemsCount"));
 		Assert.assertEquals(1, jsonObject.getLong("totalItemsCount"));
+	}
+
+	private void _testPutStructuredContentWithLocalizedValues()
+		throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent randomLocalizedStructuredContent =
+			_randomStructuredContent(locale);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				randomLocalizedStructuredContent);
+
+		randomLocalizedStructuredContent = _randomStructuredContent(locale);
+
+		StructuredContentResource englishStructuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent putStructuredContent =
+			englishStructuredContentResource.putStructuredContent(
+				postStructuredContent.getId(),
+				randomLocalizedStructuredContent);
+
+		_assertLocalizedValues(
+			putStructuredContent, LocaleUtil.toW3cLanguageId(locale));
+		_assertEquals(randomLocalizedStructuredContent, putStructuredContent);
+		assertValid(putStructuredContent);
+	}
+
+	private void _testPutStructuredContentWithoutLocalizedValues()
+		throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent structuredContent1 = _randomStructuredContent(locale);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.postSiteStructuredContent(
+				testGetSiteStructuredContentsPage_getSiteId(),
+				structuredContent1);
+
+		StructuredContent structuredContent2 = _randomStructuredContent(locale);
+
+		ContentFieldValue englishContentFieldValue = new ContentFieldValue() {
+			{
+				data = RandomTestUtil.randomString(10);
+			}
+		};
+
+		structuredContent2.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = englishContentFieldValue;
+						name = "MyText";
+					}
+				}
+			});
+
+		StructuredContentResource englishStructuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent putStructuredContent =
+			englishStructuredContentResource.putStructuredContent(
+				postStructuredContent.getId(), structuredContent2);
+
+		Map<String, ContentFieldValue> expectedContentFieldValues =
+			HashMapBuilder.put(
+				"en-US", () -> englishContentFieldValue
+			).put(
+				"es-ES",
+				() -> {
+					ContentField initialContentField =
+						structuredContent1.getContentFields()[0];
+
+					return initialContentField.getContentFieldValue_i18n(
+					).get(
+						"es-ES"
+					);
+				}
+			).build();
+
+		structuredContent2.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = expectedContentFieldValues.get(
+							LocaleUtil.toW3cLanguageId(locale));
+						contentFieldValue_i18n = expectedContentFieldValues;
+						name = "MyText";
+					}
+				}
+			});
+
+		_assertLocalizedValues(
+			putStructuredContent, LocaleUtil.toW3cLanguageId(locale));
+		_assertEquals(structuredContent2, putStructuredContent);
+		assertValid(putStructuredContent);
 	}
 
 	private JSONObject _waitForFinish(


### PR DESCRIPTION
# What is this trying to solve?

This addresses the issue described in [LPD-54384](https://liferay.atlassian.net/browse/LPD-54384), where the behavior of the PUT API for updating structured content translations was inconsistent or unclear.

**Expected PUT API behavior:**

1. **Without i18n map and with availableLanguages:**
Only the newly provided locale should be added or updated, without modifying existing locales.

2. **With i18n map:**
All existing locales should be overridden by the provided ones.
(Note: A default value must still be provided when using i18n.)

# How am I fixing it?

Before invoking the updateArticle process, the code now evaluates the presence of the i18n map and the preferred locale. Based on this, it prepares and updates the fields accordingly to match the expected behavior.

# How can you verify that it works?

Run the included automated tests.