### PR TITLE
LPD-54409 Fix poshi tests due to pagination changes

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotMemberships.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotMemberships.testcase
@@ -253,6 +253,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewOrganizationPagination {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		for (var num : list "1,2,3,4,5") {
 			JSONOrganization.addOrganization(organizationName = "Organization Name ${num}");
 		}
@@ -280,6 +282,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewUsersPagination {
+		property custom.properties = "search.container.page.default.delta=4${line.separator}search.container.page.delta.values=4,8,20,40,60";
+
 		for (var num : list "1,2,3,4,5") {
 			JSONUser.addUser(
 				userEmailAddress = "userea${num}@liferay.com",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/announcements/AnnouncementsPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/announcements/AnnouncementsPage.testcase
@@ -292,6 +292,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewAnnouncementsPagination {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		for (var entryCount : list "1,2,3,4,5,6,7") {
 			JSONAnnouncement.addAnnouncement(
 				announcementContent = "Announcements Entry Content ${entryCount}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
@@ -554,6 +554,7 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanViewPagersForCategoriesAndThreads {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
 		property portal.acceptance = "quarantine";
 
 		for (var categoryName : list "MB Category1 Name,MB Category2 Name,MB Category3 Name,MB Category4 Name,MB Category5 Name,MB Category6 Name") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
@@ -5829,6 +5829,7 @@ definition {
 	@description = "LPS-132254 When a user selects the value of the number of rows (4, 8, 40, 60) displayed in the list, the Content Dashboard will display the number of rows selected"
 	@priority = 5
 	test PaginationDisplaySelectedNumberOfRows {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
 		property portal.acceptance = "true";
 
 		var groupId = JSONGroupSetter.setGroupId(groupName = "Test Site Name");
@@ -5856,6 +5857,8 @@ definition {
 	@description = "LPS-132254 When a user use the <, > buttons, the page displayed moves forward/backward"
 	@priority = 3
 	test PaginationMoveAcrossPagesWithButtons {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		var groupId = JSONGroupSetter.setGroupId(groupName = "Test Site Name");
 
 		task ("Create 6 WC using JSON") {
@@ -5887,6 +5890,8 @@ definition {
 	@description = "LPS-132254 When a user clicks on a page number, that page is displayed in the Content Dashboard"
 	@priority = 3
 	test PaginationMoveAcrossPagesWithNumber {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		var groupId = JSONGroupSetter.setGroupId(groupName = "Test Site Name");
 
 		task ("Create 6 WC using JSON") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMAdmin.testcase
@@ -58,6 +58,8 @@ definition {
 	@description = "This is a test for LPS-91199. It checks that all files selected on different pages can be deleted."
 	@priority = 4
 	test CanDeleteAllDocumentsOnDifferentPagesAtOnce {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		for (var entryCount : list "1,2,3,4,5") {
 			JSONDocument.addFileWithUploadedFile(
 				dmDocumentDescription = "DM Document Description",
@@ -80,6 +82,7 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanMoveDocumentsWithMultiplePaginations {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
 		property portal.acceptance = "quarantine";
 		property portal.release = "quarantine";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMFileEntry.testcase
@@ -466,6 +466,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanCheckInAllDocumentsOnDifferentPagesAtOnce {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		JSONDocument.addFileWithUploadedFile(
 			dmDocumentTitle = "Document_1.doc",
 			groupName = "Guest",
@@ -3169,6 +3171,8 @@ definition {
 	@description = "This ensures that All the version entries are ordered by version with the latest version at the top in the version history page."
 	@priority = 4
 	test CanViewAllFileVersionsFromVersionsPage {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		var documentId = JSONDocument.addFileWithUploadedFile(
 			dmDocumentDescription = "DM Document Description",
 			dmDocumentTitle = "Document Version 1.0",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMWidget.testcase
@@ -189,6 +189,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test SelectionPersistsWhenTraversingPages {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		HeadlessSite.addSite(siteName = "Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/webcontentdisplay/WebContentDisplay.testcase
@@ -1664,6 +1664,8 @@ ${httpUtil.URLtoString(request.getAttribute("CTX").getResource(".").toURI().crea
 	@description = "View pagination in related assets within a web content."
 	@priority = 3
 	test ViewRelatedAssetsAfterChangePagination {
+		property custom.properties = "search.container.page.delta.values=4,8,20,40,60";
+
 		task ("Add six web contents") {
 			for (var i : list "1,2,3,4,5,6") {
 				JSONWebcontent.addWebContent(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54409

Pagination was changed, so some tests are failing:

LocalFile.ContentDashboard#PaginationDisplaySelectedNumberOfRows
LocalFile.DMAdmin#CanDeleteAllDocumentsOnDifferentPagesAtOnce
LocalFile.DMAdmin#CanMoveDocumentsWithMultiplePaginations
LocalFile.MBPage#CanViewPagersForCategoriesAndThreads
LocalFile.DepotMemberships#CanViewOrganizationPagination
LocalFile.DepotMemberships#CanViewUsersPagination
LocalFile.ContentDashboard#PaginationMoveAcrossPagesWithButtons
LocalFile.ContentDashboard#PaginationMoveAcrossPagesWithNumber
LocalFile.DMWidget#SelectionPersistsWhenTraversingPages
LocalFile.WebContentDisplay#ViewRelatedAssetsAfterChangePagination
LocalFile.DMFileEntry#CanViewAllFileVersionsFromVersionsPage
LocalFile.DMFileEntry#CanCheckInAllDocumentsOnDifferentPagesAtOnce

The fix is to use property custom.properties = "search.container.page.default.delta=4${line.separator}search.container.page.delta.values=4,8,20,40,60";
so as to have a custom delta for search container. 

NOTE: This only works in the CI, tests won't pass in local