### PR TITLE
LPD-55865 Approved filter causes folder pagination issues in Web Content view

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleTitleComparator.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/comparator/FolderArticleTitleComparator.java
@@ -13,9 +13,9 @@ import com.liferay.portal.kernel.util.OrderByComparator;
  */
 public class FolderArticleTitleComparator extends OrderByComparator<Object> {
 
-	public static final String ORDER_BY_ASC = "title ASC";
+	public static final String ORDER_BY_ASC = "modelFolder DESC, title ASC";
 
-	public static final String ORDER_BY_DESC = "title DESC";
+	public static final String ORDER_BY_DESC = "modelFolder DESC, title DESC";
 
 	public static final String[] ORDER_BY_FIELDS = {"title"};
 

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/util/comparator/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.0.1

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1562,17 +1562,52 @@ public class JournalDisplayContext {
 		SearchContainer<Object> articleAndFolderSearchContainer =
 			_getArticleAndFolderSearchContainer();
 
-		SearchResponse searchResponse =
-			JournalSearcherUtil.searchJournalArticleAndFolders(
+		int end = articleAndFolderSearchContainer.getEnd();
+		int start = articleAndFolderSearchContainer.getStart();
+
+		int delta = end - start;
+
+		SearchResponse journalFolderSearchResponse =
+			JournalSearcherUtil.searchJournalFolders(
 				searchContext -> _populateSearchContext(
-					articleAndFolderSearchContainer.getStart(),
-					articleAndFolderSearchContainer.getEnd(), searchContext,
-					false));
+					start, end, searchContext, false));
+
+		int articlesCount;
+		List<Document> documents = new ArrayList<>();
+		int foldersCount = journalFolderSearchResponse.getTotalHits();
+
+		if (start < foldersCount) {
+			documents.addAll(
+				journalFolderSearchResponse.getDocuments71(
+				).subList(
+					start, Math.min(end, foldersCount)
+				));
+
+			SearchResponse articleSearchResponse =
+				_getJournalArticleSearchResponse(0, delta - documents.size());
+
+			articlesCount = articleSearchResponse.getTotalHits();
+
+			if (delta > documents.size()) {
+				documents.addAll(articleSearchResponse.getDocuments71());
+			}
+		}
+		else {
+			int journalArticlesStart = start - foldersCount;
+
+			SearchResponse articleSearchResponse =
+				_getJournalArticleSearchResponse(
+					journalArticlesStart, delta + journalArticlesStart);
+
+			documents.addAll(articleSearchResponse.getDocuments71());
+
+			articlesCount = articleSearchResponse.getTotalHits();
+		}
 
 		articleAndFolderSearchContainer.setResultsAndTotal(
 			() -> JournalSearcherUtil.transformJournalArticleAndFolders(
-				searchResponse.getDocuments71()),
-			searchResponse.getTotalHits());
+				documents),
+			articlesCount + foldersCount);
 
 		_articleSearchContainer = articleAndFolderSearchContainer;
 
@@ -1852,6 +1887,14 @@ public class JournalDisplayContext {
 		}
 
 		return jsonArray;
+	}
+
+	private SearchResponse _getJournalArticleSearchResponse(
+		int start, int end) {
+
+		return JournalSearcherUtil.searchJournalArticles(
+			searchContext -> _populateSearchContext(
+				start, end, searchContext, false));
 	}
 
 	private String _getSearchIn() {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalSearcherUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalSearcherUtil.java
@@ -30,37 +30,20 @@ public class JournalSearcherUtil {
 	public static SearchResponse searchJournalArticleAndFolders(
 		Consumer<SearchContext> searchContextConsumer) {
 
-		Searcher searcher = _searcherSnapshot.get();
-		SearchRequestBuilderFactory searchRequestBuilderFactory =
-			_searchRequestBuilderFactorySnapshot.get();
-
-		return searcher.search(
-			searchRequestBuilderFactory.builder(
-			).emptySearchEnabled(
-				true
-			).modelIndexerClasses(
-				JournalArticle.class, JournalFolder.class
-			).withSearchContext(
-				searchContextConsumer
-			).build());
+		return _search(
+			searchContextConsumer, JournalArticle.class, JournalFolder.class);
 	}
 
 	public static SearchResponse searchJournalArticles(
 		Consumer<SearchContext> searchContextConsumer) {
 
-		Searcher searcher = _searcherSnapshot.get();
-		SearchRequestBuilderFactory searchRequestBuilderFactory =
-			_searchRequestBuilderFactorySnapshot.get();
+		return _search(searchContextConsumer, JournalArticle.class);
+	}
 
-		return searcher.search(
-			searchRequestBuilderFactory.builder(
-			).emptySearchEnabled(
-				true
-			).modelIndexerClasses(
-				JournalArticle.class
-			).withSearchContext(
-				searchContextConsumer
-			).build());
+	public static SearchResponse searchJournalFolders(
+		Consumer<SearchContext> searchContextConsumer) {
+
+		return _search(searchContextConsumer, JournalFolder.class);
 	}
 
 	public static List<Object> transformJournalArticleAndFolders(
@@ -103,6 +86,25 @@ public class JournalSearcherUtil {
 					GetterUtil.getString(document.get(Field.ARTICLE_ID)),
 					GetterUtil.getDouble(document.get(Field.VERSION)));
 			});
+	}
+
+	private static SearchResponse _search(
+		Consumer<SearchContext> searchContextConsumer,
+		Class<?>... modelIndexerClasses) {
+
+		Searcher searcher = _searcherSnapshot.get();
+		SearchRequestBuilderFactory searchRequestBuilderFactory =
+			_searchRequestBuilderFactorySnapshot.get();
+
+		return searcher.search(
+			searchRequestBuilderFactory.builder(
+			).emptySearchEnabled(
+				true
+			).modelIndexerClasses(
+				modelIndexerClasses
+			).withSearchContext(
+				searchContextConsumer
+			).build());
 	}
 
 	private static final Snapshot<JournalArticleLocalService>

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -379,3 +379,60 @@ test(
 		expect(/[[{]/.test(inputValue || '')).toBeFalsy();
 	}
 );
+
+test(
+	'Folders come first when having multiple pages and filtering by Approved',
+	{
+		tag: '@LPD-55865',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		for (let i = 1; i <= 6; i++) {
+			await apiHelpers.jsonWebServicesJournal.addFolder({
+				groupId: site.id,
+				name: `Folder ${i}`,
+			});
+		}
+
+		for (let i = 1; i <= 6; i++) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: `Web Content ${i}`},
+			});
+		}
+
+		for (let i = 7; i <= 12; i++) {
+			await apiHelpers.jsonWebServicesJournal.addFolder({
+				groupId: site.id,
+				name: `Folder ${i}`,
+			});
+		}
+
+		for (let i = 7; i <= 12; i++) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: `Web Content ${i}`},
+			});
+		}
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Approved'}).click();
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Web Content'}).click();
+
+		const foldersList = await page
+			.getByRole('link')
+			.filter({hasText: 'Folder'})
+			.all();
+		expect(foldersList.length).toBe(12);
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-55865
When filtering by Approved status, and both folders and web content articles are present, the folders are getting split across multiple pages. Instead of showing all folders first, they are mixed with articles in pagination, which affects the expected order.

### **How am I fixing it?**
To fix the issue, the implementation first fetches all the folders. Then, if there's still space left on the page, it fetches only as many web content articles as needed to fill that space. Finally, it combines the folders and articles into one list, always showing the folders first.

### **How can you verify that it works?**
Start a Liferay instance
Create Six folders and Six Web Content articles.
Repeat the above process
Apply a filter using the Approved status.
Expected Result:
All 12 folders should appear at the top of the content list on the first page