### PR TITLE
LPD-55172 Link in web content points to staging page even when published to live

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -79,7 +80,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
+import javax.portlet.WindowStateException;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -941,6 +944,23 @@ public class JournalManagementToolbarDisplayContext
 				assetTagsItemSelectorCriterion));
 	}
 
+	private PortletURL _getControlPanelPortletURL(
+		PortletRequest portletRequest) {
+
+		PortletURL portletURL = PortalUtil.getControlPanelPortletURL(
+			portletRequest, _themeDisplay.getScopeGroup(),
+			JournalPortletKeys.JOURNAL, 0, 0, PortletRequest.RENDER_PHASE);
+
+		try {
+			portletURL.setWindowState(portletRequest.getWindowState());
+		}
+		catch (WindowStateException windowStateException) {
+			_log.error(windowStateException);
+		}
+
+		return portletURL;
+	}
+
 	private CreationMenu _getCreationMenu() throws PortalException {
 		return new CreationMenu() {
 			{
@@ -986,47 +1006,50 @@ public class JournalManagementToolbarDisplayContext
 					Collections.sort(
 						ddmStructures, _getDDMStructureOrderByComparator());
 
+					PortletRequest portletRequest =
+						(PortletRequest)httpServletRequest.getAttribute(
+							JavaConstants.JAVAX_PORTLET_REQUEST);
+
+					PortletURL controlPanelPortletURL =
+						_getControlPanelPortletURL(portletRequest);
+
 					for (DDMStructure ddmStructure : ddmStructures) {
-						PortletURL portletURL =
-							PortletURLBuilder.createRenderURL(
-								liferayPortletResponse
-							).setMVCRenderCommandName(
-								"/journal/edit_article"
-							).setRedirect(
-								() -> {
-									if (_journalDisplayContext.
-											isFilterApplied() ||
-										_journalDisplayContext.isSearch()) {
+						PortletURL portletURL = PortletURLBuilder.create(
+							controlPanelPortletURL
+						).setMVCRenderCommandName(
+							"/journal/edit_article"
+						).setRedirect(
+							() -> {
+								if (_journalDisplayContext.isFilterApplied() ||
+									_journalDisplayContext.isSearch()) {
 
-										return PortletURLBuilder.
-											createRenderURL(
-												liferayPortletResponse
-											).buildString();
-									}
-
-									return PortalUtil.getCurrentURL(
-										httpServletRequest);
+									return PortletURLBuilder.createRenderURL(
+										liferayPortletResponse
+									).buildString();
 								}
-							).setBackURL(
-								_themeDisplay.getURLCurrent()
-							).setParameter(
-								"backURLTitle",
-								() -> {
-									PortletDisplay portletDisplay =
-										_themeDisplay.getPortletDisplay();
 
-									return portletDisplay.
-										getPortletDisplayName();
-								}
-							).setParameter(
-								"ddmStructureId", ddmStructure.getStructureId()
-							).setParameter(
-								"folderId", _journalDisplayContext.getFolderId()
-							).setParameter(
-								"groupId", _themeDisplay.getScopeGroupId()
-							).setParameter(
-								"showSelectFolder", false
-							).buildPortletURL();
+								return PortalUtil.getCurrentURL(
+									httpServletRequest);
+							}
+						).setBackURL(
+							_themeDisplay.getURLCurrent()
+						).setParameter(
+							"backURLTitle",
+							() -> {
+								PortletDisplay portletDisplay =
+									_themeDisplay.getPortletDisplay();
+
+								return portletDisplay.getPortletDisplayName();
+							}
+						).setParameter(
+							"ddmStructureId", ddmStructure.getStructureId()
+						).setParameter(
+							"folderId", _journalDisplayContext.getFolderId()
+						).setParameter(
+							"groupId", _themeDisplay.getScopeGroupId()
+						).setParameter(
+							"showSelectFolder", false
+						).buildPortletURL();
 
 						UnsafeConsumer<DropdownItem, Exception> unsafeConsumer =
 							dropdownItem -> {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -30,6 +30,7 @@ import com.liferay.journal.web.internal.item.selector.JournalArticleTranslations
 import com.liferay.journal.web.internal.portlet.JournalPortlet;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalFolderPermission;
+import com.liferay.journal.web.internal.util.JournalPortletUtil;
 import com.liferay.journal.web.internal.util.JournalUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
@@ -580,25 +581,9 @@ public class JournalArticleActionDropdownItemsProvider {
 
 		return dropdownItem -> {
 			dropdownItem.setHref(
-				PortletURLBuilder.createRenderURL(
-					_liferayPortletResponse
-				).setMVCRenderCommandName(
-					"/journal/edit_article"
-				).setRedirect(
-					_getRedirect()
-				).setParameter(
-					"articleId", _article.getArticleId()
-				).setParameter(
-					"backURLTitle", portletDisplay.getPortletDisplayName()
-				).setParameter(
-					"folderId", _article.getFolderId()
-				).setParameter(
-					"groupId", _article.getGroupId()
-				).setParameter(
-					"referringPortletResource", _getReferringPortletResource()
-				).setParameter(
-					"version", _article.getVersion()
-				).buildString());
+				JournalPortletUtil.getEditArticlePortletURL(
+					_article, _httpServletRequest, portletDisplay,
+					_getRedirect(), _getReferringPortletResource()));
 			dropdownItem.setIcon("pencil");
 
 			String label = "edit";

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalPortletUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalPortletUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.web.internal.util;
 
 import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
@@ -21,14 +22,19 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.taglib.servlet.taglib.util.BreadcrumbEntryBuilder;
 import com.liferay.site.navigation.taglib.servlet.taglib.util.BreadcrumbEntryListBuilder;
@@ -37,6 +43,8 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+import javax.portlet.WindowStateException;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -110,6 +118,32 @@ public class JournalPortletUtil {
 		}
 
 		return orderByComparator;
+	}
+
+	public static String getEditArticlePortletURL(
+		JournalArticle article, HttpServletRequest httpServletRequest,
+		PortletDisplay portletDisplay, String redirect,
+		String referringPortletResource) {
+
+		return PortletURLBuilder.create(
+			_getPortletURL(httpServletRequest)
+		).setMVCRenderCommandName(
+			"/journal/edit_article"
+		).setRedirect(
+			redirect
+		).setParameter(
+			"articleId", article.getArticleId()
+		).setParameter(
+			"backURLTitle", portletDisplay.getPortletDisplayName()
+		).setParameter(
+			"folderId", article.getFolderId()
+		).setParameter(
+			"groupId", article.getGroupId()
+		).setParameter(
+			"referringPortletResource", referringPortletResource
+		).setParameter(
+			"version", article.getVersion()
+		).buildString();
 	}
 
 	public static List<BreadcrumbEntry> getPortletBreadcrumbEntries(
@@ -222,5 +256,33 @@ public class JournalPortletUtil {
 
 		return 0;
 	}
+
+	private static PortletURL _getPortletURL(
+		HttpServletRequest httpServletRequest) {
+
+		PortletRequest portletRequest =
+			(PortletRequest)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletURL portletURL = PortalUtil.getControlPanelPortletURL(
+			portletRequest, themeDisplay.getScopeGroup(),
+			JournalPortletKeys.JOURNAL, 0, 0, PortletRequest.RENDER_PHASE);
+
+		try {
+			portletURL.setWindowState(portletRequest.getWindowState());
+		}
+		catch (WindowStateException windowStateException) {
+			_log.error(windowStateException);
+		}
+
+		return portletURL;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalPortletUtil.class);
 
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -62,25 +62,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 				String editURL = StringPool.BLANK;
 
 				if (JournalArticlePermission.contains(permissionChecker, curArticle, ActionKeys.UPDATE)) {
-					editURL = PortletURLBuilder.createRenderURL(
-						liferayPortletResponse
-					).setMVCRenderCommandName(
-						"/journal/edit_article"
-					).setRedirect(
-						currentURL
-					).setParameter(
-						"articleId", curArticle.getArticleId()
-					).setParameter(
-						"backURLTitle", portletDisplay.getPortletDisplayName()
-					).setParameter(
-						"folderId", curArticle.getFolderId()
-					).setParameter(
-						"groupId", curArticle.getGroupId()
-					).setParameter(
-						"referringPortletResource", referringPortletResource
-					).setParameter(
-						"version", curArticle.getVersion()
-					).buildString();
+					editURL = JournalPortletUtil.getEditArticlePortletURL(curArticle, request, portletDisplay, currentURL, referringPortletResource);
 				}
 				%>
 


### PR DESCRIPTION
Link in web content points to staging page even when published to live

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-55172)

When the portlet is not staged, we are doing the editing in staging, which will in some cases have issues with how the toolbar contributor for ckeditor is implemented

# How am I fixing it?

Following the same pattern as with Documents Library, that is, if the portlet is not staged, it will be created and edited in live, and then when saved, redirected to staging

# How can you verify that it works?

Follow the steps in the ticket

# How about the tests?

There are several tests that already cover this. From creating web content, to editing web content. So we have to check that they don't fail