### PR TITLE
LPD-56626 DDMStructureValidationModelListenerException when importing a web content structure as JSON into another site

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/previous_version_valid_data_definition.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/previous_version_valid_data_definition.json
@@ -55,6 +55,7 @@
 			}
 		}
 	],
+	"dataDefinitionKey": "111",
 	"defaultDataLayout": {
 		"dataLayoutFields": {
 		},

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -75,6 +75,7 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			DataDefinitionUtil.updateDataDefinitionFields(
 				dataDefinition, ddmStructure);
 
+			dataDefinition.setDataDefinitionKey(ddmStructure::getStructureKey);
 			dataDefinition.setExternalReferenceCode(
 				ddmStructure::getExternalReferenceCode);
 


### PR DESCRIPTION
DDMStructureValidationModelListenerException when importing a web content structure as JSON into another site

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-56626)

When trying to import and override a structure from another site, an error is thrown when checking for the autogenerated key, this happens because the data definition that we are importing still has a reference to the exported data definition

# How am I fixing it?

When importing, change the data definition key, just as we do with the external reference code

# How can you verify that it works?

Follow the steps in the ticket or execute ImportAndOverrideDataDefinitionMVCActionCommandTest test