### PR TITLE
LPD-54950 Deactivate consistently failing tests

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-test/src/testIntegration/java/com/liferay/document/library/opener/google/drive/test/DLOpenerGoogleDriveManagerTest.java
@@ -53,6 +53,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -97,6 +98,7 @@ public class DLOpenerGoogleDriveManagerTest {
 		PrincipalThreadLocal.setName(_originalName);
 	}
 
+	@Ignore
 	@Test
 	public void testCheckInUploadsAnEmptyFileToGoogle() throws Exception {
 		_test(
@@ -127,6 +129,7 @@ public class DLOpenerGoogleDriveManagerTest {
 			});
 	}
 
+	@Ignore
 	@Test
 	public void testCheckOutUploadsTheFileToGoogle() throws Exception {
 		_test(
@@ -158,6 +161,7 @@ public class DLOpenerGoogleDriveManagerTest {
 			});
 	}
 
+	@Ignore
 	@Test
 	public void testCreateUploadsAnEmptyFileToGoogle() throws Exception {
 		_test(

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ItemSelector.testcase
@@ -1332,6 +1332,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test FilePaginationDisplaysCorrectCount {
+		property portal.acceptance = "quarantine";
+		
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		for (var documentTitle : list "Document_1,Document_2,Document_3,Document_4,Commerce_Black,Commerce_White") {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/layout/display/page/test/JournalArticleLayoutDisplayPageProviderTest.java
@@ -45,6 +45,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -291,6 +292,7 @@ public class JournalArticleLayoutDisplayPageProviderTest {
 			_layoutDisplayPageProvider.getURLSeparator());
 	}
 
+	@Ignore
 	@Test
 	public void testGetURLSeparatorWithConfiguredURLSeparator()
 		throws Exception {

--- a/modules/apps/ratings/ratings-test/src/testFunctional/tests/Ratings.testcase
+++ b/modules/apps/ratings/ratings-test/src/testFunctional/tests/Ratings.testcase
@@ -314,7 +314,7 @@ definition {
 	@refactordone
 	test CanRateBlogsEntry {
 		property custom.properties = "feature.flag.LPD-35013=true${line.separator}jsonws.web.service.paths.excludes=";
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/Translations.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/Translations.testcase
@@ -121,6 +121,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewTranslatedFieldContentAfterEditing {
+		property portal.acceptance = "quarantine";
+
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
 
 		NavItem.gotoStructures();

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageExportImport.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageExportImport.testcase
@@ -384,6 +384,8 @@ definition {
 	@description = "This ensures that the user can import the exported content page xliff file with 1.2 version."
 	@priority = 5
 	test CanImportExportedCustomizeXliffFile {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",
@@ -476,6 +478,8 @@ definition {
 	@description = "This ensures that the user can import the exported content page xliff file with default version."
 	@priority = 5
 	test CanImportExportedDefaultXliffFile {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",
@@ -558,6 +562,8 @@ definition {
 	@description = "This ensures that imported translation for a content page experience can be merged to the correct experience of a content page."
 	@priority = 5
 	test CanImportExportedTranslationForCorrespondingExperience {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",
@@ -1337,6 +1343,8 @@ definition {
 	@description = "This ensures that the user can import the translated content page file with Button fragment."
 	@priority = 5
 	test CanTranslateAndImportButtonFragment {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",
@@ -1428,6 +1436,8 @@ definition {
 	@description = "This ensures that the user can import the translated content page file with HTML fragment."
 	@priority = 5
 	test CanTranslateAndImportHTMLFragment {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",
@@ -1637,6 +1647,8 @@ definition {
 	@description = "This ensures that only the valid translation files can be uploaded from a zip file."
 	@priority = 5
 	test OnlyValidEntriesAreUploadedFromZip {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "ContentPage",

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageWorkflow.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageWorkflow.testcase
@@ -27,7 +27,7 @@ definition {
 	@description = "This ensures that an imported content page translation can be approved through the workflow."
 	@priority = 5
 	test CanApproveImportedTranslation {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -460,7 +460,7 @@ definition {
 	@description = "This ensures that translation files can be uploaded and resubmitted from a zip file after workflow is enabled."
 	@priority = 4
 	test CanResubmitImportedEntryFromZip {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -627,7 +627,7 @@ definition {
 	@description = "This ensures that an imported translation can be resubmitted after being rejected."
 	@priority = 5
 	test CanResubmitRejectedImportedTranslation {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsInterface.testcase
@@ -438,6 +438,8 @@ definition {
 	@priority = 5
 	@refactordone
 	test EditedValuesArePreservedInSideBySideUI {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",
 			groupName = "Guest",

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsWorkflow.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsWorkflow.testcase
@@ -135,6 +135,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanApproveEntryFromPartiallyImportedZip {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WebContent",
 			description = "Description",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -160,6 +160,8 @@ definition {
 	@description = "This is a test for LPS-136762. It checks that content can be added in full screen mode."
 	@priority = 2
 	test CanAddContentInFullScreenMode {
+		property portal.acceptance = "quarantine";
+		
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBNotifications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBNotifications.testcase
@@ -270,6 +270,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewWebsiteNotificationForUpdatedThreadInCategory {
+		property portal.acceptance = "quarantine";
+
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
 			categoryName = "MB Category Name",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
@@ -282,6 +282,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanReplyToThreadAsGuest {
+		property portal.acceptance = "quarantine";
+
 		Navigator.gotoPage(pageName = "Message Boards Page");
 
 		MessageboardsThread.addPG(
@@ -552,6 +554,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewPagersForCategoriesAndThreads {
+		property portal.acceptance = "quarantine";
+
 		for (var categoryName : list "MB Category1 Name,MB Category2 Name,MB Category3 Name,MB Category4 Name,MB Category5 Name,MB Category6 Name") {
 			JSONMBMessage.addCategory(
 				categoryDescription = "${categoryName} Description",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
@@ -313,6 +313,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewImportedPages {
+		property portal.acceptance = "quarantine";
+
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMAdmin.testcase
@@ -80,7 +80,7 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanMoveDocumentsWithMultiplePaginations {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property portal.release = "quarantine";
 
 		HeadlessSite.addSite(siteName = "Site Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMNotifications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMNotifications.testcase
@@ -180,7 +180,7 @@ The DM file [$DOCUMENT_TITLE$] has been added to Home folder.
 	@refactordone
 	test CanViewEmailNotificationForNewDocumentInFolder {
 		property custom.properties = "dl.actions.visible=true${line.separator}jsonws.web.service.paths.excludes=";
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property test.smtp.server.enabled = "true";
 
 		var siteName = TestCase.getSiteName(siteName = ${siteName});

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -1373,7 +1373,7 @@ definition {
 	@description = "This is a test for LPS-90066 and LPS-127728. A user can preview a scheduled web content via View Usage. The warning message should have link in Web Content Display."
 	@priority = 5
 	test PreviewScheduledWebContentInWCD {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		task ("Add a web content article with a future display date") {
 			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");


### PR DESCRIPTION
Hi team,
The tests in this PR have been consistently failing in the Acceptance test suites.

If these are lower priority tests that will not be fixed in the near future it might be best to deactivate for now so it's not adding noise to test results or using up CI resources. For more information, please see this [Slack post](https://liferay.slack.com/archives/C0251HKT0K0/p1747027740422599).

If everything looks good, please forward. If not, please let the Release team know in #t-release on Slack. Thanks!