### PR TITLE
LPD-55456 Technical Task | Add "Add Entry" folder permission

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.object.service.impl;
 
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.entry.folder.util.ObjectEntryFolderThreadLocal;
@@ -23,14 +24,18 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -110,6 +115,25 @@ public class ObjectEntryFolderLocalServiceImpl
 				serviceContext);
 		}
 		else {
+			if (FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+				ModelPermissions modelPermissions =
+					serviceContext.getModelPermissions();
+
+				if (modelPermissions == null) {
+					modelPermissions = ModelPermissionsFactory.create(
+						ObjectEntryFolder.class.getName());
+
+					serviceContext.setModelPermissions(modelPermissions);
+				}
+
+				modelPermissions.addRolePermissions(
+					DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR,
+					ActionKeys.ADD_ENTRY, ActionKeys.VIEW);
+				modelPermissions.addRolePermissions(
+					DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
+					ActionKeys.ADD_ENTRY, ActionKeys.VIEW);
+			}
+
 			_resourceLocalService.addModelResources(
 				objectEntryFolder.getCompanyId(),
 				objectEntryFolder.getGroupId(), objectEntryFolder.getUserId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -12,12 +12,14 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.object.configuration.ObjectConfiguration;
 import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.definition.security.permission.resource.ObjectDefinitionPortletResourcePermissionRegistryUtil;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
 import com.liferay.object.exception.ObjectEntryCountException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -36,6 +38,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -53,6 +56,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionUtil;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -83,6 +87,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Marco Leo
@@ -107,7 +113,7 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
 			_checkAddObjectEntryPortletResourcePermission(
-				groupId, objectDefinitionId, values);
+				groupId, objectDefinitionId, objectEntryFolderId, values);
 		}
 
 		_validateSubmissionLimit(objectDefinitionId, getUser());
@@ -130,7 +136,7 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 		if (objectEntry == null) {
 			_checkAddObjectEntryPortletResourcePermission(
-				groupId, objectDefinitionId, values);
+				groupId, objectDefinitionId, objectEntryFolderId, values);
 		}
 		else {
 			checkModelResourcePermission(
@@ -466,7 +472,7 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 		_checkAddObjectEntryPortletResourcePermission(
 			groupId, objectEntry.getObjectDefinitionId(),
-			objectEntry.getValues());
+			objectEntry.getObjectEntryFolderId(), objectEntry.getValues());
 
 		objectEntryLocalService.validate(
 			groupId, objectEntry, objectValidationRuleExternalReferenceCodes,
@@ -481,9 +487,20 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 	}
 
 	private void _checkAddObjectEntryPortletResourcePermission(
-			long groupId, long objectDefinitionId,
+			long groupId, long objectDefinitionId, long objectEntryFolderId,
 			Map<String, Serializable> values)
 		throws PortalException {
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-17564") &&
+			(objectEntryFolderId !=
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT)) {
+
+			ModelResourcePermissionUtil.check(
+				_objectEntryFoldermodelResourcePermission,
+				getPermissionChecker(), groupId, objectEntryFolderId,
+				ActionKeys.ADD_ENTRY);
+		}
 
 		PortletResourcePermission portletResourcePermission =
 			_getPortletResourcePermission(objectDefinitionId);
@@ -894,6 +911,14 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Reference
 	private ObjectDefinitionPersistence _objectDefinitionPersistence;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(model.class.name=com.liferay.object.model.ObjectEntryFolder)"
+	)
+	private volatile ModelResourcePermission<ObjectEntryFolder>
+		_objectEntryFoldermodelResourcePermission;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
@@ -58,6 +58,9 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
+			<site-member-defaults>
+				<action-key>VIEW</action-key>
+			</site-member-defaults>
 			<guest-unsupported>
 				<action-key>ADD_ENTRY</action-key>
 				<action-key>ADD_FOLDER</action-key>

--- a/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/object/object-service/src/main/resources/resource-actions/default.xml
@@ -52,12 +52,14 @@
 		<weight>1</weight>
 		<permissions>
 			<supports>
+				<action-key>ADD_ENTRY</action-key>
 				<action-key>ADD_FOLDER</action-key>
 				<action-key>DELETE</action-key>
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
 			<guest-unsupported>
+				<action-key>ADD_ENTRY</action-key>
 				<action-key>ADD_FOLDER</action-key>
 				<action-key>DELETE</action-key>
 				<action-key>UPDATE</action-key>

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
@@ -25,6 +26,11 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -36,6 +42,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -69,6 +76,7 @@ public class ObjectEntryFolderLocalServiceTest {
 		_objectDefinition = _addObjectDefinition();
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testAddObjectEntryFolder() throws Exception {
 		String externalReferenceCode = StringUtil.randomString();
@@ -146,6 +154,30 @@ public class ObjectEntryFolderLocalServiceTest {
 				LocaleUtil.getSiteDefault(), objectEntryFolder.getName()
 			).build(),
 			objectEntryFolder.getLabelMap());
+
+		Role role = _roleLocalService.fetchRole(
+			TestPropsValues.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_ADMINISTRATOR);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.ADD_ENTRY));
+
+		role = _roleLocalService.fetchRole(
+			TestPropsValues.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER);
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				TestPropsValues.getCompanyId(),
+				ObjectEntryFolder.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+				role.getRoleId(), ActionKeys.ADD_ENTRY));
 	}
 
 	@Test
@@ -426,5 +458,11 @@ public class ObjectEntryFolderLocalServiceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -147,7 +147,7 @@ public class ObjectEntryFolderLocalServiceTest {
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				RandomTestUtil.randomString(), null, StringUtil.randomString(),
-				ServiceContextTestUtil.getServiceContext());
+				new ServiceContext());
 
 		AssertUtils.assertEquals(
 			HashMapBuilder.put(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.configuration.ObjectConfiguration;
 import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
@@ -22,6 +23,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -38,6 +40,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -58,6 +61,7 @@ import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -108,11 +112,12 @@ public class ObjectEntryServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_adminUser = TestPropsValues.getUser();
+		_group = GroupTestUtil.addGroup();
 		_guestUser = _userLocalService.getGuestUser(
 			TestPropsValues.getCompanyId());
 
-		_objectDefinition = ObjectDefinitionTestUtil.addCustomObjectDefinition(
-			false,
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			false, ObjectDefinitionTestUtil.getRandomName(),
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -121,12 +126,8 @@ public class ObjectEntryServiceTest {
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-					"Last Name", "lastName", false)));
-
-		_objectDefinition =
-			_objectDefinitionLocalService.publishCustomObjectDefinition(
-				TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId());
+					"Last Name", "lastName", false)),
+			ObjectDefinitionConstants.SCOPE_SITE, TestPropsValues.getUserId());
 
 		_originalPermissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -168,7 +169,7 @@ public class ObjectEntryServiceTest {
 
 		Assert.assertNotNull(
 			_objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null,
@@ -184,14 +185,15 @@ public class ObjectEntryServiceTest {
 			PrincipalException.MustHavePermission.class,
 			StringBundler.concat(
 				"User ", _guestUser.getUserId(), " must have ADD_OBJECT_ENTRY ",
-				"permission for ", _objectDefinition.getResourceName(), " "),
+				"permission for ", _objectDefinition.getResourceName(), " ",
+				_group.getGroupId()),
 			() -> _objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null, Collections.emptyMap(),
 				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getGroupId(), _guestUser.getUserId())));
+					_group.getGroupId(), _guestUser.getUserId())));
 
 		_setUser(_user);
 
@@ -199,9 +201,10 @@ public class ObjectEntryServiceTest {
 			PrincipalException.MustHavePermission.class,
 			StringBundler.concat(
 				"User ", _user.getUserId(), " must have ADD_OBJECT_ENTRY ",
-				"permission for ", _objectDefinition.getResourceName(), " "),
+				"permission for ", _objectDefinition.getResourceName(), " ",
+				_group.getGroupId()),
 			() -> _objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null, Collections.emptyMap(),
@@ -221,7 +224,7 @@ public class ObjectEntryServiceTest {
 
 		Assert.assertNotNull(
 			_objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null,
@@ -242,7 +245,7 @@ public class ObjectEntryServiceTest {
 
 		Assert.assertNotNull(
 			_objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null,
@@ -731,7 +734,7 @@ public class ObjectEntryServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-			TestPropsValues.getUserId(), 0,
+			TestPropsValues.getUserId(), _group.getGroupId(),
 			_objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
@@ -818,7 +821,7 @@ public class ObjectEntryServiceTest {
 		_setUser(_adminUser);
 
 		_objectEntryService.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
+			_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null, Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext(
@@ -830,7 +833,7 @@ public class ObjectEntryServiceTest {
 
 		try {
 			ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
-				0, _objectDefinition.getObjectDefinitionId(),
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 				null, Collections.emptyMap(),
@@ -847,7 +850,8 @@ public class ObjectEntryServiceTest {
 						_objectDefinition.getDefaultLanguageId()),
 					" has been reached and will no longer be accepted"),
 				() -> _objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					_group.getGroupId(),
+					_objectDefinition.getObjectDefinitionId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					null, Collections.emptyMap(),
@@ -869,7 +873,8 @@ public class ObjectEntryServiceTest {
 
 			Assert.assertNotNull(
 				_objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					_group.getGroupId(),
+					_objectDefinition.getObjectDefinitionId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					null, Collections.emptyMap(),
@@ -884,7 +889,8 @@ public class ObjectEntryServiceTest {
 						_objectDefinition.getDefaultLanguageId()),
 					" has been reached and will no longer be accepted"),
 				() -> _objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					_group.getGroupId(),
+					_objectDefinition.getObjectDefinitionId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					null, Collections.emptyMap(),
@@ -922,7 +928,7 @@ public class ObjectEntryServiceTest {
 		_addResourcePermissionToGuestUser();
 
 		ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
+			_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null, Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext(
@@ -942,7 +948,8 @@ public class ObjectEntryServiceTest {
 		try {
 			Assert.assertNotNull(
 				_objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					_group.getGroupId(),
+					_objectDefinition.getObjectDefinitionId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					null, Collections.emptyMap(),
@@ -957,7 +964,8 @@ public class ObjectEntryServiceTest {
 						_objectDefinition.getDefaultLanguageId()),
 					" has been reached and will no longer be accepted"),
 				() -> _objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					_group.getGroupId(),
+					_objectDefinition.getObjectDefinitionId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					null, Collections.emptyMap(),
@@ -974,7 +982,8 @@ public class ObjectEntryServiceTest {
 
 	private ObjectEntry _addObjectEntry(User user) throws Exception {
 		return _objectEntryLocalService.addObjectEntry(
-			user.getUserId(), 0, _objectDefinition.getObjectDefinitionId(),
+			user.getUserId(), _group.getGroupId(),
+			_objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
@@ -1074,6 +1083,9 @@ public class ObjectEntryServiceTest {
 	@Inject
 	private ConfigurationProvider _configurationProvider;
 
+	@DeleteAfterTestRun
+	private Group _group;
+
 	private User _guestUser;
 
 	@DeleteAfterTestRun
@@ -1081,6 +1093,9 @@ public class ObjectEntryServiceTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -20,6 +20,7 @@ import com.liferay.object.exception.ObjectEntryCountException;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -69,8 +70,11 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -100,7 +104,9 @@ import org.junit.runner.RunWith;
 /**
  * @author Marco Leo
  */
-@FeatureFlag("LPD-34594")
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-34594")}
+)
 @RunWith(Arquillian.class)
 public class ObjectEntryServiceTest {
 
@@ -254,6 +260,63 @@ public class ObjectEntryServiceTest {
 				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId(), _guestUser.getUserId())));
+
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), StringUtil.randomString()
+				).build(),
+				StringUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), ObjectEntryFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+			role.getRoleId(), new String[] {ActionKeys.ADD_ENTRY});
+
+		_setUser(_user);
+
+		Assert.assertNotNull(
+			_objectEntryService.addObjectEntry(
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
+				objectEntryFolder.getObjectEntryFolderId(), null,
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", RandomStringUtils.randomAlphabetic(5)
+				).build(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), _guestUser.getUserId())));
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			TestPropsValues.getCompanyId(), ObjectEntryFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+			role.getRoleId(), ActionKeys.ADD_ENTRY);
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(),
+				" must have ADD_ENTRY permission for ",
+				ObjectEntryFolder.class.getName(), " ",
+				objectEntryFolder.getObjectEntryFolderId()),
+			() -> _objectEntryService.addObjectEntry(
+				_group.getGroupId(), _objectDefinition.getObjectDefinitionId(),
+				objectEntryFolder.getObjectEntryFolderId(), null,
+				HashMapBuilder.<String, Serializable>put(
+					"firstName", RandomStringUtils.randomAlphabetic(5)
+				).build(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), _guestUser.getUserId())));
 	}
 
 	@Test


### PR DESCRIPTION
I am sending the PR again because Brian did not like the permission name , so, I have changed it from ADD_ASSET to ADD_ENTRY. See Brian comment : https://github.com/brianchandotcom/liferay-portal/pull/162463#issuecomment-2951260829

https://liferay.atlassian.net/browse/LPD-55456

### What is this trying to solve?

Add "Add Asset" permission for ObjectEntryFolder resource in order to add the possibility to manage if it is possible to add an asset to a folder like we have right now for Web Content and Document & Media.

### How am I fixing it?
Create new permission and upgrade for created object entry folders and thus allow object entries to be created under a folder as was possible until now

### How can you verify that it works?

Run included tests

### Additional information

This PR does not include permission check in the UI. 
