### PR TITLE
LPD-55446 Technical Task | Add Service layer to AssetVocabulary and AssetCategory with permissions checks - Only check ADD permission if do not exists

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.asset.categories.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.exception.NoSuchCategoryException;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetCategoryService;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
@@ -44,9 +46,12 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -141,6 +146,25 @@ public class AssetCategoryServiceTest {
 			catch (PrincipalException.MustHavePermission principalException) {
 				Assert.assertNotNull(principalException);
 			}
+
+			// Without resource permission existing category
+
+			String externalReferenceCode = RandomTestUtil.randomString();
+
+			_assetCategoryLocalService.addCategory(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				_group.getGroupId(),
+				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.US, RandomTestUtil.randomString()),
+				_assetVocabulary.getVocabularyId(), null, new ServiceContext());
+
+			assetCategory = _assetCategoryService.getOrAddIncompleteCategory(
+				externalReferenceCode, _group.getGroupId());
+
+			Assert.assertNotNull(assetCategory);
 		}
 	}
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryServiceTest.java
@@ -147,7 +147,7 @@ public class AssetCategoryServiceTest {
 				Assert.assertNotNull(principalException);
 			}
 
-			// Without resource permission existing category
+			// Without permissions, existing category
 
 			String externalReferenceCode = RandomTestUtil.randomString();
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -550,7 +550,7 @@ public class AssetVocabularyServiceTest {
 				Assert.assertNotNull(principalException);
 			}
 
-			// Without resource permission existing vocabulary
+			// Without permissions, existing vocabulary
 
 			String externalReferenceCode = RandomTestUtil.randomString();
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetVocabularyServiceTest.java
@@ -549,6 +549,26 @@ public class AssetVocabularyServiceTest {
 			catch (PrincipalException.MustHavePermission principalException) {
 				Assert.assertNotNull(principalException);
 			}
+
+			// Without resource permission existing vocabulary
+
+			String externalReferenceCode = RandomTestUtil.randomString();
+
+			_assetVocabularyLocalService.addVocabulary(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.SPAIN, RandomTestUtil.randomString()
+				).build(),
+				null, null, AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+			vocabulary = _assetVocabularyService.getOrAddIncompleteVocabulary(
+				externalReferenceCode, _group.getGroupId());
+
+			Assert.assertNotNull(vocabulary);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
@@ -384,6 +384,49 @@ public class AssetVocabularyServiceHttp {
 	}
 
 	public static com.liferay.asset.kernel.model.AssetVocabulary
+			fetchVocabularyByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AssetVocabularyServiceUtil.class,
+				"fetchVocabularyByExternalReferenceCode",
+				_fetchVocabularyByExternalReferenceCodeParameterTypes8);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.asset.kernel.model.AssetVocabulary)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.asset.kernel.model.AssetVocabulary
 			getAssetVocabularyByExternalReferenceCode(
 				HttpPrincipal httpPrincipal, long groupId,
 				String externalReferenceCode)
@@ -393,7 +436,7 @@ public class AssetVocabularyServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class,
 				"getAssetVocabularyByExternalReferenceCode",
-				_getAssetVocabularyByExternalReferenceCodeParameterTypes8);
+				_getAssetVocabularyByExternalReferenceCodeParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -432,7 +475,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupsVocabularies",
-				_getGroupsVocabulariesParameterTypes9);
+				_getGroupsVocabulariesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -466,7 +509,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupsVocabularies",
-				_getGroupsVocabulariesParameterTypes10);
+				_getGroupsVocabulariesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, className);
@@ -501,7 +544,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupsVocabularies",
-				_getGroupsVocabulariesParameterTypes11);
+				_getGroupsVocabulariesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, className, classTypePK);
@@ -535,7 +578,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes12);
+				_getGroupVocabulariesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -577,7 +620,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes13);
+				_getGroupVocabulariesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, createDefaultVocabulary);
@@ -623,7 +666,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes14);
+				_getGroupVocabulariesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, createDefaultVocabulary, start, end,
@@ -665,7 +708,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes15);
+				_getGroupVocabulariesParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, visibilityType);
@@ -702,7 +745,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes16);
+				_getGroupVocabulariesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end, orderByComparator);
@@ -740,7 +783,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes17);
+				_getGroupVocabulariesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, start, end, orderByComparator);
@@ -773,7 +816,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes18);
+				_getGroupVocabulariesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -808,7 +851,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabularies",
-				_getGroupVocabulariesParameterTypes19);
+				_getGroupVocabulariesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, visibilityTypes);
@@ -841,7 +884,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabulariesCount",
-				_getGroupVocabulariesCountParameterTypes20);
+				_getGroupVocabulariesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -872,7 +915,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabulariesCount",
-				_getGroupVocabulariesCountParameterTypes21);
+				_getGroupVocabulariesCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name);
@@ -904,7 +947,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabulariesCount",
-				_getGroupVocabulariesCountParameterTypes22);
+				_getGroupVocabulariesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -942,7 +985,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabulariesDisplay",
-				_getGroupVocabulariesDisplayParameterTypes23);
+				_getGroupVocabulariesDisplayParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, start, end, addDefaultVocabulary,
@@ -989,7 +1032,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getGroupVocabulariesDisplay",
-				_getGroupVocabulariesDisplayParameterTypes24);
+				_getGroupVocabulariesDisplayParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, start, end, orderByComparator);
@@ -1033,7 +1076,7 @@ public class AssetVocabularyServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class,
 				"getOrAddIncompleteVocabulary",
-				_getOrAddIncompleteVocabularyParameterTypes25);
+				_getOrAddIncompleteVocabularyParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId);
@@ -1073,7 +1116,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "getVocabulary",
-				_getVocabularyParameterTypes26);
+				_getVocabularyParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, vocabularyId);
@@ -1115,7 +1158,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "searchVocabulariesDisplay",
-				_searchVocabulariesDisplayParameterTypes27);
+				_searchVocabulariesDisplayParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, title, addDefaultVocabulary, start, end);
@@ -1159,7 +1202,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "searchVocabulariesDisplay",
-				_searchVocabulariesDisplayParameterTypes28);
+				_searchVocabulariesDisplayParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, title, addDefaultVocabulary, start, end,
@@ -1205,7 +1248,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "updateVocabulary",
-				_updateVocabularyParameterTypes29);
+				_updateVocabularyParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, vocabularyId, titleMap, descriptionMap, settings);
@@ -1249,7 +1292,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "updateVocabulary",
-				_updateVocabularyParameterTypes30);
+				_updateVocabularyParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, vocabularyId, titleMap, descriptionMap, settings,
@@ -1295,7 +1338,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AssetVocabularyServiceUtil.class, "updateVocabulary",
-				_updateVocabularyParameterTypes31);
+				_updateVocabularyParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, vocabularyId, title, titleMap, descriptionMap,
@@ -1369,80 +1412,84 @@ public class AssetVocabularyServiceHttp {
 	private static final Class<?>[] _fetchVocabularyParameterTypes7 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getAssetVocabularyByExternalReferenceCodeParameterTypes8 =
+		_fetchVocabularyByExternalReferenceCodeParameterTypes8 = new Class[] {
+			String.class, long.class
+		};
+	private static final Class<?>[]
+		_getAssetVocabularyByExternalReferenceCodeParameterTypes9 =
 			new Class[] {long.class, String.class};
-	private static final Class<?>[] _getGroupsVocabulariesParameterTypes9 =
-		new Class[] {long[].class};
 	private static final Class<?>[] _getGroupsVocabulariesParameterTypes10 =
-		new Class[] {long[].class, String.class};
+		new Class[] {long[].class};
 	private static final Class<?>[] _getGroupsVocabulariesParameterTypes11 =
+		new Class[] {long[].class, String.class};
+	private static final Class<?>[] _getGroupsVocabulariesParameterTypes12 =
 		new Class[] {long[].class, String.class, long.class};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes12 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getGroupVocabulariesParameterTypes13 =
-		new Class[] {long.class, boolean.class};
+		new Class[] {long.class};
 	private static final Class<?>[] _getGroupVocabulariesParameterTypes14 =
+		new Class[] {long.class, boolean.class};
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes15 =
 		new Class[] {
 			long.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes15 =
-		new Class[] {long.class, int.class};
 	private static final Class<?>[] _getGroupVocabulariesParameterTypes16 =
+		new Class[] {long.class, int.class};
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes17 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes17 =
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes18 =
 		new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes18 =
-		new Class[] {long[].class};
 	private static final Class<?>[] _getGroupVocabulariesParameterTypes19 =
+		new Class[] {long[].class};
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes20 =
 		new Class[] {long[].class, int[].class};
-	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes20 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes21 =
-		new Class[] {long.class, String.class};
+		new Class[] {long.class};
 	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes22 =
+		new Class[] {long.class, String.class};
+	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes23 =
 		new Class[] {long[].class};
 	private static final Class<?>[]
-		_getGroupVocabulariesDisplayParameterTypes23 = new Class[] {
+		_getGroupVocabulariesDisplayParameterTypes24 = new Class[] {
 			long.class, String.class, int.class, int.class, boolean.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getGroupVocabulariesDisplayParameterTypes24 = new Class[] {
+		_getGroupVocabulariesDisplayParameterTypes25 = new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getOrAddIncompleteVocabularyParameterTypes25 = new Class[] {
+		_getOrAddIncompleteVocabularyParameterTypes26 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _getVocabularyParameterTypes26 =
+	private static final Class<?>[] _getVocabularyParameterTypes27 =
 		new Class[] {long.class};
-	private static final Class<?>[] _searchVocabulariesDisplayParameterTypes27 =
+	private static final Class<?>[] _searchVocabulariesDisplayParameterTypes28 =
 		new Class[] {
 			long.class, String.class, boolean.class, int.class, int.class
 		};
-	private static final Class<?>[] _searchVocabulariesDisplayParameterTypes28 =
+	private static final Class<?>[] _searchVocabulariesDisplayParameterTypes29 =
 		new Class[] {
 			long.class, String.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.search.Sort.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes29 =
+	private static final Class<?>[] _updateVocabularyParameterTypes30 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class, String.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes30 =
+	private static final Class<?>[] _updateVocabularyParameterTypes31 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class, String.class,
 			int.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes31 =
+	private static final Class<?>[] _updateVocabularyParameterTypes32 =
 		new Class[] {
 			long.class, String.class, java.util.Map.class, java.util.Map.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryServiceImpl.java
@@ -287,6 +287,14 @@ public class AssetCategoryServiceImpl extends AssetCategoryServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
+		AssetCategory assetCategory =
+			assetCategoryService.fetchCategoryByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		if (assetCategory != null) {
+			return assetCategory;
+		}
+
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_CATEGORY);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -176,6 +176,24 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 	}
 
 	@Override
+	public AssetVocabulary fetchVocabularyByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		AssetVocabulary vocabulary =
+			assetVocabularyLocalService.
+				fetchAssetVocabularyByExternalReferenceCode(
+					externalReferenceCode, groupId);
+
+		if (vocabulary != null) {
+			AssetVocabularyPermission.check(
+				getPermissionChecker(), vocabulary, ActionKeys.VIEW);
+		}
+
+		return vocabulary;
+	}
+
+	@Override
 	public AssetVocabulary getAssetVocabularyByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -396,6 +396,14 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
+		AssetVocabulary assetVocabulary =
+			assetVocabularyService.fetchVocabularyByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		if (assetVocabulary != null) {
+			return assetVocabulary;
+		}
+
 		AssetCategoriesPermission.check(
 			getPermissionChecker(), groupId, ActionKeys.ADD_VOCABULARY);
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyService.java
@@ -90,6 +90,11 @@ public interface AssetVocabularyService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public AssetVocabulary fetchVocabularyByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AssetVocabulary getAssetVocabularyByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceUtil.java
@@ -106,6 +106,14 @@ public class AssetVocabularyServiceUtil {
 		return getService().fetchVocabulary(vocabularyId);
 	}
 
+	public static AssetVocabulary fetchVocabularyByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().fetchVocabularyByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	public static AssetVocabulary getAssetVocabularyByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceWrapper.java
@@ -118,6 +118,15 @@ public class AssetVocabularyServiceWrapper
 	}
 
 	@Override
+	public AssetVocabulary fetchVocabularyByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetVocabularyService.fetchVocabularyByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
 	public AssetVocabulary getAssetVocabularyByExternalReferenceCode(
 			long groupId, String externalReferenceCode)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.3.0
+version 14.4.0


### PR DESCRIPTION
LPD-55446 Technical Task | Add Service layer to AssetVocabulary and AssetCategory with permissions checks

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46893

After the slack conversation on what kind of permissions should be checked, this PR modify how the permission are checked

# How am I fixing it?

Checking the ADD permission only if the object do not exists

# How can you verify that it works?

Run the included automated tests.



# Commits

- **LPD-55446 only check the ADD permission if is needed the addition**
- **LPD-55446 add test with the new permission behaviour**
