### PR TITLE
LPD-54298 Make sure the button is submitted only once

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -55,6 +55,7 @@ export default function _JournalPortlet({
 	let articleId = initialArticleId;
 	let defaultLanguageId = initialDefaultLanguageId;
 	let selectedLanguageId = initialDefaultLanguageId;
+	let formSubmitted = false;
 
 	const lockHolder = {};
 
@@ -184,7 +185,9 @@ export default function _JournalPortlet({
 					submitAsyncForm(form, {redirectOnSave});
 				}
 			}
-			else {
+			else if (!formSubmitted) {
+				formSubmitted = true;
+
 				form.submit();
 			}
 		}


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-54298)

# How did I fix it
Although in https://github.com/liferay-content-management/liferay-portal/pull/6595 I control that the onClick is triggered only once, the publish/schedule button is of type submit, which means that after the onClick, the submit button is also triggered. Thus, I have to control that also the submit event is only fired once. 

# How to test it
Follow the steps on the issue (enabling Publications), then **sometimes** you can see these duplicated articles. As there is no clear steps to reproduce it, I don't think this case can be covered by a unit or functional test.