### PR TITLE
LPD-56207 Wrong type for the related DDMStructure when creating a document type

### DIFF
--- a/modules/apps/document-library/document-library-service/bnd.bnd
+++ b/modules/apps/document-library/document-library-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Document Library Service
 Bundle-SymbolicName: com.liferay.document.library.service
 Bundle-Version: 6.0.138
-Liferay-Require-SchemaVersion: 3.2.10
+Liferay-Require-SchemaVersion: 3.2.11
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/service/DataEngineDLFileEntryTypeLocalServiceWrapper.java
@@ -7,19 +7,12 @@ package com.liferay.document.library.internal.service;
 
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceWrapper;
-import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 
 import java.util.Collections;
-import java.util.Locale;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -27,50 +20,6 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = ServiceWrapper.class)
 public class DataEngineDLFileEntryTypeLocalServiceWrapper
 	extends DLFileEntryTypeLocalServiceWrapper {
-
-	@Override
-	public DLFileEntryType addDLFileEntryType(DLFileEntryType dlFileEntryType) {
-		DLFileEntryType fileEntryType = super.addDLFileEntryType(
-			dlFileEntryType);
-
-		_updateDDMStructure(fileEntryType.getDataDefinitionId());
-
-		return fileEntryType;
-	}
-
-	@Override
-	public DLFileEntryType addFileEntryType(
-			String externalReferenceCode, long userId, long groupId,
-			long dataDefinitionId, String fileEntryTypeKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			int scope, ServiceContext serviceContext)
-		throws PortalException {
-
-		DLFileEntryType fileEntryType = super.addFileEntryType(
-			externalReferenceCode, userId, groupId, dataDefinitionId,
-			fileEntryTypeKey, nameMap, descriptionMap, scope, serviceContext);
-
-		_updateDDMStructure(dataDefinitionId);
-
-		return fileEntryType;
-	}
-
-	@Override
-	public DLFileEntryType addFileEntryType(
-			String externalReferenceCode, long userId, long groupId,
-			long dataDefinitionId, String fileEntryTypeKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		DLFileEntryType fileEntryType = super.addFileEntryType(
-			externalReferenceCode, userId, groupId, dataDefinitionId,
-			fileEntryTypeKey, nameMap, descriptionMap, serviceContext);
-
-		_updateDDMStructure(dataDefinitionId);
-
-		return fileEntryType;
-	}
 
 	@Override
 	public DLFileEntryType deleteFileEntryType(DLFileEntryType dlFileEntryType)
@@ -83,21 +32,5 @@ public class DataEngineDLFileEntryTypeLocalServiceWrapper
 
 		return dlFileEntryType;
 	}
-
-	private void _updateDDMStructure(long structureId) {
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
-			structureId);
-
-		if (ddmStructure == null) {
-			return;
-		}
-
-		ddmStructure.setType(DDMStructureConstants.TYPE_AUTO);
-
-		_ddmStructureLocalService.updateDDMStructure(ddmStructure);
-	}
-
-	@Reference
-	private DDMStructureLocalService _ddmStructureLocalService;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/registry/DLServiceUpgradeStepRegistrator.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.ViewCountUpgradeProcess;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
@@ -180,6 +181,11 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 			"3.2.9", "3.2.10",
 			new DLFolderAdvancedUpdateResourcePermissionUpgradeProcess(
 				_resourceActionLocalService));
+
+		registry.register(
+			"3.2.10", "3.2.11",
+			new com.liferay.document.library.internal.upgrade.v3_2_11.
+				DLFileEntryTypesDDMStructureUpgradeProcess(_portal));
 	}
 
 	@Reference
@@ -190,6 +196,9 @@ public class DLServiceUpgradeStepRegistrator implements UpgradeStepRegistrator {
 
 	@Reference
 	private DLConfigurationUpgradeHelper _dlConfigurationUpgradeHelper;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_11/DLFileEntryTypesDDMStructureUpgradeProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/upgrade/v3_2_11/DLFileEntryTypesDDMStructureUpgradeProcess.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_11;
+
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class DLFileEntryTypesDDMStructureUpgradeProcess extends UpgradeProcess {
+
+	public DLFileEntryTypesDDMStructureUpgradeProcess(Portal portal) {
+		_portal = portal;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"update DDMStructure set type_ = ? where classNameId = ? and " +
+					"structureKey not in ('DL_VIDEO_EXTERNAL_SHORTCUT'," +
+						"'GOOGLE_DOCS')")) {
+
+			preparedStatement.setLong(1, DDMStructureConstants.TYPE_DEFAULT);
+			preparedStatement.setLong(
+				2, _portal.getClassNameId(DLFileEntryMetadata.class.getName()));
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final Portal _portal;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/upgrade/v3_2_11/test/DLFileEntryTypesDDMStructureUpgradeProcessTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/internal/upgrade/v3_2_11/test/DLFileEntryTypesDDMStructureUpgradeProcessTest.java
@@ -1,0 +1,164 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.upgrade.v3_2_11.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class DLFileEntryTypesDDMStructureUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_globalGroup = company.getGroup();
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		DLFileEntryType dlFileEntryType = _addFileEntryType();
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+			dlFileEntryType.getDataDefinitionId());
+
+		ddmStructure.setType(DDMStructureConstants.TYPE_AUTO);
+
+		_ddmStructureLocalService.updateDDMStructure(ddmStructure);
+
+		_runUpgrade();
+
+		_assertDDMStructure(
+			_ddmStructureLocalService.getDDMStructure(
+				dlFileEntryType.getDataDefinitionId()),
+			DDMStructureConstants.TYPE_DEFAULT);
+
+		for (String structureKey :
+				Arrays.asList("DL_VIDEO_EXTERNAL_SHORTCUT", "GOOGLE_DOCS")) {
+
+			_assertDDMStructure(
+				_ddmStructureLocalService.getStructure(
+					_globalGroup.getGroupId(),
+					_portal.getClassNameId(DLFileEntryMetadata.class.getName()),
+					structureKey),
+				DDMStructureConstants.TYPE_AUTO);
+		}
+	}
+
+	private DLFileEntryType _addFileEntryType() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		return _dlFileEntryTypeService.addFileEntryType(
+			null, _group.getGroupId(), ddmStructure.getStructureId(), null,
+			Collections.singletonMap(LocaleUtil.US, "New File Entry Type"),
+			Collections.singletonMap(LocaleUtil.US, "New File Entry Type"),
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+	}
+
+	private void _assertDDMStructure(
+		DDMStructure ddmStructure, int expectedType) {
+
+		Assert.assertEquals(expectedType, ddmStructure.getType());
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_entityCache.clearCache();
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.document.library.internal.upgrade.v3_2_11." +
+			"DLFileEntryTypesDDMStructureUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.document.library.internal.upgrade.registry.DLServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject
+	private DLFileEntryTypeService _dlFileEntryTypeService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	private Group _globalGroup;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -16,12 +16,14 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeService;
 import com.liferay.document.library.util.DLFileEntryTypeUtil;
+import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeRequest;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -76,6 +78,17 @@ public class DLFileEntryTypeServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddFileEntryTypeDDMStructure() throws Exception {
+		DLFileEntryType dlFileEntryType = _addFileEntryType(null);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+			dlFileEntryType.getDataDefinitionId());
+
+		Assert.assertEquals(
+			DDMStructureConstants.TYPE_DEFAULT, ddmStructure.getType());
 	}
 
 	@Test
@@ -442,6 +455,9 @@ public class DLFileEntryTypeServiceTest {
 
 	@Inject(filter = "ddm.form.deserializer.type=xsd")
 	private DDMFormDeserializer _ddmFormDeserializer;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Inject
 	private DLAppLocalService _dlAppLocalService;


### PR DESCRIPTION
Wrong type for the related DDMStructure when creating a document type

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-56207)

This issue was found when trying to use the item selector to select document types. When creating document types they are saved with the wrong type in the database, so that's why they can never be selected

# How am I fixing it?

Remove the wrapper and set the type of auto only for external video and google docs. All the other document types will have default as type

# How can you verify that it works?

Follow the steps in the ticket or run the provided tests
