### PR TITLE
Cms upgrade processes

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.217
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 10.18.0
+Liferay-Require-SchemaVersion: 10.18.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -11,6 +11,7 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectValidationRuleSettingConstants;
 import com.liferay.object.internal.upgrade.v10_0_1.ObjectDefinitionPortletIdUpgradeProcess;
+import com.liferay.object.internal.upgrade.v10_18_1.ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess;
 import com.liferay.object.internal.upgrade.v10_1_1.ObjectDefinitionStaleUserIdUpgradeProcess;
 import com.liferay.object.internal.upgrade.v10_1_1.ObjectFieldStaleUserIdUpgradeProcess;
 import com.liferay.object.internal.upgrade.v10_1_1.ObjectRelationshipStaleUserIdUpgradeProcess;
@@ -623,6 +624,11 @@ public class ObjectServiceUpgradeStepRegistrator
 			"10.17.0", "10.18.0",
 			new com.liferay.object.internal.upgrade.v10_18_0.
 				ObjectFieldUpgradeProcess());
+
+		registry.register(
+			"10.18.0", "10.18.1",
+			new ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess(
+				_resourcePermissionLocalService, _roleLocalService));
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_18_1/ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_18_1/ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess.java
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v10_18_1;
+
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Mikel Lorza
+ */
+public class ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess
+	extends UpgradeProcess {
+
+	public ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess(
+		ResourcePermissionLocalService resourcePermissionLocalService,
+		RoleLocalService roleLocalService) {
+
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+		_roleLocalService = roleLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long bitwiseValue = _getBitwiseValue();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select companyId,objectEntryFolderId from " +
+					"ObjectEntryFolder")) {
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			while (resultSet.next()) {
+				long companyId = resultSet.getLong(1);
+
+				Role role = _roleLocalService.getRole(
+					companyId, RoleConstants.USER);
+
+				String objectEntryFolderId = resultSet.getString(2);
+
+				ResourcePermission resourcePermission =
+					_resourcePermissionLocalService.fetchResourcePermission(
+						companyId, ObjectEntryFolder.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL, objectEntryFolderId,
+						role.getRoleId());
+
+				if (resourcePermission != null) {
+					resourcePermission.setActionIds(
+						resourcePermission.getActionIds() | bitwiseValue);
+
+					_resourcePermissionLocalService.updateResourcePermission(
+						resourcePermission);
+				}
+				else {
+					_resourcePermissionLocalService.setResourcePermissions(
+						companyId, ObjectEntryFolder.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL, objectEntryFolderId,
+						role.getRoleId(), new String[] {ActionKeys.ADD_ASSET});
+				}
+			}
+		}
+	}
+
+	private long _getBitwiseValue() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select bitwiseValue from ResourceAction where name = ? and " +
+					"actionId = ?")) {
+
+			preparedStatement.setString(1, ObjectEntryFolder.class.getName());
+			preparedStatement.setString(2, ActionKeys.ADD_ASSET);
+
+			ResultSet resultSet = preparedStatement.executeQuery();
+
+			if (resultSet.next()) {
+				return resultSet.getLong("bitwiseValue");
+			}
+
+			return 0;
+		}
+	}
+
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService;
+	private final RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_18_1/test/ObjectEntryFolderAddAssetResourcePermissionUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_18_1/test/ObjectEntryFolderAddAssetResourcePermissionUpgradeProcessTest.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v10_18_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryFolderAddAssetResourcePermissionUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.fromLanguageId(
+						UpgradeProcessUtil.getDefaultLanguageId(
+							TestPropsValues.getCompanyId())),
+					StringUtil.randomString()
+				).build(),
+				StringUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), ObjectEntryFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		_runUpgrade();
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.ADD_ASSET));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.VIEW));
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.internal.upgrade.v10_18_1." +
+			"ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ResourceLocalService _resourceLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ActionKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ActionKeys.java
@@ -22,6 +22,8 @@ public class ActionKeys {
 
 	public static final String ADD_ARTICLE = "ADD_ARTICLE";
 
+	public static final String ADD_ASSET = "ADD_ASSET";
+
 	public static final String ADD_ATTACHMENT = "ADD_ATTACHMENT";
 
 	public static final String ADD_CATEGORY = "ADD_CATEGORY";


### PR DESCRIPTION
### What is this trying to solve?

The purpose of this PR is to have a branch where we have all upgrade processes to take into account when we delete the principal FF LPD-17564.

1. https://liferay.atlassian.net/browse/LPD-55344 --> ObjectEntryFolderAddAssetResourcePermissionUpgradeProcess : add an upgrade process to add ADD_ASSET permission to the existing ObjectEntryFolder
