### PR TITLE
LPD-55598 Prevent circular references in object entry folders

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -156,7 +156,7 @@ public class ObjectEntryFolderResourceTest
 			postParentObjectEntryFolder.getId(),
 			patchObjectEntryFolder2.getParentObjectEntryFolderId());
 
-		// Change parent object entry folder to itself
+		// Change parent object entry folder to child object entry folder
 
 		ObjectEntryFolder postObjectEntryFolder3 =
 			testPatchObjectEntryFolder_addObjectEntryFolder();
@@ -164,35 +164,61 @@ public class ObjectEntryFolderResourceTest
 		AssertUtils.assertFailure(
 			Problem.ProblemException.class,
 			"Object entry folder " + postObjectEntryFolder3.getId() +
-				" cannot be its own parent",
+				" cannot have one of its children or itself as a parent",
 			() -> {
-				postObjectEntryFolder3.setParentObjectEntryFolderId(
+				ObjectEntryFolder childObjectEntryFolder =
+					testPatchObjectEntryFolder_addObjectEntryFolder();
+
+				childObjectEntryFolder.setParentObjectEntryFolderId(
 					postObjectEntryFolder3.getId());
+
+				objectEntryFolderResource.patchObjectEntryFolder(
+					childObjectEntryFolder.getId(), childObjectEntryFolder);
+
+				postObjectEntryFolder3.setParentObjectEntryFolderId(
+					childObjectEntryFolder.getId());
 
 				objectEntryFolderResource.patchObjectEntryFolder(
 					postObjectEntryFolder3.getId(), postObjectEntryFolder3);
 			});
 
-		// Preserve preexisting parent object entry folder ID
+		// Change parent object entry folder to itself
 
 		ObjectEntryFolder postObjectEntryFolder4 =
 			testPatchObjectEntryFolder_addObjectEntryFolder();
 
-		postObjectEntryFolder4.setParentObjectEntryFolderId(
+		AssertUtils.assertFailure(
+			Problem.ProblemException.class,
+			"Object entry folder " + postObjectEntryFolder4.getId() +
+				" cannot have one of its children or itself as a parent",
+			() -> {
+				postObjectEntryFolder4.setParentObjectEntryFolderId(
+					postObjectEntryFolder4.getId());
+
+				objectEntryFolderResource.patchObjectEntryFolder(
+					postObjectEntryFolder4.getId(), postObjectEntryFolder4);
+			});
+
+		// Preserve preexisting parent object entry folder ID
+
+		ObjectEntryFolder postObjectEntryFolder5 =
+			testPatchObjectEntryFolder_addObjectEntryFolder();
+
+		postObjectEntryFolder5.setParentObjectEntryFolderId(
 			postParentObjectEntryFolder.getId());
 
 		objectEntryFolderResource.patchObjectEntryFolder(
-			postObjectEntryFolder4.getId(), postObjectEntryFolder4);
+			postObjectEntryFolder5.getId(), postObjectEntryFolder5);
 
-		postObjectEntryFolder4.setParentObjectEntryFolderId((Long)null);
+		postObjectEntryFolder5.setParentObjectEntryFolderId((Long)null);
 
-		ObjectEntryFolder patchObjectEntryFolder4 =
+		ObjectEntryFolder patchObjectEntryFolder5 =
 			objectEntryFolderResource.patchObjectEntryFolder(
-				postObjectEntryFolder4.getId(), postObjectEntryFolder4);
+				postObjectEntryFolder5.getId(), postObjectEntryFolder5);
 
 		Assert.assertEquals(
 			postParentObjectEntryFolder.getId(),
-			patchObjectEntryFolder4.getParentObjectEntryFolderId());
+			patchObjectEntryFolder5.getParentObjectEntryFolderId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -156,69 +155,26 @@ public class ObjectEntryFolderResourceTest
 			postParentObjectEntryFolder.getId(),
 			patchObjectEntryFolder2.getParentObjectEntryFolderId());
 
-		// Change parent object entry folder to child object entry folder
+		// Preserve preexisting parent object entry folder ID
 
 		ObjectEntryFolder postObjectEntryFolder3 =
 			testPatchObjectEntryFolder_addObjectEntryFolder();
 
-		AssertUtils.assertFailure(
-			Problem.ProblemException.class,
-			"Object entry folder " + postObjectEntryFolder3.getId() +
-				" cannot have one of its children or itself as a parent",
-			() -> {
-				ObjectEntryFolder childObjectEntryFolder =
-					testPatchObjectEntryFolder_addObjectEntryFolder();
-
-				childObjectEntryFolder.setParentObjectEntryFolderId(
-					postObjectEntryFolder3.getId());
-
-				objectEntryFolderResource.patchObjectEntryFolder(
-					childObjectEntryFolder.getId(), childObjectEntryFolder);
-
-				postObjectEntryFolder3.setParentObjectEntryFolderId(
-					childObjectEntryFolder.getId());
-
-				objectEntryFolderResource.patchObjectEntryFolder(
-					postObjectEntryFolder3.getId(), postObjectEntryFolder3);
-			});
-
-		// Change parent object entry folder to itself
-
-		ObjectEntryFolder postObjectEntryFolder4 =
-			testPatchObjectEntryFolder_addObjectEntryFolder();
-
-		AssertUtils.assertFailure(
-			Problem.ProblemException.class,
-			"Object entry folder " + postObjectEntryFolder4.getId() +
-				" cannot have one of its children or itself as a parent",
-			() -> {
-				postObjectEntryFolder4.setParentObjectEntryFolderId(
-					postObjectEntryFolder4.getId());
-
-				objectEntryFolderResource.patchObjectEntryFolder(
-					postObjectEntryFolder4.getId(), postObjectEntryFolder4);
-			});
-
-		// Preserve preexisting parent object entry folder ID
-
-		ObjectEntryFolder postObjectEntryFolder5 =
-			testPatchObjectEntryFolder_addObjectEntryFolder();
-
-		postObjectEntryFolder5.setParentObjectEntryFolderId(
+		postObjectEntryFolder3.setParentObjectEntryFolderId(
 			postParentObjectEntryFolder.getId());
 
 		objectEntryFolderResource.patchObjectEntryFolder(
-			postObjectEntryFolder5.getId(), postObjectEntryFolder5);
+			postObjectEntryFolder3.getId(), postObjectEntryFolder3);
 
-		postObjectEntryFolder5.setParentObjectEntryFolderId((Long)null);
+		postObjectEntryFolder3.setParentObjectEntryFolderId((Long)null);
 
-		ObjectEntryFolder patchObjectEntryFolder5 =
+		ObjectEntryFolder patchObjectEntryFolder3 =
 			objectEntryFolderResource.patchObjectEntryFolder(
-				postObjectEntryFolder5.getId(), postObjectEntryFolder5);
+				postObjectEntryFolder3.getId(), postObjectEntryFolder3);
 
 		Assert.assertEquals(
 			postParentObjectEntryFolder.getId(),
-			patchObjectEntryFolder5.getParentObjectEntryFolderId());
+			patchObjectEntryFolder3.getParentObjectEntryFolderId());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -73,7 +73,7 @@ public class ObjectEntryFolderLocalServiceImpl
 			externalReferenceCode, groupId, user.getCompanyId());
 
 		_validateParentObjectEntryFolderId(
-			groupId, 0, parentObjectEntryFolderId);
+			groupId, null, parentObjectEntryFolderId);
 		_validateName(
 			groupId, user.getCompanyId(), 0, parentObjectEntryFolderId, name);
 
@@ -277,8 +277,7 @@ public class ObjectEntryFolderLocalServiceImpl
 			objectEntryFolderPersistence.findByPrimaryKey(objectEntryFolderId);
 
 		_validateParentObjectEntryFolderId(
-			objectEntryFolder.getGroupId(),
-			objectEntryFolder.getObjectEntryFolderId(),
+			objectEntryFolder.getGroupId(), objectEntryFolder,
 			parentObjectEntryFolderId);
 		_validateName(
 			objectEntryFolder.getGroupId(), objectEntryFolder.getCompanyId(),
@@ -396,7 +395,7 @@ public class ObjectEntryFolderLocalServiceImpl
 	}
 
 	private void _validateParentObjectEntryFolderId(
-			long groupId, long objectEntryFolderId,
+			long groupId, ObjectEntryFolder objectEntryFolder,
 			long parentObjectEntryFolderId)
 		throws PortalException {
 
@@ -407,23 +406,28 @@ public class ObjectEntryFolderLocalServiceImpl
 			return;
 		}
 
-		if (objectEntryFolderId == parentObjectEntryFolderId) {
-			throw new ObjectEntryFolderParentObjectEntryFolderIdException(
-				StringBundler.concat(
-					"Object entry folder ", objectEntryFolderId,
-					" cannot be its own parent"));
-		}
-
-		ObjectEntryFolder objectEntryFolder =
+		ObjectEntryFolder parentObjectEntryFolder =
 			objectEntryFolderPersistence.findByPrimaryKey(
 				parentObjectEntryFolderId);
 
-		if (objectEntryFolder.getGroupId() != groupId) {
+		if (parentObjectEntryFolder.getGroupId() != groupId) {
 			throw new ObjectEntryFolderScopeException(
 				StringBundler.concat(
 					"Group ID ", groupId,
 					" does not match parent object entry folder group ID ",
-					objectEntryFolder.getGroupId()));
+					parentObjectEntryFolder.getGroupId()));
+		}
+
+		if ((objectEntryFolder != null) &&
+			StringUtil.startsWith(
+				parentObjectEntryFolder.getTreePath(),
+				objectEntryFolder.getTreePath())) {
+
+			throw new ObjectEntryFolderParentObjectEntryFolderIdException(
+				StringBundler.concat(
+					"Object entry folder ",
+					objectEntryFolder.getObjectEntryFolderId(),
+					" cannot have one of its children or itself as a parent"));
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.entry.folder.util.ObjectEntryFolderThreadLocal;
 import com.liferay.object.exception.DuplicateObjectEntryFolderExternalReferenceCodeException;
 import com.liferay.object.exception.ObjectEntryFolderNameException;
+import com.liferay.object.exception.ObjectEntryFolderParentObjectEntryFolderIdException;
 import com.liferay.object.exception.ObjectEntryFolderScopeException;
 import com.liferay.object.exception.RequiredObjectEntryFolderException;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -326,6 +327,40 @@ public class ObjectEntryFolderLocalServiceTest {
 				LocaleUtil.getSiteDefault(), objectEntryFolder2.getName()
 			).build(),
 			objectEntryFolder2.getLabelMap());
+
+		AssertUtils.assertFailure(
+			ObjectEntryFolderParentObjectEntryFolderIdException.class,
+			StringBundler.concat(
+				"Object entry folder ",
+				objectEntryFolder1.getObjectEntryFolderId(),
+				" cannot have one of its children or itself as a parent"),
+			() -> _objectEntryFolderLocalService.updateObjectEntryFolder(
+				TestPropsValues.getUserId(),
+				objectEntryFolder1.getObjectEntryFolderId(),
+				objectEntryFolder1.getObjectEntryFolderId(),
+				objectEntryFolder1.getDescription(),
+				objectEntryFolder1.getLabelMap(), objectEntryFolder1.getName(),
+				new ServiceContext()));
+		AssertUtils.assertFailure(
+			ObjectEntryFolderParentObjectEntryFolderIdException.class,
+			StringBundler.concat(
+				"Object entry folder ",
+				objectEntryFolder1.getObjectEntryFolderId(),
+				" cannot have one of its children or itself as a parent"),
+			() -> {
+				ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder(
+					StringUtil.randomString(), _group.getGroupId(),
+					StringUtil.randomString(),
+					objectEntryFolder1.getObjectEntryFolderId());
+
+				_objectEntryFolderLocalService.updateObjectEntryFolder(
+					TestPropsValues.getUserId(),
+					objectEntryFolder1.getObjectEntryFolderId(),
+					objectEntryFolder.getObjectEntryFolderId(),
+					objectEntryFolder1.getDescription(),
+					objectEntryFolder1.getLabelMap(),
+					objectEntryFolder1.getName(), new ServiceContext());
+			});
 	}
 
 	private ObjectDefinition _addObjectDefinition() throws Exception {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55598

It is possible to set as parent as a descendant folder, causing cycles.

# How am I fixing it?

By validating the tree paths prior to updating a folder.

# How can you verify that it works?

Run the included integration tests.