### PR TITLE
LPD-55250 Office 365 Checkin and Cancel Checkout fails

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
@@ -41,6 +41,7 @@ import com.microsoft.graph.models.extensions.IGraphServiceClient;
 import com.microsoft.graph.models.extensions.Permission;
 import com.microsoft.graph.models.extensions.SharingLink;
 import com.microsoft.graph.models.extensions.User;
+import com.microsoft.graph.options.HeaderOption;
 import com.microsoft.graph.requests.extensions.GraphServiceClient;
 import com.microsoft.graph.requests.extensions.IDriveItemCreateLinkRequest;
 import com.microsoft.graph.requests.extensions.IDriveItemRequest;
@@ -52,6 +53,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
@@ -118,7 +120,9 @@ public class DLOpenerOneDriveManager {
 		).drive(
 		).items(
 			_getOneDriveReferenceKey(fileEntry)
-		).buildRequest();
+		).buildRequest(
+			Arrays.asList(new HeaderOption("Prefer", "bypass-shared-lock"))
+		);
 
 		try {
 			iDriveItemRequest.delete();


### PR DESCRIPTION
Office 365 Checkin and Cancel Checkout fails

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-55250)

Office 365 is locked for some time after creating it, leading to errors when trying to check in or check out

# How am I fixing it?

Adding a header to bypass the lock

# How can you verify that it works?

Follow the steps in the ticket

# What about tests?

We cannot test this because of external factors, like the library