### PR TITLE
LPD-55166 Update url title when using headless apis

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -574,6 +574,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		String fileName = null;
 		String title = null;
+		String urlTitle = null;
 		String description = null;
 		Date displayDate = null;
 		Date expirationDate = null;
@@ -581,6 +582,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		if (document != null) {
 			fileName = document.getFileName();
 			title = document.getTitle();
+			urlTitle = document.getFriendlyUrlPath();
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
@@ -612,7 +614,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		return _toDocument(
 			_dlAppService.addFileEntry(
 				externalReferenceCode, repositoryId, documentFolderId, fileName,
-				contentType, title, null, description, null,
+				contentType, title, urlTitle, description, null,
 				binaryFile.getInputStream(), binaryFile.getSize(), displayDate,
 				expirationDate, null,
 				_createServiceContext(
@@ -1019,6 +1021,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		String fileName = null;
 		String title = null;
+		String urlTitle = null;
 		String description = null;
 		Date displayDate = null;
 		Date expirationDate = null;
@@ -1026,6 +1029,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		if (document != null) {
 			fileName = document.getFileName();
 			title = document.getTitle();
+			urlTitle = document.getFriendlyUrlPath();
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
@@ -1042,7 +1046,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		return _toDocument(
 			_dlAppService.updateFileEntry(
 				fileEntry.getFileEntryId(), fileName,
-				binaryFile.getContentType(), title, null, description, null,
+				binaryFile.getContentType(), title, urlTitle, description, null,
 				DLVersionNumberIncrease.AUTOMATIC, binaryFile.getInputStream(),
 				binaryFile.getSize(), displayDate, expirationDate,
 				fileEntry.getReviewDate(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -65,6 +65,7 @@ import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 import java.io.File;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -219,6 +220,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	public void testPostSiteDocument() throws Exception {
 		super.testPostSiteDocument();
 
+		_testPostSiteDocumentWithFriendlyUrlPath();
 		_testPostSiteDocumentWithNoMultipartFiles();
 	}
 
@@ -227,6 +229,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	public void testPutDocument() throws Exception {
 		super.testPutDocument();
 
+		_testPutSiteDocumentWithFriendlyUrlPath();
 		_testPutSiteDocumentWithNoMultipartFiles();
 	}
 
@@ -535,6 +538,20 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		_assertDocumentType(dlFileEntryType, postDocument);
 	}
 
+	private void _testPostSiteDocumentWithFriendlyUrlPath() throws Exception {
+		Document randomDocument = randomDocument();
+
+		String friendlyUrlPath = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		randomDocument.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document postDocument = testPostSiteDocument_addDocument(
+			randomDocument, Collections.emptyMap());
+
+		Assert.assertEquals(friendlyUrlPath, postDocument.getFriendlyUrlPath());
+	}
+
 	private void _testPostSiteDocumentWithNoMultipartFiles() throws Exception {
 		Document randomDocument = randomDocument();
 
@@ -547,6 +564,23 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		Assert.assertEquals(StringPool.BLANK, postDocument.getContentUrl());
 		Assert.assertEquals(
 			0, GetterUtil.getLong(postDocument.getSizeInBytes()));
+	}
+
+	private void _testPutSiteDocumentWithFriendlyUrlPath() throws Exception {
+		Document randomDocument = randomDocument();
+
+		Document postDocument = testPostSiteDocument_addDocument(
+			randomDocument, Collections.emptyMap());
+
+		String friendlyUrlPath = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		postDocument.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document putDocument = documentResource.putDocument(
+			postDocument.getId(), postDocument, Collections.emptyMap());
+
+		Assert.assertEquals(friendlyUrlPath, putDocument.getFriendlyUrlPath());
 	}
 
 	private void _testPutSiteDocumentWithNoMultipartFiles() throws Exception {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55166

When posting/putting a document, the url title is always set to the default value (post) or not updated (put).

# How am I fixing it?

By passing a the url title to the underlying services when provided.

# How can you verify that it works?

Run the included integration tests.