### PR TITLE
LPD-55741 Use ERC first to fetch existingAssetTag

### DIFF
--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -128,8 +128,15 @@ public class AssetTagStagedModelDataHandler
 		ServiceContext serviceContext = _createServiceContext(
 			portletDataContext, assetTag);
 
-		AssetTag existingAssetTag = fetchStagedModelByUuidAndGroupId(
-			assetTag.getUuid(), portletDataContext.getScopeGroupId());
+		AssetTag existingAssetTag =
+			_assetTagLocalService.fetchAssetTagByExternalReferenceCode(
+				assetTag.getExternalReferenceCode(),
+				portletDataContext.getScopeGroupId());
+
+		if (existingAssetTag == null) {
+			existingAssetTag = fetchStagedModelByUuidAndGroupId(
+				assetTag.getUuid(), portletDataContext.getScopeGroupId());
+		}
 
 		Map<String, String[]> parameterMap =
 			portletDataContext.getParameterMap();


### PR DESCRIPTION
# What is this trying to solve?
[AssetTagStagedModelDataHandler does not use ERC to look up existingAssetTag](https://liferay.atlassian.net/browse/LPD-55741)
ATSMDH should follow the pattern introduced with ERCs, lookup of existing stagedModel should happen first.

# How am I fixing it?
By preceding the uuid based lookup of the existingAssetTag with an ERC based lookup

# Why doesn't this include any test?
This is an established pattern.