### PR TITLE
LPD 52357 Cannot publish Web Content with an Image Field selected from Web Content Images tab

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/repository/capabilities/TemporaryFileEntriesCapabilityImpl.java
@@ -60,6 +60,17 @@ public class TemporaryFileEntriesCapabilityImpl
 			String fileName, String mimeType, InputStream inputStream)
 		throws PortalException {
 
+		return addTemporaryFileEntry(
+			temporaryFileEntriesScope, null, fileName, mimeType, inputStream);
+	}
+
+	@Override
+	public FileEntry addTemporaryFileEntry(
+			TemporaryFileEntriesScope temporaryFileEntriesScope,
+			String externalReferenceCode, String fileName, String mimeType,
+			InputStream inputStream)
+		throws PortalException {
+
 		Folder folder = _addTempFolder(temporaryFileEntriesScope);
 
 		File file = null;
@@ -77,7 +88,7 @@ public class TemporaryFileEntriesCapabilityImpl
 			serviceContext.setAddGuestPermissions(true);
 
 			return _documentRepository.addFileEntry(
-				null, temporaryFileEntriesScope.getUserId(),
+				externalReferenceCode, temporaryFileEntriesScope.getUserId(),
 				folder.getFolderId(), fileName, mimeType, fileName, fileName,
 				StringPool.BLANK, StringPool.BLANK, file, null, null, null,
 				serviceContext);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldTemplateContextContributor.java
@@ -141,10 +141,31 @@ public class ImageDDMFormFieldTemplateContextContributor
 	}
 
 	private FileEntry _getFileEntry(JSONObject valueJSONObject) {
+		if ((valueJSONObject == null) || (valueJSONObject.length() <= 0)) {
+			return null;
+		}
+
+		String uuid = valueJSONObject.getString("uuid");
+		long groupId = valueJSONObject.getLong("groupId");
+
 		try {
-			return _dlAppService.getFileEntryByUuidAndGroupId(
-				valueJSONObject.getString("uuid"),
-				valueJSONObject.getLong("groupId"));
+			return _dlAppService.getFileEntryByUuidAndGroupId(uuid, groupId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get file entry", portalException);
+			}
+
+			return _getFileEntryByExternalReferenceCode(uuid, groupId);
+		}
+	}
+
+	private FileEntry _getFileEntryByExternalReferenceCode(
+		String uuid, long groupId) {
+
+		try {
+			return _dlAppService.getFileEntryByExternalReferenceCode(
+				uuid, groupId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueAccessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueAccessor.java
@@ -102,10 +102,27 @@ public class ImageDDMFormFieldValueAccessor
 			return null;
 		}
 
+		String uuid = valueJSONObject.getString("uuid");
+		long groupId = valueJSONObject.getLong("groupId");
+
 		try {
-			return _dlAppService.getFileEntryByUuidAndGroupId(
-				valueJSONObject.getString("uuid"),
-				valueJSONObject.getLong("groupId"));
+			return _dlAppService.getFileEntryByUuidAndGroupId(uuid, groupId);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get file entry", portalException);
+			}
+
+			return _getFileEntryByExternalReferenceCode(uuid, groupId);
+		}
+	}
+
+	private FileEntry _getFileEntryByExternalReferenceCode(
+		String uuid, long groupId) {
+
+		try {
+			return _dlAppService.getFileEntryByExternalReferenceCode(
+				uuid, groupId);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -261,8 +261,18 @@ public class DLReferencesExportImportContentProcessor
 			long groupId = MapUtil.getLong(map, "groupId");
 
 			if (Validator.isNotNull(uuid)) {
-				fileEntry = _dlAppLocalService.getFileEntryByUuidAndGroupId(
-					uuid, groupId);
+				try {
+					fileEntry = _dlAppLocalService.getFileEntryByUuidAndGroupId(
+						uuid, groupId);
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("Unable to get file entry", portalException);
+					}
+
+					return _dlAppLocalService.
+						getFileEntryByExternalReferenceCode(uuid, groupId);
+				}
 			}
 			else {
 				if (map.containsKey("friendlyURL")) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6071,24 +6071,36 @@ public class JournalArticleLocalServiceImpl
 
 				Folder folder = article.addImagesFolder();
 
-				String fileEntryName = DLUtil.getUniqueFileName(
-					folder.getGroupId(), folder.getFolderId(),
-					tempFileEntry.getFileName(), false);
+				FileEntry portletFileEntry =
+					_portletFileRepository.
+						fetchPortletFileEntryByExternalReferenceCode(
+							tempFileEntry.getUuid(), folder.getGroupId());
 
-				// The UUID of the temporary file is stored on the field once
-				// saved as temp. However, when the system auto saves, this
-				// temporary file will be deleted and it's published with a
-				// different UUID, so it doesn't match. To be able to use the
-				// file, we'll use the temporary file's UUID as published file
-				// entry ERC so we could fetch it using this field.
-				// See LPD-52357.
+				if (portletFileEntry == null) {
+					String fileEntryName = DLUtil.getUniqueFileName(
+						folder.getGroupId(), folder.getFolderId(),
+						tempFileEntry.getFileName(), false);
 
-				fileEntry = _portletFileRepository.addPortletFileEntry(
-					tempFileEntry.getUuid(), folder.getGroupId(),
-					tempFileEntry.getUserId(), JournalArticle.class.getName(),
-					article.getResourcePrimKey(), JournalConstants.SERVICE_NAME,
-					folder.getFolderId(), tempFileEntry.getContentStream(),
-					fileEntryName, tempFileEntry.getMimeType(), false);
+					// The UUID of the temporary file is stored on the field
+					// once saved as temp. However, when the system auto saves,
+					// this temporary file will be deleted and it's published
+					// with a different UUID, so it doesn't match. To be able to
+					// use the file, we'll use the temporary file's UUID as
+					// published file entry ERC so we could fetch it using this
+					// field. See LPD-52357.
+
+					fileEntry = _portletFileRepository.addPortletFileEntry(
+						tempFileEntry.getUuid(), folder.getGroupId(),
+						tempFileEntry.getUserId(),
+						JournalArticle.class.getName(),
+						article.getResourcePrimKey(),
+						JournalConstants.SERVICE_NAME, folder.getFolderId(),
+						tempFileEntry.getContentStream(), fileEntryName,
+						tempFileEntry.getMimeType(), false);
+				}
+				else {
+					fileEntry = portletFileEntry;
+				}
 			}
 
 			String previewURL = _dlURLHelper.getPreviewURL(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6075,9 +6075,17 @@ public class JournalArticleLocalServiceImpl
 					folder.getGroupId(), folder.getFolderId(),
 					tempFileEntry.getFileName(), false);
 
+				// The UUID of the temporary file is stored on the field once
+				// saved as temp. However, when the system auto saves, this
+				// temporary file will be deleted and it's published with a
+				// different UUID, so it doesn't match. To be able to use the
+				// file, we'll use the temporary file's UUID as published file
+				// entry ERC so we could fetch it using this field.
+				// See LPD-52357.
+
 				fileEntry = _portletFileRepository.addPortletFileEntry(
-					null, folder.getGroupId(), tempFileEntry.getUserId(),
-					JournalArticle.class.getName(),
+					tempFileEntry.getUuid(), folder.getGroupId(),
+					tempFileEntry.getUserId(), JournalArticle.class.getName(),
 					article.getResourcePrimKey(), JournalConstants.SERVICE_NAME,
 					folder.getFolderId(), tempFileEntry.getContentStream(),
 					fileEntryName, tempFileEntry.getMimeType(), false);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
@@ -38,6 +38,7 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -60,6 +61,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -457,6 +459,9 @@ public class JournalArticleInfoItemFormProviderTest {
 			"/com/liferay/journal/dependencies/liferay.png");
 
 		FileEntry tempFileEntry = TempFileEntryUtil.addTempFileEntry(
+			String.valueOf(
+				new UUID(
+					SecureRandomUtil.nextLong(), SecureRandomUtil.nextLong())),
 			_group.getGroupId(), TestPropsValues.getUserId(),
 			JournalArticle.class.getName(), "image.png", inputStream,
 			ContentTypes.IMAGE_PNG);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
@@ -142,6 +143,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -2239,6 +2241,9 @@ public class JournalArticleLocalServiceTest {
 				fileName);
 
 		return TempFileEntryUtil.addTempFileEntry(
+			String.valueOf(
+				new UUID(
+					SecureRandomUtil.nextLong(), SecureRandomUtil.nextLong())),
 			_group.getGroupId(), TestPropsValues.getUserId(),
 			JournalArticle.class.getName(), fileName, inputStream,
 			ContentTypes.IMAGE_JPEG);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/trash/test/JournalArticleTrashHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/trash/test/JournalArticleTrashHandlerTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.model.WorkflowedModel;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -72,6 +73,7 @@ import com.liferay.trash.test.util.WhenIsVersionableBaseModel;
 import java.io.InputStream;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -267,6 +269,9 @@ public class JournalArticleTrashHandlerTest
 			"/com/liferay/journal/dependencies/liferay.png");
 
 		FileEntry tempFileEntry = TempFileEntryUtil.addTempFileEntry(
+			String.valueOf(
+				new UUID(
+					SecureRandomUtil.nextLong(), SecureRandomUtil.nextLong())),
 			group.getGroupId(), TestPropsValues.getUserId(),
 			JournalArticle.class.getName(), "liferay.png", inputStream,
 			ContentTypes.IMAGE_PNG);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -44,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.util.Map;
+import java.util.UUID;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -198,6 +200,10 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 				fileName, curFileName -> _exists(themeDisplay, curFileName));
 
 			return TempFileEntryUtil.addTempFileEntry(
+				String.valueOf(
+					new UUID(
+						SecureRandomUtil.nextLong(),
+						SecureRandomUtil.nextLong())),
 				themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 				_tempFolderName, uniqueFileName, inputStream, contentType);
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/capabilities/TemporaryFileEntriesCapability.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/capabilities/TemporaryFileEntriesCapability.java
@@ -25,6 +25,12 @@ public interface TemporaryFileEntriesCapability extends Capability {
 			String fileName, String mimeType, InputStream inputStream)
 		throws PortalException;
 
+	public FileEntry addTemporaryFileEntry(
+			TemporaryFileEntriesScope temporaryFileEntriesScope,
+			String externalReferenceCode, String fileName, String mimeType,
+			InputStream inputStream)
+		throws PortalException;
+
 	public void deleteExpiredTemporaryFileEntries() throws PortalException;
 
 	public void deleteTemporaryFileEntry(

--- a/portal-kernel/src/com/liferay/portal/kernel/repository/capabilities/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/repository/capabilities/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
@@ -79,6 +79,29 @@ public class TempFileEntryUtil {
 		}
 	}
 
+	public static FileEntry addTempFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String folderName, String fileName, InputStream inputStream,
+			String mimeType)
+		throws PortalException {
+
+		boolean dlAppHelperEnabled = DLAppHelperThreadLocal.isEnabled();
+
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
+
+			TemporaryFileEntriesCapability temporaryFileEntriesCapability =
+				_getTemporaryFileEntriesCapability(groupId);
+
+			return temporaryFileEntriesCapability.addTemporaryFileEntry(
+				new TemporaryFileEntriesScope(_UUID, userId, folderName),
+				externalReferenceCode, fileName, mimeType, inputStream);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(dlAppHelperEnabled);
+		}
+	}
+
 	public static void deleteTempFileEntry(long fileEntryId)
 		throws PortalException {
 


### PR DESCRIPTION
LPD-52357 Cannot publish Web Content with an Image Field selected from Web Content Images tab

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52357

the field image was stored (ddm field) the temporary uuid data on the page.
With the introduction of the autosaving, that image is practically persisted to a final file on the database, once the item selector is closed (dependent on the autosaving time) so the file with the uuid is lost and the page was still storing the old data without possibility of change (only reloading the page)
This causes that the image was not shown on the page and publishing was failing.

# How am I fixing it?

To keep track of it we will use the temporary file UUID as ERC for the final file and making the find to have a fallback to erc.

# How can you verify that it works?

Steps to reproduce: 

- Enable FF for autosave in Web Content: Instance Settings > Feature Flag > Autosave for Web Content Articles (LPD-11228)
- Go to Content & Data > Web Content > Structures
- Create a structure with an Image field and save. 
- Create a Web Content based in that structure, and select an image:
- Upload an image from the Web Content Images tab (it works ok with the Documents and Media tab)
- Publish with permissions



There is already test failing the FF
```
poshi tests failing after the FF removal : 
LocalFile.WebContentWithCustomStructures#ViewAndEditAsWellAsDeleteContentWithTitleAndAllFields
LocalFile.WebContentDisplayWithStaging#ViewWebContentWithEditedImageField
LocalFile.WebContentWithCustomStructures#AddWebContentWithImageField
```


# Commits



- **LPD-52357 add Temporary FileEntry with given ERC**
- **LPD-52357 baseline**
- **LPD-52357 add the portlet file entry with the ERC the temporary uuid**
- **LPD-52357 when obtaining the FileEntry By UUID And groupId, fallback with the ExternalReferenceCode instead the uuid**



