### PR TITLE
LPD-56625 The "Show Columns" setting in the D&M widget does not reflect the "Document Type" setting correctly

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/helper/DLPortletInstanceSettingsHelper.java
@@ -227,7 +227,7 @@ public class DLPortletInstanceSettingsHelper {
 	}
 
 	private String[] _getAllEntryColumns() {
-		String allEntryColumns = "name,description,size,status";
+		String allEntryColumns = "name,description,document-type,size,status";
 
 		if (ViewCountManagerUtil.isViewCountEnabled(
 				ClassNameLocalServiceUtil.getClassNameId(


### PR DESCRIPTION
The "Show Columns" setting in the D&M widget does not reflect the "Document Type" setting correctly

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-56625)

Document type is lost when moving to available columns

# How am I fixing it?

Add the entry to the list, seems this was left out during development

# How can you verify that it works?

Follow the steps in the ticket
