### PR TITLE
LPD-54638 Avoid hardcoding CMS url prefix

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSpacesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSpacesSectionDisplayContext.java
@@ -13,6 +13,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -67,8 +68,8 @@ public class AllSpacesSectionDisplayContext {
 					"redirect",
 					StringBundler.concat(
 						_themeDisplay.getPortalURL(),
-						_themeDisplay.getPathMain(), _themeDisplay.getPathCms(),
-						"/e/space-settings/",
+						_themeDisplay.getPathMain(),
+						GroupConstants.CMS_FRIENDLY_URL, "/e/space-settings/",
 						_portal.getClassNameId(DepotEntry.class), "/{id}"));
 				dropdownItem.putData(
 					"title", _language.get(_httpServletRequest, "new-space"));
@@ -96,7 +97,7 @@ public class AllSpacesSectionDisplayContext {
 			new FDSActionDropdownItem(
 				StringBundler.concat(
 					_themeDisplay.getPathFriendlyURLPublic(),
-					_themeDisplay.getPathCms(), "/e/space-settings/",
+					GroupConstants.CMS_FRIENDLY_URL, "/e/space-settings/",
 					_portal.getClassNameId(DepotEntry.class), "/{id}"),
 				"cog", "edit",
 				LanguageUtil.get(_httpServletRequest, "space-settings"), "get",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -123,7 +124,8 @@ public abstract class BaseSectionDisplayContext {
 			new FDSActionDropdownItem(
 				StringBundler.concat(
 					themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
-					"/cms/edit_content_item?className={entryClassName}&",
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/edit_content_item?className={entryClassName}&",
 					"objectEntryId={embedded.id}&redirect=",
 					themeDisplay.getURLCurrent()),
 				"pencil", "edit", LanguageUtil.get(httpServletRequest, "edit"),
@@ -177,8 +179,8 @@ public abstract class BaseSectionDisplayContext {
 						StringBundler.concat(
 							themeDisplay.getPortalURL(),
 							themeDisplay.getPathMain(),
-							"/cms/add_structured_content_item?",
-							"objectDefinitionId=",
+							GroupConstants.CMS_FRIENDLY_URL,
+							"/add_structured_content_item?objectDefinitionId=",
 							objectDefinition.getObjectDefinitionId(), "&plid=",
 							themeDisplay.getPlid()));
 					dropdownItem.putData(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesSectionFragmentRenderer.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -108,7 +109,7 @@ public class SpacesSectionFragmentRenderer extends BaseSectionFragmentRenderer {
 						"url",
 						StringBundler.concat(
 							themeDisplay.getPathFriendlyURLPublic(),
-							themeDisplay.getPathCms(), "/e/space/",
+							GroupConstants.CMS_FRIENDLY_URL, "/e/space/",
 							_portal.getClassNameId(DepotEntry.class),
 							StringPool.SLASH, assetLibrary.getId())
 					));
@@ -120,6 +121,11 @@ public class SpacesSectionFragmentRenderer extends BaseSectionFragmentRenderer {
 
 			componentTag.setProps(
 				HashMapBuilder.<String, Object>put(
+					"allSpacesURL",
+					StringBundler.concat(
+						themeDisplay.getPathFriendlyURLPublic(),
+						GroupConstants.CMS_FRIENDLY_URL, "/all-spaces")
+				).put(
 					"assetLibraries", assetLibrariesJSONArray
 				).put(
 					"assetLibrariesCount", assetLibrariesCount

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
@@ -19,12 +19,14 @@ export interface AssetLibrary {
 }
 
 interface SpacesNavigationProps {
+	allSpacesURL: string;
 	assetLibraries: AssetLibrary[];
 	assetLibrariesCount: number;
 	showAddButton: boolean;
 }
 
 const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
+	allSpacesURL,
 	assetLibraries,
 	assetLibrariesCount,
 	showAddButton,
@@ -73,10 +75,7 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 					))}
 
 					<li className="nav-item" role="none">
-						<ClayLink
-							className="nav-link"
-							href="/web/cms/all-spaces"
-						>
+						<ClayLink className="nav-link" href={allSpacesURL}>
 							<span className="mr-2 sticker">
 								<ClayIcon symbol="box-container" />
 							</span>

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1530,7 +1530,6 @@ public class ServicePreAction extends Action {
 		themeDisplay.setLocale(locale);
 		themeDisplay.setLookAndFeel(theme, colorScheme);
 		themeDisplay.setPathApplet(contextPath.concat("/applets"));
-		themeDisplay.setPathCms(contextPath.concat("/cms"));
 		themeDisplay.setPathContext(contextPath);
 		themeDisplay.setPathFriendlyURLPrivateGroup(
 			friendlyURLPrivateGroupPath);

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 161.0.1
+Bundle-Version: 162.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
@@ -583,10 +583,6 @@ public class ThemeDisplay
 		return _pathApplet;
 	}
 
-	public String getPathCms() {
-		return _pathCms;
-	}
-
 	/**
 	 * Returns the base URL for the color scheme's images, which can be
 	 * configured in the theme's <code>liferay-look-and-feel.xml</code>.
@@ -1568,10 +1564,6 @@ public class ThemeDisplay
 		_pathApplet = pathApplet;
 	}
 
-	public void setPathCms(String pathCms) {
-		_pathCms = pathCms;
-	}
-
 	public void setPathColorSchemeImages(String pathColorSchemeImages) {
 		_pathColorSchemeImages = pathColorSchemeImages;
 	}
@@ -2038,7 +2030,6 @@ public class ThemeDisplay
 	private String _mainJSURL;
 	private List<NavItem> _navItems;
 	private String _pathApplet = StringPool.BLANK;
-	private String _pathCms = StringPool.BLANK;
 	private String _pathColorSchemeImages = StringPool.BLANK;
 	private String _pathContext = StringPool.BLANK;
 	private String _pathControlPanelSpritemap = StringPool.BLANK;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 12.1.0
+version 13.0.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54638

Some URLs are hardcoding the CMS url prefix.

# How am I fixing it?

By using the existing constant.  I'm also removing the legacy `ThemeDisplay#getPathCms` and `ThemeDisplay#setPathCms` methods to avoid confusion with the new CMS.

# How can you verify that it works?

All existing tests should pass.