### PR TITLE
LPD-55865 Fix Articles Count

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1567,47 +1567,38 @@ public class JournalDisplayContext {
 
 		int delta = end - start;
 
+		List<Document> documents = new ArrayList<>();
+
 		SearchResponse journalFolderSearchResponse =
 			JournalSearcherUtil.searchJournalFolders(
 				searchContext -> _populateSearchContext(
 					start, end, searchContext, false));
 
-		int articlesCount;
-		List<Document> documents = new ArrayList<>();
 		int foldersCount = journalFolderSearchResponse.getTotalHits();
 
+		int journalArticlesStart = start - foldersCount;
+
+		int journalArticlesEnd = delta + journalArticlesStart;
+
 		if (start < foldersCount) {
-			List<Document> folderDocuments =
-				journalFolderSearchResponse.getDocuments71();
+			documents.addAll(journalFolderSearchResponse.getDocuments71());
 
-			documents.addAll(
-				folderDocuments.subList(start, Math.min(end, foldersCount)));
+			journalArticlesEnd = Math.max(1, delta - documents.size());
 
-			SearchResponse articleSearchResponse =
-				_getJournalArticleSearchResponse(0, delta - documents.size());
-
-			articlesCount = articleSearchResponse.getTotalHits();
-
-			if (delta > documents.size()) {
-				documents.addAll(articleSearchResponse.getDocuments71());
-			}
+			journalArticlesStart = 0;
 		}
-		else {
-			int journalArticlesStart = start - foldersCount;
 
-			SearchResponse articleSearchResponse =
-				_getJournalArticleSearchResponse(
-					journalArticlesStart, delta + journalArticlesStart);
+		SearchResponse articleSearchResponse = _getJournalArticleSearchResponse(
+			journalArticlesStart, journalArticlesEnd);
 
+		if (documents.size() < delta) {
 			documents.addAll(articleSearchResponse.getDocuments71());
-
-			articlesCount = articleSearchResponse.getTotalHits();
 		}
 
 		articleAndFolderSearchContainer.setResultsAndTotal(
 			() -> JournalSearcherUtil.transformJournalArticleAndFolders(
 				documents),
-			articlesCount + foldersCount);
+			articleSearchResponse.getTotalHits() + foldersCount);
 
 		_articleSearchContainer = articleAndFolderSearchContainer;
 


### PR DESCRIPTION
**Continuation PR for [#6647](https://github.com/liferay-content-management/liferay-portal/pull/6647)**

### **What is this trying to solve?**
This PR addresses a bug introduced in the previous PR, where Web Content folders were not rendered correctly when the total number of folders exceeded the configured delta value.

### **How am I fixing it?**
The issue occurred due to improper handling of pagination logic for Web Contents. This fix ensures that all web contents are accurately retrieved and displayed when the count surpasses the delta limit.