### PR TITLE
LPD-56872 Transfer Asset Reindex to a Message Listener to avoid unnecesary waits.

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -51,10 +51,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			deleteAssetEntryAssetCategoryRelByAssetCategoryId(
 				category.getCategoryId());
 
-		List<AssetEntry> assetEntries = _getAssetEntriesByAssetCategoryId(
-			category.getCategoryId());
-
-		_assetEntryLocalService.reindex(assetEntries);
+		_reindexCategoryAssetEntries(category.getCategoryId());
 
 		return super.deleteCategory(category, skipRebuildTree);
 	}
@@ -115,18 +112,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			categoryId);
 
 		if (!Objects.equals(category.getName(), name)) {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					Message message = new Message();
-
-					message.put("categoryId", category.getCategoryId());
-
-					_messageBus.sendMessage(
-						DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
-						message);
-
-					return null;
-				});
+			_reindexCategoryAssetEntries(category.getCategoryId());
 		}
 
 		return super.updateCategory(
@@ -175,6 +161,21 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 				if (entry != null) {
 					return entry;
 				}
+
+				return null;
+			});
+	}
+
+	private void _reindexCategoryAssetEntries(Long categoryId) {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				Message message = new Message();
+
+				message.put("categoryId", categoryId);
+
+				_messageBus.sendMessage(
+					DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+					message);
 
 				return null;
 			});

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -166,7 +166,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			});
 	}
 
-	private void _reindexCategoryAssetEntries(Long categoryId) {
+	private void _reindexCategoryAssetEntries(long categoryId) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				Message message = new Message();

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -16,10 +16,14 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Collections;
@@ -111,10 +115,18 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			categoryId);
 
 		if (!Objects.equals(category.getName(), name)) {
-			List<AssetEntry> assetEntries = _getAssetEntriesByAssetCategoryId(
-				category.getCategoryId());
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					Message message = new Message();
 
-			_assetEntryLocalService.reindex(assetEntries);
+					message.put("categoryId", category.getCategoryId());
+
+					_messageBus.sendMessage(
+						DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+						message);
+
+					return null;
+				});
 		}
 
 		return super.updateCategory(
@@ -180,5 +192,8 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private MessageBus _messageBus;
 
 }

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -166,12 +166,12 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			});
 	}
 
-	private void _reindexCategoryAssetEntries(long categoryId) {
+	private void _reindexCategoryAssetEntries(long assetCategoryId) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				Message message = new Message();
 
-				message.put("categoryId", categoryId);
+				message.put("categoryId", assetCategoryId);
 
 				_messageBus.sendMessage(
 					DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.asset.categories.internal.service;
 
+import com.liferay.asset.categories.internal.service.constants.AssetCategoryDestinationNames;
 import com.liferay.asset.categories.internal.util.comparator.AssetEntryAssetCategoryRelAssetCategoryIdComparator;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
@@ -16,7 +17,6 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
@@ -174,7 +174,8 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 				message.put("categoryId", assetCategoryId);
 
 				_messageBus.sendMessage(
-					DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+					AssetCategoryDestinationNames.
+						ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
 					message);
 
 				return null;

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper.java
@@ -51,7 +51,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			deleteAssetEntryAssetCategoryRelByAssetCategoryId(
 				category.getCategoryId());
 
-		_reindexCategoryAssetEntries(category.getCategoryId());
+		_reindexAssetCategoryAssetEntries(category.getCategoryId());
 
 		return super.deleteCategory(category, skipRebuildTree);
 	}
@@ -112,7 +112,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			categoryId);
 
 		if (!Objects.equals(category.getName(), name)) {
-			_reindexCategoryAssetEntries(category.getCategoryId());
+			_reindexAssetCategoryAssetEntries(category.getCategoryId());
 		}
 
 		return super.updateCategory(
@@ -166,7 +166,7 @@ public class AssetEntryAssetCategoryRelAssetCategoryLocalServiceWrapper
 			});
 	}
 
-	private void _reindexCategoryAssetEntries(long assetCategoryId) {
+	private void _reindexAssetCategoryAssetEntries(long assetCategoryId) {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
 				Message message = new Message();

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/constants/AssetCategoryDestinationNames.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/constants/AssetCategoryDestinationNames.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.service.constants;
+
+/**
+ * @author Manuel Rives
+ */
+public class AssetCategoryDestinationNames {
+
+	public static final String ASSET_CATEGORY_ASSET_ENTRIES_REINDEX =
+		"liferay/asset_category_asset_entries_reindex";
+
+}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.internal.service.messaging;
+
+import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
+import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Manuel Rives
+ */
+@Component(
+	property = "destination.name=" + DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+	service = MessageListener.class
+)
+public class AssetCategoryAssetEntriesReindexMessageListener
+	extends BaseMessageListener {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		DestinationConfiguration destinationConfiguration =
+			new DestinationConfiguration(
+				DestinationConfiguration.DESTINATION_TYPE_SERIAL,
+				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Override
+	protected void doReceive(Message message) throws Exception {
+		List<AssetEntry> assetEntries = _getAssetEntriesByAssetCategoryId(
+			message.getLong("categoryId"));
+
+		_assetEntryLocalService.reindex(assetEntries);
+	}
+
+	private List<AssetEntry> _getAssetEntriesByAssetCategoryId(
+		long assetCategoryId) {
+
+		List<AssetEntryAssetCategoryRel> assetEntryAssetCategoryRels =
+			_assetEntryAssetCategoryRelLocalService.
+				getAssetEntryAssetCategoryRelsByAssetCategoryId(
+					assetCategoryId);
+
+		return TransformUtil.transform(
+			assetEntryAssetCategoryRels,
+			assetEntryAssetCategoryRel -> {
+				AssetEntry entry = _assetEntryLocalService.fetchEntry(
+					assetEntryAssetCategoryRel.getAssetEntryId());
+
+				if (entry != null) {
+					return entry;
+				}
+
+				return null;
+			});
+	}
+
+	@Reference
+	private AssetEntryAssetCategoryRelLocalService
+		_assetEntryAssetCategoryRelLocalService;
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -5,6 +5,7 @@
 
 package com.liferay.asset.categories.internal.service.messaging;
 
+import com.liferay.asset.categories.internal.service.constants.AssetCategoryDestinationNames;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -12,7 +13,6 @@ import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
-import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Manuel Rives
  */
 @Component(
-	property = "destination.name=" + DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
+	property = "destination.name=" + AssetCategoryDestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX,
 	service = MessageListener.class
 )
 public class AssetCategoryAssetEntriesReindexMessageListener
@@ -39,7 +39,8 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 		DestinationConfiguration destinationConfiguration =
 			new DestinationConfiguration(
 				DestinationConfiguration.DESTINATION_TYPE_SERIAL,
-				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
+				AssetCategoryDestinationNames.
+					ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
 
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -77,10 +77,8 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 
 		return TransformUtil.transform(
 			assetEntryAssetCategoryRels,
-			assetEntryAssetCategoryRel -> {
-				return _assetEntryLocalService.fetchEntry(
-					assetEntryAssetCategoryRel.getAssetEntryId());
-			});
+			assetEntryAssetCategoryRel -> _assetEntryLocalService.fetchEntry(
+					assetEntryAssetCategoryRel.getAssetEntryId()));
 	}
 
 	@Reference

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -70,13 +70,10 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 	}
 
 	private List<AssetEntry> _getAssetEntries(long assetCategoryId) {
-		List<AssetEntryAssetCategoryRel> assetEntryAssetCategoryRels =
+		return TransformUtil.transform(
 			_assetEntryAssetCategoryRelLocalService.
 				getAssetEntryAssetCategoryRelsByAssetCategoryId(
-					assetCategoryId);
-
-		return TransformUtil.transform(
-			assetEntryAssetCategoryRels,
+					assetCategoryId),
 			assetEntryAssetCategoryRel -> _assetEntryLocalService.fetchEntry(
 					assetEntryAssetCategoryRel.getAssetEntryId()));
 	}

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -78,14 +78,8 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 		return TransformUtil.transform(
 			assetEntryAssetCategoryRels,
 			assetEntryAssetCategoryRel -> {
-				AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+				return _assetEntryLocalService.fetchEntry(
 					assetEntryAssetCategoryRel.getAssetEntryId());
-
-				if (assetEntry != null) {
-					return assetEntry;
-				}
-
-				return null;
 			});
 	}
 

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -63,15 +63,13 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		List<AssetEntry> assetEntries = _getAssetEntriesByAssetCategoryId(
+		List<AssetEntry> assetEntries = _getAssetEntries(
 			message.getLong("categoryId"));
 
 		_assetEntryLocalService.reindex(assetEntries);
 	}
 
-	private List<AssetEntry> _getAssetEntriesByAssetCategoryId(
-		long assetCategoryId) {
-
+	private List<AssetEntry> _getAssetEntries(long assetCategoryId) {
 		List<AssetEntryAssetCategoryRel> assetEntryAssetCategoryRels =
 			_assetEntryAssetCategoryRelLocalService.
 				getAssetEntryAssetCategoryRelsByAssetCategoryId(
@@ -80,11 +78,11 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 		return TransformUtil.transform(
 			assetEntryAssetCategoryRels,
 			assetEntryAssetCategoryRel -> {
-				AssetEntry entry = _assetEntryLocalService.fetchEntry(
+				AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 					assetEntryAssetCategoryRel.getAssetEntryId());
 
-				if (entry != null) {
-					return entry;
+				if (assetEntry != null) {
+					return assetEntry;
 				}
 
 				return null;

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/messaging/AssetCategoryAssetEntriesReindexMessageListener.java
@@ -5,9 +5,7 @@
 
 package com.liferay.asset.categories.internal.service.messaging;
 
-import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
-import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
@@ -18,8 +16,6 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.util.MapUtil;
-
-import java.util.List;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -63,19 +59,14 @@ public class AssetCategoryAssetEntriesReindexMessageListener
 
 	@Override
 	protected void doReceive(Message message) throws Exception {
-		List<AssetEntry> assetEntries = _getAssetEntries(
-			message.getLong("categoryId"));
-
-		_assetEntryLocalService.reindex(assetEntries);
-	}
-
-	private List<AssetEntry> _getAssetEntries(long assetCategoryId) {
-		return TransformUtil.transform(
-			_assetEntryAssetCategoryRelLocalService.
-				getAssetEntryAssetCategoryRelsByAssetCategoryId(
-					assetCategoryId),
-			assetEntryAssetCategoryRel -> _assetEntryLocalService.fetchEntry(
-					assetEntryAssetCategoryRel.getAssetEntryId()));
+		_assetEntryLocalService.reindex(
+			TransformUtil.transform(
+				_assetEntryAssetCategoryRelLocalService.
+					getAssetEntryAssetCategoryRelsByAssetCategoryId(
+						message.getLong("categoryId")),
+				assetEntryAssetCategoryRel ->
+					_assetEntryLocalService.fetchEntry(
+						assetEntryAssetCategoryRel.getAssetEntryId())));
 	}
 
 	@Reference

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleAssetEntryTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -76,7 +77,8 @@ public class JournalArticleAssetEntryTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -10,9 +10,6 @@ package com.liferay.portal.kernel.messaging;
  */
 public interface DestinationNames {
 
-	public static final String ASSET_CATEGORY_ASSET_ENTRIES_REINDEX =
-		"liferay/asset_category_asset_entries_reindex";
-
 	public static final String ASYNC_SERVICE = "liferay/async_service";
 
 	public static final String BACKGROUND_TASK = "liferay/background_task";

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -10,6 +10,9 @@ package com.liferay.portal.kernel.messaging;
  */
 public interface DestinationNames {
 
+	public static final String ASSET_CATEGORY_ASSET_ENTRIES_REINDEX =
+		"liferay/asset_category_asset_entries_reindex";
+
 	public static final String ASYNC_SERVICE = "liferay/async_service";
 
 	public static final String BACKGROUND_TASK = "liferay/background_task";

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -171,8 +171,6 @@ public class SynchronousDestinationTestRule
 				BufferedIncrementThreadLocal.setForceSyncWithSafeCloseable(
 					true);
 
-			replaceDestination(
-				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
 			replaceDestination(DestinationNames.ASYNC_SERVICE);
 			replaceDestination(DestinationNames.BACKGROUND_TASK);
 			replaceDestination(DestinationNames.BACKGROUND_TASK_STATUS);
@@ -193,6 +191,7 @@ public class SynchronousDestinationTestRule
 			replaceDestination(DestinationNames.SUBSCRIPTION_SENDER);
 			replaceDestination("liferay/adaptive_media_processor");
 			replaceDestination("liferay/asset_auto_tagger");
+			replaceDestination("liferay/asset_category_asset_entries_reindex");
 			replaceDestination("liferay/ddm_structure_reindex");
 			replaceDestination("liferay/report_request");
 			replaceDestination("liferay/reports_admin");

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -171,6 +171,8 @@ public class SynchronousDestinationTestRule
 				BufferedIncrementThreadLocal.setForceSyncWithSafeCloseable(
 					true);
 
+			replaceDestination(
+				DestinationNames.ASSET_CATEGORY_ASSET_ENTRIES_REINDEX);
 			replaceDestination(DestinationNames.ASYNC_SERVICE);
 			replaceDestination(DestinationNames.BACKGROUND_TASK);
 			replaceDestination(DestinationNames.BACKGROUND_TASK_STATUS);


### PR DESCRIPTION
This is a follow up of https://github.com/liferay-content-management/liferay-portal/pull/6703 with Brian requested changes.

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-56872 Transfer Asset Reindex to a Message Listener to avoid unnecesary waits.
### How am I fixing it?
Transfering the reindexation of Assets to the background
### How can you verify that it works?
1. Create a category.
2. Create 300 Basic Contents that are assigned to that category.
3. Rename the category
### Why does this pull not include tests?
This cannot be observed reliably from a test. This is a performance change.