### PR TITLE
LPD-56021 Space picker is readOnly, not disabled

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/components/folders/EditFolder.tsx
@@ -190,10 +190,10 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 					/>
 
 					<FieldPicker
-						disabled
 						items={spaceItems}
 						label={Liferay.Language.get('space')}
 						name="folderSpace"
+						readOnly
 						required
 						selectedKey={values.folderSpace}
 					/>


### PR DESCRIPTION
Link to issue: https://liferay.atlassian.net/browse/LPD-56021

# Motivation
When editing a folder, the space field should be read only instead of disabled.

No need to add tests, as the behaviour doesn't change, it is just a visual thing. 