### PR TITLE
LPD-56362 Fix test to allow past dates when scheduling a web content

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -269,22 +269,6 @@ baseTest(
 
 		const currentDate = new Date();
 
-		currentDate.setMinutes(currentDate.getMinutes() - 5);
-
-		const beforeCurrentDateUTC = new Date(
-			currentDate.toLocaleString('en-US', {timeZone: 'UTC'})
-		);
-
-		await page
-			.getByPlaceholder('YYYY-MM-DD HH:mm')
-			.fill(
-				`${beforeCurrentDateUTC.getFullYear()}-${String(beforeCurrentDateUTC.getMonth() + 1).padStart(2, '0')}-${String(beforeCurrentDateUTC.getDate()).padStart(2, '0')} ${String(beforeCurrentDateUTC.getHours()).padStart(2, '0')}:${String(beforeCurrentDateUTC.getMinutes()).padStart(2, '0')}`
-			);
-
-		await expect(
-			page.getByText('Error: The date entered is in the past.')
-		).toBeVisible();
-
 		currentDate.setMinutes(currentDate.getMinutes() + 10);
 
 		const afterCurrentDateUTC = new Date(


### PR DESCRIPTION
PR https://github.com/liferay-content-management/liferay-portal/pull/6673

### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-56362

### **How am I fixing it?**
The fix involves removing the validation in the test case that restricts scheduling for past dates.