### PR TITLE
LPD-55643 Include extension in title liferay-document-library:repository-browser

### DIFF
--- a/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
+++ b/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
@@ -13,8 +13,9 @@ import com.liferay.petra.memory.FinalizeManager;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -45,6 +46,7 @@ import java.nio.file.Path;
 
 import java.util.HashMap;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -82,19 +84,12 @@ public class RepositoryBrowserServletTest {
 			"file", _BYTES);
 
 		_servlet.service(
-			_getMockMultipartHttpServletRequest(name, mockMultipartFile, true),
+			_getMockMultipartHttpServletRequest(
+				name, RandomTestUtil.randomString(), mockMultipartFile, ".txt",
+				false, true),
 			new MockHttpServletResponse());
 
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			_user);
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
-
-			_dlAppService.getFileEntry(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				name);
-		}
+		_getFileEntry(name);
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
@@ -105,19 +100,12 @@ public class RepositoryBrowserServletTest {
 			"file", _BYTES);
 
 		_servlet.service(
-			_getMockMultipartHttpServletRequest(name, mockMultipartFile, false),
+			_getMockMultipartHttpServletRequest(
+				name, RandomTestUtil.randomString(), mockMultipartFile, ".txt",
+				false, false),
 			new MockHttpServletResponse());
 
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			_user);
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
-
-			_dlAppService.getFileEntry(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				name);
-		}
+		_getFileEntry(name);
 	}
 
 	@Test
@@ -125,19 +113,10 @@ public class RepositoryBrowserServletTest {
 		String name = RandomTestUtil.randomString();
 
 		_servlet.service(
-			_getMockMultipartHttpServletRequest(name, true),
+			_getMockMultipartHttpServletRequest(0, name, "PUT", false, true),
 			new MockHttpServletResponse());
 
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			_user);
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
-
-			_dlAppService.getFolder(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				name);
-		}
+		_getFolder(name);
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
@@ -145,25 +124,189 @@ public class RepositoryBrowserServletTest {
 		String name = RandomTestUtil.randomString();
 
 		_servlet.service(
-			_getMockMultipartHttpServletRequest(name, false),
+			_getMockMultipartHttpServletRequest(0, name, "PUT", false, false),
 			new MockHttpServletResponse());
 
-		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
-			_user);
-
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_user, permissionChecker)) {
-
-			_dlAppService.getFolder(
-				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				name);
-		}
+		_getFolder(name);
 	}
 
-	private FileItem _createFileItem(byte[] bytes, String fileName)
+	@Test
+	public void testIncludeExtensionWhenNewNameHasDifferentExtension()
 		throws Exception {
 
-		Path tempFilePath = Files.createTempFile(null, ".txt");
+		String extension = "txt";
+		String mimeType = "text/plain";
+		String fileName = RandomTestUtil.randomString() + "." + extension;
+		String newName = RandomTestUtil.randomString() + ".pdf";
+
+		String expectedNewName = newName + "." + extension;
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileName, newName, mockMultipartFile, extension, true, true),
+			new MockHttpServletResponse());
+
+		FileEntry fileEntry = _getFileEntry(fileName);
+
+		_assertFileEntryAttributes(
+			fileEntry, fileName, fileName, extension, mimeType);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileEntry.getFileEntryId(), newName, "POST", true, true),
+			new MockHttpServletResponse());
+
+		_assertFileEntryAttributes(
+			_getFileEntry(expectedNewName), expectedNewName, expectedNewName,
+			extension, mimeType);
+	}
+
+	@Test
+	public void testIncludeExtensionWhenNewNameHasSameExtension()
+		throws Exception {
+
+		String extension = "txt";
+		String mimeType = "text/plain";
+		String fileName = RandomTestUtil.randomString() + "." + extension;
+		String newName = RandomTestUtil.randomString() + "." + extension;
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileName, newName, mockMultipartFile, extension, true, true),
+			new MockHttpServletResponse());
+
+		FileEntry fileEntry = _getFileEntry(fileName);
+
+		_assertFileEntryAttributes(
+			fileEntry, fileName, fileName, extension, mimeType);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileEntry.getFileEntryId(), newName, "POST", true, true),
+			new MockHttpServletResponse());
+
+		_assertFileEntryAttributes(
+			_getFileEntry(newName), newName, newName, extension, mimeType);
+	}
+
+	@Test
+	public void testIncludeExtensionWhenOriginalFileHasExtensionANDNewNameHasNoExtension()
+		throws Exception {
+
+		String extension = "txt";
+		String mimeType = "text/plain";
+		String fileName = RandomTestUtil.randomString() + "." + extension;
+		String newName = RandomTestUtil.randomString();
+
+		String expectedNewName = newName + "." + extension;
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileName, newName, mockMultipartFile, extension, true, true),
+			new MockHttpServletResponse());
+
+		FileEntry fileEntry = _getFileEntry(fileName);
+
+		_assertFileEntryAttributes(
+			fileEntry, fileName, fileName, extension, mimeType);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileEntry.getFileEntryId(), newName, "POST", true, true),
+			new MockHttpServletResponse());
+
+		_assertFileEntryAttributes(
+			_getFileEntry(expectedNewName), expectedNewName, expectedNewName,
+			extension, mimeType);
+	}
+
+	@Test
+	public void testIncludeExtensionWhenOriginalHasNoExtension()
+		throws Exception {
+
+		String extension = "";
+		String mimeType = "text/plain";
+		String fileName = RandomTestUtil.randomString();
+		String newName = RandomTestUtil.randomString();
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileName, newName, mockMultipartFile, extension, true, true),
+			new MockHttpServletResponse());
+
+		FileEntry fileEntry = _getFileEntry(fileName);
+
+		_assertFileEntryAttributes(
+			fileEntry, fileName, fileName, extension, mimeType);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileEntry.getFileEntryId(), newName, "POST", true, true),
+			new MockHttpServletResponse());
+
+		_assertFileEntryAttributes(
+			_getFileEntry(newName), newName, newName, extension, mimeType);
+	}
+
+	@Test
+	public void testNotIncludeExtension() throws Exception {
+		String extension = "txt";
+		String mimeType = "text/plain";
+		String title = RandomTestUtil.randomString();
+
+		String fileName = title + "." + extension;
+
+		String newName = RandomTestUtil.randomString() + "." + extension;
+
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"file", _BYTES);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileName, newName, mockMultipartFile, extension, false, true),
+			new MockHttpServletResponse());
+
+		FileEntry fileEntry = _getFileEntry(title);
+
+		_assertFileEntryAttributes(
+			fileEntry, fileName, title, extension, mimeType);
+
+		_servlet.service(
+			_getMockMultipartHttpServletRequest(
+				fileEntry.getFileEntryId(), newName, "POST", false, true),
+			new MockHttpServletResponse());
+
+		_assertFileEntryAttributes(
+			_getFileEntry(newName), newName, newName, extension, mimeType);
+	}
+
+	private void _assertFileEntryAttributes(
+		FileEntry fileEntry, String fileName, String title, String extension,
+		String mimeType) {
+
+		Assert.assertEquals(fileName, fileEntry.getFileName());
+		Assert.assertEquals(title, fileEntry.getTitle());
+		Assert.assertEquals(extension, fileEntry.getExtension());
+		Assert.assertEquals(mimeType, fileEntry.getMimeType());
+	}
+
+	private FileItem _createFileItem(
+			byte[] bytes, String fileName, String extension)
+		throws Exception {
+
+		Path tempFilePath = Files.createTempFile(null, extension);
 
 		Files.write(tempFilePath, bytes);
 
@@ -221,8 +364,29 @@ public class RepositoryBrowserServletTest {
 			null);
 	}
 
+	private FileEntry _getFileEntry(String title) throws Exception {
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, _permissionCheckerFactory.create(_user))) {
+
+			return _dlAppService.getFileEntry(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				title);
+		}
+	}
+
+	private Folder _getFolder(String name) throws Exception {
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_user, _permissionCheckerFactory.create(_user))) {
+
+			return _dlAppService.getFolder(
+				_group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				name);
+		}
+	}
+
 	private MockMultipartHttpServletRequest _getMockMultipartHttpServletRequest(
-			String name, boolean viewableByGuest)
+			long fileEntryId, String name, String method,
+			boolean includeExtension, boolean viewableByGuest)
 		throws Exception {
 
 		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
@@ -234,7 +398,11 @@ public class RepositoryBrowserServletTest {
 			WebKeys.USER, TestPropsValues.getUser());
 		mockMultipartHttpServletRequest.setContentType(
 			"multipart/form-data;boundary=" + System.currentTimeMillis());
-		mockMultipartHttpServletRequest.setMethod("PUT");
+		mockMultipartHttpServletRequest.setMethod(method);
+		mockMultipartHttpServletRequest.setParameter(
+			"fileEntryId", String.valueOf(fileEntryId));
+		mockMultipartHttpServletRequest.setParameter(
+			"includeExtension", String.valueOf(includeExtension));
 		mockMultipartHttpServletRequest.setParameter("name", name);
 		mockMultipartHttpServletRequest.setParameter(
 			"repositoryId", String.valueOf(_group.getGroupId()));
@@ -245,13 +413,13 @@ public class RepositoryBrowserServletTest {
 	}
 
 	private HttpServletRequest _getMockMultipartHttpServletRequest(
-			String fileName, MockMultipartFile mockMultipartFile,
-			boolean viewableByGuest)
+			String fileName, String name, MockMultipartFile mockMultipartFile,
+			String extension, boolean includeExtension, boolean viewableByGuest)
 		throws Exception {
 
 		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
 			_getMockMultipartHttpServletRequest(
-				RandomTestUtil.randomString(), viewableByGuest);
+				0, name, "PUT", includeExtension, viewableByGuest);
 
 		mockMultipartHttpServletRequest.addFile(mockMultipartFile);
 		mockMultipartHttpServletRequest.setContent(_BYTES);
@@ -262,7 +430,10 @@ public class RepositoryBrowserServletTest {
 			UploadTestUtil.createUploadServletRequest(
 				mockMultipartHttpServletRequest,
 				HashMapBuilder.put(
-					"file", new FileItem[] {_createFileItem(_BYTES, fileName)}
+					"file",
+					new FileItem[] {
+						_createFileItem(_BYTES, fileName, extension)
+					}
 				).build(),
 				new HashMap<>()),
 			null, RandomTestUtil.randomString());

--- a/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
+++ b/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/internal/servlet/test/RepositoryBrowserServletTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.context.ContextUserReplace;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -131,6 +132,7 @@ public class RepositoryBrowserServletTest {
 	}
 
 	@Test
+	@TestInfo("LPD-55643")
 	public void testIncludeExtensionWhenNewNameHasDifferentExtension()
 		throws Exception {
 
@@ -165,6 +167,7 @@ public class RepositoryBrowserServletTest {
 	}
 
 	@Test
+	@TestInfo("LPD-55643")
 	public void testIncludeExtensionWhenNewNameHasSameExtension()
 		throws Exception {
 
@@ -196,6 +199,7 @@ public class RepositoryBrowserServletTest {
 	}
 
 	@Test
+	@TestInfo("LPD-55643")
 	public void testIncludeExtensionWhenOriginalFileHasExtensionANDNewNameHasNoExtension()
 		throws Exception {
 
@@ -230,6 +234,7 @@ public class RepositoryBrowserServletTest {
 	}
 
 	@Test
+	@TestInfo("LPD-55643")
 	public void testIncludeExtensionWhenOriginalHasNoExtension()
 		throws Exception {
 
@@ -261,6 +266,7 @@ public class RepositoryBrowserServletTest {
 	}
 
 	@Test
+	@TestInfo("LPD-55643")
 	public void testNotIncludeExtension() throws Exception {
 		String extension = "txt";
 		String mimeType = "text/plain";

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserManagementToolbarDisplayContext.java
@@ -40,7 +40,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 	public RepositoryBrowserManagementToolbarDisplayContext(
 		Set<String> actions, long folderId,
 		ModelResourcePermission<Folder> folderModelResourcePermission,
-		HttpServletRequest httpServletRequest,
+		HttpServletRequest httpServletRequest, boolean includeExtension,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse, long repositoryId,
 		SearchContainer<Object> searchContainer, boolean viewableByGuest) {
@@ -52,6 +52,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 		_actions = actions;
 		_folderId = folderId;
 		_folderModelResourcePermission = folderModelResourcePermission;
+		_includeExtension = includeExtension;
 		_repositoryId = repositoryId;
 		_viewableByGuest = viewableByGuest;
 
@@ -106,6 +107,8 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 					ActionKeys.ADD_DOCUMENT),
 			dropdownItem -> {
 				dropdownItem.putData("action", "uploadFile");
+				dropdownItem.putData(
+					"includeExtension", String.valueOf(_includeExtension));
 				dropdownItem.setIcon("upload");
 				dropdownItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "file-upload"));
@@ -173,6 +176,7 @@ public class RepositoryBrowserManagementToolbarDisplayContext
 	private final long _folderId;
 	private final ModelResourcePermission<Folder>
 		_folderModelResourcePermission;
+	private final boolean _includeExtension;
 	private final long _repositoryId;
 	private final ThemeDisplay _themeDisplay;
 	private final boolean _viewableByGuest;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -85,7 +85,7 @@ public class RepositoryBrowserTagDisplayContext {
 			fileShortcutModelResourcePermission,
 		ModelResourcePermission<Folder> folderModelResourcePermission,
 		long folderId, HttpServletRequest httpServletRequest,
-		LiferayPortletRequest liferayPortletRequest,
+		boolean includeExtension, LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		PortletRequest portletRequest, long repositoryId, long rootFolderId,
 		boolean viewableByGuest) {
@@ -98,6 +98,7 @@ public class RepositoryBrowserTagDisplayContext {
 		_folderModelResourcePermission = folderModelResourcePermission;
 		_folderId = folderId;
 		_httpServletRequest = httpServletRequest;
+		_includeExtension = includeExtension;
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 		_portletRequest = portletRequest;
@@ -191,13 +192,15 @@ public class RepositoryBrowserTagDisplayContext {
 
 		return new RepositoryBrowserManagementToolbarDisplayContext(
 			_actions, _folderId, _folderModelResourcePermission,
-			_httpServletRequest, _liferayPortletRequest,
+			_httpServletRequest, _includeExtension, _liferayPortletRequest,
 			_liferayPortletResponse, _repositoryId, getSearchContainer(),
 			_viewableByGuest);
 	}
 
 	public Map<String, Object> getRepositoryBrowserComponentContext() {
 		return HashMapBuilder.<String, Object>put(
+			"includeExtension", String.valueOf(_includeExtension)
+		).put(
 			"parentFolderId", String.valueOf(_folderId)
 		).put(
 			"repositoryBrowserURL", _getRepositoryBrowserURL()
@@ -702,6 +705,7 @@ public class RepositoryBrowserTagDisplayContext {
 	private final ModelResourcePermission<Folder>
 		_folderModelResourcePermission;
 	private final HttpServletRequest _httpServletRequest;
+	private final boolean _includeExtension;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final PortletRequest _portletRequest;

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/display/context/RepositoryBrowserTagDisplayContext.java
@@ -415,7 +415,8 @@ public class RepositoryBrowserTagDisplayContext {
 			dropdownItem -> {
 				dropdownItem.putData("action", "rename");
 				dropdownItem.putData(
-					"renameURL", _getRenameFileEntryURL(fileEntry));
+					"renameURL",
+					_getRenameFileEntryURL(fileEntry, _includeExtension));
 				dropdownItem.putData("value", fileEntry.getTitle());
 				dropdownItem.setIcon("pencil");
 				dropdownItem.setLabel(
@@ -612,10 +613,16 @@ public class RepositoryBrowserTagDisplayContext {
 		return null;
 	}
 
-	private String _getRenameFileEntryURL(FileEntry fileEntry) {
-		return HttpComponentsUtil.addParameter(
+	private String _getRenameFileEntryURL(
+		FileEntry fileEntry, boolean includeExtension) {
+
+		String renameFileEntryURL = HttpComponentsUtil.addParameter(
 			_getRepositoryBrowserURL(), "fileEntryId",
 			fileEntry.getFileEntryId());
+
+		return HttpComponentsUtil.addParameter(
+			renameFileEntryURL, "includeExtension",
+			String.valueOf(includeExtension));
 	}
 
 	private String _getRenameFolderURL(Folder folder) {

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -195,7 +195,14 @@ public class RepositoryBrowserServlet extends HttpServlet {
 				String sourceFileName = uploadServletRequest.getFileName(
 					"file");
 
-				String title = FileUtil.stripExtension(sourceFileName);
+				String title = sourceFileName;
+
+				boolean includeExtension = ParamUtil.getBoolean(
+					httpServletRequest, "includeExtension");
+
+				if (!includeExtension) {
+					title = FileUtil.stripExtension(sourceFileName);
+				}
 
 				ServiceContext serviceContext =
 					ServiceContextFactory.getInstance(

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/internal/servlet/RepositoryBrowserServlet.java
@@ -7,8 +7,10 @@ package com.liferay.document.library.taglib.internal.servlet;
 
 import com.liferay.document.library.kernel.exception.DuplicateFileEntryException;
 import com.liferay.document.library.kernel.exception.DuplicateFolderNameException;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -32,6 +34,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.Servlet;
@@ -128,6 +131,47 @@ public class RepositoryBrowserServlet extends HttpServlet {
 				httpServletRequest, "fileEntryId");
 
 			if (fileEntryId != 0) {
+				boolean includeExtension = ParamUtil.getBoolean(
+					httpServletRequest, "includeExtension");
+
+				if (includeExtension) {
+					try {
+						FileEntry fileEntry = _dlAppService.getFileEntry(
+							fileEntryId);
+
+						if (fileEntry != null) {
+							String fileExtension = fileEntry.getExtension();
+
+							if (Validator.isNotNull(fileExtension) &&
+								!name.toLowerCase(
+								).endsWith(
+									"." + StringUtil.toLowerCase(fileExtension)
+								)) {
+
+								name = name + "." + fileExtension;
+							}
+						}
+					}
+					catch (NoSuchFileEntryException noSuchFileEntryException) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"File entry with identifier ", fileEntryId,
+									" not found while trying to keep ",
+									"extension."),
+								noSuchFileEntryException);
+						}
+					}
+					catch (PortalException portalException) {
+						if (_log.isWarnEnabled()) {
+							_log.error(
+								"Error retrieving File entry with identifier " +
+									fileEntryId,
+								portalException);
+						}
+					}
+				}
+
 				_dlAppService.updateFileEntry(
 					fileEntryId, null, null, name, null, null, null,
 					DLVersionNumberIncrease.NONE, (byte[])null, null, null,

--- a/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
+++ b/modules/apps/document-library/document-library-taglib/src/main/java/com/liferay/document/library/taglib/servlet/taglib/RepositoryBrowserTag.java
@@ -55,6 +55,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 		return _repositoryId;
 	}
 
+	public boolean isIncludeExtension() {
+		return _includeExtension;
+	}
+
 	public boolean isViewableByGuest() {
 		return _viewableByGuest;
 	}
@@ -65,6 +69,10 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	public void setFolderId(long folderId) {
 		_folderId = folderId;
+	}
+
+	public void setIncludeExtension(boolean includeExtension) {
+		_includeExtension = includeExtension;
 	}
 
 	@Override
@@ -88,6 +96,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 		_actions = StringPool.BLANK;
 		_folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+		_includeExtension = false;
 		_repositoryId = 0;
 		_viewableByGuest = false;
 	}
@@ -117,7 +126,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 					FileShortcut.class.getName()),
 				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
 					Folder.class.getName()),
-				_getFolderId(), httpServletRequest,
+				_getFolderId(), httpServletRequest, isIncludeExtension(),
 				PortalUtil.getLiferayPortletRequest(portletRequest),
 				PortalUtil.getLiferayPortletResponse(portletResponse),
 				portletRequest, _getRepositoryId(), getFolderId(),
@@ -170,6 +179,7 @@ public class RepositoryBrowserTag extends IncludeTag {
 
 	private String _actions = StringPool.BLANK;
 	private long _folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+	private boolean _includeExtension;
 	private long _repositoryId;
 	private boolean _viewableByGuest;
 

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/liferay-document-library.tld
@@ -43,6 +43,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>includeExtension</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>repositoryId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/js/repository_browser/RepositoryBrowserComponent.js
@@ -7,6 +7,7 @@ import {openToast} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 
 export default function RepositoryBrowserComponent({
+	includeExtension,
 	namespace,
 	parentFolderId,
 	repositoryBrowserURL,
@@ -20,7 +21,7 @@ export default function RepositoryBrowserComponent({
 
 		formData.append('file', fileInput.files[0]);
 
-		const uploadFileURL = `${repositoryBrowserURL}?repositoryId=${repositoryId}&parentFolderId=${parentFolderId}&viewableByGuest=${viewableByGuest}`;
+		const uploadFileURL = `${repositoryBrowserURL}?includeExtension=${includeExtension}&repositoryId=${repositoryId}&parentFolderId=${parentFolderId}&viewableByGuest=${viewableByGuest}`;
 
 		fetch(uploadFileURL, {
 			body: formData,

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-resources/src/main/java/com/liferay/fragment/entry/processor/resources/util/ResourcesFragmentEntryProcessorUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-resources/src/main/java/com/liferay/fragment/entry/processor/resources/util/ResourcesFragmentEntryProcessorUtil.java
@@ -13,8 +13,12 @@ import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,8 +51,16 @@ public class ResourcesFragmentEntryProcessorUtil {
 				continue;
 			}
 
-			FileEntry fileEntry = fragmentCollection.getResource(
-				matcher.group(1));
+			String fileName = matcher.group(1);
+
+			FileEntry fileEntry = fragmentCollection.getResource(fileName);
+
+			if ((fileEntry == null) &&
+				Validator.isNotNull(FileUtil.getExtension(fileName))) {
+
+				fileEntry = fragmentCollection.getResource(
+					FileUtil.stripExtension(fileName));
+			}
 
 			String fileEntryURL = StringPool.BLANK;
 
@@ -57,12 +69,22 @@ public class ResourcesFragmentEntryProcessorUtil {
 					fileEntry, fileEntry.getFileVersion(), null,
 					StringPool.BLANK, false, false);
 			}
+			else {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"FileEntry with fileName " + fileName +
+							" not found while trying to get download URL");
+				}
+			}
 
 			code = StringUtil.replace(code, matcher.group(), fileEntryURL);
 		}
 
 		return code;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ResourcesFragmentEntryProcessorUtil.class);
 
 	private static final Pattern _pattern = Pattern.compile(
 		"\\[resources:(.+?)\\]");

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -306,9 +306,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				QueryUtil.ALL_POS);
 
 		for (Object object : foldersAndFileEntriesAndFileShortcuts) {
-			if (object instanceof Folder) {
-				Folder childFolder = (Folder)object;
-
+			if (object instanceof Folder childFolder) {
 				String childFolderPath = childFolder.getName();
 
 				if (!Validator.isBlank(parentPath)) {
@@ -319,9 +317,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				resourcesMap.putAll(
 					_getResourcesMap(childFolder, childFolderPath));
 			}
-			else if (object instanceof FileEntry) {
-				FileEntry fileEntry = (FileEntry)object;
-
+			else if (object instanceof FileEntry fileEntry) {
 				String fileEntryPath = fileEntry.getFileName();
 
 				if (!Validator.isBlank(parentPath)) {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -6,6 +6,8 @@
 package com.liferay.fragment.model.impl.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
@@ -20,6 +22,7 @@ import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -81,7 +84,20 @@ public class FragmentCollectionImplTest {
 
 		Assert.assertEquals(resourcesMap.toString(), 1, resourcesMap.size());
 
-		Assert.assertNotNull(resourcesMap.get("liferay.png"));
+		FileEntry fileEntry = resourcesMap.get("liferay.png");
+
+		Assert.assertNotNull(fileEntry);
+
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), null, null, "liferayUpdate", null, null,
+			null, DLVersionNumberIncrease.NONE, (byte[])null, null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		resourcesMap = _fragmentCollection.getResourcesMap();
+
+		Assert.assertEquals(resourcesMap.toString(), 1, resourcesMap.size());
+		Assert.assertNotNull(resourcesMap.get("liferayUpdate.png"));
 	}
 
 	@Test
@@ -119,6 +135,9 @@ public class FragmentCollectionImplTest {
 
 		FileUtil.delete(zipWriter.getFile());
 	}
+
+	@Inject
+	private static DLAppService _dlAppService;
 
 	private FragmentCollection _fragmentCollection;
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -73,6 +74,7 @@ public class FragmentCollectionImplTest {
 	}
 
 	@Test
+	@TestInfo({"LPD-33704", "LPD-55643"})
 	public void testGetResourcesMap() throws Exception {
 		Map<String, FileEntry> resourcesMap =
 			_fragmentCollection.getResourcesMap();
@@ -83,6 +85,7 @@ public class FragmentCollectionImplTest {
 	}
 
 	@Test
+	@TestInfo("LPD-33704")
 	public void testPopulateZipWriter() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -13,6 +13,7 @@ FragmentCollectionResourcesDisplayContext fragmentCollectionResourcesDisplayCont
 
 <liferay-document-library:repository-browser
 	folderId="<%= fragmentCollectionResourcesDisplayContext.getFolderId() %>"
+	includeExtension="<%= true %>"
 	repositoryId="<%= fragmentCollectionResourcesDisplayContext.getRepositoryId() %>"
 	viewableByGuest="<%= true %>"
 />

--- a/modules/test/playwright/tests/fragment-web/main/fragmentsAdmin.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/main/fragmentsAdmin.spec.ts
@@ -304,7 +304,7 @@ test(
 		await apiHelpers.jsonWebServicesFragmentEntry.addFragmentEntry({
 			fragmentCollectionId: globalFragmentCollection.fragmentCollectionId,
 			groupId: globalSiteId,
-			html: '<div class="fragment-name"><img src="[resources:image]" /></div>',
+			html: '<div class="fragment-name"><img src="[resources:image.jpg]" /></div>',
 			name: fragmentEntryName,
 		});
 
@@ -362,7 +362,7 @@ test(
 			path.join(__dirname, '/dependencies/image.jpg')
 		);
 
-		await expect(page.getByText('Image')).toBeVisible();
+		await expect(page.getByText('Image.jpg')).toBeVisible();
 
 		// Assert global fragment in current site
 
@@ -400,7 +400,7 @@ test(
 
 		await resources.click();
 
-		await expect(page.getByText('Image')).toBeVisible();
+		await expect(page.getByText('Image.jpg')).toBeVisible();
 
 		// Delete global fragment collection
 


### PR DESCRIPTION
Already passed review https://github.com/liferay-page-management/liferay-portal/pull/17281

Please review your test suite https://github.com/liferay-page-management/liferay-portal/pull/17281#issuecomment-2930166711

LPD-55643 Include extension in title liferay-document-library:repository-browser

# What is this trying to solve?
Synchronize fileName with title, include extension in both so it can be found using [fetchPortletFileEntry(long groupId, long folderId, String fileName)](https://github.com/liferay/liferay-portal/blob/bae5246d3bd8e5e66d8223655625bd1b64199b28/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java#L403) as [fetchFileEntry(long folderId, String title)](https://github.com/liferay/liferay-portal/blob/17fb99f43cf5e3e8c27413752ce61d9f9f0ca58f/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java#L84) works with title not fileName
 
# How am I fixing it?
Force title to have extension so it can be used as a resource in fragments and not lose the type after import.

# How can you verify that it works?
Run the included automated tests.
Follow the steps described in [ LPD-55643](https://liferay.atlassian.net/browse/LPD-55643) and [LPD-33704](https://liferay.atlassian.net/browse/LPD-33704)