### PR TITLE
LPD-53490 Technical Task | Expose file URL's in headless API's for file previews

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -53,6 +53,11 @@
 					"name": {
 						"type": "string"
 					},
+					"previewURL": {
+						"description": "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)",
+						"readOnly": true,
+						"type": "string"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
 					},

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 21.0.1
+Bundle-Version: 21.1.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -339,6 +339,51 @@ public class FileEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<String> _nameSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)"
+	)
+	public String getPreviewURL() {
+		if (_previewURLSupplier != null) {
+			previewURL = _previewURLSupplier.get();
+
+			_previewURLSupplier = null;
+		}
+
+		return previewURL;
+	}
+
+	public void setPreviewURL(String previewURL) {
+		this.previewURL = previewURL;
+
+		_previewURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPreviewURL(
+		UnsafeSupplier<String, Exception> previewURLUnsafeSupplier) {
+
+		_previewURLSupplier = () -> {
+			try {
+				return previewURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String previewURL;
+
+	@JsonIgnore
+	private Supplier<String> _previewURLSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public Scope getScope() {
@@ -547,6 +592,22 @@ public class FileEntry implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String previewURL = getPreviewURL();
+
+		if (previewURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"previewURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(previewURL));
 
 			sb.append("\"");
 		}

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -52,6 +52,13 @@ components:
                     readOnly: true
                 name:
                     type: string
+                previewURL:
+                    # @review
+                    description:
+                        optional field that specifies the preview URL of the file to be used, can be embedded with
+                        nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)
+                    readOnly: true
+                    type: string
                 scope:
                     $ref: "#/components/schemas/Scope"
                 thumbnailURL:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -641,6 +641,23 @@ public class ObjectEntryDTOConverter
 				objectDefinition.getExternalReferenceCode(),
 				objectEntry.getExternalReferenceCode(), _portal));
 		fileEntry.setName(dlFileEntry::getFileName);
+		fileEntry.setPreviewURL(
+			() -> NestedFieldsSupplier.supply(
+				objectFieldName + ".previewURL",
+				fieldName -> {
+					LiferayFileEntry liferayFileEntry = new LiferayFileEntry(
+						dlFileEntry);
+
+					String previewURL = _dlURLHelper.getPreviewURL(
+						liferayFileEntry, liferayFileEntry.getFileVersion(),
+						null, StringPool.BLANK, false, false);
+
+					if (Validator.isNull(previewURL)) {
+						return null;
+					}
+
+					return previewURL;
+				}));
 		fileEntry.setScope(
 			() -> {
 				if ((objectEntry.getGroupId() == dlFileEntry.getGroupId()) &&

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -257,6 +257,11 @@
 					"name": {
 						"type": "string"
 					},
+					"previewURL": {
+						"description": "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)",
+						"readOnly": true,
+						"type": "string"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -257,6 +257,11 @@
 					"name": {
 						"type": "string"
 					},
+					"previewURL": {
+						"description": "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)",
+						"readOnly": true,
+						"type": "string"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -257,6 +257,11 @@
 					"name": {
 						"type": "string"
 					},
+					"previewURL": {
+						"description": "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)",
+						"readOnly": true,
+						"type": "string"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -257,6 +257,11 @@
 					"name": {
 						"type": "string"
 					},
+					"previewURL": {
+						"description": "optional field that specifies the preview URL of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.previewURL`)",
+						"readOnly": true,
+						"type": "string"
+					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
 					},


### PR DESCRIPTION
LPD-53490 Technical Task | Expose file URL's in headless API's for file previews

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52833

In order to support file previews we’ll need file URL information computed in the backend and the information available via API.

# How am I fixing it?

Expose file URL's in headless API's for file previews with a nested field.

# How can you verify that it works?


1. Go to CMS and create a Basic document with a File.
2. Edit again and copy the last number of the navigation bar (ie. http://localhost:8080/web/cms/e/basic-document/XXXXX/{basicDocumentId})
3. go to http://localhost:8080/o/api?endpoint=http://localhost:8080/o/cms/basic-documents/openapi.json
4. Fill the field basicDocumentId with the id of 2.
5. On the field "nestedFields" put file.previewURL



# Commits
- **LPD-53490 add previewURL to the FileEntry object**
- **LPD-53490 buildRest**
- **LPD-53490 create method to obtain the previewURL for the file of an object entry**
- **LPD-53490 fix tests**
