### PR TITLE
LPD-56626 Cannot override structure key after import structure

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -44,6 +44,7 @@ page import="com.liferay.dynamic.data.mapping.exception.NoSuchTemplateException"
 page import="com.liferay.dynamic.data.mapping.exception.RequiredStructureException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.RequiredTemplateException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.StorageFieldRequiredException" %><%@
+page import="com.liferay.dynamic.data.mapping.exception.StructureDuplicateStructureKeyException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.StructureNameException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.TemplateNameException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.TemplateSmallImageContentException" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -90,6 +90,14 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 			<c:when test="<%= errorException instanceof PrincipalException.MustHavePermission %>">
 				<liferay-ui:message key="you-do-not-have-the-required-permissions" />
 			</c:when>
+			<c:when test="<%= errorException instanceof StructureDuplicateStructureKeyException %>">
+
+				<%
+				StructureDuplicateStructureKeyException sdske = (StructureDuplicateStructureKeyException)errorException;
+				%>
+
+				<liferay-ui:message arguments="<%= sdske.getStructureKey() %>" key="dynamic-data-mapping-structure-with-structure-key-x-already-exists" translateArguments="<%= false %>" />
+			</c:when>
 			<c:otherwise>
 
 				<%

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -84,6 +84,9 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 			<c:when test="<%= errorException instanceof DataLayoutValidationException %>">
 				<liferay-ui:message key="please-enter-a-valid-form-layout" />
 			</c:when>
+			<c:when test="<%= errorException instanceof DDMStructureValidationModelListenerException %>">
+				<liferay-ui:message key="the-structure-key-cannot-be-modified" />
+			</c:when>
 			<c:when test="<%= errorException instanceof PrincipalException.MustHavePermission %>">
 				<liferay-ui:message key="you-do-not-have-the-required-permissions" />
 			</c:when>


### PR DESCRIPTION
DDMStructureValidationModelListenerException when importing a web content structure as JSON into another site

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-56626)

When trying to import and override a structure from another site, an error is thrown when checking for the autogenerated key, this happens because the data definition that we are importing still has a reference to the exported data definition. 

We have a configuration that controls it, and the specific error is thrown but never shown in the interface, just a generic error. So there is no feedback to the user about why the process failed

# How am I fixing it?

Taking into account the specific error messages that are thrown so that they are shown in the UI

# How can you verify that it works?

## Case 1

* Verify that the configuration for Autogenerate Structure Key is enabled in Instance Settings
* Add a new structure
* Export the json for the structure
* Open the json file and change the dataDefinitionKey
* On the kebab for the structure, select Import and Override

There was a generic error thrown, now an error specifies that the structure key cannot be changed

## Case 2

* Add a new structure
* Export the json for the structure
* Create a new structure
* On the kebab for the structure, select Import and Override

There was a generic error thrown, now an error specifies that there is already a structure key in the system