### PR TITLE
LPD-54532 Playwright test for Edit Folder

### DIFF
--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -40,6 +40,7 @@ import {ListTypeAdminApiHelper} from './ListTypeAdminApiHelper';
 import {NotificationApiHelper} from './NotificationApiHelper';
 import {ObjectAdminApiHelper} from './ObjectAdminApiHelper';
 import {ObjectEntryApiHelper} from './ObjectEntryApiHelper';
+import {ObjectEntryFolderApiHelper} from './ObjectEntryFolderApiHelper';
 import {SCIMApiHelper} from './SCIMApiHelper';
 import {SearchExperiencesApiHelper} from './SearchExperiencesApiHelper';
 import {JSONWebServicesAnnouncementsEntryApiHelper} from './json-web-services/JSONWebServicesAnnouncementsEntryApiHelper';
@@ -167,6 +168,7 @@ export class ApiHelpers {
 	readonly notification: NotificationApiHelper;
 	readonly objectAdmin: ObjectAdminApiHelper;
 	readonly objectEntry: ObjectEntryApiHelper;
+	readonly objectFolder: ObjectEntryFolderApiHelper;
 	readonly page: Page;
 	readonly scim: SCIMApiHelper;
 	readonly searchExperiences: SearchExperiencesApiHelper;
@@ -265,6 +267,7 @@ export class ApiHelpers {
 		this.notification = new NotificationApiHelper(this);
 		this.objectAdmin = new ObjectAdminApiHelper(this);
 		this.objectEntry = new ObjectEntryApiHelper(this);
+		this.objectFolder = new ObjectEntryFolderApiHelper(this);
 		this.page = page;
 		this.scim = new SCIMApiHelper(this);
 		this.searchExperiences = new SearchExperiencesApiHelper(this);

--- a/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
@@ -16,15 +16,15 @@ export class ObjectEntryFolderApiHelper {
 		parentObjectEntryFolderExternalReferenceCode = 'L_FILES',
 		scopeKey,
 		title,
-	} : {
-		parentObjectEntryFolderExternalReferenceCode?: 'L_FILES' | 'L_CONTENT'
-		scopeKey: string,
-		title: string,
+	}: {
+		parentObjectEntryFolderExternalReferenceCode?: 'L_FILES' | 'L_CONTENT';
+		scopeKey: string;
+		title: string;
 	}) {
 		const data = JSON.stringify({
 			parentObjectEntryFolderExternalReferenceCode,
 			title,
-		})
+		});
 
 		return this.apiHelpers.post(
 			`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,

--- a/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ApiHelpers} from './ApiHelpers';
+
+export class ObjectEntryFolderApiHelper {
+	readonly apiHelpers: ApiHelpers;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+	}
+
+	async createObjectEntryFolder({
+		parentObjectEntryFolderExternalReferenceCode = 'L_FILES',
+		scopeKey,
+		title,
+	} : {
+		parentObjectEntryFolderExternalReferenceCode?: 'L_FILES' | 'L_CONTENT'
+		scopeKey: string,
+		title: string,
+	}) {
+		const data = JSON.stringify({
+			parentObjectEntryFolderExternalReferenceCode,
+			title,
+		})
+
+		return this.apiHelpers.post(
+			`/o/headless-object/v1.0/scopes/${scopeKey}/object-entry-folders`,
+			{data}
+		);
+	}
+}

--- a/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectEntryFolderApiHelper.ts
@@ -31,4 +31,10 @@ export class ObjectEntryFolderApiHelper {
 			{data}
 		);
 	}
+
+	async deleteObjectEntryFolder(objectEntryFolderId: number) {
+		return this.apiHelpers.delete(
+			`/o/headless-object/v1.0/object-entry-folders/${objectEntryFolderId}`
+		);
+	}
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -28,16 +28,17 @@ test(
 	async ({apiHelpers, filesPage, page}) => {
 		const folderTitle = 'Test Folder';
 
-		const folderData = await apiHelpers.objectFolder.createObjectEntryFolder({
-			scopeKey: 'Default',
-			title: folderTitle
-		});
+		const folderData =
+			await apiHelpers.objectFolder.createObjectEntryFolder({
+				scopeKey: 'Default',
+				title: folderTitle,
+			});
 
 		await filesPage.goto();
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
-			target:  page.getByRole('menuitem', { name: 'Edit' }),
+			target: page.getByRole('menuitem', {name: 'Edit'}),
 			trigger: page
 				.locator('.card-row')
 				.filter({hasText: folderTitle})
@@ -48,9 +49,12 @@ test(
 
 		await page.getByLabel('Name').fill(newFolderTitle);
 		await page.getByLabel('Description').fill('folder description');
-		await page.getByRole('button', { name: 'Save' }).click();
+		await page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForAlert(page, `Success:${newFolderTitle} was updated successfully.`);
+		await waitForAlert(
+			page,
+			`Success:${newFolderTitle} was updated successfully.`
+		);
 
 		await expect(page.getByLabel(newFolderTitle)).toBeVisible();
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -28,7 +28,7 @@ test(
 	async ({apiHelpers, filesPage, page}) => {
 		const folderTitle = 'Test Folder';
 
-		await apiHelpers.objectFolder.createObjectEntryFolder({
+		const folderData = await apiHelpers.objectFolder.createObjectEntryFolder({
 			scopeKey: 'Default',
 			title: folderTitle
 		});
@@ -53,5 +53,7 @@ test(
 		await waitForAlert(page, `Success:${newFolderTitle} was updated successfully.`);
 
 		await expect(page.getByLabel(newFolderTitle)).toBeVisible();
+
+		await apiHelpers.objectFolder.deleteObjectEntryFolder(folderData.id);
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/folders.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {waitForAlert} from '../../../utils/waitForAlert';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-11232': {enabled: true},
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Can edit a folder',
+	{tag: '@LPD-42841'},
+	async ({apiHelpers, filesPage, page}) => {
+		const folderTitle = 'Test Folder';
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			scopeKey: 'Default',
+			title: folderTitle
+		});
+
+		await filesPage.goto();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target:  page.getByRole('menuitem', { name: 'Edit' }),
+			trigger: page
+				.locator('.card-row')
+				.filter({hasText: folderTitle})
+				.getByLabel('More actions'),
+		});
+
+		const newFolderTitle = 'Edited Folder';
+
+		await page.getByLabel('Name').fill(newFolderTitle);
+		await page.getByLabel('Description').fill('folder description');
+		await page.getByRole('button', { name: 'Save' }).click();
+
+		await waitForAlert(page, `Success:${newFolderTitle} was updated successfully.`);
+
+		await expect(page.getByLabel(newFolderTitle)).toBeVisible();
+	}
+);


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-54532). 

**Note**: depends on https://liferay.atlassian.net/browse/LPD-55427 (pull https://github.com/liferay-content-management/liferay-portal/pull/6635), do not forward until that one is sent, but of course can be reviewed (only the last 4 commits)

# Motivation

Added functional test for story https://liferay.atlassian.net/browse/LPD-42841. I consider that this single test is enough for the whole history. 

```
 ✔ npm run playwright -- test -g 'LPD-42841' --reporter list --repeat-each=10

> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-42841 --reporter list --repeat-each=10


Running 10 tests using 1 worker

  ✓  1 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.6s)
  ✓  2 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.6s)
  ✓  3 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.0s)
  ✓  4 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.2s)
  ✓  5 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.3s)
  ✓  6 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.2s)
  ✓  7 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.3s)
  ✓  8 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.6s)
  ✓  9 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.1s)
  ✓  10 [site-cms-site-initializer.main] › site-cms-site-initializer/main/folders.spec.ts:25:1 › Can edit a folder (8.1s)

  10 passed (1.5m)
```