### PR TITLE
LPD-55314 Folders are not visible in the Related asset window

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -252,6 +252,8 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 					).setParameter(
 						"groupId", curFolder.getGroupId()
 					).buildPortletURL();
+
+					row.setPrimaryKey(String.valueOf(curFolder.getPrimaryKey()));
 					%>
 
 					<c:choose>

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -335,3 +335,47 @@ test(
 		expect(count).toBe(1);
 	}
 );
+
+test(
+	'Validate PrimaryKey for Folder in Related Assets',
+	{
+		tag: '@LPD-55314',
+	},
+	async ({apiHelpers, journalEditArticlePage, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'Basic Web content'},
+		});
+
+		await apiHelpers.jsonWebServicesJournal.addFolder({
+			groupId: site.id,
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('link', {name: 'Basic Web content'}).click();
+
+		await journalEditArticlePage.openRelatedAsset('Basic Web Content');
+
+		await journalEditArticlePage.changeViewInRelatedAssetPopUp(
+			'Basic Web Content',
+			'list'
+		);
+
+		const relatedAssetsFrame = page.frameLocator(
+			`iframe[title="Select Basic Web Content"]`
+		);
+
+		const inputValue = await relatedAssetsFrame
+			.locator(
+				'#_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_articlesPrimaryKeys'
+			)
+			.getAttribute('value');
+
+		expect(/[[{]/.test(inputValue || '')).toBeFalsy();
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-55314 
When a folder is created, Related Assets for Web Content fail to display any web content articles or folders if the system is connected to a DB2 database.

### **How am I fixing it?**
Add a primary key for folders so that instead of returning the entire JSON, the JournalRowChecker returns a proper primary key value.

### **How can you verify that it works?**

1. Start a Liferay instance connected to DB2.
2. Create two Web Content articles and one folder.
3. Open the Related Assets panel for one of the articles.

**Expected Result:**
The folder and web content articles should be visible in the selection modal without errors.