### PR TITLE
LPD-52794 Create individual sharing entries headless endpoints

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/dto/v1_0/Collaborator.java
@@ -5,12 +5,9 @@
 
 package com.liferay.headless.object.dto.v1_0;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.petra.function.UnsafeSupplier;
@@ -51,7 +48,7 @@ import java.util.function.Supplier;
 )
 @io.swagger.v3.oas.annotations.media.Schema(
 	description = "Represents a collaborator for an entry.",
-	requiredProperties = {"actionIds", "externalReferenceCode", "type"}
+	requiredProperties = {"actionIds", "type"}
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "Collaborator")
@@ -283,12 +280,52 @@ public class Collaborator implements Serializable {
 	}
 
 	@GraphQLField(description = "The collaborator external reference code.")
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	@NotEmpty
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String externalReferenceCode;
 
 	@JsonIgnore
 	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The collaborator ID."
+	)
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The collaborator ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The collaborator name."
@@ -422,9 +459,7 @@ public class Collaborator implements Serializable {
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The collaborator type.", example = "User"
 	)
-	@JsonGetter("type")
-	@Valid
-	public Type getType() {
+	public String getType() {
 		if (_typeSupplier != null) {
 			type = _typeSupplier.get();
 
@@ -434,25 +469,14 @@ public class Collaborator implements Serializable {
 		return type;
 	}
 
-	@JsonIgnore
-	public String getTypeAsString() {
-		Type type = getType();
-
-		if (type == null) {
-			return null;
-		}
-
-		return type.toString();
-	}
-
-	public void setType(Type type) {
+	public void setType(String type) {
 		this.type = type;
 
 		_typeSupplier = null;
 	}
 
 	@JsonIgnore
-	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+	public void setType(UnsafeSupplier<String, Exception> typeUnsafeSupplier) {
 		_typeSupplier = () -> {
 			try {
 				return typeUnsafeSupplier.get();
@@ -468,11 +492,11 @@ public class Collaborator implements Serializable {
 
 	@GraphQLField(description = "The collaborator type.")
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	@NotNull
-	protected Type type;
+	@NotEmpty
+	protected String type;
 
 	@JsonIgnore
-	private Supplier<Type> _typeSupplier;
+	private Supplier<String> _typeSupplier;
 
 	@Override
 	public boolean equals(Object object) {
@@ -586,6 +610,18 @@ public class Collaborator implements Serializable {
 			sb.append("\"");
 		}
 
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
 		String name = getName();
 
 		if (name != null) {
@@ -630,7 +666,7 @@ public class Collaborator implements Serializable {
 			sb.append(share);
 		}
 
-		Type type = getType();
+		String type = getType();
 
 		if (type != null) {
 			if (sb.length() > 1) {
@@ -641,7 +677,7 @@ public class Collaborator implements Serializable {
 
 			sb.append("\"");
 
-			sb.append(type);
+			sb.append(_escape(type));
 
 			sb.append("\"");
 		}
@@ -657,44 +693,6 @@ public class Collaborator implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
-
-	@GraphQLName("Type")
-	public static enum Type {
-
-		USER("User"), USER_GROUP("UserGroup");
-
-		@JsonCreator
-		public static Type create(String value) {
-			if ((value == null) || value.equals("")) {
-				return null;
-			}
-
-			for (Type type : values()) {
-				if (Objects.equals(type.getValue(), value)) {
-					return type;
-				}
-			}
-
-			throw new IllegalArgumentException("Invalid enum value: " + value);
-		}
-
-		@JsonValue
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private Type(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
-	}
 
 	private static String _escape(Object object) {
 		return StringUtil.replace(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/resource/v1_0/CollaboratorResource.java
@@ -48,8 +48,28 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CollaboratorResource {
 
+	public void deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception;
+
+	public Collaborator getObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
 		throws Exception;
 
 	public Page<Collaborator>
@@ -71,6 +91,17 @@ public interface CollaboratorResource {
 			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage(
 				String scopeKey, String externalReferenceCode,
 				Collaborator[] collaborators)
+		throws Exception;
+
+	public Collaborator putObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId,
+			Collaborator collaborator)
+		throws Exception;
+
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId, Collaborator collaborator)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/java/com/liferay/headless/object/util/v1_0/CollaboratorUtil.java
@@ -15,14 +15,17 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.sharing.service.SharingEntryService;
 
 import jakarta.ws.rs.core.UriInfo;
@@ -37,9 +40,30 @@ import java.util.Objects;
  */
 public class CollaboratorUtil {
 
+	public static Collaborator addOrUpdateCollaborator(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			Collaborator collaborator, long collaboratorId,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, long groupId,
+			SharingEntryService sharingEntryService, String type,
+			UserGroupLocalService userGroupLocalService, UriInfo uriInfo,
+			User user, UserLocalService userLocalService)
+		throws Exception {
+
+		_validateType(type);
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry,
+			_addOrUpdateSharingEntry(
+				classNameId, classPK, collaborator, collaboratorId, groupId,
+				sharingEntryService, type, userGroupLocalService,
+				userLocalService),
+			uriInfo, user);
+	}
+
 	public static Page<Collaborator> addOrUpdateCollaborators(
 			AcceptLanguage acceptLanguage, long classNameId, long classPK,
-			Collaborator[] collaborators, long companyId,
+			Collaborator[] collaborators,
 			DTOConverter<SharingEntry, Collaborator> dtoConverter,
 			DTOConverterRegistry dtoConverterRegistry, long groupId,
 			SharingEntryService sharingEntryService, UriInfo uriInfo, User user,
@@ -58,8 +82,9 @@ public class CollaboratorUtil {
 
 		for (Collaborator collaborator : collaborators) {
 			SharingEntry sharingEntry = _addOrUpdateSharingEntry(
-				classNameId, classPK, collaborator, companyId, groupId,
-				sharingEntryService, userGroupLocalService, userLocalService);
+				classNameId, classPK, collaborator, collaborator.getId(),
+				groupId, sharingEntryService, collaborator.getType(),
+				userGroupLocalService, userLocalService);
 
 			newSharingEntries.add(sharingEntry);
 			sharingEntriesIds.add(sharingEntry.getSharingEntryId());
@@ -77,6 +102,71 @@ public class CollaboratorUtil {
 				sharingEntry -> toCollaborator(
 					acceptLanguage, dtoConverter, dtoConverterRegistry,
 					sharingEntry, uriInfo, user)));
+	}
+
+	public static void deleteCollaborator(
+			long classNameId, long classPK, Long collaboratorId,
+			SharingEntryService sharingEntryService, String type)
+		throws Exception {
+
+		_validateType(type);
+
+		if (StringUtil.equals("User", type)) {
+			sharingEntryService.deleteSharingEntry(
+				0, collaboratorId, classNameId, classPK);
+		}
+		else {
+			sharingEntryService.deleteSharingEntry(
+				collaboratorId, 0, classNameId, classPK);
+		}
+	}
+
+	public static Collaborator getCollaborator(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			Long collaboratorId,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry,
+			SharingEntryService sharingEntryService, String type,
+			UriInfo uriInfo, User user)
+		throws Exception {
+
+		_validateType(type);
+
+		if (StringUtil.equals("User", type)) {
+			return toCollaborator(
+				acceptLanguage, dtoConverter, dtoConverterRegistry,
+				sharingEntryService.getSharingEntry(
+					0, collaboratorId, classNameId, classPK),
+				uriInfo, user);
+		}
+
+		return toCollaborator(
+			acceptLanguage, dtoConverter, dtoConverterRegistry,
+			sharingEntryService.getSharingEntry(
+				collaboratorId, 0, classNameId, classPK),
+			uriInfo, user);
+	}
+
+	public static Page<Collaborator> getCollaborators(
+			AcceptLanguage acceptLanguage, long classNameId, long classPK,
+			DTOConverter<SharingEntry, Collaborator> dtoConverter,
+			DTOConverterRegistry dtoConverterRegistry, long groupId,
+			Pagination pagination,
+			SharingEntryLocalService sharingEntryLocalService,
+			SharingEntryService sharingEntryService, UriInfo uriInfo, User user)
+		throws Exception {
+
+		return Page.of(
+			TransformUtil.transform(
+				sharingEntryService.getSharingEntries(
+					classNameId, classPK, groupId,
+					pagination.getStartPosition(), pagination.getEndPosition()),
+				sharingEntry -> toCollaborator(
+					acceptLanguage, dtoConverter, dtoConverterRegistry,
+					sharingEntry, uriInfo, user)),
+			pagination,
+			sharingEntryLocalService.getSharingEntriesCount(
+				classNameId, classPK));
 	}
 
 	public static long getGroupId(
@@ -115,27 +205,25 @@ public class CollaboratorUtil {
 
 	private static SharingEntry _addOrUpdateSharingEntry(
 			long classNameId, long classPK, Collaborator collaborator,
-			long companyId, long groupId,
-			SharingEntryService sharingEntryService,
+			long collaboratorId, long groupId,
+			SharingEntryService sharingEntryService, String type,
 			UserGroupLocalService userGroupLocalService,
 			UserLocalService userLocalService)
 		throws Exception {
 
+		_validateType(type);
+
 		long toUserGroupId = 0;
 		long toUserId = 0;
 
-		if (Objects.equals(
-				Collaborator.Type.USER_GROUP, collaborator.getType())) {
-
-			UserGroup userGroup =
-				userGroupLocalService.getUserGroupByExternalReferenceCode(
-					collaborator.getExternalReferenceCode(), companyId);
+		if (StringUtil.equals("UserGroup", type)) {
+			UserGroup userGroup = userGroupLocalService.getUserGroup(
+				collaboratorId);
 
 			toUserGroupId = userGroup.getUserGroupId();
 		}
 		else {
-			User user = userLocalService.getUserByExternalReferenceCode(
-				collaborator.getExternalReferenceCode(), companyId);
+			User user = userLocalService.getUser(collaboratorId);
 
 			toUserId = user.getUserId();
 		}
@@ -153,6 +241,15 @@ public class CollaboratorUtil {
 				collaborator.getActionIds(),
 				SharingEntryAction::parseFromActionId),
 			collaborator.getDateExpired(), new ServiceContext());
+	}
+
+	private static void _validateType(String type) {
+		if (!StringUtil.equals("User", type) &&
+			!StringUtil.equals("UserGroup", type)) {
+
+			throw new IllegalArgumentException(
+				"Collaborator type must be \"User\" or \"UserGroup\"");
+		}
 	}
 
 }

--- a/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-object/headless-object-api/src/main/resources/com/liferay/headless/object/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/dto/v1_0/Collaborator.java
@@ -132,6 +132,25 @@ public class Collaborator implements Cloneable, Serializable {
 
 	protected String externalReferenceCode;
 
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
 	public String getName() {
 		return name;
 	}
@@ -193,23 +212,15 @@ public class Collaborator implements Cloneable, Serializable {
 
 	protected Boolean share;
 
-	public Type getType() {
+	public String getType() {
 		return type;
 	}
 
-	public String getTypeAsString() {
-		if (type == null) {
-			return null;
-		}
-
-		return type.toString();
-	}
-
-	public void setType(Type type) {
+	public void setType(String type) {
 		this.type = type;
 	}
 
-	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+	public void setType(UnsafeSupplier<String, Exception> typeUnsafeSupplier) {
 		try {
 			type = typeUnsafeSupplier.get();
 		}
@@ -218,7 +229,7 @@ public class Collaborator implements Cloneable, Serializable {
 		}
 	}
 
-	protected Type type;
+	protected String type;
 
 	@Override
 	public Collaborator clone() throws CloneNotSupportedException {
@@ -249,39 +260,6 @@ public class Collaborator implements Cloneable, Serializable {
 
 	public String toString() {
 		return CollaboratorSerDes.toJSON(this);
-	}
-
-	public static enum Type {
-
-		USER("User"), USER_GROUP("UserGroup");
-
-		public static Type create(String value) {
-			for (Type type : values()) {
-				if (Objects.equals(type.getValue(), value) ||
-					Objects.equals(type.name(), value)) {
-
-					return type;
-				}
-			}
-
-			return null;
-		}
-
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private Type(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
 	}
 
 }

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/resource/v1_0/CollaboratorResource.java
@@ -36,6 +36,36 @@ public interface CollaboratorResource {
 		return new Builder();
 	}
 
+	public void deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception;
+
+	public Collaborator getObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception;
+
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
 		throws Exception;
@@ -43,6 +73,18 @@ public interface CollaboratorResource {
 	public HttpInvoker.HttpResponse
 			getObjectEntryFolderCollaboratorsPageHttpResponse(
 				Long objectEntryFolderId, Pagination pagination)
+		throws Exception;
+
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
 		throws Exception;
 
 	public Page<Collaborator>
@@ -87,6 +129,29 @@ public interface CollaboratorResource {
 			postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPageHttpResponse(
 				String scopeKey, String externalReferenceCode,
 				Collaborator[] collaborators)
+		throws Exception;
+
+	public Collaborator putObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId,
+			Collaborator collaborator)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+				Long objectEntryFolderId, String type, Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception;
+
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId, Collaborator collaborator)
 		throws Exception;
 
 	public static class Builder {
@@ -198,6 +263,340 @@ public interface CollaboratorResource {
 	public static class CollaboratorResourceImpl
 		implements CollaboratorResource {
 
+		public void deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+				Long objectEntryFolderId, String type, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					objectEntryFolderId, type, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String type, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, type, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator getObjectEntryFolderCollaboratorByTypeCollaborator(
+				Long objectEntryFolderId, String type, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					objectEntryFolderId, type, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String type, Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 				Long objectEntryFolderId, Pagination pagination)
 			throws Exception {
@@ -304,6 +703,120 @@ public interface CollaboratorResource {
 						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators");
 
 			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, type, collaboratorId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -774,6 +1287,237 @@ public interface CollaboratorResource {
 
 			httpInvoker.path("scopeKey", scopeKey);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator putObjectEntryFolderCollaboratorByTypeCollaborator(
+				Long objectEntryFolderId, String type, Long collaboratorId,
+				Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					objectEntryFolderId, type, collaboratorId, collaborator);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					Long objectEntryFolderId, String type, Long collaboratorId,
+					Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(collaborator.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("objectEntryFolderId", objectEntryFolderId);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Collaborator
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId, Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					scopeKey, externalReferenceCode, type, collaboratorId,
+					collaborator);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return CollaboratorSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					String scopeKey, String externalReferenceCode, String type,
+					Long collaboratorId, Collaborator collaborator)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(collaborator.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}");
+
+			httpInvoker.path("scopeKey", scopeKey);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+			httpInvoker.path("type", type);
+			httpInvoker.path("collaboratorId", collaboratorId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
+++ b/modules/apps/headless/headless-object/headless-object-client/src/main/java/com/liferay/headless/object/client/serdes/v1_0/CollaboratorSerDes.java
@@ -121,6 +121,16 @@ public class CollaboratorSerDes {
 			sb.append("\"");
 		}
 
+		if (collaborator.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(collaborator.getId());
+		}
+
 		if (collaborator.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -168,7 +178,7 @@ public class CollaboratorSerDes {
 
 			sb.append("\"");
 
-			sb.append(collaborator.getType());
+			sb.append(_escape(collaborator.getType()));
 
 			sb.append("\"");
 		}
@@ -234,6 +244,13 @@ public class CollaboratorSerDes {
 				String.valueOf(collaborator.getExternalReferenceCode()));
 		}
 
+		if (collaborator.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(collaborator.getId()));
+		}
+
 		if (collaborator.getName() == null) {
 			map.put("name", null);
 		}
@@ -297,6 +314,9 @@ public class CollaboratorSerDes {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				return false;
 			}
@@ -350,6 +370,12 @@ public class CollaboratorSerDes {
 						(String)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					collaborator.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					collaborator.setName((String)jsonParserFieldValue);
@@ -367,8 +393,7 @@ public class CollaboratorSerDes {
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
 				if (jsonParserFieldValue != null) {
-					collaborator.setType(
-						Collaborator.Type.create((String)jsonParserFieldValue));
+					collaborator.setType((String)jsonParserFieldValue);
 				}
 			}
 		}

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -50,7 +50,6 @@ components:
                 type:
                     description:
                         The collaborator type.
-                    enum: [User,UserGroup]
                     example: User
                     type: string
             required:

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -60,7 +60,6 @@ components:
                     type: string
             required:
                 -   actionIds
-                -   externalReferenceCode
                 -   type
             type: object
         ObjectEntryFolder:
@@ -327,7 +326,6 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
-            tags: ["Collaborator"]
         post:
             description:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
@@ -366,6 +364,119 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
+            tags: ["Collaborator"]
+    "/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryFolderCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator of an object entry.
+            operationId: getObjectEntryFolderCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putObjectEntryFolderCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryFolderId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
             tags: ["Collaborator"]
     "/scopes/{scopeKey}/object-entry-folder/by-external-reference-code/{externalReferenceCode}":
         delete:
@@ -624,7 +735,6 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
-            tags: ["Collaborator"]
         post:
             description:
                 Add or update all the collaborators received in the request. Delete existing collaborators that are not
@@ -667,4 +777,129 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Collaborator"
                                 type: array
+            tags: ["Collaborator"]
+    "/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds.
+            operationId: deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry folder.
+            operationId: getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Collaborator"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Collaborator"
             tags: ["Collaborator"]

--- a/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-object/headless-object-impl/rest-openapi.yaml
@@ -32,7 +32,13 @@ components:
                     # @review
                     description:
                         The collaborator external reference code.
+                    readOnly: true
                     type: string
+                id:
+                    description:
+                        The collaborator ID.
+                    format: int64
+                    type: integer
                 name:
                     description:
                         The collaborator name.

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/dto/v1_0/converter/CollaboratorDTOConverter.java
@@ -65,6 +65,14 @@ public class CollaboratorDTOConverter
 
 						return userGroup.getExternalReferenceCode();
 					});
+				setId(
+					() -> {
+						if (user != null) {
+							return user.getUserId();
+						}
+
+						return userGroup.getUserGroupId();
+					});
 				setName(
 					() -> {
 						if (user != null) {
@@ -95,10 +103,10 @@ public class CollaboratorDTOConverter
 				setType(
 					() -> {
 						if (user != null) {
-							return Type.USER;
+							return "User";
 						}
 
-						return Type.USER_GROUP;
+						return "UserGroup";
 					});
 			}
 		};

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/mutation/v1_0/Mutation.java
@@ -56,6 +56,49 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	public boolean deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("type") String type,
+			@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+						objectEntryFolderId, type, collaboratorId));
+
+		return true;
+	}
+
+	@GraphQLField(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	public boolean
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("type") String type,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						scopeKey, externalReferenceCode, type, collaboratorId));
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Add or update all the collaborators received in the request. Delete existing collaborators that are not included in the request. Send a notification for the new collaborators and those whose permissions are different."
 	)
 	public java.util.Collection<Collaborator>
@@ -116,6 +159,49 @@ public class Mutation {
 
 				return paginationPage.getItems();
 			});
+	}
+
+	@GraphQLField(
+		description = "Add or update a collaborator received in the request."
+	)
+	public Collaborator updateObjectEntryFolderCollaboratorByTypeCollaborator(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("type") String type,
+			@GraphQLName("collaboratorId") Long collaboratorId,
+			@GraphQLName("collaborator") Collaborator collaborator)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					putObjectEntryFolderCollaboratorByTypeCollaborator(
+						objectEntryFolderId, type, collaboratorId,
+						collaborator));
+	}
+
+	@GraphQLField(
+		description = "Add or update a collaborator received in the request."
+	)
+	public Collaborator
+			updateScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("type") String type,
+				@GraphQLName("collaboratorId") Long collaboratorId,
+				@GraphQLName("collaborator") Collaborator collaborator)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						scopeKey, externalReferenceCode, type, collaboratorId,
+						collaborator));
 	}
 
 	@GraphQLField(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/query/v1_0/Query.java
@@ -61,6 +61,29 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaboratorByTypeCollaborator(collaboratorId: ___, objectEntryFolderId: ___, type: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborator of an object entry."
+	)
+	public Collaborator objectEntryFolderCollaboratorByTypeCollaborator(
+			@GraphQLName("objectEntryFolderId") Long objectEntryFolderId,
+			@GraphQLName("type") String type,
+			@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					getObjectEntryFolderCollaboratorByTypeCollaborator(
+						objectEntryFolderId, type, collaboratorId));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectEntryFolderCollaborators(objectEntryFolderId: ___, page: ___, pageSize: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
@@ -78,6 +101,32 @@ public class Query {
 			collaboratorResource -> new CollaboratorPage(
 				collaboratorResource.getObjectEntryFolderCollaboratorsPage(
 					objectEntryFolderId, Pagination.of(page, pageSize))));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(collaboratorId: ___, externalReferenceCode: ___, scopeKey: ___, type: ___){actionIds, actions, creator, dateExpired, externalReferenceCode, id, name, portrait, share, type}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the collaborator for an object entry folder."
+	)
+	public Collaborator
+			scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@GraphQLName("scopeKey") String scopeKey,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("type") String type,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_collaboratorResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			collaboratorResource ->
+				collaboratorResource.
+					getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+						scopeKey, externalReferenceCode, type, collaboratorId));
 	}
 
 	/**
@@ -178,6 +227,37 @@ public class Query {
 						Pagination.of(page, pageSize),
 						_sortsBiFunction.apply(
 							objectEntryFolderResource, sortsString))));
+	}
+
+	@GraphQLTypeExtension(ObjectEntryFolder.class)
+	public class
+		GetObjectEntryFolderCollaboratorByTypeCollaboratorTypeExtension {
+
+		public GetObjectEntryFolderCollaboratorByTypeCollaboratorTypeExtension(
+			ObjectEntryFolder objectEntryFolder) {
+
+			_objectEntryFolder = objectEntryFolder;
+		}
+
+		@GraphQLField(
+			description = "Retrieves the collaborator of an object entry."
+		)
+		public Collaborator collaboratorByTypeCollaborator(
+				@GraphQLName("type") String type,
+				@GraphQLName("collaboratorId") Long collaboratorId)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_collaboratorResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				collaboratorResource ->
+					collaboratorResource.
+						getObjectEntryFolderCollaboratorByTypeCollaborator(
+							_objectEntryFolder.getId(), type, collaboratorId));
+		}
+
+		private ObjectEntryFolder _objectEntryFolder;
+
 	}
 
 	@GraphQLTypeExtension(ObjectEntryFolder.class)

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -82,6 +82,16 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#deleteObjectEntryFolderCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"deleteObjectEntryFolderCollaboratorByTypeCollaborator"));
+					put(
+						"mutation#deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator"));
+					put(
 						"mutation#createObjectEntryFolderCollaboratorsPage",
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
@@ -96,6 +106,16 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
 							"postScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorsPage"));
+					put(
+						"mutation#updateObjectEntryFolderCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"putObjectEntryFolderCollaboratorByTypeCollaborator"));
+					put(
+						"mutation#updateScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator"));
 					put(
 						"mutation#deleteObjectEntryFolder",
 						new ObjectValuePair<>(
@@ -133,10 +153,20 @@ public class ServletDataImpl implements ServletData {
 							"putScopeScopeKeyObjectEntryFolderByExternalReferenceCode"));
 
 					put(
+						"query#objectEntryFolderCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorByTypeCollaborator"));
+					put(
 						"query#objectEntryFolderCollaborators",
 						new ObjectValuePair<>(
 							CollaboratorResourceImpl.class,
 							"getObjectEntryFolderCollaboratorsPage"));
+					put(
+						"query#scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator"));
 					put(
 						"query#scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaborators",
 						new ObjectValuePair<>(
@@ -158,6 +188,11 @@ public class ServletDataImpl implements ServletData {
 							ObjectEntryFolderResourceImpl.class,
 							"getScopeScopeKeyObjectEntryFoldersPage"));
 
+					put(
+						"query#ObjectEntryFolder.collaboratorByTypeCollaborator",
+						new ObjectValuePair<>(
+							CollaboratorResourceImpl.class,
+							"getObjectEntryFolderCollaboratorByTypeCollaborator"));
 					put(
 						"query#ObjectEntryFolder.collaborators",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -70,6 +70,176 @@ public abstract class BaseCollaboratorResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("type")
+			String type,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("collaboratorId")
+			Long collaboratorId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry folder and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator of an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Collaborator getObjectEntryFolderCollaboratorByTypeCollaborator(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("type")
+			String type,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("collaboratorId")
+			Long collaboratorId)
+		throws Exception {
+
+		return new Collaborator();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -103,9 +273,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@jakarta.ws.rs.GET
 	@jakarta.ws.rs.Path(
 		"/object-entry-folders/{objectEntryFolderId}/collaborators"
@@ -121,6 +289,78 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry folder."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new Collaborator();
 	}
 
 	/**
@@ -163,9 +403,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@jakarta.ws.rs.GET
 	@jakarta.ws.rs.Path(
 		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators"
@@ -250,9 +488,7 @@ public abstract class BaseCollaboratorResourceImpl
 			)
 		}
 	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
-	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
 	@jakarta.ws.rs.Consumes("application/json")
 	@jakarta.ws.rs.Path(
 		"/object-entry-folders/{objectEntryFolderId}/collaborators/export-batch"
@@ -340,6 +576,121 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryFolderId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/object-entry-folders/{objectEntryFolderId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public Collaborator putObjectEntryFolderCollaboratorByTypeCollaborator(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("objectEntryFolderId")
+			Long objectEntryFolderId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("type")
+			String type,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("collaboratorId")
+			Long collaboratorId,
+			Collaborator collaborator)
+		throws Exception {
+
+		return new Collaborator();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}' -d $'{"actionIds": ___, "dateExpired": ___, "id": ___, "share": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/object-entry-folders/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				Collaborator collaborator)
+		throws Exception {
+
+		return new Collaborator();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -37,6 +37,75 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 
 	@Override
+	public void deleteObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			_sharingEntryService, type);
+	}
+
+	@Override
+	public void
+			deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			_sharingEntryService, type);
+	}
+
+	@Override
+	public Collaborator getObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, type, contextUriInfo, contextUser);
+	}
+
+	@Override
 	public Page<Collaborator> getObjectEntryFolderCollaboratorsPage(
 			Long objectEntryFolderId, Pagination pagination)
 		throws Exception {
@@ -45,10 +114,48 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryFolderCollaboratorsPage(
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.getObjectEntryFolder(
-				objectEntryFolderId),
-			pagination);
+				objectEntryFolderId);
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
+	}
+
+	@Override
+	public Collaborator
+			getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -62,15 +169,24 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryFolderCollaboratorsPage(
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode,
 					CollaboratorUtil.getGroupId(
 						contextCompany.getCompanyId(), _groupLocalService,
 						scopeKey),
-					contextCompany.getCompanyId()),
-			pagination);
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(),
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -82,10 +198,19 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryFolderCollaboratorsPage(
-			collaborators,
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.getObjectEntryFolder(
-				objectEntryFolderId));
+				objectEntryFolderId);
+
+		return CollaboratorUtil.addOrUpdateCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborators,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService,
+			contextUriInfo, contextUser, _userGroupLocalService,
+			_userLocalService);
 	}
 
 	@Override
@@ -99,52 +224,80 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryFolderCollaboratorsPage(
-			collaborators,
+		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode,
 					CollaboratorUtil.getGroupId(
 						contextCompany.getCompanyId(), _groupLocalService,
 						scopeKey),
-					contextCompany.getCompanyId()));
-	}
-
-	private Page<Collaborator> _getObjectEntryFolderCollaboratorsPage(
-			ObjectEntryFolder objectEntryFolder, Pagination pagination)
-		throws Exception {
-
-		long classNameId = _classNameLocalService.getClassNameId(
-			ObjectEntryFolder.class.getName());
-
-		return Page.of(
-			transform(
-				_sharingEntryService.getSharingEntries(
-					classNameId, objectEntryFolder.getObjectEntryFolderId(),
-					objectEntryFolder.getGroupId(),
-					pagination.getStartPosition(), pagination.getEndPosition()),
-				sharingEntry -> CollaboratorUtil.toCollaborator(
-					contextAcceptLanguage, _collaboratorDTOConverter,
-					_dtoConverterRegistry, sharingEntry, contextUriInfo,
-					contextUser)),
-			pagination,
-			_sharingEntryLocalService.getSharingEntriesCount(
-				classNameId, objectEntryFolder.getObjectEntryFolderId()));
-	}
-
-	private Page<Collaborator> _postObjectEntryFolderCollaboratorsPage(
-			Collaborator[] collaborators, ObjectEntryFolder objectEntryFolder)
-		throws Exception {
+					contextCompany.getCompanyId());
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
 			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				ObjectEntryFolder.class.getName()),
 			objectEntryFolder.getObjectEntryFolderId(), collaborators,
-			contextCompany.getCompanyId(), _collaboratorDTOConverter,
-			_dtoConverterRegistry, objectEntryFolder.getGroupId(),
-			_sharingEntryService, contextUriInfo, contextUser,
-			_userGroupLocalService, _userLocalService);
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService,
+			contextUriInfo, contextUser, _userGroupLocalService,
+			_userLocalService);
+	}
+
+	@Override
+	public Collaborator putObjectEntryFolderCollaboratorByTypeCollaborator(
+			Long objectEntryFolderId, String type, Long collaboratorId,
+			Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId);
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborator,
+			collaboratorId, _collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService, type,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode,
+					CollaboratorUtil.getGroupId(
+						contextCompany.getCompanyId(), _groupLocalService,
+						scopeKey),
+					contextCompany.getCompanyId());
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), collaborator,
+			collaboratorId, _collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntryFolder.getGroupId(), _sharingEntryService, type,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/BaseCollaboratorResourceTestCase.java
@@ -171,6 +171,7 @@ public abstract class BaseCollaboratorResourceTestCase {
 		collaborator.setExternalReferenceCode(regex);
 		collaborator.setName(regex);
 		collaborator.setPortrait(regex);
+		collaborator.setType(regex);
 
 		String json = CollaboratorSerDes.toJSON(collaborator);
 
@@ -181,6 +182,281 @@ public abstract class BaseCollaboratorResourceTestCase {
 		Assert.assertEquals(regex, collaborator.getExternalReferenceCode());
 		Assert.assertEquals(regex, collaborator.getName());
 		Assert.assertEquals(regex, collaborator.getPortrait());
+		Assert.assertEquals(regex, collaborator.getType());
+	}
+
+	@Test
+	public void testDeleteObjectEntryFolderCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Collaborator collaborator =
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator();
+
+		assertHttpResponseStatusCode(
+			204,
+			collaboratorResource.
+				deleteObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					collaborator.getType(), collaborator.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					collaborator.getType(), collaborator.getId()));
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					collaborator.getType(), 0L));
+	}
+
+	protected Long
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		Collaborator collaborator =
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator();
+
+		assertHttpResponseStatusCode(
+			204,
+			collaboratorResource.
+				deleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+						collaborator),
+					collaborator.getType(), collaborator.getId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					collaborator.getExternalReferenceCode(),
+					collaborator.getType(), collaborator.getId()));
+		assertHttpResponseStatusCode(
+			404,
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorHttpResponse(
+					testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					"-", collaborator.getType(), 0L));
+	}
+
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected Collaborator
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetObjectEntryFolderCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testGetObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator();
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaborator(
+					testGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					postCollaborator.getType(), postCollaborator.getId());
+
+		assertEquals(postCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected Long
+			testGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator collaborator =
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"objectEntryFolderCollaboratorByTypeCollaborator",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"objectEntryFolderId",
+											testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId());
+
+										put(
+											"type",
+											"\"" + collaborator.getType() +
+												"\"");
+
+										put(
+											"collaboratorId",
+											collaborator.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/objectEntryFolderCollaboratorByTypeCollaborator"))));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessObject_v1_0",
+								new GraphQLField(
+									"objectEntryFolderCollaboratorByTypeCollaborator",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"objectEntryFolderId",
+												testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId());
+
+											put(
+												"type",
+												"\"" + collaborator.getType() +
+													"\"");
+
+											put(
+												"collaboratorId",
+												collaborator.getId());
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessObject_v1_0",
+						"Object/objectEntryFolderCollaboratorByTypeCollaborator"))));
+	}
+
+	protected Long
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaboratorNotFound()
+		throws Exception {
+
+		Long irrelevantObjectEntryFolderId = RandomTestUtil.randomLong();
+		String irrelevantType = "\"" + RandomTestUtil.randomString() + "\"";
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"objectEntryFolderCollaboratorByTypeCollaborator",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"objectEntryFolderId",
+									irrelevantObjectEntryFolderId);
+								put("type", irrelevantType);
+								put("collaboratorId", irrelevantCollaboratorId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"objectEntryFolderCollaboratorByTypeCollaborator",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"objectEntryFolderId",
+										irrelevantObjectEntryFolderId);
+									put("type", irrelevantType);
+									put(
+										"collaboratorId",
+										irrelevantCollaboratorId);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected Collaborator
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return testGraphQLCollaborator_addCollaborator();
 	}
 
 	@Test
@@ -363,6 +639,217 @@ public abstract class BaseCollaboratorResourceTestCase {
 		throws Exception {
 
 		return null;
+	}
+
+	@Test
+	public void testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator();
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					postCollaborator.getType(), postCollaborator.getId());
+
+		assertEquals(postCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator collaborator =
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator();
+
+		// No namespace
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"scopeKey",
+											"\"" +
+												testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey() +
+													"\"");
+
+										put(
+											"externalReferenceCode",
+											"\"" +
+												testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+													collaborator) + "\"");
+
+										put(
+											"type",
+											"\"" + collaborator.getType() +
+												"\"");
+
+										put(
+											"collaboratorId",
+											collaborator.getId());
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator"))));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertTrue(
+			equals(
+				collaborator,
+				CollaboratorSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"headlessObject_v1_0",
+								new GraphQLField(
+									"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+									new HashMap<String, Object>() {
+										{
+											put(
+												"scopeKey",
+												"\"" +
+													testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey() +
+														"\"");
+
+											put(
+												"externalReferenceCode",
+												"\"" +
+													testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+														collaborator) + "\"");
+
+											put(
+												"type",
+												"\"" + collaborator.getType() +
+													"\"");
+
+											put(
+												"collaboratorId",
+												collaborator.getId());
+										}
+									},
+									getGraphQLFields()))),
+						"JSONObject/data", "JSONObject/headlessObject_v1_0",
+						"Object/scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator"))));
+	}
+
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	@Test
+	public void testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaboratorNotFound()
+		throws Exception {
+
+		String irrelevantScopeKey = "\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantType = "\"" + RandomTestUtil.randomString() + "\"";
+		Long irrelevantCollaboratorId = RandomTestUtil.randomLong();
+
+		// No namespace
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+						new HashMap<String, Object>() {
+							{
+								put("scopeKey", irrelevantScopeKey);
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+								put("type", irrelevantType);
+								put("collaboratorId", irrelevantCollaboratorId);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		// Using the namespace headlessObject_v1_0
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"headlessObject_v1_0",
+						new GraphQLField(
+							"scopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator",
+							new HashMap<String, Object>() {
+								{
+									put("scopeKey", irrelevantScopeKey);
+									put(
+										"externalReferenceCode",
+										irrelevantExternalReferenceCode);
+									put("type", irrelevantType);
+									put(
+										"collaboratorId",
+										irrelevantCollaboratorId);
+								}
+							},
+							getGraphQLFields()))),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected Collaborator
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return testGraphQLCollaborator_addCollaborator();
 	}
 
 	@Test
@@ -600,6 +1087,114 @@ public abstract class BaseCollaboratorResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Test
+	public void testPutObjectEntryFolderCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator();
+
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putObjectEntryFolderCollaboratorByTypeCollaborator(
+					testPutObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					postCollaborator.getType(), postCollaborator.getId(),
+					randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getObjectEntryFolderCollaboratorByTypeCollaborator(
+					testPutObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId(),
+					putCollaborator.getType(), putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected Long
+			testPutObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator
+			testPutObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator();
+
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					postCollaborator.getType(), postCollaborator.getId(),
+					randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					putCollaborator.getExternalReferenceCode(),
+					putCollaborator.getType(), putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return collaborator.getExternalReferenceCode();
+	}
+
+	protected Collaborator
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Collaborator testGraphQLCollaborator_addCollaborator()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	protected void assertContains(
 		Collaborator collaborator, List<Collaborator> collaborators) {
 
@@ -670,6 +1265,10 @@ public abstract class BaseCollaboratorResourceTestCase {
 
 	protected void assertValid(Collaborator collaborator) throws Exception {
 		boolean valid = true;
+
+		if (collaborator.getId() == null) {
+			valid = false;
+		}
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
@@ -923,6 +1522,16 @@ public abstract class BaseCollaboratorResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						collaborator1.getId(), collaborator2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						collaborator1.getName(), collaborator2.getName())) {
@@ -1161,6 +1770,11 @@ public abstract class BaseCollaboratorResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("name")) {
 			Object object = collaborator.getName();
 
@@ -1259,8 +1873,49 @@ public abstract class BaseCollaboratorResourceTestCase {
 		}
 
 		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
+			Object object = collaborator.getType();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
 		}
 
 		throw new IllegalArgumentException(
@@ -1311,10 +1966,12 @@ public abstract class BaseCollaboratorResourceTestCase {
 				dateExpired = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				portrait = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				share = RandomTestUtil.randomBoolean();
+				type = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
 	}

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -45,6 +45,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,15 +65,19 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_objectEntryFolder = _addObjectEntryFolder();
+	}
+
 	@Override
 	@Test
 	public void testPostObjectEntryFolderCollaboratorsPage() throws Exception {
 		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
 
-		_addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+		_addUserCollaborator(objectEntryFolder);
 
 		Collaborator[] collaborators = {
 			_getUserCollaborator(), _getUserGroupCollaborator(),
@@ -94,10 +99,7 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
 
-		_addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+		_addUserCollaborator(objectEntryFolder);
 
 		Collaborator[] collaborators = {
 			_getUserCollaborator(), _getUserGroupCollaborator(),
@@ -116,27 +118,114 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		Collaborator postCollaborator =
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator();
+		Collaborator randomCollaborator = randomCollaborator();
+
+		Collaborator putCollaborator =
+			collaboratorResource.
+				putScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					randomCollaborator.getType(), postCollaborator.getId(),
+					randomCollaborator);
+
+		assertEquals(randomCollaborator, putCollaborator);
+		assertValid(putCollaborator);
+
+		Collaborator getCollaborator =
+			collaboratorResource.
+				getScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator(
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey(),
+					testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+						postCollaborator),
+					randomCollaborator.getType(), putCollaborator.getId());
+
+		assertEquals(randomCollaborator, getCollaborator);
+		assertValid(getCollaborator);
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {
-			"actionIds", "dateExpired", "externalReferenceCode", "name",
-			"share", "type"
-		};
+		return new String[] {"actionIds", "dateExpired", "share", "type"};
 	}
 
 	@Override
 	protected Collaborator randomCollaborator() throws Exception {
 		return new Collaborator() {
 			{
+				actionIds = new String[] {
+					SharingEntryAction.VIEW.getActionId()
+				};
 				dateExpired = _randomDatePlusAYear();
-				externalReferenceCode = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
-				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				portrait = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				share = RandomTestUtil.randomBoolean();
-				type = Type.USER;
+				type = "User";
 			}
 		};
+	}
+
+	@Override
+	protected Collaborator
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected Long
+			testDeleteObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testDeleteScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
+	@Override
+	protected Collaborator
+			testGetObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserGroupCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected Long
+			testGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
 	}
 
 	@Override
@@ -146,9 +235,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		throws Exception {
 
 		return _addUserGroupCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolderId);
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectEntryFolderId));
 	}
 
 	@Override
@@ -156,9 +244,32 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			testGetObjectEntryFolderCollaboratorsPage_getObjectEntryFolderId()
 		throws Exception {
 
-		ObjectEntryFolder objectEntryFolder = _addObjectEntryFolder();
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
 
-		return objectEntryFolder.getObjectEntryFolderId();
+	@Override
+	protected Collaborator
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
 	}
 
 	@Override
@@ -168,16 +279,11 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				Collaborator collaborator)
 		throws Exception {
 
-		ObjectEntryFolder objectEntryFolder =
+		return _addUserCollaborator(
 			_objectEntryFolderLocalService.
 				getObjectEntryFolderByExternalReferenceCode(
 					externalReferenceCode, testGroup.getGroupId(),
-					testCompany.getCompanyId());
-
-		return _addUserCollaborator(
-			_classNameLocalService.getClassNameId(
-				ObjectEntryFolder.class.getName()),
-			objectEntryFolder.getObjectEntryFolderId());
+					testCompany.getCompanyId()));
 	}
 
 	@Override
@@ -198,6 +304,79 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return testGroup.getGroupKey();
 	}
 
+	@Override
+	protected Collaborator testGraphQLCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected Long
+			testGraphQLGetObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testGraphQLGetScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
+	@Override
+	protected Collaborator
+			testPutObjectEntryFolderCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected Long
+			testPutObjectEntryFolderCollaboratorByTypeCollaborator_getObjectEntryFolderId()
+		throws Exception {
+
+		return _objectEntryFolder.getObjectEntryFolderId();
+	}
+
+	@Override
+	protected Collaborator
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_addCollaborator()
+		throws Exception {
+
+		return _addUserCollaborator(_objectEntryFolder);
+	}
+
+	@Override
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getExternalReferenceCode(
+				Collaborator collaborator)
+		throws Exception {
+
+		return _objectEntryFolder.getExternalReferenceCode();
+	}
+
+	@Override
+	protected String
+			testPutScopeScopeKeyObjectEntryFolderByExternalReferenceCodeCollaboratorByTypeCollaborator_getScopeKey()
+		throws Exception {
+
+		return testGroup.getGroupKey();
+	}
+
 	private ObjectEntryFolder _addObjectEntryFolder() throws Exception {
 		return _objectEntryFolderLocalService.addObjectEntryFolder(
 			null, TestPropsValues.getUserId(), testGroup.getGroupId(),
@@ -209,7 +388,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 			RandomTestUtil.randomString(), new ServiceContext());
 	}
 
-	private Collaborator _addUserCollaborator(long classNameId, long classPK)
+	private Collaborator _addUserCollaborator(
+			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
 		User user = _getUser();
@@ -217,14 +397,17 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
 				null, TestPropsValues.getUserId(), 0, user.getUserId(),
-				classNameId, classPK, testGroup.getGroupId(), true,
-				Arrays.asList(SharingEntryAction.VIEW), null,
+				_classNameLocalService.getClassNameId(
+					ObjectEntryFolder.class.getName()),
+				objectEntryFolder.getObjectEntryFolderId(),
+				objectEntryFolder.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), _randomDatePlusAYear(),
 				ServiceContextTestUtil.getServiceContext(
 					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
 
 	private Collaborator _addUserGroupCollaborator(
-			long classNameId, long classPK)
+			ObjectEntryFolder objectEntryFolder)
 		throws Exception {
 
 		UserGroup userGroup = _getUserGroup();
@@ -232,8 +415,12 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 		return _toCollaborator(
 			_sharingEntryLocalService.addSharingEntry(
 				null, TestPropsValues.getUserId(), userGroup.getUserGroupId(),
-				0, classNameId, classPK, testGroup.getGroupId(), true,
-				Arrays.asList(SharingEntryAction.VIEW), null,
+				0,
+				_classNameLocalService.getClassNameId(
+					ObjectEntryFolder.class.getName()),
+				objectEntryFolder.getObjectEntryFolderId(),
+				testGroup.getGroupId(), true,
+				Arrays.asList(SharingEntryAction.VIEW), _randomDatePlusAYear(),
 				ServiceContextTestUtil.getServiceContext(
 					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
@@ -269,9 +456,10 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				};
 				dateExpired = _randomDatePlusAYear();
 				externalReferenceCode = user.getExternalReferenceCode();
+				id = user.getUserId();
 				name = user.getFullName();
 				share = true;
-				type = Type.USER;
+				type = "User";
 			}
 		};
 	}
@@ -294,9 +482,10 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 				};
 				dateExpired = _randomDatePlusAYear();
 				externalReferenceCode = userGroup.getExternalReferenceCode();
+				id = userGroup.getUserGroupId();
 				name = userGroup.getName();
 				share = true;
-				type = Type.USER_GROUP;
+				type = "UserGroup";
 			}
 		};
 	}
@@ -325,9 +514,10 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 						SharingEntryAction::getActionId, String.class);
 					dateExpired = sharingEntry.getExpirationDate();
 					externalReferenceCode = user.getExternalReferenceCode();
+					id = user.getUserId();
 					name = user.getFullName();
 					share = sharingEntry.isShareable();
-					type = Type.USER;
+					type = "User";
 				}
 			};
 		}
@@ -343,9 +533,10 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 					SharingEntryAction::getActionId, String.class);
 				dateExpired = sharingEntry.getExpirationDate();
 				externalReferenceCode = userGroup.getExternalReferenceCode();
+				id = userGroup.getUserGroupId();
 				name = userGroup.getName();
 				share = sharingEntry.isShareable();
-				type = Type.USER_GROUP;
+				type = "UserGroup";
 			}
 		};
 	}
@@ -355,6 +546,8 @@ public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	private ObjectEntryFolder _objectEntryFolder;
 
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/CollaboratorResource.java
@@ -41,9 +41,30 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CollaboratorResource {
 
+	public void deleteObjectEntryCollaboratorByTypeCollaborator(
+			Long objectEntryId, String type, Long collaboratorId)
+		throws Exception;
+
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByTypeCollaborator(
+				Long objectEntryId, String type, Long collaboratorId)
+		throws Exception;
+
 	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
 			getObjectEntryCollaboratorsPage(
 				Long objectEntryId, Pagination pagination)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
 		throws Exception;
 
 	public Page<com.liferay.headless.object.dto.v1_0.Collaborator>
@@ -69,6 +90,19 @@ public interface CollaboratorResource {
 				String scopeKey, String externalReferenceCode,
 				com.liferay.headless.object.dto.v1_0.Collaborator[]
 					collaborators)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByTypeCollaborator(
+				Long objectEntryId, String type, Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception;
+
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -896,7 +896,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
-            operationId: deleteScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -928,7 +928,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
-            operationId: getScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -976,7 +976,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            operationId: putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: scopeKey
@@ -1407,7 +1407,7 @@ paths:
         delete:
             description:
                 Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
-            operationId: deleteObjectEntryCollaborator
+            operationId: deleteObjectEntryCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -1435,7 +1435,7 @@ paths:
         get:
             description:
                 Retrieves the collaborator for an object entry.
-            operationId: getObjectEntryCollaborator
+            operationId: getObjectEntryCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId
@@ -1479,7 +1479,7 @@ paths:
         put:
             description:
                 Add or update a collaborator received in the request.
-            operationId: putObjectEntryCollaborator
+            operationId: putObjectEntryCollaboratorByTypeCollaborator
             parameters:
                 -   in: path
                     name: objectEntryId

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -892,6 +892,131 @@ paths:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
             tags: ["Collaborator"]
+    "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            operationId: getScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putScopeScopeKeyObjectEntryByExternalReferenceCodeCollaborator
+            parameters:
+                -   in: path
+                    name: scopeKey
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                    application/xml:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/object-actions/{objectActionName}":
         put:
             operationId: putScopeScopeKeyByExternalReferenceCodeObjectActionObjectActionName
@@ -1277,6 +1402,119 @@ paths:
                                 items:
                                     $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
                                 type: array
+            tags: ["Collaborator"]
+    "/{objectEntryId}/collaborators/by-type/{type}/{collaboratorId}":
+        delete:
+            description:
+                Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.
+            operationId: deleteObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["Collaborator"]
+        get:
+            description:
+                Retrieves the collaborator for an object entry.
+            operationId: getObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: nestedFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            tags: ["Collaborator"]
+        put:
+            description:
+                Add or update a collaborator received in the request.
+            operationId: putObjectEntryCollaborator
+            parameters:
+                -   in: path
+                    name: objectEntryId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: path
+                    name: type
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: collaboratorId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                    application/xml:
+                        schema:
+                            $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
+                        application/xml:
+                            schema:
+                                $ref: ../../headless/headless-object/headless-object-impl/rest-openapi.yaml#Collaborator
             tags: ["Collaborator"]
     "/{objectEntryId}/object-actions/{objectActionName}":
         put:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseCollaboratorResourceImpl.java
@@ -67,6 +67,162 @@ public abstract class BaseCollaboratorResourceImpl
 				   <com.liferay.headless.object.dto.v1_0.Collaborator> {
 
 	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteObjectEntryCollaboratorByTypeCollaborator(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("type")
+			String type,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("collaboratorId")
+			Long collaboratorId)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getObjectEntryCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
 		description = "Retrieves the collaborators of an object entry."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -114,6 +270,73 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the collaborator for an object entry."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@io.swagger.v3.oas.annotations.Operation(
@@ -313,6 +536,112 @@ public abstract class BaseCollaboratorResourceImpl
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/{objectEntryId}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putObjectEntryCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("objectEntryId")
+				Long objectEntryId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
+	}
+
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Add or update a collaborator received in the request."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "type"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "collaboratorId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Collaborator")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public com.liferay.headless.object.dto.v1_0.Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("type")
+				String type,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("collaboratorId")
+				Long collaboratorId,
+				com.liferay.headless.object.dto.v1_0.Collaborator collaborator)
+		throws Exception {
+
+		return new com.liferay.headless.object.dto.v1_0.Collaborator();
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CollaboratorResourceImpl.java
@@ -50,6 +50,69 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 	}
 
 	@Override
+	public void deleteObjectEntryCollaboratorByTypeCollaborator(
+			Long objectEntryId, String type, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			_sharingEntryService, type);
+	}
+
+	@Override
+	public void
+			deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		CollaboratorUtil.deleteCollaborator(
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			_sharingEntryService, type);
+	}
+
+	@Override
+	public Collaborator getObjectEntryCollaboratorByTypeCollaborator(
+			Long objectEntryId, String type, Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, type, contextUriInfo, contextUser);
+	}
+
+	@Override
 	public Page<Collaborator> getObjectEntryCollaboratorsPage(
 			Long objectEntryId, Pagination pagination)
 		throws Exception {
@@ -58,8 +121,42 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryCollaboratorsPage(
-			_objectEntryLocalService.getObjectEntry(objectEntryId), pagination);
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
+	}
+
+	@Override
+	public Collaborator
+			getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.getCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			_sharingEntryService, type, contextUriInfo, contextUser);
 	}
 
 	@Override
@@ -73,13 +170,19 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _getObjectEntryCollaboratorsPage(
-			_objectEntryLocalService.getObjectEntry(
-				externalReferenceCode, contextCompany.getCompanyId(),
-				CollaboratorUtil.getGroupId(
-					contextCompany.getCompanyId(), _groupLocalService,
-					scopeKey)),
-			pagination);
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.getCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), _collaboratorDTOConverter,
+			_dtoConverterRegistry, objectEntry.getGroupId(), pagination,
+			_sharingEntryLocalService, _sharingEntryService, contextUriInfo,
+			contextUser);
 	}
 
 	@Override
@@ -91,9 +194,17 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryCollaboratorsPage(
-			collaborators,
-			_objectEntryLocalService.getObjectEntry(objectEntryId));
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.addOrUpdateCollaborators(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborators,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
 	}
 
 	@Override
@@ -107,48 +218,70 @@ public class CollaboratorResourceImpl extends BaseCollaboratorResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _postObjectEntryCollaboratorsPage(
-			collaborators,
-			_objectEntryLocalService.getObjectEntry(
-				externalReferenceCode, contextCompany.getCompanyId(),
-				CollaboratorUtil.getGroupId(
-					contextCompany.getCompanyId(), _groupLocalService,
-					scopeKey)));
-	}
-
-	private Page<Collaborator> _getObjectEntryCollaboratorsPage(
-		ObjectEntry objectEntry, Pagination pagination) {
-
-		long classNameId = _classNameLocalService.getClassNameId(
-			objectEntry.getModelClassName());
-
-		return Page.of(
-			transform(
-				_sharingEntryLocalService.getSharingEntries(
-					classNameId, objectEntry.getObjectEntryId(),
-					pagination.getStartPosition(), pagination.getEndPosition()),
-				sharingEntry -> CollaboratorUtil.toCollaborator(
-					contextAcceptLanguage, _collaboratorDTOConverter,
-					_dtoConverterRegistry, sharingEntry, contextUriInfo,
-					contextUser)),
-			pagination,
-			_sharingEntryLocalService.getSharingEntriesCount(
-				classNameId, objectEntry.getObjectEntryId()));
-	}
-
-	private Page<Collaborator> _postObjectEntryCollaboratorsPage(
-			Collaborator[] collaborators, ObjectEntry objectEntry)
-		throws Exception {
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
 
 		return CollaboratorUtil.addOrUpdateCollaborators(
 			contextAcceptLanguage,
 			_classNameLocalService.getClassNameId(
 				objectEntry.getModelClassName()),
 			objectEntry.getObjectEntryId(), collaborators,
-			contextCompany.getCompanyId(), _collaboratorDTOConverter,
-			_dtoConverterRegistry, objectEntry.getGroupId(),
-			_sharingEntryService, contextUriInfo, contextUser,
-			_userGroupLocalService, _userLocalService);
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, contextUriInfo,
+			contextUser, _userGroupLocalService, _userLocalService);
+	}
+
+	@Override
+	public Collaborator putObjectEntryCollaboratorByTypeCollaborator(
+			Long objectEntryId, String type, Long collaboratorId,
+			Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, type,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
+	}
+
+	@Override
+	public Collaborator
+			putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator(
+				String scopeKey, String externalReferenceCode, String type,
+				Long collaboratorId, Collaborator collaborator)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			externalReferenceCode, contextCompany.getCompanyId(),
+			CollaboratorUtil.getGroupId(
+				contextCompany.getCompanyId(), _groupLocalService, scopeKey));
+
+		return CollaboratorUtil.addOrUpdateCollaborator(
+			contextAcceptLanguage,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), collaborator, collaboratorId,
+			_collaboratorDTOConverter, _dtoConverterRegistry,
+			objectEntry.getGroupId(), _sharingEntryService, type,
+			_userGroupLocalService, contextUriInfo, contextUser,
+			_userLocalService);
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -415,6 +415,17 @@ public class CollaboratorResourceTest {
 				continue;
 			}
 
+			if (Objects.equals(assertFieldName, "id")) {
+				if (!StringUtil.equals(
+						jsonObject1.getString("id"),
+						jsonObject2.getString("id"))) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(assertFieldName, "name")) {
 				if (!StringUtil.equals(
 						jsonObject1.getString("name"),
@@ -468,6 +479,8 @@ public class CollaboratorResourceTest {
 		).put(
 			"externalReferenceCode", user.getExternalReferenceCode()
 		).put(
+			"id", user.getUserId()
+		).put(
 			"name", user.getFullName()
 		).put(
 			"share", true
@@ -495,6 +508,8 @@ public class CollaboratorResourceTest {
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
 		).put(
 			"externalReferenceCode", userGroup.getExternalReferenceCode()
+		).put(
+			"id", userGroup.getUserGroupId()
 		).put(
 			"name", userGroup.getName()
 		).put(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -40,7 +39,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.sharing.security.permission.SharingEntryAction;
-import com.liferay.sharing.service.SharingEntryLocalService;
 
 import java.io.Serializable;
 
@@ -533,12 +531,6 @@ public class CollaboratorResourceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Inject
-	private Portal _portal;
-
-	@Inject
-	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups = new ArrayList<>();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -88,6 +88,55 @@ public class CollaboratorResourceTest {
 	}
 
 	@Test
+	public void testDeleteObjectEntryCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertDeleteObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				user.getUserId()),
+			user);
+	}
+
+	@Test
+	public void testDeleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertDeleteObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/User/", user.getUserId()),
+			user);
+	}
+
+	@Test
+	public void testGetObjectEntryCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertGetObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators/by-type/User/",
+				user.getUserId()),
+			user);
+	}
+
+	@Test
 	public void testGetObjectEntryCollaboratorsPage() throws Exception {
 		JSONArray jsonArray = JSONUtil.putAll(
 			_getUserCollaboratorJSONObject(),
@@ -110,6 +159,23 @@ public class CollaboratorResourceTest {
 			Http.Method.GET);
 
 		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testGetScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		User user = _getUser();
+
+		_assertGetObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/User/", user.getUserId()),
+			user);
 	}
 
 	@Test
@@ -179,6 +245,41 @@ public class CollaboratorResourceTest {
 		_assertEquals(jsonArray, jsonObject.getJSONArray("items"));
 	}
 
+	@Test
+	public void testPutObjectEntryCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		UserGroup userGroup = _getUserGroup();
+
+		_assertPutObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(),
+				"/collaborators/by-type/UserGroup/",
+				userGroup.getUserGroupId()),
+			userGroup);
+	}
+
+	@Test
+	public void testPutScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		UserGroup userGroup = _getUserGroup();
+
+		_assertPutObjectEntryCollaborator(
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), "/scopes/",
+				_group.getGroupId(), "/by-external-reference-code/",
+				objectEntry.getExternalReferenceCode(),
+				"/collaborators/by-type/UserGroup/",
+				userGroup.getUserGroupId()),
+			userGroup);
+	}
+
 	private static ObjectDefinition _getObjectDefinition() throws Exception {
 		return ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
@@ -228,6 +329,25 @@ public class CollaboratorResourceTest {
 		Assert.assertTrue(contains);
 	}
 
+	private void _assertDeleteObjectEntryCollaborator(
+			String endPoint, User user)
+		throws Exception {
+
+		JSONObject jsonObject1 = _getUserCollaboratorJSONObject(user);
+
+		_assertEquals(
+			jsonObject1,
+			HTTPTestUtil.invokeToJSONObject(
+				jsonObject1.toString(), endPoint, Http.Method.PUT));
+
+		HTTPTestUtil.invokeToJSONObject(null, endPoint, Http.Method.DELETE);
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			null, endPoint, Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject2.getString("status"));
+	}
+
 	private void _assertEquals(
 		JSONArray actualJSONArray, JSONArray expectedJSONArray) {
 
@@ -238,6 +358,37 @@ public class CollaboratorResourceTest {
 			_assertContains(
 				actualJSONArray, expectedJSONArray.getJSONObject(i));
 		}
+	}
+
+	private void _assertEquals(JSONObject jsonObject1, JSONObject jsonObject2) {
+		Assert.assertTrue(_equals(jsonObject1, jsonObject2));
+	}
+
+	private void _assertGetObjectEntryCollaborator(String endpoint, User user)
+		throws Exception {
+
+		JSONObject jsonObject = _getUserCollaboratorJSONObject(user);
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonObject.toString(), endpoint, Http.Method.PUT);
+
+		_assertEquals(
+			jsonObject,
+			HTTPTestUtil.invokeToJSONObject(null, endpoint, Http.Method.GET));
+	}
+
+	private void _assertPutObjectEntryCollaborator(
+			String endPoint, UserGroup userGroup)
+		throws Exception {
+
+		JSONObject jsonObject = _getUserGroupCollaboratorJSONObject(userGroup);
+
+		HTTPTestUtil.invokeToJSONObject(
+			jsonObject.toString(), endPoint, Http.Method.PUT);
+
+		_assertEquals(
+			jsonObject,
+			HTTPTestUtil.invokeToJSONObject(null, endPoint, Http.Method.GET));
 	}
 
 	private boolean _equals(JSONObject jsonObject1, JSONObject jsonObject2) {
@@ -306,7 +457,11 @@ public class CollaboratorResourceTest {
 	}
 
 	private JSONObject _getUserCollaboratorJSONObject() throws Exception {
-		User user = _getUser();
+		return _getUserCollaboratorJSONObject(_getUser());
+	}
+
+	private JSONObject _getUserCollaboratorJSONObject(User user)
+		throws Exception {
 
 		return JSONUtil.put(
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())
@@ -330,7 +485,11 @@ public class CollaboratorResourceTest {
 	}
 
 	private JSONObject _getUserGroupCollaboratorJSONObject() throws Exception {
-		UserGroup userGroup = _getUserGroup();
+		return _getUserGroupCollaboratorJSONObject(_getUserGroup());
+	}
+
+	private JSONObject _getUserGroupCollaboratorJSONObject(UserGroup userGroup)
+		throws Exception {
 
 		return JSONUtil.put(
 			"actionIds", JSONUtil.put(SharingEntryAction.VIEW.getActionId())

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -2502,6 +2503,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -3039,6 +3245,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1961,6 +1962,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2498,6 +2704,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -2014,6 +2015,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2551,6 +2757,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1627,6 +1628,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -2164,6 +2370,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object9Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject9CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject9CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject9CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -2980,6 +2981,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/validate": {
 			"post": {
 				"operationId": "postValidate",
@@ -3517,6 +3723,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object2Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject2CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject2CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject2CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -90,7 +90,13 @@
 					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
+						"readOnly": true,
 						"type": "string"
+					},
+					"id": {
+						"description": "The collaborator ID.",
+						"format": "int64",
+						"type": "integer"
 					},
 					"name": {
 						"description": "The collaborator name.",
@@ -108,10 +114,6 @@
 					},
 					"type": {
 						"description": "The collaborator type.",
-						"enum": [
-							"User",
-							"UserGroup"
-						],
 						"example": "User",
 						"type": "string"
 					},
@@ -123,7 +125,6 @@
 				},
 				"required": [
 					"actionIds",
-					"externalReferenceCode",
 					"type"
 				],
 				"type": "object",
@@ -1339,6 +1340,211 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/validate": {
 			"post": {
 				"operationId": "postScopeScopeKeyValidate",
@@ -1886,6 +2092,187 @@
 							"application/xml": {
 								"schema": {
 									"$ref": "#/components/schemas/PageCollaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
+		"/{object8Id}/collaborators/by-type/{type}/{collaboratorId}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject8CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject8CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject8CollaboratorByTypeCollaborator",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "collaboratorId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
 								}
 							}
 						},

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryService.java
@@ -101,6 +101,10 @@ public interface SharingEntryService extends BaseService {
 		throws PortalException;
 
 	public SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException;
+
+	public SharingEntry deleteSharingEntry(
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException;
 
@@ -130,6 +134,11 @@ public interface SharingEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SharingEntry getSharingEntry(long sharingEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceUtil.java
@@ -103,6 +103,14 @@ public class SharingEntryServiceUtil {
 	}
 
 	public static SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		return getService().deleteSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
+	}
+
+	public static SharingEntry deleteSharingEntry(
 			long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
@@ -153,6 +161,14 @@ public class SharingEntryServiceUtil {
 		throws PortalException {
 
 		return getService().getSharingEntry(sharingEntryId);
+	}
+
+	public static SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		return getService().getSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	public static SharingEntry getSharingEntryByExternalReferenceCode(

--- a/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
+++ b/modules/apps/sharing/sharing-api/src/main/java/com/liferay/sharing/service/SharingEntryServiceWrapper.java
@@ -100,6 +100,15 @@ public class SharingEntryServiceWrapper
 
 	@Override
 	public com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.deleteSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
+	}
+
+	@Override
+	public com.liferay.sharing.model.SharingEntry deleteSharingEntry(
 			long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -163,6 +172,15 @@ public class SharingEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _sharingEntryService.getSharingEntry(sharingEntryId);
+	}
+
+	@Override
+	public com.liferay.sharing.model.SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _sharingEntryService.getSharingEntry(
+			toUserGroupId, toUserId, classNameId, classPK);
 	}
 
 	@Override

--- a/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
+++ b/modules/apps/sharing/sharing-api/src/main/resources/com/liferay/sharing/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/http/SharingEntryServiceHttp.java
@@ -141,6 +141,47 @@ public class SharingEntryServiceHttp {
 	}
 
 	public static com.liferay.sharing.model.SharingEntry deleteSharingEntry(
+			HttpPrincipal httpPrincipal, long toUserGroupId, long toUserId,
+			long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "deleteSharingEntry",
+				_deleteSharingEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, toUserGroupId, toUserId, classNameId, classPK);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.sharing.model.SharingEntry deleteSharingEntry(
 			HttpPrincipal httpPrincipal, long sharingEntryId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -148,7 +189,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "deleteSharingEntry",
-				_deleteSharingEntryParameterTypes2);
+				_deleteSharingEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, serviceContext);
@@ -189,7 +230,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "deleteSharingEntry",
-				_deleteSharingEntryParameterTypes3);
+				_deleteSharingEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntry);
@@ -232,7 +273,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"deleteSharingEntryByExternalReferenceCode",
-				_deleteSharingEntryByExternalReferenceCodeParameterTypes4);
+				_deleteSharingEntryByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -275,7 +316,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"fetchSharingEntryByExternalReferenceCode",
-				_fetchSharingEntryByExternalReferenceCodeParameterTypes5);
+				_fetchSharingEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -317,7 +358,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "getSharingEntries",
-				_getSharingEntriesParameterTypes6);
+				_getSharingEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, classNameId, classPK, groupId, start, end);
@@ -358,10 +399,51 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "getSharingEntry",
-				_getSharingEntryParameterTypes7);
+				_getSharingEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.sharing.model.SharingEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.sharing.model.SharingEntry getSharingEntry(
+			HttpPrincipal httpPrincipal, long toUserGroupId, long toUserId,
+			long classNameId, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SharingEntryServiceUtil.class, "getSharingEntry",
+				_getSharingEntryParameterTypes9);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, toUserGroupId, toUserId, classNameId, classPK);
 
 			Object returnObj = null;
 
@@ -401,7 +483,7 @@ public class SharingEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class,
 				"getSharingEntryByExternalReferenceCode",
-				_getSharingEntryByExternalReferenceCodeParameterTypes8);
+				_getSharingEntryByExternalReferenceCodeParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -446,7 +528,7 @@ public class SharingEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SharingEntryServiceUtil.class, "updateSharingEntry",
-				_updateSharingEntryParameterTypes9);
+				_updateSharingEntryParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, sharingEntryId, sharingEntryActions, shareable,
@@ -498,27 +580,31 @@ public class SharingEntryServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteSharingEntryParameterTypes2 =
+		new Class[] {long.class, long.class, long.class, long.class};
+	private static final Class<?>[] _deleteSharingEntryParameterTypes3 =
 		new Class[] {
 			long.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteSharingEntryParameterTypes3 =
+	private static final Class<?>[] _deleteSharingEntryParameterTypes4 =
 		new Class[] {com.liferay.sharing.model.SharingEntry.class};
 	private static final Class<?>[]
-		_deleteSharingEntryByExternalReferenceCodeParameterTypes4 =
+		_deleteSharingEntryByExternalReferenceCodeParameterTypes5 =
 			new Class[] {String.class, long.class};
 	private static final Class<?>[]
-		_fetchSharingEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+		_fetchSharingEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getSharingEntriesParameterTypes6 =
+	private static final Class<?>[] _getSharingEntriesParameterTypes7 =
 		new Class[] {long.class, long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getSharingEntryParameterTypes7 =
+	private static final Class<?>[] _getSharingEntryParameterTypes8 =
 		new Class[] {long.class};
+	private static final Class<?>[] _getSharingEntryParameterTypes9 =
+		new Class[] {long.class, long.class, long.class, long.class};
 	private static final Class<?>[]
-		_getSharingEntryByExternalReferenceCodeParameterTypes8 = new Class[] {
+		_getSharingEntryByExternalReferenceCodeParameterTypes10 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _updateSharingEntryParameterTypes9 =
+	private static final Class<?>[] _updateSharingEntryParameterTypes11 =
 		new Class[] {
 			long.class, java.util.Collection.class, boolean.class,
 			java.util.Date.class,

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -122,6 +122,21 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 
 	@Override
 	public SharingEntry deleteSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
+
+		sharingPermission.checkManageCollaboratorsPermission(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId());
+
+		return sharingEntryLocalService.deleteSharingEntry(sharingEntry);
+	}
+
+	@Override
+	public SharingEntry deleteSharingEntry(
 			long sharingEntryId, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -187,6 +202,22 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 
 		SharingEntry sharingEntry = sharingEntryLocalService.getSharingEntry(
 			sharingEntryId);
+
+		sharingPermission.check(
+			getPermissionChecker(), sharingEntry.getClassNameId(),
+			sharingEntry.getClassPK(), sharingEntry.getGroupId(),
+			Collections.singletonList(SharingEntryAction.VIEW));
+
+		return sharingEntry;
+	}
+
+	@Override
+	public SharingEntry getSharingEntry(
+			long toUserGroupId, long toUserId, long classNameId, long classPK)
+		throws PortalException {
+
+		SharingEntry sharingEntry = sharingEntryPersistence.findByTUG_TU_C_C(
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		sharingPermission.check(
 			getPermissionChecker(), sharingEntry.getClassNameId(),

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/service/impl/SharingEntryServiceImpl.java
@@ -68,7 +68,7 @@ public class SharingEntryServiceImpl extends SharingEntryServiceBaseImpl {
 		throws PortalException {
 
 		SharingEntry sharingEntry = sharingEntryPersistence.fetchByTUG_TU_C_C(
-			0, toUserId, classNameId, classPK);
+			toUserGroupId, toUserId, classNameId, classPK);
 
 		if (sharingEntry == null) {
 			return sharingEntryService.addSharingEntry(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52794

# How am I fixing it?

Add individual headless apis to manage a sharing entry for an object entry folder and an object entry. So, with these apis you can add, update, get and delete a collaborator for an object entry or a object folder. Add and update have been merged into the PUT method following headless recommendations, for more info please see : https://liferay.slack.com/archives/C08N71T5VGT/p1744646885361209

# How can you verify that it works?

Run included tests