### PR TITLE
LPD-54692 Prevent self references in object entry folders

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderParentObjectEntryFolderExceptionMapper.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/jaxrs/exception/mapper/ObjectEntryFolderParentObjectEntryFolderExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.object.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectEntryFolderParentObjectEntryFolderException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Object)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Object.ObjectEntryFolderParentObjectEntryFolderExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectEntryFolderParentObjectEntryFolderExceptionMapper
+	extends BaseExceptionMapper
+		<ObjectEntryFolderParentObjectEntryFolderException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectEntryFolderParentObjectEntryFolderException
+			objectEntryFolderParentObjectEntryFolderException) {
+
+		return new Problem(objectEntryFolderParentObjectEntryFolderException);
+	}
+
+}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -349,26 +349,26 @@ public class ObjectEntryFolderResourceImpl
 		}
 
 		com.liferay.object.model.ObjectEntryFolder
-			objectEntryFolderPersistence =
+			persistedObjectEntryFolder =
 				_objectEntryFolderService.
 					fetchObjectEntryFolderByExternalReferenceCode(
 						parentObjectEntryFolderExternalReferenceCode, groupId,
 						contextUser.getCompanyId());
 
 		if ((parentObjectEntryFolderId != null) &&
-			((objectEntryFolderPersistence == null) ||
-			 (objectEntryFolderPersistence.getObjectEntryFolderId() !=
+			((persistedObjectEntryFolder == null) ||
+			 (persistedObjectEntryFolder.getObjectEntryFolderId() !=
 				 parentObjectEntryFolderId))) {
 
 			throw new NoSuchObjectEntryFolderException();
 		}
 
-		if (objectEntryFolderPersistence == null) {
+		if (persistedObjectEntryFolder == null) {
 			if (!addObjectEntryFolder) {
 				throw new NoSuchObjectEntryFolderException();
 			}
 
-			objectEntryFolderPersistence =
+			persistedObjectEntryFolder =
 				_objectEntryFolderService.addObjectEntryFolder(
 					parentObjectEntryFolderExternalReferenceCode, groupId,
 					ObjectEntryFolderConstants.
@@ -379,7 +379,7 @@ public class ObjectEntryFolderResourceImpl
 					).build());
 		}
 
-		return objectEntryFolderPersistence.getObjectEntryFolderId();
+		return persistedObjectEntryFolder.getObjectEntryFolderId();
 	}
 
 	private ObjectEntryFolder _patchObjectEntryFolder(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -333,7 +333,7 @@ public class ObjectEntryFolderResourceImpl
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT;
 			}
 
-			if (parentObjectEntryFolderId > ObjectEntryFolderConstants.
+			if (parentObjectEntryFolderId != ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
 
 				_objectEntryFolderService.getObjectEntryFolder(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -237,7 +237,9 @@ public class ObjectEntryFolderResourceImpl
 
 		return _addObjectEntryFolder(
 			groupId,
-			_getParentObjectEntryFolderId(false, groupId, objectEntryFolder),
+			GetterUtil.getLong(
+				_getParentObjectEntryFolderId(
+					false, groupId, objectEntryFolder)),
 			objectEntryFolder);
 	}
 
@@ -262,14 +264,18 @@ public class ObjectEntryFolderResourceImpl
 		if (persistedObjectEntryFolder == null) {
 			return _addObjectEntryFolder(
 				groupId,
-				_getParentObjectEntryFolderId(true, groupId, objectEntryFolder),
+				GetterUtil.getLong(
+					_getParentObjectEntryFolderId(
+						true, groupId, objectEntryFolder)),
 				objectEntryFolder);
 		}
 
 		return _toObjectEntryFolder(
 			_objectEntryFolderService.updateObjectEntryFolder(
 				persistedObjectEntryFolder.getObjectEntryFolderId(),
-				_getParentObjectEntryFolderId(true, groupId, objectEntryFolder),
+				GetterUtil.getLong(
+					_getParentObjectEntryFolderId(
+						true, groupId, objectEntryFolder)),
 				objectEntryFolder.getDescription(),
 				LocalizedMapUtil.getLocalizedMap(
 					contextAcceptLanguage.getPreferredLocale(),
@@ -316,7 +322,7 @@ public class ObjectEntryFolderResourceImpl
 		throw new NoSuchGroupException();
 	}
 
-	private long _getParentObjectEntryFolderId(
+	private Long _getParentObjectEntryFolderId(
 			boolean addObjectEntryFolder, long groupId,
 			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
@@ -329,8 +335,7 @@ public class ObjectEntryFolderResourceImpl
 
 		if (Validator.isNull(parentObjectEntryFolderExternalReferenceCode)) {
 			if (parentObjectEntryFolderId == null) {
-				return ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT;
+				return null;
 			}
 
 			if (parentObjectEntryFolderId != ObjectEntryFolderConstants.
@@ -396,13 +401,10 @@ public class ObjectEntryFolderResourceImpl
 				persistedObjectEntryFolder.getLabelMap());
 		}
 
-		long parentObjectEntryFolderId = _getParentObjectEntryFolderId(
+		Long parentObjectEntryFolderId = _getParentObjectEntryFolderId(
 			false, persistedObjectEntryFolder.getGroupId(), objectEntryFolder);
 
-		if (parentObjectEntryFolderId ==
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
-
+		if (parentObjectEntryFolderId == null) {
 			parentObjectEntryFolderId =
 				persistedObjectEntryFolder.getObjectEntryFolderId();
 		}

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -406,7 +406,7 @@ public class ObjectEntryFolderResourceImpl
 
 		if (parentObjectEntryFolderId == null) {
 			parentObjectEntryFolderId =
-				persistedObjectEntryFolder.getObjectEntryFolderId();
+				persistedObjectEntryFolder.getParentObjectEntryFolderId();
 		}
 
 		return _toObjectEntryFolder(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -338,8 +338,9 @@ public class ObjectEntryFolderResourceImpl
 				return null;
 			}
 
-			if (parentObjectEntryFolderId != ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
+			if (parentObjectEntryFolderId !=
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
 
 				_objectEntryFolderService.getObjectEntryFolder(
 					parentObjectEntryFolderId);
@@ -348,12 +349,11 @@ public class ObjectEntryFolderResourceImpl
 			return parentObjectEntryFolderId;
 		}
 
-		com.liferay.object.model.ObjectEntryFolder
-			persistedObjectEntryFolder =
-				_objectEntryFolderService.
-					fetchObjectEntryFolderByExternalReferenceCode(
-						parentObjectEntryFolderExternalReferenceCode, groupId,
-						contextUser.getCompanyId());
+		com.liferay.object.model.ObjectEntryFolder persistedObjectEntryFolder =
+			_objectEntryFolderService.
+				fetchObjectEntryFolderByExternalReferenceCode(
+					parentObjectEntryFolderExternalReferenceCode, groupId,
+					contextUser.getCompanyId());
 
 		if ((parentObjectEntryFolderId != null) &&
 			((persistedObjectEntryFolder == null) ||

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -12,14 +12,17 @@ import com.liferay.headless.object.client.dto.v1_0.ObjectEntryFolder;
 import com.liferay.headless.object.client.pagination.Page;
 import com.liferay.headless.object.client.pagination.Pagination;
 import com.liferay.headless.object.client.problem.Problem;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -104,6 +107,92 @@ public class ObjectEntryFolderResourceTest
 				Collections.singletonList(objectEntryFolder1),
 				(List<ObjectEntryFolder>)page.getItems());
 		}
+	}
+
+	@Override
+	@Test
+	public void testPatchObjectEntryFolder() throws Exception {
+		super.testPatchObjectEntryFolder();
+
+		ObjectEntryFolder postParentObjectEntryFolder =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		// Change parent object entry folder to default object entry folder
+
+		ObjectEntryFolder postObjectEntryFolder1 =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		postObjectEntryFolder1.setParentObjectEntryFolderId(
+			postParentObjectEntryFolder.getId());
+
+		objectEntryFolderResource.patchObjectEntryFolder(
+			postObjectEntryFolder1.getId(), postObjectEntryFolder1);
+
+		postObjectEntryFolder1.setParentObjectEntryFolderId(
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
+
+		ObjectEntryFolder patchObjectEntryFolder1 =
+			objectEntryFolderResource.patchObjectEntryFolder(
+				postObjectEntryFolder1.getId(), postObjectEntryFolder1);
+
+		Assert.assertEquals(
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			GetterUtil.getLong(
+				patchObjectEntryFolder1.getParentObjectEntryFolderId()));
+
+		// Change parent object entry folder to existing object entry folder
+
+		ObjectEntryFolder postObjectEntryFolder2 =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		postObjectEntryFolder2.setParentObjectEntryFolderId(
+			postParentObjectEntryFolder.getId());
+
+		ObjectEntryFolder patchObjectEntryFolder2 =
+			objectEntryFolderResource.patchObjectEntryFolder(
+				postObjectEntryFolder2.getId(), postObjectEntryFolder2);
+
+		Assert.assertEquals(
+			postParentObjectEntryFolder.getId(),
+			patchObjectEntryFolder2.getParentObjectEntryFolderId());
+
+		// Change parent object entry folder to itself
+
+		ObjectEntryFolder postObjectEntryFolder3 =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		AssertUtils.assertFailure(
+			Problem.ProblemException.class,
+			"Can not set the parent entry folder ID of object entry folder " +
+				postObjectEntryFolder3.getId() + " to itself",
+			() -> {
+				postObjectEntryFolder3.setParentObjectEntryFolderId(
+					postObjectEntryFolder3.getId());
+
+				objectEntryFolderResource.patchObjectEntryFolder(
+					postObjectEntryFolder3.getId(), postObjectEntryFolder3);
+			});
+
+		// Preserve preexisting parent object entry folder ID
+
+		ObjectEntryFolder postObjectEntryFolder4 =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		postObjectEntryFolder4.setParentObjectEntryFolderId(
+			postParentObjectEntryFolder.getId());
+
+		objectEntryFolderResource.patchObjectEntryFolder(
+			postObjectEntryFolder4.getId(), postObjectEntryFolder4);
+
+		postObjectEntryFolder4.setParentObjectEntryFolderId((Long)null);
+
+		ObjectEntryFolder patchObjectEntryFolder4 =
+			objectEntryFolderResource.patchObjectEntryFolder(
+				postObjectEntryFolder4.getId(), postObjectEntryFolder4);
+
+		Assert.assertEquals(
+			postParentObjectEntryFolder.getId(),
+			patchObjectEntryFolder4.getParentObjectEntryFolderId());
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectEntryFolderParentObjectEntryFolderException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectEntryFolderParentObjectEntryFolderException.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Marco Leo
+ */
+public class ObjectEntryFolderParentObjectEntryFolderException
+	extends PortalException {
+
+	public ObjectEntryFolderParentObjectEntryFolderException() {
+	}
+
+	public ObjectEntryFolderParentObjectEntryFolderException(String msg) {
+		super(msg);
+	}
+
+	public ObjectEntryFolderParentObjectEntryFolderException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public ObjectEntryFolderParentObjectEntryFolderException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 30.3.0
+version 30.4.0

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -1234,6 +1234,7 @@
 		<exception>ObjectEntryCount</exception>
 		<exception>ObjectEntryDefaultLanguageId</exception>
 		<exception>ObjectEntryFolderName</exception>
+		<exception>ObjectEntryFolderParentObjectEntryFolder</exception>
 		<exception>ObjectEntryFolderScope</exception>
 		<exception>ObjectEntryValues</exception>
 		<exception>ObjectFieldBusinessType</exception>

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.entry.folder.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
 import com.liferay.object.exception.ObjectEntryFolderNameException;
+import com.liferay.object.exception.ObjectEntryFolderParentObjectEntryFolderException;
 import com.liferay.object.exception.ObjectEntryFolderScopeException;
 import com.liferay.object.exception.RequiredObjectEntryFolderException;
 import com.liferay.object.model.ObjectEntry;
@@ -71,7 +72,8 @@ public class ObjectEntryFolderLocalServiceImpl
 		_validateExternalReferenceCode(
 			externalReferenceCode, groupId, user.getCompanyId());
 
-		_validateParentObjectEntryFolderId(groupId, parentObjectEntryFolderId);
+		_validateParentObjectEntryFolderId(
+			groupId, 0, parentObjectEntryFolderId);
 		_validateName(
 			groupId, user.getCompanyId(), 0, parentObjectEntryFolderId, name);
 
@@ -275,7 +277,9 @@ public class ObjectEntryFolderLocalServiceImpl
 			objectEntryFolderPersistence.findByPrimaryKey(objectEntryFolderId);
 
 		_validateParentObjectEntryFolderId(
-			objectEntryFolder.getGroupId(), parentObjectEntryFolderId);
+			objectEntryFolder.getGroupId(),
+			objectEntryFolder.getObjectEntryFolderId(),
+			parentObjectEntryFolderId);
 		_validateName(
 			objectEntryFolder.getGroupId(), objectEntryFolder.getCompanyId(),
 			objectEntryFolderId, parentObjectEntryFolderId, name);
@@ -392,7 +396,8 @@ public class ObjectEntryFolderLocalServiceImpl
 	}
 
 	private void _validateParentObjectEntryFolderId(
-			long groupId, long parentObjectEntryFolderId)
+			long groupId, long objectEntryFolderId,
+			long parentObjectEntryFolderId)
 		throws PortalException {
 
 		if (parentObjectEntryFolderId ==
@@ -400,6 +405,13 @@ public class ObjectEntryFolderLocalServiceImpl
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT) {
 
 			return;
+		}
+
+		if (objectEntryFolderId == parentObjectEntryFolderId) {
+			throw new ObjectEntryFolderParentObjectEntryFolderException(
+				StringBundler.concat(
+					"Can not set the parent entry folder ID of object entry ",
+					"folder ", objectEntryFolderId, " to itself"));
 		}
 
 		ObjectEntryFolder objectEntryFolder =


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-54692

> [!NOTE]
> This is just a rebase on top of current master, following up on https://github.com/brianchandotcom/liferay-portal/pull/161783#event-17645326615

It is possible to make folders refer to themselves as parents.

Note that it is still possible to create indirect circular references; that will be fixed in a different pr.

# How can you verify that it works?

Run the included integration tests.