### PR TITLE
LPD-55427 Fix link to Edit folder action

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
@@ -151,17 +151,20 @@ public class ContentsSectionDisplayContextTest
 			_getFDSActionDropdownItems();
 
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 3,
+			fdsActionDropdownItems.toString(), 4,
 			fdsActionDropdownItems.size());
 
 		_assertFDSActionDropdownItem(
 			fdsActionDropdownItems.get(0), "pencil", "edit", "edit", "get",
 			"item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(1), "password-policies", "permissions",
+			fdsActionDropdownItems.get(1), "pencil", "editFolder", "edit",
+			"get", "item");
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(2), "password-policies", "permissions",
 			"permissions", "get", "item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(2), "trash", "delete", "delete",
+			fdsActionDropdownItems.get(3), "trash", "delete", "delete",
 			"delete", "item");
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ContentsSectionDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -17,11 +18,13 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -104,6 +107,26 @@ public class ContentsSectionDisplayContext extends BaseSectionDisplayContext {
 		).put(
 			"title", language.get(httpServletRequest, "no-content-yet")
 		).build();
+	}
+
+	@Override
+	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			super.getFDSActionDropdownItems();
+
+		fdsActionDropdownItems.add(
+			1,
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					themeDisplay.getPathFriendlyURLPublic(),
+					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
+					_portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
+				"pencil", "editFolder",
+				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
+				null));
+
+		return fdsActionDropdownItems;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/FilesSectionDisplayContext.java
@@ -116,6 +116,18 @@ public class FilesSectionDisplayContext extends BaseSectionDisplayContext {
 		fdsActionDropdownItems.add(
 			1,
 			new FDSActionDropdownItem(
+				StringBundler.concat(
+					themeDisplay.getPathFriendlyURLPublic(),
+					GroupConstants.CMS_FRIENDLY_URL, "/e/edit-folder/",
+					_portal.getClassNameId(ObjectEntryFolder.class),
+					"/{embedded.id}?redirect=", themeDisplay.getURLCurrent()),
+				"pencil", "editFolder",
+				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
+				null));
+
+		fdsActionDropdownItems.add(
+			2,
+			new FDSActionDropdownItem(
 				"{embedded.file.link.href}", "download", "download",
 				LanguageUtil.get(httpServletRequest, "download"), "get", null,
 				"link"));

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/ContentsFDSPropsTransformer.ts
@@ -18,13 +18,18 @@ const ACTIONS = {
 	createFolder: createFolderAction,
 };
 
+const OBJECT_ENTRY_FOLDER_CLASSNAME =
+	'com.liferay.object.model.ObjectEntryFolder';
+
 export default function ContentFDSPropsTransformer({
 	additionalProps,
 	creationMenu,
+	itemsActions = [],
 	...otherProps
 }: {
 	additionalProps: any;
 	creationMenu: any;
+	itemsActions?: any[];
 	otherProps: any;
 }) {
 	return {
@@ -61,5 +66,29 @@ export default function ContentFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
+		itemsActions: itemsActions.map((action) => {
+			if (action?.data?.id === 'edit') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName !==
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
+				};
+			}
+			else if (action?.data?.id === 'editFolder') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName ===
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
+				};
+			}
+
+			return action;
+		}),
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/FDSPropsTransformer/FilesFDSPropsTransformer.ts
@@ -18,6 +18,9 @@ const ACTIONS = {
 	createFolder: createFolderAction,
 };
 
+const OBJECT_ENTRY_FOLDER_CLASSNAME =
+	'com.liferay.object.model.ObjectEntryFolder';
+
 export default function FilesFDSPropsTransformer({
 	additionalProps,
 	creationMenu,
@@ -69,6 +72,26 @@ export default function FilesFDSPropsTransformer({
 					...action,
 					isVisible: (item: any) =>
 						Boolean(item?.embedded?.file?.link?.href),
+				};
+			}
+			else if (action?.data?.id === 'edit') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName !==
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
+				};
+			}
+			else if (action?.data?.id === 'editFolder') {
+				return {
+					...action,
+					isVisible: (item: any) =>
+						Boolean(
+							item?.entryClassName ===
+								OBJECT_ENTRY_FOLDER_CLASSNAME
+						),
 				};
 			}
 


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-55427)

# Motivation
Link to Edit action for folders stopped working due to recent changes in https://liferay.atlassian.net/browse/LPD-54517. 

# How did I solve it
We cannot go to the same Struts action, but instead we can have a new Edit action that redirects directly to the Edit folder page. In the frontend side, we only show one of those Edit actions, depending on the entryClassName. 

# Test
The story is still in progress and the tests will be added in task https://liferay.atlassian.net/browse/LPD-54532 (In fact, while working on tests I discovered this issue)

# Notes
For some reason, the link is not working yet. The value is like `http://localhost:8080/c/cms/e/edit-folder/30516/35528?redirect=/web/cms/contents`, that is redirected to the same page (or sometimes to an error page 🤔). If I change manually to `http://localhost:8080/WEB/cms/e/edit-folder/30516/35528?redirect=/web/cms/contents` it works. 
But the link to Content or File entries is also with `http://localhost:8080/c/...` and it is working. So here I would need your help @adolfopa 🙏 