### PR TITLE
LPD-55075 Cannot rate documents

### DIFF
--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -41,7 +41,7 @@ const Ratings = ({
 
 	const sendVoteRequest = useCallback(
 		(score) => {
-			if (Liferay?.Session?.get('sessionState') === 'expired') {
+			if (Liferay.Session.sessionState === 'expired') {
 				errorToast(
 					`${Liferay.Language.get('you-must-be-signed-in-to-rate')}`
 				);


### PR DESCRIPTION
Documents cannot be rated

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-55075)

There is an error thrown when trying to rate documents, this is because we seem to be using a deprecated method

# How am I fixing it?

Use the same pattern as we do in other places and use the variable to check if the session has expired

# How can you verify that it works?

Follow the steps in the ticket, or execute for example :

LocalFile.DMFileEntry#CanCopyRatingFromParentToChildSite
