### PR TITLE
LPD-55667 Adding DateTime to EntityFieldsProvider

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 34.0.2
+Bundle-Version: 34.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
@@ -27,7 +27,8 @@ public class DDMConstants {
 
 	public static final String[] SUPPORTED_DDM_FORM_FIELD_TYPES = {
 		DDMFormFieldType.CHECKBOX, DDMFormFieldType.CHECKBOX_MULTIPLE,
-		DDMFormFieldType.COLOR, DDMFormFieldType.DATE, DDMFormFieldType.DECIMAL,
+		DDMFormFieldType.COLOR, DDMFormFieldType.DATE,
+		DDMFormFieldType.DATETIME, DDMFormFieldType.DECIMAL,
 		DDMFormFieldType.DOCUMENT_LIBRARY, DDMFormFieldType.FIELDSET,
 		DDMFormFieldType.GEOLOCATION, DDMFormFieldType.GRID,
 		DDMFormFieldType.IMAGE, DDMFormFieldType.INTEGER,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
@@ -21,7 +21,7 @@ public class DDMFormFieldType {
 
 	public static final String DATE = "ddm-date";
 
-	public static final String DATETIME = "date_time";
+	public static final String DATETIME = "datetime";
 
 	public static final String DECIMAL = "ddm-decimal";
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
@@ -21,6 +21,8 @@ public class DDMFormFieldType {
 
 	public static final String DATE = "ddm-date";
 
+	public static final String DATETIME = "date_time";
+
 	public static final String DECIMAL = "ddm-decimal";
 
 	public static final String DOCUMENT_LIBRARY = "ddm-documentlibrary";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
@@ -41,7 +41,7 @@ public class FieldConstants {
 
 	public static final String DATE = "date";
 
-	public static final String DATETIME = "date_time";
+	public static final String DATETIME = "datetime";
 
 	public static final String DOCUMENT_LIBRARY = "document-library";
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
@@ -41,6 +41,8 @@ public class FieldConstants {
 
 	public static final String DATE = "date";
 
+	public static final String DATETIME = "date_time";
+
 	public static final String DOCUMENT_LIBRARY = "document-library";
 
 	public static final String DOUBLE = "double";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.5.0
+version 7.6.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/storage/constants/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/storage/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.DateEntityField;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.DoubleEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.IntegerEntityField;
@@ -83,6 +84,18 @@ public class EntityFieldsProvider {
 					ddmStructure.getStructureId(),
 					ddmFormField.getFieldReference(), locale, "String"),
 				this::_toFieldValue);
+		}
+		else if (Objects.equals(
+					ddmFormField.getDataType(), FieldConstants.DATETIME)) {
+
+			return new DateTimeEntityField(
+				ddmFormField.getFieldReference(),
+				locale -> _toFilterableOrSortableFieldName(
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"),
+				locale -> _toFilterableOrSortableFieldName(
+					ddmStructure.getStructureId(),
+					ddmFormField.getFieldReference(), locale, "String"));
 		}
 		else if (Objects.equals(
 					ddmFormField.getDataType(), FieldConstants.DOUBLE) ||

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -350,6 +350,7 @@ public class StructuredContentResourceTest
 
 		_testGetContentStructureStructuredContentsPageLocalizedWithFilter();
 		_testGetContentStructureStructuredContentsPageUnlocalizedWithFilter();
+		_testGetContentStructureStructuredContentsPageWithSortDateTimeField();
 	}
 
 	@Override
@@ -1658,6 +1659,44 @@ public class StructuredContentResourceTest
 		items = (List<StructuredContent>)page.getItems();
 
 		assertEquals(structuredContent1, items.get(0));
+	}
+
+	private void _testGetContentStructureStructuredContentsPageWithSortDateTimeField()
+		throws Exception {
+
+		DDMStructure ddmStructure = _addDDMStructure(
+			testGroup, "test-ddm-structure-datetime.json");
+
+		JournalArticle journalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0,
+				_read("test-journal-article-datetime.xml"),
+				ddmStructure.getStructureKey(), null, LocaleUtil.US, null,
+				ServiceContextTestUtil.getServiceContext(
+					testCompany.getCompanyId(), testGroup.getGroupId(),
+					TestPropsValues.getUserId()));
+
+		Page<StructuredContent> page =
+			structuredContentResource.getContentStructureStructuredContentsPage(
+				ddmStructure.getStructureId(), null, null, null,
+				Pagination.of(1, 10), "contentFields/DateTime90775749:asc'");
+
+		Assert.assertNotNull(page);
+
+		List<StructuredContent> items =
+			(List<StructuredContent>)page.getItems();
+
+		Assert.assertEquals(items.toString(), 1, items.size());
+
+		StructuredContent structuredContent = items.get(0);
+
+		Assert.assertEquals(
+			String.valueOf(journalArticle.getResourcePrimKey()),
+			String.valueOf(structuredContent.getId()));
+
+		structuredContentResource.deleteStructuredContent(
+			structuredContent.getId());
 	}
 
 	private void _testGetSiteStructuredContentsPageByDefaultPriority()

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-datetime.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-datetime.json
@@ -1,0 +1,35 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fields": [
+		{
+			"dataType": "datetime",
+			"fieldNamespace": "",
+			"fieldReference": "DateTime90775749",
+			"indexType": "keyword",
+			"inline": true,
+			"label": {
+				"en_US": "Date and Time"
+			},
+			"localizable": "[#LOCALIZABLE#]",
+			"name": "DateTime90775749",
+			"nativeField": false,
+			"options": [
+			],
+			"predefinedValue": {
+				"en_US": "[]"
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"type": "date_time",
+			"visibilityExpression": ""
+		}
+	]
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-datetime.xml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-journal-article-datetime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="DateTime90775749" index-type="keyword" instance-id="gTvjpM5x" name="DateTime90775749" type="date_time">
+		<dynamic-content language-id="en_US"><![CDATA[2025-05-18 12:00]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55667
Its not possible to sort with DateTime type field in headless api using :http://localhost:8080/o/headless-delivery/v1.0/content-structures/37213/structured-contents?sort=contentFields/Date:asc call

### How am I fixing it?
DATETIME constans was missing from :
DDMConstants, DDMFormFieldType, FieldConstants
Added return state DateTimeEntityField in EntityFieldsProvider.java for "date_time" type.

### How can we test:

running integration test : StructuredContentResourceTest.testGetContentStructureStructuredContentsPage