### PR TITLE
LPD-58219 Capture exception in view descriptor

### DIFF
--- a/modules/apps/journal/journal-web-test/build.gradle
+++ b/modules/apps/journal/journal-web-test/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:info:info-api")
+	testIntegrationImplementation project(":apps:item-selector:item-selector-api")
+	testIntegrationImplementation project(":apps:item-selector:item-selector-criteria-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/display/test/JournalArticleItemSelectorViewDisplayContextTest.java
+++ b/modules/apps/journal/journal-web-test/src/testIntegration/java/com/liferay/journal/web/internal/display/test/JournalArticleItemSelectorViewDisplayContextTest.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.display.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
+import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleItemSelectorViewDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetPayloadWithAssetType() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_getPayload(journalArticle));
+
+		DDMStructure ddmStructure = DDMStructureLocalServiceUtil.getStructure(
+			journalArticle.getDDMStructureId());
+
+		Assert.assertEquals(
+			ddmStructure.getName(LocaleUtil.getDefault()),
+			jsonObject.getString("assetType"));
+	}
+
+	@Test
+	public void testGetPayloadWithoutAssetType() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
+			JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey());
+
+		assetEntry.setClassTypeId(0);
+
+		_assetEntryLocalService.updateAssetEntry(assetEntry);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.journal.web.internal.display.context." +
+					"JournalArticleItemSelectorViewDisplayContext",
+				LoggerTestUtil.ERROR)) {
+
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+				_getPayload(journalArticle));
+
+			Assert.assertEquals(
+				StringPool.BLANK, jsonObject.getString("assetType"));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to get classType for article with ID: " +
+					journalArticle.getArticleId(),
+				logEntry.getMessage());
+		}
+	}
+
+	private String _getPayload(JournalArticle journalArticle)
+		throws IOException, ServletException {
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		_itemSelectorView.renderHTML(
+			httpServletRequest, new MockHttpServletResponse(), null, null, null,
+			false);
+
+		return ReflectionTestUtil.invoke(
+			httpServletRequest.getAttribute(
+				"JOURNAL_ARTICLE_ITEM_SELECTOR_VIEW_DISPLAY_CONTEXT"),
+			"getPayload", new Class<?>[] {JournalArticle.class},
+			journalArticle);
+	}
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.journal.web.internal.item.selector.JournalArticleItemSelectorView",
+		type = ItemSelectorView.class
+	)
+	private ItemSelectorView<InfoItemItemSelectorCriterion> _itemSelectorView;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -40,6 +40,8 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -206,10 +208,20 @@ public class JournalArticleItemSelectorViewDisplayContext {
 				ClassTypeReader classTypeReader =
 					assetRendererFactory.getClassTypeReader();
 
-				ClassType classType = classTypeReader.getClassType(
-					assetEntry.getClassTypeId(), _themeDisplay.getLocale());
+				try {
+					ClassType classType = classTypeReader.getClassType(
+						assetEntry.getClassTypeId(), _themeDisplay.getLocale());
 
-				return classType.getName();
+					return classType.getName();
+				}
+				catch (Exception exception) {
+					_log.error(
+						"Unable to get classType for article with ID: " +
+							journalArticle.getArticleId(),
+						exception);
+				}
+
+				return StringPool.BLANK;
 			}
 		).put(
 			"className", JournalArticle.class.getName()
@@ -766,6 +778,9 @@ public class JournalArticleItemSelectorViewDisplayContext {
 				Boolean.TRUE);
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleItemSelectorViewDisplayContext.class);
 
 	private SearchContainer<?> _articleSearchContainer;
 	private Long _ddmStructureId;


### PR DESCRIPTION
Link https://liferay.atlassian.net/browse/LPD-58219

There are certain cases with bad data after an update. In these cases the asset entry classTypeId column for a web content will be null or 0. So when trying to select web content in a web content display widget, the view is empty and an error is thrown in the logs.

The idea is to capture the exception and show which web content is failing, and most important, don't let the view break.

There are ways to reproduce this in the portal, but it involves changing values in the DB, so the easiest way would be to execute the provided tests