### PR TITLE
LPD-56188 Fix PW failing test in journalArticle: Can paginate Web Content in an Asset Publisher

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -1701,8 +1701,7 @@ assetPublisherDeprecationTest(
 		await configurationFrame
 			.getByRole('tab', {name: 'Asset Selection'})
 			.click();
-		await configurationFrame.getByText('Dynamic').click();
-		await configurationFrame.getByLabel('close').click();
+		await configurationFrame.getByText('Dynamic', {exact: true}).click();
 		await configurationFrame
 			.getByRole('tab', {name: 'Display Settings'})
 			.click();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-56188

This playwright test is failing:

* File: journalArticle.spect.ts
* Test: Can paginate Web Content in an Asset Publisher

# How am I fixing it?

Better specify the form element

# How can you verify that it works?

`npm run playwright -- test -g 'Can paginate Web Content in an Asset Publisher'`
