### PR TITLE
LPD-47606 DM global Access from desktop modal only works once

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -43,8 +43,6 @@ DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAcce
 			if (webdavContentContainer) {
 				html = webdavContentContainer.innerHTML;
 
-				webdavContentContainer.remove();
-
 				Liferay.Util.openModal({
 					bodyHTML: html,
 					onOpen: function (event) {

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -851,3 +851,28 @@ test(
 		);
 	}
 );
+
+test(
+	'Access from Desktop modal can be opened multiple times',
+	{tag: '@LPD-47606'},
+	async ({documentLibraryPage, page, site}) => {
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+
+		await page.click('button[title="Options"]');
+
+		await page.getByRole('menuitem', {name: 'Access from Desktop'}).click();
+
+		await page.getByRole('dialog').waitFor({state: 'visible'});
+
+		await page
+			.getByRole('dialog')
+			.getByRole('button', {name: 'close'})
+			.click();
+
+		await page.click('button[title="Options"]');
+
+		await page.getByRole('menuitem', {name: 'Access from Desktop'}).click();
+
+		await expect(page.getByRole('dialog')).toBeVisible();
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-47606

Fixes an issue where the 'Access from Desktop' modal could not be opened more than once.

### **How am I fixing it?**
By removing the logic that deletes the modal when it is closed.

### **How can you verify that it works?**
By running the following Playwright test:
**npm run playwright -- test -g 'Access from Desktop modal can be opened multiple times'**