### PR TITLE
LPD-54488 Technical Task | Add status column to AssetVocabulary and AssetCategory tables

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -13,6 +13,7 @@ import com.liferay.asset.kernel.exception.AssetCategoryLimitException;
 import com.liferay.asset.kernel.exception.AssetCategoryNameException;
 import com.liferay.asset.kernel.exception.DuplicateCategoryException;
 import com.liferay.asset.kernel.exception.DuplicateCategoryExternalReferenceCodeException;
+import com.liferay.asset.kernel.exception.NoSuchCategoryException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
@@ -23,10 +24,12 @@ import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ListTypeConstants;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
@@ -55,6 +58,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -630,6 +634,37 @@ public class AssetCategoryLocalServiceTest {
 	}
 
 	@Test
+	public void testGetOrAddIncompleteCategory() throws Exception {
+
+		// Lazy referencing disabled
+
+		try {
+			_assetCategoryLocalService.getOrAddIncompleteCategory(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId());
+
+			Assert.fail();
+		}
+		catch (NoSuchCategoryException noSuchCategoryException) {
+			Assert.assertNotNull(noSuchCategoryException);
+		}
+
+		// Lazy referencing enabled
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			AssetCategory assetCategory =
+				_assetCategoryLocalService.getOrAddIncompleteCategory(
+					RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+					_group.getGroupId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE, assetCategory.getStatus());
+		}
+	}
+
+	@Test
 	public void testSearch() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -849,6 +884,42 @@ public class AssetCategoryLocalServiceTest {
 
 		Assert.assertTrue(assetCategories.contains(assetCategory1));
 		Assert.assertTrue(assetCategories.contains(assetCategory2));
+	}
+
+	@Test
+	public void testUpdateAssetCategoryWithLazyReferencingEnabled()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			AssetCategory assetCategory =
+				_assetCategoryLocalService.getOrAddIncompleteCategory(
+					RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+					_group.getGroupId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE, assetCategory.getStatus());
+
+			String name = RandomTestUtil.randomString();
+
+			assetCategory = _assetCategoryLocalService.updateCategory(
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				Collections.singletonMap(LocaleUtil.getSiteDefault(), name),
+				assetCategory.getDescriptionMap(),
+				_assetVocabulary.getVocabularyId(), null, new ServiceContext());
+
+			Assert.assertEquals(name, assetCategory.getName());
+			Assert.assertEquals(
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				assetCategory.getParentCategoryId());
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED, assetCategory.getStatus());
+			Assert.assertEquals(
+				_assetVocabulary.getVocabularyId(),
+				assetCategory.getVocabularyId());
+		}
 	}
 
 	@Test

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyLocalServiceTest.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class AssetVocabularyLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetOrAddIncompleteVocabulary() throws Exception {
+
+		// Lazy referencing disabled
+
+		try {
+			_assetVocabularyLocalService.getOrAddIncompleteVocabulary(
+				StringUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId());
+
+			Assert.fail();
+		}
+		catch (NoSuchVocabularyException noSuchVocabularyException) {
+			Assert.assertNotNull(noSuchVocabularyException);
+		}
+
+		// Lazy referencing enabled
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			AssetVocabulary vocabulary =
+				_assetVocabularyLocalService.getOrAddIncompleteVocabulary(
+					StringUtil.randomString(), TestPropsValues.getUserId(),
+					_group.getGroupId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE, vocabulary.getStatus());
+		}
+	}
+
+	@Test
+	public void testUpdateAssetVocabularyWithLazyReferencingEnabled()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			AssetVocabulary vocabulary =
+				_assetVocabularyLocalService.getOrAddIncompleteVocabulary(
+					StringUtil.randomString(), TestPropsValues.getUserId(),
+					_group.getGroupId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE, vocabulary.getStatus());
+
+			Locale locale = _portal.getSiteDefaultLocale(_group.getGroupId());
+			String title = RandomTestUtil.randomString();
+
+			vocabulary = _assetVocabularyLocalService.updateVocabulary(
+				vocabulary.getVocabularyId(),
+				HashMapBuilder.put(
+					locale, title
+				).build(),
+				null, vocabulary.getSettings(),
+				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED, vocabulary.getStatus());
+			Assert.assertEquals(title, vocabulary.getTitle(locale));
+			Assert.assertEquals(
+				AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL,
+				vocabulary.getVisibilityType());
+		}
+	}
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -154,6 +154,8 @@ public class AssetCategoryPersistenceTest {
 
 		newAssetCategory.setLastPublishDate(RandomTestUtil.nextDate());
 
+		newAssetCategory.setStatus(RandomTestUtil.nextInt());
+
 		_assetCategories.add(_persistence.update(newAssetCategory));
 
 		AssetCategory existingAssetCategory = _persistence.findByPrimaryKey(
@@ -208,6 +210,8 @@ public class AssetCategoryPersistenceTest {
 		Assert.assertEquals(
 			Time.getShortTimestamp(existingAssetCategory.getLastPublishDate()),
 			Time.getShortTimestamp(newAssetCategory.getLastPublishDate()));
+		Assert.assertEquals(
+			existingAssetCategory.getStatus(), newAssetCategory.getStatus());
 	}
 
 	@Test(expected = DuplicateAssetCategoryExternalReferenceCodeException.class)
@@ -437,7 +441,7 @@ public class AssetCategoryPersistenceTest {
 			"groupId", true, "companyId", true, "userId", true, "userName",
 			true, "createDate", true, "modifiedDate", true, "parentCategoryId",
 			true, "treePath", true, "name", true, "vocabularyId", true,
-			"lastPublishDate", true);
+			"lastPublishDate", true, "status", true);
 	}
 
 	@Test
@@ -781,6 +785,8 @@ public class AssetCategoryPersistenceTest {
 		assetCategory.setVocabularyId(RandomTestUtil.nextLong());
 
 		assetCategory.setLastPublishDate(RandomTestUtil.nextDate());
+
+		assetCategory.setStatus(RandomTestUtil.nextInt());
 
 		_assetCategories.add(_persistence.update(assetCategory));
 

--- a/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
+++ b/modules/test/persistence-test/src/testIntegration/java/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
@@ -152,6 +152,8 @@ public class AssetVocabularyPersistenceTest {
 
 		newAssetVocabulary.setLastPublishDate(RandomTestUtil.nextDate());
 
+		newAssetVocabulary.setStatus(RandomTestUtil.nextInt());
+
 		_assetVocabularies.add(_persistence.update(newAssetVocabulary));
 
 		AssetVocabulary existingAssetVocabulary = _persistence.findByPrimaryKey(
@@ -206,6 +208,9 @@ public class AssetVocabularyPersistenceTest {
 			Time.getShortTimestamp(
 				existingAssetVocabulary.getLastPublishDate()),
 			Time.getShortTimestamp(newAssetVocabulary.getLastPublishDate()));
+		Assert.assertEquals(
+			existingAssetVocabulary.getStatus(),
+			newAssetVocabulary.getStatus());
 	}
 
 	@Test(
@@ -372,7 +377,7 @@ public class AssetVocabularyPersistenceTest {
 			"groupId", true, "companyId", true, "userId", true, "userName",
 			true, "createDate", true, "modifiedDate", true, "name", true,
 			"title", true, "description", true, "settings", true,
-			"visibilityType", true, "lastPublishDate", true);
+			"visibilityType", true, "lastPublishDate", true, "status", true);
 	}
 
 	@Test
@@ -710,6 +715,8 @@ public class AssetVocabularyPersistenceTest {
 		assetVocabulary.setVisibilityType(RandomTestUtil.nextInt());
 
 		assetVocabulary.setLastPublishDate(RandomTestUtil.nextDate());
+
+		assetVocabulary.setStatus(RandomTestUtil.nextInt());
 
 		_assetVocabularies.add(_persistence.update(assetVocabulary));
 

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 112.0.1
+Bundle-Version: 112.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1282,6 +1282,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="vocabularyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.portlet.asset.model.impl.AssetEntryImpl" table="AssetEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="entryId" type="long">
@@ -1364,6 +1365,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="settings_" name="settings" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="visibilityType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="status" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.portlet.asset.model.impl.AssetVocabularyGroupRelImpl" table="AssetVocabularyGroupRel">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="assetVocabularyGroupRelId" type="long">

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -109,6 +109,7 @@
 		</field>
 		<field name="vocabularyId" type="long" />
 		<field name="lastPublishDate" type="Date" />
+		<field name="status" type="int" />
 	</model>
 	<model name="com.liferay.asset.kernel.model.AssetEntry">
 		<field name="mvccVersion" type="long" />
@@ -200,6 +201,7 @@
 		</field>
 		<field name="visibilityType" type="int" />
 		<field name="lastPublishDate" type="Date" />
+		<field name="status" type="int" />
 	</model>
 	<model name="com.liferay.asset.kernel.model.AssetVocabularyGroupRel">
 		<field name="mvccVersion" type="long" />

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -620,6 +620,15 @@ public class PortalUpgradeProcessRegistryImpl
 				"activitySettingId asc"),
 			new DeleteDuplicateUniqueFinderRowsUpgradeProcess(
 				"Ticket", new String[] {"key_"}, "ticketId asc"));
+
+		upgradeVersionTreeMap.put(
+			new Version(32, 2, 0),
+			UpgradeProcessFactory.addColumns("AssetCategory", "status INTEGER"),
+			UpgradeProcessFactory.runSQL("update AssetCategory set status = 0"),
+			UpgradeProcessFactory.addColumns(
+				"AssetVocabulary", "status INTEGER"),
+			UpgradeProcessFactory.runSQL(
+				"update AssetVocabulary set status = 0"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryCacheModel.java
@@ -68,7 +68,7 @@ public class AssetCategoryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -106,6 +106,8 @@ public class AssetCategoryCacheModel
 		sb.append(vocabularyId);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
+		sb.append(", status=");
+		sb.append(status);
 		sb.append("}");
 
 		return sb.toString();
@@ -197,6 +199,8 @@ public class AssetCategoryCacheModel
 			assetCategoryImpl.setLastPublishDate(new Date(lastPublishDate));
 		}
 
+		assetCategoryImpl.setStatus(status);
+
 		assetCategoryImpl.resetOriginalValues();
 
 		return assetCategoryImpl;
@@ -231,6 +235,8 @@ public class AssetCategoryCacheModel
 
 		vocabularyId = objectInput.readLong();
 		lastPublishDate = objectInput.readLong();
+
+		status = objectInput.readInt();
 	}
 
 	@Override
@@ -303,6 +309,8 @@ public class AssetCategoryCacheModel
 
 		objectOutput.writeLong(vocabularyId);
 		objectOutput.writeLong(lastPublishDate);
+
+		objectOutput.writeInt(status);
 	}
 
 	public long mvccVersion;
@@ -323,5 +331,6 @@ public class AssetCategoryCacheModel
 	public String description;
 	public long vocabularyId;
 	public long lastPublishDate;
+	public int status;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
@@ -79,7 +79,8 @@ public class AssetCategoryModelImpl
 		{"modifiedDate", Types.TIMESTAMP}, {"parentCategoryId", Types.BIGINT},
 		{"treePath", Types.VARCHAR}, {"name", Types.VARCHAR},
 		{"title", Types.CLOB}, {"description", Types.CLOB},
-		{"vocabularyId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP}
+		{"vocabularyId", Types.BIGINT}, {"lastPublishDate", Types.TIMESTAMP},
+		{"status", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -104,10 +105,11 @@ public class AssetCategoryModelImpl
 		TABLE_COLUMNS_MAP.put("description", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("vocabularyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,treePath STRING null,name VARCHAR(255) null,title TEXT null,description TEXT null,vocabularyId LONG,lastPublishDate DATE null,primary key (categoryId, ctCollectionId))";
+		"create table AssetCategory (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,categoryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,parentCategoryId LONG,treePath STRING null,name VARCHAR(255) null,title TEXT null,description TEXT null,vocabularyId LONG,lastPublishDate DATE null,status INTEGER,primary key (categoryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table AssetCategory";
 
@@ -324,6 +326,7 @@ public class AssetCategoryModelImpl
 				"vocabularyId", AssetCategory::getVocabularyId);
 			attributeGetterFunctions.put(
 				"lastPublishDate", AssetCategory::getLastPublishDate);
+			attributeGetterFunctions.put("status", AssetCategory::getStatus);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -402,6 +405,9 @@ public class AssetCategoryModelImpl
 				"lastPublishDate",
 				(BiConsumer<AssetCategory, Date>)
 					AssetCategory::setLastPublishDate);
+			attributeSetterBiConsumers.put(
+				"status",
+				(BiConsumer<AssetCategory, Integer>)AssetCategory::setStatus);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -992,6 +998,21 @@ public class AssetCategoryModelImpl
 		_lastPublishDate = lastPublishDate;
 	}
 
+	@JSON
+	@Override
+	public int getStatus() {
+		return _status;
+	}
+
+	@Override
+	public void setStatus(int status) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_status = status;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -1160,6 +1181,7 @@ public class AssetCategoryModelImpl
 		assetCategoryImpl.setDescription(getDescription());
 		assetCategoryImpl.setVocabularyId(getVocabularyId());
 		assetCategoryImpl.setLastPublishDate(getLastPublishDate());
+		assetCategoryImpl.setStatus(getStatus());
 
 		assetCategoryImpl.resetOriginalValues();
 
@@ -1204,6 +1226,8 @@ public class AssetCategoryModelImpl
 			this.<Long>getColumnOriginalValue("vocabularyId"));
 		assetCategoryImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
+		assetCategoryImpl.setStatus(
+			this.<Integer>getColumnOriginalValue("status"));
 
 		return assetCategoryImpl;
 	}
@@ -1383,6 +1407,8 @@ public class AssetCategoryModelImpl
 			assetCategoryCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
+		assetCategoryCacheModel.status = getStatus();
+
 		return assetCategoryCacheModel;
 	}
 
@@ -1465,6 +1491,7 @@ public class AssetCategoryModelImpl
 	private String _descriptionCurrentLanguageId;
 	private long _vocabularyId;
 	private Date _lastPublishDate;
+	private int _status;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1515,6 +1542,7 @@ public class AssetCategoryModelImpl
 		_columnOriginalValues.put("description", _description);
 		_columnOriginalValues.put("vocabularyId", _vocabularyId);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
+		_columnOriginalValues.put("status", _status);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1573,6 +1601,8 @@ public class AssetCategoryModelImpl
 		columnBitmasks.put("vocabularyId", 65536L);
 
 		columnBitmasks.put("lastPublishDate", 131072L);
+
+		columnBitmasks.put("status", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyCacheModel.java
@@ -68,7 +68,7 @@ public class AssetVocabularyCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(35);
+		StringBundler sb = new StringBundler(37);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -104,6 +104,8 @@ public class AssetVocabularyCacheModel
 		sb.append(visibilityType);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
+		sb.append(", status=");
+		sb.append(status);
 		sb.append("}");
 
 		return sb.toString();
@@ -193,6 +195,8 @@ public class AssetVocabularyCacheModel
 			assetVocabularyImpl.setLastPublishDate(new Date(lastPublishDate));
 		}
 
+		assetVocabularyImpl.setStatus(status);
+
 		assetVocabularyImpl.resetOriginalValues();
 
 		return assetVocabularyImpl;
@@ -223,6 +227,8 @@ public class AssetVocabularyCacheModel
 
 		visibilityType = objectInput.readInt();
 		lastPublishDate = objectInput.readLong();
+
+		status = objectInput.readInt();
 	}
 
 	@Override
@@ -293,6 +299,8 @@ public class AssetVocabularyCacheModel
 
 		objectOutput.writeInt(visibilityType);
 		objectOutput.writeLong(lastPublishDate);
+
+		objectOutput.writeInt(status);
 	}
 
 	public long mvccVersion;
@@ -312,5 +320,6 @@ public class AssetVocabularyCacheModel
 	public String settings;
 	public int visibilityType;
 	public long lastPublishDate;
+	public int status;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
@@ -79,7 +79,7 @@ public class AssetVocabularyModelImpl
 		{"modifiedDate", Types.TIMESTAMP}, {"name", Types.VARCHAR},
 		{"title", Types.VARCHAR}, {"description", Types.VARCHAR},
 		{"settings_", Types.VARCHAR}, {"visibilityType", Types.INTEGER},
-		{"lastPublishDate", Types.TIMESTAMP}
+		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -103,10 +103,11 @@ public class AssetVocabularyModelImpl
 		TABLE_COLUMNS_MAP.put("settings_", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("visibilityType", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetVocabulary (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,vocabularyId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name VARCHAR(75) null,title STRING null,description STRING null,settings_ STRING null,visibilityType INTEGER,lastPublishDate DATE null,primary key (vocabularyId, ctCollectionId))";
+		"create table AssetVocabulary (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,vocabularyId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,name VARCHAR(75) null,title STRING null,description STRING null,settings_ STRING null,visibilityType INTEGER,lastPublishDate DATE null,status INTEGER,primary key (vocabularyId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table AssetVocabulary";
 
@@ -310,6 +311,7 @@ public class AssetVocabularyModelImpl
 				"visibilityType", AssetVocabulary::getVisibilityType);
 			attributeGetterFunctions.put(
 				"lastPublishDate", AssetVocabulary::getLastPublishDate);
+			attributeGetterFunctions.put("status", AssetVocabulary::getStatus);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -390,6 +392,10 @@ public class AssetVocabularyModelImpl
 				"lastPublishDate",
 				(BiConsumer<AssetVocabulary, Date>)
 					AssetVocabulary::setLastPublishDate);
+			attributeSetterBiConsumers.put(
+				"status",
+				(BiConsumer<AssetVocabulary, Integer>)
+					AssetVocabulary::setStatus);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -946,6 +952,21 @@ public class AssetVocabularyModelImpl
 		_lastPublishDate = lastPublishDate;
 	}
 
+	@JSON
+	@Override
+	public int getStatus() {
+		return _status;
+	}
+
+	@Override
+	public void setStatus(int status) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_status = status;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -1114,6 +1135,7 @@ public class AssetVocabularyModelImpl
 		assetVocabularyImpl.setSettings(getSettings());
 		assetVocabularyImpl.setVisibilityType(getVisibilityType());
 		assetVocabularyImpl.setLastPublishDate(getLastPublishDate());
+		assetVocabularyImpl.setStatus(getStatus());
 
 		assetVocabularyImpl.resetOriginalValues();
 
@@ -1158,6 +1180,8 @@ public class AssetVocabularyModelImpl
 			this.<Integer>getColumnOriginalValue("visibilityType"));
 		assetVocabularyImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
+		assetVocabularyImpl.setStatus(
+			this.<Integer>getColumnOriginalValue("status"));
 
 		return assetVocabularyImpl;
 	}
@@ -1336,6 +1360,8 @@ public class AssetVocabularyModelImpl
 			assetVocabularyCacheModel.lastPublishDate = Long.MIN_VALUE;
 		}
 
+		assetVocabularyCacheModel.status = getStatus();
+
 		return assetVocabularyCacheModel;
 	}
 
@@ -1417,6 +1443,7 @@ public class AssetVocabularyModelImpl
 	private String _settings;
 	private int _visibilityType;
 	private Date _lastPublishDate;
+	private int _status;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1466,6 +1493,7 @@ public class AssetVocabularyModelImpl
 		_columnOriginalValues.put("settings_", _settings);
 		_columnOriginalValues.put("visibilityType", _visibilityType);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
+		_columnOriginalValues.put("status", _status);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1523,6 +1551,8 @@ public class AssetVocabularyModelImpl
 		columnBitmasks.put("visibilityType", 32768L);
 
 		columnBitmasks.put("lastPublishDate", 65536L);
+
+		columnBitmasks.put("status", 131072L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/packageinfo
@@ -1,1 +1,1 @@
-version 7.4.0
+version 7.5.0

--- a/portal-impl/src/com/liferay/portlet/asset/service.xml
+++ b/portal-impl/src/com/liferay/portlet/asset/service.xml
@@ -30,6 +30,7 @@
 		<column localized="true" name="description" type="String" />
 		<column name="vocabularyId" type="long" />
 		<column name="lastPublishDate" type="Date" />
+		<column name="status" type="int" />
 
 		<!-- Order -->
 
@@ -285,6 +286,7 @@
 		<column name="settings" type="String" />
 		<column name="visibilityType" type="int" />
 		<column name="lastPublishDate" type="Date" />
+		<column name="status" type="int" />
 
 		<!-- Order -->
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -9,9 +9,12 @@ import com.liferay.asset.kernel.exception.AssetCategoryNameException;
 import com.liferay.asset.kernel.exception.DuplicateCategoryException;
 import com.liferay.asset.kernel.exception.DuplicateCategoryExternalReferenceCodeException;
 import com.liferay.asset.kernel.exception.InvalidAssetCategoryException;
+import com.liferay.asset.kernel.exception.NoSuchCategoryException;
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.persistence.AssetVocabularyPersistence;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -47,6 +50,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -422,6 +426,52 @@ public class AssetCategoryLocalServiceImpl
 	@Override
 	public List<AssetCategory> getEntryCategories(long entryId) {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public AssetCategory getOrAddIncompleteCategory(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException {
+
+		AssetCategory assetCategory = fetchAssetCategoryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+
+		if (assetCategory != null) {
+			return assetCategory;
+		}
+
+		if (!LazyReferencingThreadLocal.isEnabled()) {
+			throw new NoSuchCategoryException(
+				StringBundler.concat(
+					"Unable to find asset category with external reference ",
+					"code ", externalReferenceCode, " and group ", groupId));
+		}
+
+		assetCategory = assetCategoryLocalService.fetchCategory(
+			groupId, AssetCategoryConstants.INCOMPLETE_PARENT_CATEGORY_ID,
+			externalReferenceCode,
+			AssetVocabularyConstants.INCOMPLETE_VOCABULARY_ID);
+
+		if (assetCategory != null) {
+			throw new DuplicateCategoryException(
+				StringBundler.concat(
+					"There is another category named ", externalReferenceCode,
+					" as a child of category ",
+					AssetCategoryConstants.INCOMPLETE_PARENT_CATEGORY_ID));
+		}
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setIncompleteModelWithSafeCloseable(
+					true)) {
+
+			return assetCategoryLocalService.addCategory(
+				externalReferenceCode, userId, groupId,
+				AssetCategoryConstants.INCOMPLETE_PARENT_CATEGORY_ID,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), externalReferenceCode),
+				null, AssetVocabularyConstants.INCOMPLETE_VOCABULARY_ID,
+				new String[0], new ServiceContext());
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -131,7 +131,9 @@ public class AssetCategoryLocalServiceImpl
 				parentCategoryId);
 		}
 
-		_assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
+		if (vocabularyId != AssetVocabularyConstants.INCOMPLETE_VOCABULARY_ID) {
+			_assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
+		}
 
 		long categoryId = counterLocalService.increment();
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -449,19 +449,6 @@ public class AssetCategoryLocalServiceImpl
 					"code ", externalReferenceCode, " and group ", groupId));
 		}
 
-		assetCategory = assetCategoryLocalService.fetchCategory(
-			groupId, AssetCategoryConstants.INCOMPLETE_PARENT_CATEGORY_ID,
-			externalReferenceCode,
-			AssetVocabularyConstants.INCOMPLETE_VOCABULARY_ID);
-
-		if (assetCategory != null) {
-			throw new DuplicateCategoryException(
-				StringBundler.concat(
-					"There is another category named ", externalReferenceCode,
-					" as a child of category ",
-					AssetCategoryConstants.INCOMPLETE_PARENT_CATEGORY_ID));
-		}
-
 		try (SafeCloseable safeCloseable =
 				LazyReferencingThreadLocal.setIncompleteModelWithSafeCloseable(
 					true)) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -49,6 +50,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portlet.asset.service.base.AssetCategoryLocalServiceBaseImpl;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 
@@ -153,6 +155,13 @@ public class AssetCategoryLocalServiceImpl
 		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
 		category.setVocabularyId(vocabularyId);
+
+		if (LazyReferencingThreadLocal.isIncompleteModel()) {
+			category.setStatus(WorkflowConstants.STATUS_INCOMPLETE);
+		}
+		else {
+			category.setStatus(WorkflowConstants.STATUS_APPROVED);
+		}
 
 		category = assetCategoryPersistence.update(category);
 
@@ -671,6 +680,10 @@ public class AssetCategoryLocalServiceImpl
 		category.setName(name);
 		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
+
+		if (category.getStatus() == WorkflowConstants.STATUS_INCOMPLETE) {
+			category.setStatus(WorkflowConstants.STATUS_APPROVED);
+		}
 
 		return assetCategoryPersistence.update(category);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -7,11 +7,13 @@ package com.liferay.portlet.asset.service.impl;
 
 import com.liferay.asset.kernel.exception.DuplicateVocabularyException;
 import com.liferay.asset.kernel.exception.DuplicateVocabularyExternalReferenceCodeException;
+import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
 import com.liferay.asset.kernel.exception.VocabularyNameException;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -54,6 +56,7 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.service.base.AssetVocabularyLocalServiceBaseImpl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -211,7 +214,6 @@ public class AssetVocabularyLocalServiceImpl
 		else {
 			vocabulary.setStatus(WorkflowConstants.STATUS_APPROVED);
 		}
-
 
 		vocabulary = assetVocabularyPersistence.update(vocabulary);
 
@@ -397,6 +399,49 @@ public class AssetVocabularyLocalServiceImpl
 		throws PortalException {
 
 		return assetVocabularyPersistence.findByG_N(groupId, name);
+	}
+
+	@Override
+	public AssetVocabulary getOrAddIncompleteVocabulary(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException {
+
+		AssetVocabulary assetVocabulary =
+			fetchAssetVocabularyByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		if (assetVocabulary != null) {
+			return assetVocabulary;
+		}
+
+		if (!LazyReferencingThreadLocal.isEnabled()) {
+			throw new NoSuchVocabularyException(
+				StringBundler.concat(
+					"Unable to find asset vocabulary with external reference ",
+					"code ", externalReferenceCode, " and group ", groupId));
+		}
+
+		assetVocabulary = assetVocabularyLocalService.fetchGroupVocabulary(
+			groupId, externalReferenceCode);
+
+		if (assetVocabulary != null) {
+			throw new DuplicateVocabularyException(
+				"A category vocabulary with the name " + externalReferenceCode +
+					" already exists");
+		}
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setIncompleteModelWithSafeCloseable(
+					true)) {
+
+			return assetVocabularyLocalService.addVocabulary(
+				externalReferenceCode, userId, groupId, externalReferenceCode,
+				externalReferenceCode,
+				Collections.singletonMap(
+					LocaleUtil.getSiteDefault(), externalReferenceCode),
+				null, null, AssetVocabularyConstants.VISIBILITY_TYPE_INCOMPLETE,
+				new ServiceContext());
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -421,15 +421,6 @@ public class AssetVocabularyLocalServiceImpl
 					"code ", externalReferenceCode, " and group ", groupId));
 		}
 
-		assetVocabulary = assetVocabularyLocalService.fetchGroupVocabulary(
-			groupId, externalReferenceCode);
-
-		if (assetVocabulary != null) {
-			throw new DuplicateVocabularyException(
-				"A category vocabulary with the name " + externalReferenceCode +
-					" already exists");
-		}
-
 		try (SafeCloseable safeCloseable =
 				LazyReferencingThreadLocal.setIncompleteModelWithSafeCloseable(
 					true)) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -48,6 +49,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.service.base.AssetVocabularyLocalServiceBaseImpl;
 
@@ -202,6 +204,14 @@ public class AssetVocabularyLocalServiceImpl
 		vocabulary.setDescriptionMap(descriptionMap);
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
+
+		if (LazyReferencingThreadLocal.isIncompleteModel()) {
+			vocabulary.setStatus(WorkflowConstants.STATUS_INCOMPLETE);
+		}
+		else {
+			vocabulary.setStatus(WorkflowConstants.STATUS_APPROVED);
+		}
+
 
 		vocabulary = assetVocabularyPersistence.update(vocabulary);
 
@@ -481,6 +491,10 @@ public class AssetVocabularyLocalServiceImpl
 		vocabulary.setSettings(settings);
 		vocabulary.setVisibilityType(visibilityType);
 
+		if (vocabulary.getStatus() == WorkflowConstants.STATUS_INCOMPLETE) {
+			vocabulary.setStatus(WorkflowConstants.STATUS_APPROVED);
+		}
+
 		return assetVocabularyPersistence.update(vocabulary);
 	}
 
@@ -503,6 +517,10 @@ public class AssetVocabularyLocalServiceImpl
 
 		vocabulary.setDescriptionMap(descriptionMap);
 		vocabulary.setSettings(settings);
+
+		if (vocabulary.getStatus() == WorkflowConstants.STATUS_INCOMPLETE) {
+			vocabulary.setStatus(WorkflowConstants.STATUS_APPROVED);
+		}
 
 		return assetVocabularyPersistence.update(vocabulary);
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
@@ -12830,6 +12830,7 @@ public class AssetCategoryPersistenceImpl
 		ctMergeColumnNames.add("description");
 		ctMergeColumnNames.add("vocabularyId");
 		ctMergeColumnNames.add("lastPublishDate");
+		ctMergeColumnNames.add("status");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyPersistenceImpl.java
@@ -7217,6 +7217,7 @@ public class AssetVocabularyPersistenceImpl
 		ctMergeColumnNames.add("settings_");
 		ctMergeColumnNames.add("visibilityType");
 		ctMergeColumnNames.add("lastPublishDate");
+		ctMergeColumnNames.add("status");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryConstants.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryConstants.java
@@ -22,6 +22,8 @@ public class AssetCategoryConstants {
 
 	public static final long DEFAULT_PARENT_CATEGORY_ID = 0;
 
+	public static final long INCOMPLETE_PARENT_CATEGORY_ID = -1;
+
 	public static final String PROPERTY_KEY_VALUE_SEPARATOR = "_KEY_VALUE_";
 
 }

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryModel.java
@@ -527,6 +527,20 @@ public interface AssetCategoryModel
 	@Override
 	public void setLastPublishDate(Date lastPublishDate);
 
+	/**
+	 * Returns the status of this asset category.
+	 *
+	 * @return the status of this asset category
+	 */
+	public int getStatus();
+
+	/**
+	 * Sets the status of this asset category.
+	 *
+	 * @param status the status of this asset category
+	 */
+	public void setStatus(int status);
+
 	@Override
 	public String[] getAvailableLanguageIds();
 

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryTable.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryTable.java
@@ -65,6 +65,8 @@ public class AssetCategoryTable extends BaseTable<AssetCategoryTable> {
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,
 			Column.FLAG_DEFAULT);
+	public final Column<AssetCategoryTable, Integer> status = createColumn(
+		"status", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 
 	private AssetCategoryTable() {
 		super("AssetCategory", AssetCategoryTable::new);

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetCategoryWrapper.java
@@ -54,6 +54,7 @@ public class AssetCategoryWrapper
 		attributes.put("description", getDescription());
 		attributes.put("vocabularyId", getVocabularyId());
 		attributes.put("lastPublishDate", getLastPublishDate());
+		attributes.put("status", getStatus());
 
 		return attributes;
 	}
@@ -167,6 +168,12 @@ public class AssetCategoryWrapper
 
 		if (lastPublishDate != null) {
 			setLastPublishDate(lastPublishDate);
+		}
+
+		Integer status = (Integer)attributes.get("status");
+
+		if (status != null) {
+			setStatus(status);
 		}
 	}
 
@@ -412,6 +419,16 @@ public class AssetCategoryWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the status of this asset category.
+	 *
+	 * @return the status of this asset category
+	 */
+	@Override
+	public int getStatus() {
+		return model.getStatus();
 	}
 
 	/**
@@ -760,6 +777,16 @@ public class AssetCategoryWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	/**
+	 * Sets the status of this asset category.
+	 *
+	 * @param status the status of this asset category
+	 */
+	@Override
+	public void setStatus(int status) {
+		model.setStatus(status);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyConstants.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyConstants.java
@@ -10,9 +10,9 @@ package com.liferay.asset.kernel.model;
  */
 public class AssetVocabularyConstants {
 
-	public static final int VISIBILITY_TYPE_INCOMPLETE = -1;
-
 	public static final long INCOMPLETE_VOCABULARY_ID = -1;
+
+	public static final int VISIBILITY_TYPE_INCOMPLETE = -1;
 
 	public static final int VISIBILITY_TYPE_INTERNAL = 1;
 

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyConstants.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyConstants.java
@@ -10,6 +10,10 @@ package com.liferay.asset.kernel.model;
  */
 public class AssetVocabularyConstants {
 
+	public static final int VISIBILITY_TYPE_INCOMPLETE = -1;
+
+	public static final long INCOMPLETE_VOCABULARY_ID = -1;
+
 	public static final int VISIBILITY_TYPE_INTERNAL = 1;
 
 	public static final int VISIBILITY_TYPE_PUBLIC = 0;

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyModel.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyModel.java
@@ -513,6 +513,20 @@ public interface AssetVocabularyModel
 	@Override
 	public void setLastPublishDate(Date lastPublishDate);
 
+	/**
+	 * Returns the status of this asset vocabulary.
+	 *
+	 * @return the status of this asset vocabulary
+	 */
+	public int getStatus();
+
+	/**
+	 * Sets the status of this asset vocabulary.
+	 *
+	 * @param status the status of this asset vocabulary
+	 */
+	public void setStatus(int status);
+
 	@Override
 	public String[] getAvailableLanguageIds();
 

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyTable.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyTable.java
@@ -66,6 +66,8 @@ public class AssetVocabularyTable extends BaseTable<AssetVocabularyTable> {
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,
 			Column.FLAG_DEFAULT);
+	public final Column<AssetVocabularyTable, Integer> status = createColumn(
+		"status", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 
 	private AssetVocabularyTable() {
 		super("AssetVocabulary", AssetVocabularyTable::new);

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetVocabularyWrapper.java
@@ -53,6 +53,7 @@ public class AssetVocabularyWrapper
 		attributes.put("settings", getSettings());
 		attributes.put("visibilityType", getVisibilityType());
 		attributes.put("lastPublishDate", getLastPublishDate());
+		attributes.put("status", getStatus());
 
 		return attributes;
 	}
@@ -160,6 +161,12 @@ public class AssetVocabularyWrapper
 
 		if (lastPublishDate != null) {
 			setLastPublishDate(lastPublishDate);
+		}
+
+		Integer status = (Integer)attributes.get("status");
+
+		if (status != null) {
+			setStatus(status);
 		}
 	}
 
@@ -387,6 +394,16 @@ public class AssetVocabularyWrapper
 	@Override
 	public String getSettings() {
 		return model.getSettings();
+	}
+
+	/**
+	 * Returns the status of this asset vocabulary.
+	 *
+	 * @return the status of this asset vocabulary
+	 */
+	@Override
+	public int getStatus() {
+		return model.getStatus();
 	}
 
 	/**
@@ -788,6 +805,16 @@ public class AssetVocabularyWrapper
 	@Override
 	public void setSettings(String settings) {
 		model.setSettings(settings);
+	}
+
+	/**
+	 * Sets the status of this asset vocabulary.
+	 *
+	 * @param status the status of this asset vocabulary
+	 */
+	@Override
+	public void setStatus(int status) {
+		model.setStatus(status);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 11.6.0
+version 11.7.0

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
@@ -419,6 +419,11 @@ public interface AssetCategoryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AssetCategory getOrAddIncompleteCategory(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException;
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
@@ -513,6 +513,14 @@ public class AssetCategoryLocalServiceUtil {
 		return getService().getIndexableActionableDynamicQuery();
 	}
 
+	public static AssetCategory getOrAddIncompleteCategory(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException {
+
+		return getService().getOrAddIncompleteCategory(
+			externalReferenceCode, userId, groupId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
@@ -587,6 +587,15 @@ public class AssetCategoryLocalServiceWrapper
 		return _assetCategoryLocalService.getIndexableActionableDynamicQuery();
 	}
 
+	@Override
+	public AssetCategory getOrAddIncompleteCategory(
+			String externalReferenceCode, long userId, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetCategoryLocalService.getOrAddIncompleteCategory(
+			externalReferenceCode, userId, groupId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalService.java
@@ -416,6 +416,11 @@ public interface AssetVocabularyLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AssetVocabulary getOrAddIncompleteVocabulary(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException;
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceUtil.java
@@ -505,6 +505,14 @@ public class AssetVocabularyLocalServiceUtil {
 		return getService().getIndexableActionableDynamicQuery();
 	}
 
+	public static AssetVocabulary getOrAddIncompleteVocabulary(
+			String externalReferenceCode, long userId, long groupId)
+		throws PortalException {
+
+		return getService().getOrAddIncompleteVocabulary(
+			externalReferenceCode, userId, groupId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceWrapper.java
@@ -582,6 +582,15 @@ public class AssetVocabularyLocalServiceWrapper
 			getIndexableActionableDynamicQuery();
 	}
 
+	@Override
+	public AssetVocabulary getOrAddIncompleteVocabulary(
+			String externalReferenceCode, long userId, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetVocabularyLocalService.getOrAddIncompleteVocabulary(
+			externalReferenceCode, userId, groupId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.2.0
+version 14.3.0

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -98,6 +98,7 @@ create table AssetCategory (
 	description TEXT null,
 	vocabularyId LONG,
 	lastPublishDate DATE null,
+	status INTEGER,
 	primary key (categoryId, ctCollectionId)
 );
 
@@ -189,6 +190,7 @@ create table AssetVocabulary (
 	settings_ STRING null,
 	visibilityType INTEGER,
 	lastPublishDate DATE null,
+	status INTEGER,
 	primary key (vocabularyId, ctCollectionId)
 );
 


### PR DESCRIPTION
LPD-54488 Technical Task | Add status column to AssetVocabulary and AssetCategory tables

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46893

Apply lazy reference strategy to Categories and Vocabularies when importing a ObjectEntry.

# How am I fixing it?

On this technical task, I will add the status column to the assetCategory and assetVocabulary tables to allow this 2 entities to have an incomplete status on the case that we are applying a lazy reference strategy.

# How can you verify that it works?

Run the included automated tests.



# Commits

- **LPD-54488 add status to assetCategory and AssetVocabulary tables.**
- **LPD-54488 upgrade**
- **LPD-54488 set status value to incomplete, on vocabulary and category, depending on the LazyReferencingThreadLocal. If updated, then set to approved.**
- **LPD-54488 implement getOrAddIncomplete methods for vocabulary and category**
- **LPD-54488 buildService**
- **LPD-54488 baseline**
- **LPD-54488 add test about new methods**
