### PR TITLE
LDP 56288 Add en-dash and em-dash into the unescape map and adjust view of Document title

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewEntriesDisplayContext.java
@@ -228,14 +228,10 @@ public class DLViewEntriesDisplayContext {
 			DLFileEntryPermission.contains(
 				permissionChecker, fileEntry, ActionKeys.UPDATE)) {
 
-			FileVersion fileVersion = fileEntry.getLatestFileVersion();
-
-			return fileVersion.toEscapedModel();
+			return fileEntry.getLatestFileVersion();
 		}
 
-		FileVersion fileVersion = fileEntry.getFileVersion();
-
-		return fileVersion.toEscapedModel();
+		return fileEntry.getFileVersion();
 	}
 
 	public String getRedirect() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -138,7 +138,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 															cssClass="card-title text-truncate"
 															href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
 															label="<%= latestFileVersion.getTitle() %>"
-															title="<%= HtmlUtil.escapeAttribute(latestFileVersion.getTitle()) %>"
+															title="<%= latestFileVersion.getTitle() %>"
 														/>
 
 														<c:if test="<%= !dlViewEntriesDisplayContext.hasGuestViewPermission(fileEntry) %>">
@@ -253,7 +253,7 @@ DLViewEntriesDisplayContext dlViewEntriesDisplayContext = new DLViewEntriesDispl
 															<clay:link
 																cssClass="text-truncate"
 																href="<%= dlViewEntriesDisplayContext.getViewFileEntryURL(fileEntry) %>"
-																label="<%= HtmlUtil.unescape(latestFileVersion.getTitle()) %>"
+																label="<%= latestFileVersion.getTitle() %>"
 																translated="<%= false %>"
 															/>
 


### PR DESCRIPTION
### What is this trying to solve?

[LPD-56288](https://liferay.atlassian.net/browse/LPD-56288)

When the Title of the uploaded document contains an em dash (—) or an n-dash (–), then the title at Table and card views shows encoded values for these characters.

### How am I fixing it?
- em dash (—) or an n-dash (–) into unescape map at HtmlUtil 
- Adjust view_entries.jsp page to show unexcape title