### PR TITLE
LPD-57781 Allow direct move of a category into another vocabulary's category during updating

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -990,6 +990,44 @@ public class AssetCategoryLocalServiceTest {
 			assetCategory.getTitleMap());
 	}
 
+	@Test
+	public void testUpdateAssetCategoryWithUpdatedVocabulary()
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		String assetCategoryName = RandomTestUtil.randomString();
+
+		AssetCategory assetCategory1 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(), assetCategoryName,
+			_assetVocabulary.getVocabularyId(), serviceContext);
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		AssetCategory assetCategory2 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(), assetCategoryName,
+			assetVocabulary.getVocabularyId(), serviceContext);
+
+		assetCategory1 = _assetCategoryLocalService.updateCategory(
+			TestPropsValues.getUserId(), assetCategory1.getCategoryId(),
+			assetCategory2.getCategoryId(),
+			Collections.singletonMap(
+				LocaleUtil.getSiteDefault(), assetCategory1.getName()),
+			assetCategory1.getDescriptionMap(),
+			assetVocabulary.getVocabularyId(), null, serviceContext);
+
+		Assert.assertEquals(
+			assetCategory1.getVocabularyId(), assetCategory2.getVocabularyId());
+		Assert.assertEquals(
+			assetCategory1.getParentCategoryId(),
+			assetCategory2.getCategoryId());
+	}
+
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -564,41 +564,7 @@ public class AssetCategoryLocalServiceImpl
 		AssetCategory category = assetCategoryPersistence.findByPrimaryKey(
 			categoryId);
 
-		validate(
-			categoryId, parentCategoryId, category.getName(), vocabularyId);
-
-		if (categoryId == parentCategoryId) {
-			throw new InvalidAssetCategoryException(parentCategoryId, 2);
-		}
-
-		AssetCategory parentCategory = null;
-
-		if (parentCategoryId > 0) {
-			parentCategory = assetCategoryPersistence.findByPrimaryKey(
-				parentCategoryId);
-
-			String treePath = parentCategory.getTreePath();
-
-			if (treePath.startsWith(category.getTreePath())) {
-				throw new InvalidAssetCategoryException(categoryId, 1);
-			}
-		}
-
-		if (vocabularyId != category.getVocabularyId()) {
-			_assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
-
-			updateChildrenVocabularyId(category, vocabularyId);
-
-			category.setVocabularyId(vocabularyId);
-		}
-
-		if (parentCategoryId != category.getParentCategoryId()) {
-			_rebuildTreePath(category, parentCategory);
-
-			category.setParentCategoryId(parentCategoryId);
-		}
-
-		return assetCategoryPersistence.update(category);
+		return _moveCategory(category, parentCategoryId, vocabularyId);
 	}
 
 	@Override
@@ -684,38 +650,6 @@ public class AssetCategoryLocalServiceImpl
 			categoryProperties = new String[0];
 		}
 
-		validate(categoryId, parentCategoryId, name, vocabularyId);
-
-		if (categoryId == parentCategoryId) {
-			throw new InvalidAssetCategoryException(
-				parentCategoryId,
-				InvalidAssetCategoryException.CANNOT_MOVE_INTO_ITSELF);
-		}
-
-		AssetCategory parentCategory = null;
-
-		if (parentCategoryId > 0) {
-			parentCategory = assetCategoryPersistence.findByPrimaryKey(
-				parentCategoryId);
-		}
-
-		if (vocabularyId != category.getVocabularyId()) {
-			_assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
-
-			parentCategoryId =
-				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID;
-
-			category.setVocabularyId(vocabularyId);
-
-			updateChildrenVocabularyId(category, vocabularyId);
-		}
-
-		if (parentCategoryId != category.getParentCategoryId()) {
-			_rebuildTreePath(category, parentCategory);
-
-			category.setParentCategoryId(parentCategoryId);
-		}
-
 		category.setName(name);
 		category.setTitleMap(trimmedTitleMap);
 		category.setDescriptionMap(descriptionMap);
@@ -724,7 +658,7 @@ public class AssetCategoryLocalServiceImpl
 			category.setStatus(WorkflowConstants.STATUS_APPROVED);
 		}
 
-		return assetCategoryPersistence.update(category);
+		return _moveCategory(category, parentCategoryId, vocabularyId);
 	}
 
 	protected SearchContext buildSearchContext(
@@ -837,6 +771,53 @@ public class AssetCategoryLocalServiceImpl
 		}
 
 		return trimmedTitleMap;
+	}
+
+	private AssetCategory _moveCategory(
+			AssetCategory category, long parentCategoryId, long vocabularyId)
+		throws PortalException {
+
+		validate(
+			category.getCategoryId(), parentCategoryId, category.getName(),
+			vocabularyId);
+
+		if (category.getCategoryId() == parentCategoryId) {
+			throw new InvalidAssetCategoryException(
+				parentCategoryId,
+				InvalidAssetCategoryException.CANNOT_MOVE_INTO_ITSELF);
+		}
+
+		AssetCategory parentCategory = null;
+
+		if (parentCategoryId > 0) {
+			parentCategory = assetCategoryPersistence.findByPrimaryKey(
+				parentCategoryId);
+
+			String treePath = parentCategory.getTreePath();
+
+			if (treePath.startsWith(category.getTreePath())) {
+				throw new InvalidAssetCategoryException(
+					category.getCategoryId(),
+					InvalidAssetCategoryException.
+						CANNOT_MOVE_INTO_CHILD_CATEGORY);
+			}
+		}
+
+		if (vocabularyId != category.getVocabularyId()) {
+			_assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
+
+			updateChildrenVocabularyId(category, vocabularyId);
+
+			category.setVocabularyId(vocabularyId);
+		}
+
+		if (parentCategoryId != category.getParentCategoryId()) {
+			_rebuildTreePath(category, parentCategory);
+
+			category.setParentCategoryId(parentCategoryId);
+		}
+
+		return assetCategoryPersistence.update(category);
 	}
 
 	private void _rebuildTreePath(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57781

Hi team! The purpose of this PR is to enable `updateCategory` to invoke `moveCategory` when updating a category's parent category and vocabulary. RE: https://liferay.slack.com/archives/C089V9Y3PT7/p1749594574806149

Please review it and let me know if there are any issues, thanks!