### PR TITLE
LPD-54028 Edit folder: call the API service to save the updated data

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -57,7 +57,23 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 			folderName: folderData.title,
 			folderSpace: folderData.scopeKey,
 		},
-		onSubmit: () => {},
+		onSubmit: async (formValues) => {
+			const newFolderValues: TFolder = {
+				description: formValues.folderDescription,
+				id: parseInt(folderId, 10),
+				title: formValues.folderName,
+			};
+
+			const {errorMessage, success} =
+				await FolderService.updateFolder(newFolderValues);
+
+			if (success) {
+				navigate(backURL);
+			}
+			else {
+				console.log(errorMessage);
+			}
+		},
 		validate: (values) =>
 			validate(
 				{

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -52,7 +52,14 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 		? [{label: folderData.scopeKey, value: folderData.scopeKey}]
 		: [];
 
-	const {errors, handleChange, handleSubmit, setValues, values} = useFormik({
+	const {
+		errors,
+		handleChange,
+		handleSubmit,
+		isSubmitting,
+		setValues,
+		values,
+	} = useFormik({
 		initialValues: {
 			folderDescription: folderData.description,
 			folderName: folderData.title,
@@ -145,11 +152,21 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 
 					<ClayToolbar.Item>
 						<ClayButton
+							disabled={isSubmitting}
 							displayType="primary"
 							form="formEditFolder"
 							size="sm"
 							type="submit"
 						>
+							{isSubmitting && (
+								<span className="inline-item inline-item-before">
+									<span
+										aria-hidden="true"
+										className="loading-animation"
+									></span>
+								</span>
+							)}
+
 							{Liferay.Language.get('save')}
 						</ClayButton>
 					</ClayToolbar.Item>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -8,7 +8,8 @@ import ClayForm from '@clayui/form';
 import {Item} from '@clayui/multi-select/lib/types';
 import ClayToolbar from '@clayui/toolbar';
 import {useFormik} from 'formik';
-import {navigate} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {navigate, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import FolderService, {TFolder} from '../../../services/FolderService';
@@ -69,9 +70,20 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 
 			if (success) {
 				navigate(backURL);
+
+				openToast({
+					message: sub(
+						Liferay.Language.get('x-was-updated-successfully'),
+						`<strong>${formValues.folderName}</strong>`
+					),
+					type: 'success',
+				});
 			}
 			else {
-				console.log(errorMessage);
+				openToast({
+					message: errorMessage,
+					type: 'danger',
+				});
 			}
 		},
 		validate: (values) =>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
@@ -8,9 +8,9 @@ import ApiHelper from '../structure_builder/services/ApiHelper';
 
 export type TFolder = {
 	description: string;
-	externalReferenceCode: string;
+	externalReferenceCode?: string;
 	id: number;
-	scopeKey: string;
+	scopeKey?: string;
 	title: string;
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/FolderService.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {patch} from '../services/api';
 import ApiHelper from '../structure_builder/services/ApiHelper';
 
 export type TFolder = {
@@ -19,4 +20,11 @@ async function getFolder(folderId: string): Promise<TFolder> {
 	return await ApiHelper.get(`${OBJECT_ENTRY_FOLDER_URL}/${folderId}`);
 }
 
-export default {getFolder};
+async function updateFolder(folderData: TFolder) {
+	return await patch(
+		folderData,
+		`${OBJECT_ENTRY_FOLDER_URL}/${folderData.id}`
+	);
+}
+
+export default {getFolder, updateFolder};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/api.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/api.ts
@@ -15,6 +15,19 @@ type RequestHandlerResult<T> = {
 	success: boolean;
 };
 
+const headers = new Headers({
+	'Accept': 'application/json',
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+	'Content-Type': 'application/json',
+});
+
+export const HEADERS_ALL_LANGUAGES = new Headers({
+	'Accept': 'application/json',
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+	'Content-Type': 'application/json',
+	'X-Accept-All-Languages': 'true',
+});
+
 export async function handleRequest<T>(
 	fetcher: () => Promise<Response>,
 	{returnValue = false}: {returnValue?: boolean} = {}
@@ -73,18 +86,15 @@ export async function postFormData(formData: FormData, url: string) {
 	);
 }
 
-const headers = new Headers({
-	'Accept': 'application/json',
-	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-	'Content-Type': 'application/json',
-});
-
-export const HEADERS_ALL_LANGUAGES = new Headers({
-	'Accept': 'application/json',
-	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-	'Content-Type': 'application/json',
-	'X-Accept-All-Languages': 'true',
-});
+export async function patch(data: any, url: string) {
+	return handleRequest(() =>
+		fetch(url, {
+			body: JSON.stringify(data),
+			headers,
+			method: 'PATCH',
+		})
+	);
+}
 
 export async function fetchJSON<T>(input: RequestInfo, init?: RequestInit) {
 	const result = await fetch(input, {headers, method: 'GET', ...init});


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-54028)

# What is this trying to solve

Call the Folder's API to save the data introduced. 

# How to test it

On the CMS, go to Content or File section and create a folder. Then, click on Edit dropdown action, modify title and Save 

# Important note
On the second and next edits for a folder, I get a Java `heap space` error and keeps loading "forever", and I have to restart the server. I would like you to test this (@robertoDiaz 🙏) and check if only happens to me or there is indeed an error (in the API?) 

Tests will be included in task: https://liferay.atlassian.net/browse/LPD-54532