### PR TITLE
LPD-57223 Cannot override structure key after import structure

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/previous_version_valid_data_definition.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/previous_version_valid_data_definition.json
@@ -55,7 +55,6 @@
 			}
 		}
 	],
-	"dataDefinitionKey": "111",
 	"defaultDataLayout": {
 		"dataLayoutFields": {
 		},

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -75,7 +75,6 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			DataDefinitionUtil.updateDataDefinitionFields(
 				dataDefinition, ddmStructure);
 
-			dataDefinition.setDataDefinitionKey(ddmStructure::getStructureKey);
 			dataDefinition.setExternalReferenceCode(
 				ddmStructure::getExternalReferenceCode);
 


### PR DESCRIPTION
This reverts all changes from LPD-56626 since it causes a regression

- **Revert "LPD-56626 Add property to definition so as to test it correctly"**
- **Revert "LPD-56626 We also have to replace the definition key with the current structure key"**

