### PR TITLE
LPD-54437 Avoid deadlock in v5_5_1.DDMFieldUpgradeProcess

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
@@ -10,11 +10,8 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -40,7 +37,7 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
-		_upgrade(companyIds);
+		_upgrade();
 	}
 
 	private boolean _hasDDMFieldAttributeCompanyId0() throws Exception {
@@ -61,52 +58,45 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
-	private void _upgrade(long[] companyIds) throws Exception {
+	private void _upgrade() throws Exception {
 		if (!_hasDDMFieldAttributeCompanyId0()) {
 			return;
 		}
 
-		processConcurrently(
-			ArrayUtil.toLongArray(companyIds),
-			companyId -> {
-				DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-					StringBundler.concat(
-						"update DDMFieldAttribute set companyId = ", companyId,
-						" where exists (select 1 from DDMField inner join ",
-						"DDMStructureVersion on DDMField.ctCollectionId = ",
-						"DDMStructureVersion.ctCollectionId and ",
-						"DDMField.structureVersionId = ",
-						"DDMStructureVersion.structureVersionId and ",
-						"DDMStructureVersion.companyId = ", companyId,
-						" and DDMField.fieldId = DDMFieldAttribute.fieldId) ",
-						"and DDMFieldAttribute.companyId = 0"));
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			StringBundler.concat(
+				"update DDMFieldAttribute set companyId = ",
+				"DDMStructureVersion.companyId from DDMField inner join ",
+				"DDMStructureVersion on DDMField.structureVersionId = ",
+				"DDMStructureVersion.structureVersionId and ",
+				"DDMField.ctCollectionId = DDMStructureVersion.ctCollectionId ",
+				"where DDMFieldAttribute.companyId = 0 and DDMField.fieldId = ",
+				"DDMFieldAttribute.fieldId"));
 
-				String sql = StringBundler.concat(
-					"update DDMFieldAttribute inner join DDMField on ",
-					"DDMField.fieldId = DDMFieldAttribute.fieldId inner join ",
-					"DDMStructureVersion on DDMField.ctCollectionId = ",
-					"DDMStructureVersion.ctCollectionId and ",
-					"DDMField.structureVersionId = ",
-					"DDMStructureVersion.structureVersionId and ",
-					"DDMStructureVersion.companyId = ", companyId, " and ",
-					"DDMField.fieldId = DDMFieldAttribute.fieldId set ",
-					"DDMFieldAttribute.companyId = ", companyId,
-					" where DDMFieldAttribute.companyId = 0");
+		String sql = StringBundler.concat(
+			"update DDMFieldAttribute inner join DDMField on DDMField.fieldId ",
+			"= DDMFieldAttribute.fieldId inner join DDMStructureVersion on ",
+			"DDMField.structureVersionId = ",
+			"DDMStructureVersion.structureVersionId and ",
+			"DDMField.ctCollectionId = DDMStructureVersion.ctCollectionId set ",
+			"DDMFieldAttribute.companyId = DDMStructureVersion.companyId ",
+			"where DDMFieldAttribute.companyId = 0");
 
-				dbTypeToSQLMap.add(DBType.MARIADB, sql);
-				dbTypeToSQLMap.add(DBType.MYSQL, sql);
+		dbTypeToSQLMap.add(DBType.MARIADB, sql);
+		dbTypeToSQLMap.add(DBType.MYSQL, sql);
 
-				runSQL(dbTypeToSQLMap);
+		dbTypeToSQLMap.add(
+			DBType.ORACLE,
+			StringBundler.concat(
+				"update DDMFieldAttribute set companyId = COALESCE((select ",
+				"DDMStructureVersion.companyId from DDMField inner join ",
+				"DDMStructureVersion on DDMField.structureVersionId = ",
+				"DDMStructureVersion.structureVersionId and ",
+				"DDMField.ctCollectionId = DDMStructureVersion.ctCollectionId ",
+				"and DDMField.fieldId = DDMFieldAttribute.fieldId), 0) where ",
+				"DDMFieldAttribute.companyId = 0"));
 
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Update company ID for dynamic data mapping ",
-							"fields from 0 to ", companyId));
-				}
-			},
-			"Unable to update company IDs for dynamic data mapping field " +
-				"attributes");
+		runSQL(dbTypeToSQLMap);
 	}
 
 	private void _upgradeByCompanyId(long companyId) throws Exception {
@@ -119,8 +109,5 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 			preparedStatement.executeUpdate();
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DDMFieldAttributeUpgradeProcess.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
@@ -10,11 +10,8 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -40,7 +37,7 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
-		_upgrade(companyIds);
+		_upgrade();
 	}
 
 	private boolean _hasDDMFieldCompanyId0() throws Exception {
@@ -61,48 +58,43 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
-	private void _upgrade(long[] companyIds) throws Exception {
+	private void _upgrade() throws Exception {
 		if (!_hasDDMFieldCompanyId0()) {
 			return;
 		}
 
-		processConcurrently(
-			ArrayUtil.toLongArray(companyIds),
-			companyId -> {
-				DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-					StringBundler.concat(
-						"update DDMField set companyId = ", companyId,
-						" where exists (select 1 from DDMStructureVersion ",
-						"where DDMStructureVersion.structureVersionId = ",
-						"DDMField.structureVersionId and ",
-						"DDMStructureVersion.ctCollectionId = ",
-						"DDMField.ctCollectionId and ",
-						"DDMStructureVersion.companyId = ", companyId,
-						") and DDMField.companyId = 0"));
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			StringBundler.concat(
+				"update DDMField set companyId = ",
+				"DDMStructureVersion.companyId from DDMStructureVersion where ",
+				"DDMField.structureVersionId = ",
+				"DDMStructureVersion.structureVersionId and ",
+				"DDMField.ctCollectionId = DDMStructureVersion.ctCollectionId ",
+				"and DDMField.companyId = 0"));
 
-				String sql = StringBundler.concat(
-					"update DDMField inner join DDMStructureVersion on ",
-					"DDMStructureVersion.structureVersionId = ",
-					"DDMField.structureVersionId and ",
-					"DDMStructureVersion.ctCollectionId = ",
-					"DDMField.ctCollectionId and ",
-					"DDMStructureVersion.companyId = ", companyId,
-					" set DDMField.companyId = ", companyId,
-					" where DDMField.companyId = 0");
+		String sql = StringBundler.concat(
+			"update DDMField inner join DDMStructureVersion on ",
+			"DDMField.structureVersionId = ",
+			"DDMStructureVersion.structureVersionId and ",
+			"DDMField.ctCollectionId = DDMStructureVersion.ctCollectionId set ",
+			"DDMField.companyId = DDMStructureVersion.companyId where ",
+			"DDMField.companyId = 0");
 
-				dbTypeToSQLMap.add(DBType.MARIADB, sql);
-				dbTypeToSQLMap.add(DBType.MYSQL, sql);
+		dbTypeToSQLMap.add(DBType.MARIADB, sql);
+		dbTypeToSQLMap.add(DBType.MYSQL, sql);
 
-				runSQL(dbTypeToSQLMap);
+		dbTypeToSQLMap.add(
+			DBType.ORACLE,
+			StringBundler.concat(
+				"update DDMField set companyId = COALESCE((select ",
+				"DDMStructureVersion.companyId from DDMStructureVersion where ",
+				"DDMField.structureVersionId = ",
+				"DDMStructureVersion.structureVersionId and ",
+				"DDMField.ctCollectionId = ",
+				"DDMStructureVersion.ctCollectionId), 0) where ",
+				"DDMField.companyId = 0"));
 
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						StringBundler.concat(
-							"Update company IDs for dynamic data mapping ",
-							"fields from 0 to ", companyId));
-				}
-			},
-			"Unable to update company IDs for dynamic data mapping fields");
+		runSQL(dbTypeToSQLMap);
 	}
 
 	private void _upgradeByCompanyId(long companyId) throws Exception {
@@ -114,8 +106,5 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 			preparedStatement.executeUpdate();
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DDMFieldUpgradeProcess.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -38,8 +38,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -173,17 +171,13 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	}
 
 	private void _runUpgrade() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME, LoggerTestUtil.OFF)) {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
 
-			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-				_upgradeStepRegistrator, _CLASS_NAME);
+		upgradeProcess.upgrade();
 
-			upgradeProcess.upgrade();
-
-			_entityCache.clearCache();
-			_multiVMPool.clear();
-		}
+		_entityCache.clearCache();
+		_multiVMPool.clear();
 	}
 
 	private static final String _CLASS_NAME =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/test/DDMFieldUpgradeProcessTest.java
@@ -36,8 +36,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -152,17 +150,13 @@ public class DDMFieldUpgradeProcessTest {
 	}
 
 	private void _runUpgrade() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME, LoggerTestUtil.OFF)) {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
 
-			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-				_upgradeStepRegistrator, _CLASS_NAME);
+		upgradeProcess.upgrade();
 
-			upgradeProcess.upgrade();
-
-			_entityCache.clearCache();
-			_multiVMPool.clear();
-		}
+		_entityCache.clearCache();
+		_multiVMPool.clear();
 	}
 
 	private static final String _CLASS_NAME =


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-54437](https://liferay.atlassian.net/browse/LPD-54437)}

Improve the upgrade performance and avoid deadlocks since all queries are susceptible to update the same records.

# How am I fixing it?

- Using only one single update query.


# How can you verify that it works?

Run the related, already existing, automated tests.

**LPD-54437 Not needed anymore.**
**LPD-54437 Apply same approach as in DDMFieldUpgradeProcess.**
**LPD-54437 Avoid deadlock performing a sinle query. With four different queries performing a full scan since companyId isn't primary index the chances of a deadlock are bigger.**