### PR TITLE
LPD-56020 Do not show the child label

### DIFF
--- a/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/SiteTemplateItemSelectorViewDisplayContext.java
+++ b/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/SiteTemplateItemSelectorViewDisplayContext.java
@@ -86,7 +86,7 @@ public class SiteTemplateItemSelectorViewDisplayContext
 
 	@Override
 	public boolean isShowChildSitesLink() {
-		return true;
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-56020

# How am I fixing it?

I'm not showing the label anymore for site templates:

<img width="451" alt="Captura de pantalla 2025-05-20 a las 10 57 03" src="https://github.com/user-attachments/assets/d8eb5c90-0b5a-40dc-a6ea-80547b0ba190" />

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-56020.

# Why doesn't this include any test?

UI issue that is tricky to test or pointless
