### PR TITLE
LPD-55087 Fix POSHI tests using AssetPublisher configuration

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
@@ -165,12 +165,12 @@
 </tr>
 <tr>
 	<td>SELECT_MORE_THAN_ONE_ASSET_TYPE_MOVE_AVAILABLE</td>
-	<td>//button[contains(@class,'move-right') and contains(@title,'Move selected items from Selected to Available.')]</td>
+	<td>//button[contains(@class,'transfer-button-ltr') and contains(@aria-label,'Move selected items from Selected to Available.')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SELECT_MORE_THAN_ONE_ASSET_TYPE_MOVE_SELECTED</td>
-	<td>//button[contains(@class,'move-left') and contains(@title,'Move selected items from Available to Selected.')]</td>
+	<td>//button[contains(@class,'transfer-button-rtl') and contains(@aria-label,'Move selected items from Available to Selected.')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -183,12 +183,12 @@
 
 <tr>
 	<td>SELECT_MORE_THAN_ONE_ASSET_SUBTYPE_MOVE_AVAILABLE</td>
-	<td>xpath=(//button[contains(@class,'move-right') and contains(@title,'Move selected items from Selected to Available.')])[3]</td>
+	<td>xpath=(//button[contains(@class,'transfer-button-ltr') and contains(@aria-label,'Move selected items from Selected to Available.')])[3]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SELECT_MORE_THAN_ONE_ASSET_SUBTYPE_MOVE_SELECTED</td>
-	<td>xpath=(//button[contains(@class,'move-left') and contains(@title,'Move selected items from Available to Selected.')])[3]</td>
+	<td>xpath=(//button[contains(@class,'transfer-button-rtl') and contains(@aria-label,'Move selected items from Available to Selected.')])[3]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55087

These POSHI tests are failing:

* AssetPublisher#ConfigureSelectMoreThanOneAssetTypes
* Collections#AddAssetsToManualCollectionForSelectedItemTypes

# How am I fixing it?

Fix xpath for buttons in dual list box

# How can you verify that it works?

Execute:

`ant -f build-test.xml run-selenium-test -Dtest.class=AssetPublisher#ConfigureSelectMoreThanOneAssetTypes`
`ant -f build-test.xml run-selenium-test -Dtest.class=Collections#AddAssetsToManualCollectionForSelectedItemTypes`