### PR TITLE
LPD-57453 Web content's display date is 12 hours behind when publishing web content after noon

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -382,6 +382,12 @@ public class JournalArticleLocalServiceImpl
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, user.getTimeZone(), null);
 
+		Date date = new Date();
+
+		if (displayDate == null) {
+			displayDate = date;
+		}
+
 		Date expirationDate = null;
 		Date reviewDate = null;
 
@@ -518,8 +524,6 @@ public class JournalArticleLocalServiceImpl
 		article.setSmallImageSource(smallImageSource);
 
 		article.setSmallImageURL(smallImageURL);
-
-		Date date = new Date();
 
 		if ((expirationDate == null) || expirationDate.after(date)) {
 			article.setStatus(WorkflowConstants.STATUS_DRAFT);
@@ -4892,6 +4896,19 @@ public class JournalArticleLocalServiceImpl
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, user.getTimeZone(), null);
 
+		Date date = new Date();
+
+		if (displayDate == null) {
+			displayDate = article.getDisplayDate();
+
+			if ((displayDate != null) && displayDate.before(new Date())) {
+				displayDate = article.getDisplayDate();
+			}
+			else {
+				displayDate = date;
+			}
+		}
+
 		Date expirationDate = null;
 		Date reviewDate = null;
 
@@ -4908,8 +4925,6 @@ public class JournalArticleLocalServiceImpl
 				reviewDateMinute, user.getTimeZone(),
 				ArticleReviewDateException.class);
 		}
-
-		Date date = new Date();
 
 		boolean expired = false;
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -382,10 +382,14 @@ public class JournalArticleLocalServiceImpl
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, user.getTimeZone(), null);
 
-		Date date = new Date();
-
 		if (displayDate == null) {
-			displayDate = date;
+			Calendar calendar = CalendarFactoryUtil.getCalendar(
+				user.getTimeZone());
+
+			calendar.set(Calendar.SECOND, 0);
+			calendar.set(Calendar.MILLISECOND, 0);
+
+			displayDate = calendar.getTime();
 		}
 
 		Date expirationDate = null;
@@ -524,6 +528,8 @@ public class JournalArticleLocalServiceImpl
 		article.setSmallImageSource(smallImageSource);
 
 		article.setSmallImageURL(smallImageURL);
+
+		Date date = new Date();
 
 		if ((expirationDate == null) || expirationDate.after(date)) {
 			article.setStatus(WorkflowConstants.STATUS_DRAFT);
@@ -4896,8 +4902,6 @@ public class JournalArticleLocalServiceImpl
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, user.getTimeZone(), null);
 
-		Date date = new Date();
-
 		if (displayDate == null) {
 			displayDate = article.getDisplayDate();
 
@@ -4905,7 +4909,13 @@ public class JournalArticleLocalServiceImpl
 				displayDate = article.getDisplayDate();
 			}
 			else {
-				displayDate = date;
+				Calendar calendar = CalendarFactoryUtil.getCalendar(
+					user.getTimeZone());
+
+				calendar.set(Calendar.SECOND, 0);
+				calendar.set(Calendar.MILLISECOND, 0);
+
+				displayDate = calendar.getTime();
 			}
 		}
 
@@ -4925,6 +4935,8 @@ public class JournalArticleLocalServiceImpl
 				reviewDateMinute, user.getTimeZone(),
 				ArticleReviewDateException.class);
 		}
+
+		Date date = new Date();
 
 		boolean expired = false;
 

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -416,18 +416,24 @@ public class JournalTestUtil {
 			expirationDateMinute = expirationCal.get(Calendar.MINUTE);
 		}
 
+		int displayDateMonth = 0;
+		int displayDateDay = 0;
+		int displayDateYear = 0;
+		int displayDateHour = 0;
+		int displayDateMinute = 0;
+
 		Calendar displayCal = CalendarFactoryUtil.getCalendar(
 			user.getTimeZone());
 
 		if (displayDate != null) {
 			displayCal.setTime(displayDate);
-		}
 
-		int displayDateDay = displayCal.get(Calendar.DATE);
-		int displayDateMonth = displayCal.get(Calendar.MONTH);
-		int displayDateYear = displayCal.get(Calendar.YEAR);
-		int displayDateHour = displayCal.get(Calendar.HOUR_OF_DAY);
-		int displayDateMinute = displayCal.get(Calendar.MINUTE);
+			displayDateDay = displayCal.get(Calendar.DATE);
+			displayDateMonth = displayCal.get(Calendar.MONTH);
+			displayDateYear = displayCal.get(Calendar.YEAR);
+			displayDateHour = displayCal.get(Calendar.HOUR_OF_DAY);
+			displayDateMinute = displayCal.get(Calendar.MINUTE);
+		}
 
 		if (workflowEnabled) {
 			serviceContext = (ServiceContext)serviceContext.clone();

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -422,10 +422,10 @@ public class JournalTestUtil {
 		int displayDateHour = 0;
 		int displayDateMinute = 0;
 
-		Calendar displayCal = CalendarFactoryUtil.getCalendar(
-			user.getTimeZone());
-
 		if (displayDate != null) {
+			Calendar displayCal = CalendarFactoryUtil.getCalendar(
+				user.getTimeZone());
+
 			displayCal.setTime(displayDate);
 
 			displayDateDay = displayCal.get(Calendar.DATE);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -538,6 +538,35 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testArticleWithoutDisplayDate() throws Exception {
+		JournalArticle journalArticle1 = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		Assert.assertNotNull(journalArticle1.getDisplayDate());
+
+		JournalArticle journalArticle2 = JournalTestUtil.updateArticle(
+			journalArticle1);
+
+		Assert.assertEquals(
+			journalArticle1.getDisplayDate(), journalArticle2.getDisplayDate());
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		Date date = calendar.getTime();
+
+		journalArticle2 = JournalTestUtil.updateArticle(
+			journalArticle2.getUserId(), journalArticle2,
+			journalArticle2.getTitleMap(), journalArticle2.getContent(), date,
+			false, true, ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(date, journalArticle2.getDisplayDate());
+	}
+
+	@Test
 	public void testCopyArticle() throws Exception {
 		JournalArticle oldJournalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
@@ -25,14 +25,11 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -47,7 +44,6 @@ import jakarta.portlet.PortletRequest;
 import java.io.File;
 
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -195,15 +191,6 @@ public class JournalArticleUtil {
 			displayDateHour += 12;
 		}
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		User user = themeDisplay.getUser();
-
-		Date displayDate = portal.getDate(
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(), null);
-
 		int expirationDateMonth = ParamUtil.getInteger(
 			uploadPortletRequest, "expirationDateMonth");
 		int expirationDateDay = ParamUtil.getInteger(
@@ -315,19 +302,6 @@ public class JournalArticleUtil {
 			boolean autoArticleId = ParamUtil.getBoolean(
 				uploadPortletRequest, "autoArticleId");
 
-			if (displayDate == null) {
-				Calendar calendar = CalendarFactoryUtil.getCalendar(
-					user.getTimeZone());
-
-				calendar.setTime(new Date());
-
-				displayDateMonth = calendar.get(Calendar.MONTH);
-				displayDateDay = calendar.get(Calendar.DATE);
-				displayDateYear = calendar.get(Calendar.YEAR);
-				displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
-				displayDateMinute = calendar.get(Calendar.MINUTE);
-			}
-
 			article = journalArticleService.addArticle(
 				null, groupId, folderId, classNameId, classPK, articleId,
 				autoArticleId, titleMap, descriptionMap, friendlyURLMap,
@@ -362,28 +336,6 @@ public class JournalArticleUtil {
 			}
 
 			if (actionName.equals("/journal/update_article")) {
-				if (displayDate == null) {
-					Calendar calendar = CalendarFactoryUtil.getCalendar(
-						user.getTimeZone());
-
-					displayDate = article.getDisplayDate();
-
-					if ((displayDate != null) &&
-						displayDate.before(new Date())) {
-
-						calendar.setTime(article.getDisplayDate());
-					}
-					else {
-						calendar.setTime(new Date());
-					}
-
-					displayDateMonth = calendar.get(Calendar.MONTH);
-					displayDateDay = calendar.get(Calendar.DATE);
-					displayDateYear = calendar.get(Calendar.YEAR);
-					displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
-					displayDateMinute = calendar.get(Calendar.MINUTE);
-				}
-
 				article = journalArticleService.updateArticle(
 					groupId, folderId, articleId, version, titleMap,
 					descriptionMap, friendlyURLMap, content, ddmTemplateKey,

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
@@ -324,7 +324,7 @@ public class JournalArticleUtil {
 				displayDateMonth = calendar.get(Calendar.MONTH);
 				displayDateDay = calendar.get(Calendar.DATE);
 				displayDateYear = calendar.get(Calendar.YEAR);
-				displayDateHour = calendar.get(Calendar.HOUR);
+				displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
 				displayDateMinute = calendar.get(Calendar.MINUTE);
 			}
 
@@ -380,12 +380,8 @@ public class JournalArticleUtil {
 					displayDateMonth = calendar.get(Calendar.MONTH);
 					displayDateDay = calendar.get(Calendar.DATE);
 					displayDateYear = calendar.get(Calendar.YEAR);
-					displayDateHour = calendar.get(Calendar.HOUR);
+					displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
 					displayDateMinute = calendar.get(Calendar.MINUTE);
-
-					if (calendar.get(Calendar.AM_PM) == Calendar.PM) {
-						displayDateHour += 12;
-					}
 				}
 
 				article = journalArticleService.updateArticle(


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-57453

When publishing a web content article after 12:00PM, the display date says published 12 hours ago if user timezone is not UTC

# How am I fixing it?

Though [Simplify displayDateHour calculation](https://github.com/liferay-content-management/liferay-portal/commit/5a2c2e0597bca204b889a0471a492511cb6bad82) can fix the issue. But there was an another issue of missmatch between the seconds of creationDate and displayDate. Which is expected because fact that the display date does not account for seconds. I believe the more reliable solution might be to add a null check at the service layer to avoid unintended discrepancies

# How can you verify that it works?

Run the included automated tests.

cc : @jkappler @ak-ragnor 