### PR TITLE
LPD-55163 Put CMS Consumer role under a feature flag

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
@@ -5,10 +5,12 @@
 
 package com.liferay.depot.internal.instance.lifecycle;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.internal.util.DepotRoleUtil;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
@@ -34,6 +36,13 @@ public class DepotRolesPortalInstanceLifecycleListener
 		throws PortalException {
 
 		for (String name : DepotRoleUtil.DEPOT_ROLE_NAMES) {
+			if (name.equals(DepotRolesConstants.CMS_CONSUMER) &&
+				!FeatureFlagManagerUtil.isEnabled(
+					company.getCompanyId(), "LPD-17564")) {
+
+				continue;
+			}
+
 			Role role = _getOrCreateRole(company.getCompanyId(), name);
 
 			_resourceLocalService.addResources(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.Collections;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -60,6 +61,11 @@ public class DepotRoleContributorTest {
 	@FeatureFlag("LPD-17564")
 	@Test
 	public void testCMSConsumerRoleAssignment() throws Exception {
+		Role role = _roleLocalService.fetchRole(
+			_group.getCompanyId(), DepotRolesConstants.CMS_CONSUMER);
+
+		Assume.assumeNotNull(role);
+
 		Group group = GroupTestUtil.addGroup(
 			_group.getCompanyId(), TestPropsValues.getUserId(),
 			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
@@ -70,14 +76,11 @@ public class DepotRoleContributorTest {
 				PermissionChecker permissionChecker =
 					_permissionCheckerFactory.create(user);
 
-				long[] roleIds = permissionChecker.getRoleIds(
-					user.getUserId(), group.getGroupId());
-
-				Role role = _roleLocalService.getRole(
-					_group.getCompanyId(), DepotRolesConstants.CMS_CONSUMER);
-
 				Assert.assertTrue(
-					ArrayUtil.contains(roleIds, role.getRoleId()));
+					ArrayUtil.contains(
+						permissionChecker.getRoleIds(
+							user.getUserId(), group.getGroupId()),
+						role.getRoleId()));
 			});
 	}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55163

The CMS Consumer role is created unconditionally. We need to put it behind a feature flag.