### PR TITLE
LPD-57827 Creating a doc inside a folder should use current space

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
@@ -7,8 +7,6 @@ package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -20,7 +18,6 @@ import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -32,7 +29,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -45,11 +41,9 @@ import java.io.File;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Assert;
 import org.junit.Before;
 
 import org.osgi.framework.Bundle;
@@ -182,17 +176,6 @@ public abstract class BaseDisplayContextTestCase {
 			Collections.emptyList(), scope, status);
 	}
 
-	protected String getHref(ObjectDefinition objectDefinition) {
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("/cms/add_structured_content_item?groupId=");
-		sb.append(group.getGroupId());
-		sb.append("&objectDefinitionId=");
-		sb.append(objectDefinition.getObjectDefinitionId());
-
-		return sb.toString();
-	}
-
 	protected MockHttpServletRequest getMockHttpServletRequest()
 		throws Exception {
 
@@ -236,34 +219,6 @@ public abstract class BaseDisplayContextTestCase {
 		themeDisplay.setUser(TestPropsValues.getUser());
 
 		return themeDisplay;
-	}
-
-	protected void testGetCreationMenu(
-		CreationMenu creationMenu, Map<String, String> expectedResultMap) {
-
-		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
-			"primaryItems");
-
-		Assert.assertEquals(
-			dropdownItems.toString(), expectedResultMap.size(),
-			dropdownItems.size());
-
-		int index = 0;
-
-		for (Map.Entry<String, String> entry : expectedResultMap.entrySet()) {
-			DropdownItem dropdownItem = dropdownItems.get(index);
-
-			Assert.assertEquals(entry.getKey(), dropdownItem.get("label"));
-
-			if (Validator.isNull(entry.getValue())) {
-				Assert.assertNull(dropdownItem.get("href"));
-			}
-			else {
-				Assert.assertEquals(entry.getValue(), dropdownItem.get("href"));
-			}
-
-			index++;
-		}
 	}
 
 	@Inject

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
@@ -9,9 +9,14 @@ import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
@@ -19,7 +24,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -62,6 +66,10 @@ public abstract class BaseDisplayContextTestCase {
 	@Before
 	public void setUp() throws Exception {
 		group = GroupTestUtil.addGroup();
+
+		if (_isCMSSiteInitialized()) {
+			return;
+		}
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
@@ -108,6 +116,7 @@ public abstract class BaseDisplayContextTestCase {
 
 	protected ObjectDefinition addCustomObjectDefinition(
 			long objectFolderId, boolean active, boolean enableObjectEntryDraft,
+			List<ObjectDefinitionSetting> objectDefinitionSettings,
 			String scope, int status)
 		throws Exception {
 
@@ -121,7 +130,7 @@ public abstract class BaseDisplayContextTestCase {
 				Collections.singletonMap(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				true, scope, ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
-				Collections.emptyList(),
+				objectDefinitionSettings,
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
 						"Text", "String", true, true, null,
@@ -160,7 +169,17 @@ public abstract class BaseDisplayContextTestCase {
 			objectDefinition.getPanelCategoryKey(),
 			objectDefinition.isPortlet(), objectDefinition.getPluralLabelMap(),
 			objectDefinition.getScope(), objectDefinition.getStatus(),
-			Collections.emptyList());
+			objectDefinition.getObjectDefinitionSettings());
+	}
+
+	protected ObjectDefinition addCustomObjectDefinition(
+			long objectFolderId, boolean active, boolean enableObjectEntryDraft,
+			String scope, int status)
+		throws Exception {
+
+		return addCustomObjectDefinition(
+			objectFolderId, active, enableObjectEntryDraft,
+			Collections.emptyList(), scope, status);
 	}
 
 	protected String getHref(ObjectDefinition objectDefinition) {
@@ -177,8 +196,20 @@ public abstract class BaseDisplayContextTestCase {
 	protected MockHttpServletRequest getMockHttpServletRequest()
 		throws Exception {
 
+		return getMockHttpServletRequest(null);
+	}
+
+	protected MockHttpServletRequest getMockHttpServletRequest(
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
+
+		if (objectEntryFolder != null) {
+			mockHttpServletRequest.setAttribute(
+				InfoDisplayWebKeys.INFO_ITEM, objectEntryFolder);
+		}
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, getThemeDisplay(mockHttpServletRequest));
@@ -247,6 +278,19 @@ public abstract class BaseDisplayContextTestCase {
 	@Inject
 	protected ObjectFolderLocalService objectFolderLocalService;
 
+	private boolean _isCMSSiteInitialized() {
+		ObjectFolder objectFolder =
+			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+				group.getCompanyId());
+
+		if (objectFolder != null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private void _setUpProcessedFile(Bundle bundle, String fileName) {
 		File file = bundle.getDataFile(
 			".com.liferay.site.initializer.cms.internal.batch." + fileName +
@@ -262,9 +306,6 @@ public abstract class BaseDisplayContextTestCase {
 
 	@Inject
 	private BatchEngineUnitReader _batchEngineUnitReader;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -11,13 +11,17 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -31,6 +35,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 
@@ -39,6 +44,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
@@ -49,6 +55,64 @@ import org.junit.Test;
  */
 public abstract class BaseSectionDisplayContextTestCase
 	extends BaseDisplayContextTestCase {
+
+	@Test
+	@TestInfo("LPD-50664")
+	public void testGetCreationMenu() throws Exception {
+		Map<String, String> expectedResultMap = getExpectedCreationMenuItems();
+
+		_testGetCreationMenu(getCreationMenu(), expectedResultMap);
+
+		ObjectFolder objectFolder = null;
+
+		for (String objectFolderExternalReferenceCode :
+				getObjectFolderExternalReferenceCodes()) {
+
+			objectFolder =
+				objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+					objectFolderExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+			ObjectDefinition objectDefinition = addCustomObjectDefinition(
+				objectFolder.getObjectFolderId(), true, true,
+				ObjectDefinitionConstants.SCOPE_DEPOT,
+				WorkflowConstants.STATUS_APPROVED);
+
+			expectedResultMap.put(
+				objectDefinition.getLabel(LocaleUtil.US),
+				getRedirect(
+					objectDefinition,
+					_getRootObjectEntryFolderExternalReferenceCode(
+						objectFolderExternalReferenceCode)));
+		}
+
+		addCustomObjectDefinition(
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			false, true, ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+		addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), false, true,
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+		addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, false,
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+		addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, true,
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			WorkflowConstants.STATUS_APPROVED);
+		addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, true,
+			ObjectDefinitionConstants.SCOPE_SITE,
+			WorkflowConstants.STATUS_APPROVED);
+		addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, true,
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_DRAFT);
+
+		_testGetCreationMenu(getCreationMenu(), expectedResultMap);
+	}
 
 	@Test
 	@TestInfo("LPD-57827")
@@ -175,9 +239,56 @@ public abstract class BaseSectionDisplayContextTestCase
 			"getCreationMenu", new Class<?>[0]);
 	}
 
+	protected abstract Map<String, String> getExpectedCreationMenuItems()
+		throws PortalException;
+
 	protected abstract String getObjectFolderExternalReferenceCode();
 
-	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
+	protected List<String> getObjectFolderExternalReferenceCodes() {
+		return List.of(getObjectFolderExternalReferenceCode());
+	}
+
+	protected String getRedirect(
+		ObjectDefinition objectDefinition,
+		String objectEntryFolderExternalReferenceCode) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("/cms/add_structured_content_item?objectDefinitionId=");
+		sb.append(objectDefinition.getObjectDefinitionId());
+		sb.append("&objectEntryFolderExternalReferenceCode=");
+		sb.append(objectEntryFolderExternalReferenceCode);
+		sb.append("&plid=0&redirect=http://localhost:8080/currentURL");
+
+		return sb.toString();
+	}
+
+	protected String getRedirect(String objectDefinitionExternalReferenceCode)
+		throws PortalException {
+
+		return getRedirect(
+			objectDefinitionExternalReferenceCode,
+			getRootObjectEntryFolderExternalReferenceCode());
+	}
+
+	protected String getRedirect(
+			String objectDefinitionExternalReferenceCode,
+			String rootObjectEntryFolderExternalReferenceCode)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+		return getRedirect(
+			objectDefinition, rootObjectEntryFolderExternalReferenceCode);
+	}
+
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return null;
+	}
 
 	protected abstract Object getSectionDisplayContext(
 			HttpServletRequest httpServletRequest)
@@ -279,6 +390,16 @@ public abstract class BaseSectionDisplayContextTestCase
 			dropdownItemData);
 	}
 
+	private DropdownItem _get(List<DropdownItem> dropdownItems, String label) {
+		for (DropdownItem dropdownItem : dropdownItems) {
+			if (label.equals(dropdownItem.get("label"))) {
+				return dropdownItem;
+			}
+		}
+
+		return null;
+	}
+
 	private JSONArray _getJSONArray(List<DepotEntry> depotEntries) {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
@@ -297,6 +418,58 @@ public abstract class BaseSectionDisplayContextTestCase
 		}
 
 		return jsonArray;
+	}
+
+	private String _getRedirect(DropdownItem dropdownItem) {
+		Map<String, Object> map = (HashMap<String, Object>)dropdownItem.get(
+			"data");
+
+		if (map == null) {
+			return null;
+		}
+
+		return (String)map.get("redirect");
+	}
+
+	private String _getRootObjectEntryFolderExternalReferenceCode(
+		String objectFolderExternalReferenceCode) {
+
+		if (Objects.equals(
+				objectFolderExternalReferenceCode,
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES)) {
+
+			return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
+		}
+
+		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
+	}
+
+	private void _testGetCreationMenu(
+		CreationMenu creationMenu, Map<String, String> expectedResultMap) {
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertEquals(
+			dropdownItems.toString(), expectedResultMap.size(),
+			dropdownItems.size());
+
+		for (Map.Entry<String, String> entry : expectedResultMap.entrySet()) {
+			DropdownItem dropdownItem = _get(dropdownItems, entry.getKey());
+
+			Assert.assertNotNull(
+				"Not found DropdownItem with label " + entry.getKey(),
+				dropdownItem);
+
+			if (Validator.isNull(entry.getValue())) {
+				Assert.assertNull(_getRedirect(dropdownItem));
+			}
+			else {
+				Assert.assertEquals(
+					entry.getValue(), _getRedirect(dropdownItem));
+			}
+		}
 	}
 
 	private void _testGetDepotEntriesJSONArray(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -1,0 +1,349 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Marco Galluzzi
+ */
+public abstract class BaseSectionDisplayContextTestCase
+	extends BaseDisplayContextTestCase {
+
+	@Test
+	@TestInfo("LPD-57827")
+	public void testGetDepotEntriesJSONArrayWithMultipleDepots()
+		throws Exception {
+
+		String depotName = StringUtil.randomString();
+
+		DepotEntry depotEntry = _addDepotEntry(depotName);
+
+		try {
+			List<DepotEntry> depotEntries =
+				_depotEntryLocalService.getDepotEntries(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			Assert.assertEquals(
+				depotEntries.toString(), 2, depotEntries.size());
+
+			DepotEntry defaultDepotEntry = depotEntries.get(0);
+
+			Group defaultDepotGroup = _groupLocalService.fetchGroup(
+				defaultDepotEntry.getGroupId());
+
+			Assert.assertEquals("Default", defaultDepotGroup.getGroupKey());
+
+			Group depotGroup = _groupLocalService.fetchGroup(
+				depotEntry.getGroupId());
+
+			Assert.assertEquals(depotName, depotGroup.getGroupKey());
+
+			_testGetDepotEntriesJSONArray(depotEntries, null, null);
+			_testGetDepotEntriesJSONArray(
+				List.of(depotEntry), null,
+				String.valueOf(depotGroup.getGroupId()));
+			_testGetDepotEntriesJSONArray(
+				List.of(defaultDepotEntry), null,
+				String.valueOf(defaultDepotGroup.getGroupId()));
+
+			if (getRootObjectEntryFolderExternalReferenceCode() != null) {
+				ObjectEntryFolder objectEntryFolder = _addObjectFolderEntry(
+					depotGroup);
+
+				_testGetDepotEntriesJSONArray(
+					List.of(depotEntry), objectEntryFolder, null);
+				_testGetDepotEntriesJSONArray(
+					List.of(depotEntry), objectEntryFolder,
+					String.valueOf(depotGroup.getGroupId()));
+				_testGetDepotEntriesJSONArray(
+					null, objectEntryFolder,
+					String.valueOf(defaultDepotGroup.getGroupId()));
+			}
+		}
+		finally {
+			_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-57827")
+	public void testGetDepotEntriesJSONArrayWithOneDepotOnly()
+		throws Exception {
+
+		List<DepotEntry> depotEntries = _depotEntryLocalService.getDepotEntries(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertEquals(depotEntries.toString(), 1, depotEntries.size());
+
+		DepotEntry depotEntry = depotEntries.get(0);
+
+		Group depotGroup = _groupLocalService.fetchGroup(
+			depotEntry.getGroupId());
+
+		Assert.assertEquals("Default", depotGroup.getGroupKey());
+
+		_testGetDepotEntriesJSONArray(depotEntries, null, null);
+		_testGetDepotEntriesJSONArray(
+			depotEntries, null, String.valueOf(depotGroup.getGroupId()));
+
+		if (getRootObjectEntryFolderExternalReferenceCode() != null) {
+			ObjectEntryFolder objectEntryFolder = _addObjectFolderEntry(
+				depotGroup);
+
+			_testGetDepotEntriesJSONArray(
+				List.of(depotEntry), objectEntryFolder, null);
+			_testGetDepotEntriesJSONArray(
+				List.of(depotEntry), objectEntryFolder,
+				String.valueOf(depotGroup.getGroupId()));
+		}
+	}
+
+	protected ObjectDefinition addCustomObjectDefinition(
+			String objectDefinitionSettingName,
+			String objectDefinitionSettingValue)
+		throws Exception {
+
+		ObjectFolder objectFolder =
+			objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				getObjectFolderExternalReferenceCode(),
+				TestPropsValues.getCompanyId());
+
+		return addCustomObjectDefinition(
+			objectFolder.getObjectFolderId(), true, true,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					objectDefinitionSettingName
+				).value(
+					objectDefinitionSettingValue
+				).build()),
+			ObjectDefinitionConstants.SCOPE_DEPOT,
+			WorkflowConstants.STATUS_APPROVED);
+	}
+
+	protected CreationMenu getCreationMenu() throws Exception {
+		return getCreationMenu(null);
+	}
+
+	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			getSectionDisplayContext(
+				getMockHttpServletRequest(objectEntryFolder)),
+			"getCreationMenu", new Class<?>[0]);
+	}
+
+	protected abstract String getObjectFolderExternalReferenceCode();
+
+	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
+
+	protected abstract Object getSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception;
+
+	private DepotEntry _addDepotEntry(String name) throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), name
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), StringUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private ObjectEntryFolder _addObjectFolderEntry(Group group)
+		throws Exception {
+
+		ObjectEntryFolder rootObjectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					getRootObjectEntryFolderExternalReferenceCode(),
+					group.getGroupId(), group.getCompanyId());
+
+		return _objectEntryFolderLocalService.addObjectEntryFolder(
+			StringUtil.randomString(), group.getGroupId(),
+			TestPropsValues.getUserId(),
+			rootObjectEntryFolder.getObjectEntryFolderId(),
+			RandomTestUtil.randomString(), null, StringUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+	}
+
+	private void _assertCreationMenuContainsDropdownItem(
+		CreationMenu creationMenu, JSONArray expectedAssetLibrariesJSONArray,
+		String expectedLabel) {
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertFalse(dropdownItems.toString(), dropdownItems.isEmpty());
+
+		HashMap<String, Object> dropdownItemData = null;
+
+		for (DropdownItem dropdownItem : dropdownItems) {
+			if (Objects.equals(dropdownItem.get("label"), expectedLabel)) {
+				dropdownItemData = (HashMap<String, Object>)dropdownItem.get(
+					"data");
+
+				break;
+			}
+		}
+
+		Assert.assertNotNull(
+			String.format(
+				"Creation menu does not contain label '%s': %s", expectedLabel,
+				dropdownItems),
+			dropdownItemData);
+
+		JSONArray assetLibrariesJSONArray = (JSONArray)dropdownItemData.get(
+			"assetLibraries");
+
+		Assert.assertNotNull(assetLibrariesJSONArray);
+
+		Assert.assertEquals(
+			assetLibrariesJSONArray.toString(),
+			expectedAssetLibrariesJSONArray.length(),
+			assetLibrariesJSONArray.length());
+
+		Assert.assertTrue(
+			assetLibrariesJSONArray.toString(),
+			JSONUtil.equals(
+				expectedAssetLibrariesJSONArray, assetLibrariesJSONArray));
+	}
+
+	private void _assertCreationMenuNotContainsDropdownItem(
+		CreationMenu creationMenu, String notExpectedLabel) {
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertFalse(dropdownItems.toString(), dropdownItems.isEmpty());
+
+		HashMap<String, Object> dropdownItemData = null;
+
+		for (DropdownItem dropdownItem : dropdownItems) {
+			if (Objects.equals(dropdownItem.get("label"), notExpectedLabel)) {
+				dropdownItemData = (HashMap<String, Object>)dropdownItem.get(
+					"data");
+
+				break;
+			}
+		}
+
+		Assert.assertNull(
+			String.format(
+				"Creation menu contains label '%s': %s", notExpectedLabel,
+				dropdownItems),
+			dropdownItemData);
+	}
+
+	private JSONArray _getJSONArray(List<DepotEntry> depotEntries) {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		for (DepotEntry depotEntry : depotEntries) {
+			Group group = _groupLocalService.fetchGroup(
+				depotEntry.getGroupId());
+
+			if (group != null) {
+				jsonArray.put(
+					JSONUtil.put(
+						"groupId", group.getGroupId()
+					).put(
+						"name", group.getName(LocaleUtil.getDefault())
+					));
+			}
+		}
+
+		return jsonArray;
+	}
+
+	private void _testGetDepotEntriesJSONArray(
+			List<DepotEntry> depotEntries, ObjectEntryFolder objectEntryFolder,
+			String acceptedGroupIds)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = null;
+
+		if (acceptedGroupIds != null) {
+			objectDefinition = addCustomObjectDefinition(
+				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+				acceptedGroupIds);
+		}
+		else {
+			objectDefinition = addCustomObjectDefinition(
+				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+				StringPool.TRUE);
+		}
+
+		try {
+			CreationMenu creationMenu = getCreationMenu(objectEntryFolder);
+
+			if (depotEntries != null) {
+				_assertCreationMenuContainsDropdownItem(
+					creationMenu, _getJSONArray(depotEntries),
+					objectDefinition.getLabel(LocaleUtil.getDefault()));
+			}
+			else {
+				_assertCreationMenuNotContainsDropdownItem(
+					creationMenu,
+					objectDefinition.getLabel(LocaleUtil.getDefault()));
+			}
+		}
+		finally {
+			objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -12,10 +12,10 @@ import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -45,7 +45,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @RunWith(Arquillian.class)
 @Sync
 public class ViewAllSectionDisplayContextTest
-	extends BaseDisplayContextTestCase {
+	extends BaseSectionDisplayContextTestCase {
 
 	@ClassRule
 	@Rule
@@ -72,11 +72,7 @@ public class ViewAllSectionDisplayContextTest
 						"L_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId()))
 		).build();
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewAllSectionDisplayContext(getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 
 		ObjectFolder cmsContentStructuresObjectFolder =
 			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
@@ -130,14 +126,25 @@ public class ViewAllSectionDisplayContextTest
 			ObjectDefinitionConstants.SCOPE_SITE,
 			WorkflowConstants.STATUS_DRAFT);
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewAllSectionDisplayContext(getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 	}
 
-	private Object _getViewAllSectionDisplayContext(
+	@Override
+	protected String getObjectFolderExternalReferenceCode() {
+		if (RandomTestUtil.randomBoolean()) {
+			return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+		}
+
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+	}
+
+	@Override
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return null;
+	}
+
+	@Override
+	protected Object getSectionDisplayContext(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -7,19 +7,14 @@ package com.liferay.site.cms.site.initializer.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectFolder;
-import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -27,13 +22,12 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -54,93 +48,55 @@ public class ViewAllSectionDisplayContextTest
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Ignore
-	@Test
-	@TestInfo("LPD-50664")
-	public void testGetCreationMenu() throws Exception {
-		Map<String, String> expectedResultMap = LinkedHashMapBuilder.put(
+	@Override
+	protected Map<String, String> getExpectedCreationMenuItems()
+		throws PortalException {
+
+		return HashMapBuilder.put(
 			"Basic Document",
-			getHref(
-				objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_BASIC_DOCUMENT", TestPropsValues.getCompanyId()))
+			getRedirect(
+				"L_BASIC_DOCUMENT",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)
 		).put(
 			"Basic Web Content",
-			getHref(
-				objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId()))
+			getRedirect(
+				"L_BASIC_WEB_CONTENT",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
+		).put(
+			"Blog",
+			getRedirect(
+				"L_BLOG",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
+		).put(
+			"External Video",
+			getRedirect(
+				"L_EXTERNAL_VIDEO",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)
+		).put(
+			"Knowledge Base",
+			getRedirect(
+				"L_KNOWLEDGE_BASE",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
+		).put(
+			"multiple-files", StringPool.BLANK
 		).build();
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
-
-		ObjectFolder cmsContentStructuresObjectFolder =
-			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
-				TestPropsValues.getCompanyId());
-
-		ObjectDefinition cmsContentStructuresObjectDefinition =
-			addCustomObjectDefinition(
-				cmsContentStructuresObjectFolder.getObjectFolderId(), true,
-				true, ObjectDefinitionConstants.SCOPE_SITE,
-				WorkflowConstants.STATUS_APPROVED);
-
-		ObjectFolder cmsFileTypesObjectFolder =
-			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
-				TestPropsValues.getCompanyId());
-
-		ObjectDefinition cmsFileTypesObjectDefinition =
-			addCustomObjectDefinition(
-				cmsFileTypesObjectFolder.getObjectFolderId(), true, true,
-				ObjectDefinitionConstants.SCOPE_SITE,
-				WorkflowConstants.STATUS_APPROVED);
-
-		expectedResultMap.put(
-			cmsFileTypesObjectDefinition.getLabel(LocaleUtil.US),
-			getHref(cmsFileTypesObjectDefinition));
-
-		expectedResultMap.put(
-			cmsContentStructuresObjectDefinition.getLabel(LocaleUtil.US),
-			getHref(cmsContentStructuresObjectDefinition));
-
-		addCustomObjectDefinition(
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			false, true, ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			cmsContentStructuresObjectFolder.getObjectFolderId(), false, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			cmsContentStructuresObjectFolder.getObjectFolderId(), true, false,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			cmsContentStructuresObjectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_COMPANY,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			cmsContentStructuresObjectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_DRAFT);
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 	}
 
 	@Override
 	protected String getObjectFolderExternalReferenceCode() {
 		if (RandomTestUtil.randomBoolean()) {
-			return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+			return ObjectFolderConstants.
+				EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
 		}
 
-		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
 	}
 
 	@Override
-	protected String getRootObjectEntryFolderExternalReferenceCode() {
-		return null;
+	protected List<String> getObjectFolderExternalReferenceCodes() {
+		return List.of(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -56,23 +56,29 @@ public class ViewContentsSectionDisplayContextTest
 			_getFDSActionDropdownItems();
 
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 5,
+			fdsActionDropdownItems.toString(), 7,
 			fdsActionDropdownItems.size());
 
 		_assertFDSActionDropdownItem(
 			fdsActionDropdownItems.get(0), "view", "actionLinkFolder",
 			"view-folder", "get", "item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(1), "pencil", "editFolder", "edit",
+			fdsActionDropdownItems.get(1), "info-circle-open", "show-details",
+			"show-details", null, "item");
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(2), "pencil", "editFolder", "edit",
 			"get", "item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(2), "pencil", "actionLink", "edit",
+			fdsActionDropdownItems.get(3), "pencil", "actionLink", "edit",
 			"get", "item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(3), "password-policies", "permissions",
+			fdsActionDropdownItems.get(4), null, "version-history",
+			"view-history", "get", "item");
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(5), "password-policies", "permissions",
 			"permissions", "get", "item");
 		_assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(4), "trash", "delete", "delete",
+			fdsActionDropdownItems.get(6), "trash", "delete", "delete",
 			"delete", "item");
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -8,20 +8,14 @@ package com.liferay.site.cms.site.initializer.internal.display.context.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
-import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectFolder;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -34,7 +28,6 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,61 +49,6 @@ public class ViewContentsSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Ignore
-	@Test
-	@TestInfo("LPD-50664")
-	public void testGetCreationMenu() throws Exception {
-		Map<String, String> expectedResultMap = LinkedHashMapBuilder.put(
-			"folder", StringPool.BLANK
-		).put(
-			"Basic Web Content",
-			getHref(
-				objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId()))
-		).build();
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
-
-		ObjectFolder objectFolder =
-			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
-				TestPropsValues.getCompanyId());
-
-		ObjectDefinition objectDefinition = addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-
-		expectedResultMap.put(
-			objectDefinition.getLabel(LocaleUtil.US),
-			getHref(objectDefinition));
-
-		addCustomObjectDefinition(
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			false, true, ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), false, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, false,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_COMPANY,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_DRAFT);
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
-	}
 
 	@Test
 	public void testGetFDSActionDropdownItems() throws Exception {
@@ -136,6 +74,21 @@ public class ViewContentsSectionDisplayContextTest
 		_assertFDSActionDropdownItem(
 			fdsActionDropdownItems.get(4), "trash", "delete", "delete",
 			"delete", "item");
+	}
+
+	@Override
+	protected Map<String, String> getExpectedCreationMenuItems()
+		throws PortalException {
+
+		return HashMapBuilder.put(
+			"Basic Web Content", getRedirect("L_BASIC_WEB_CONTENT")
+		).put(
+			"Blog", getRedirect("L_BLOG")
+		).put(
+			"folder", StringPool.BLANK
+		).put(
+			"Knowledge Base", getRedirect("L_KNOWLEDGE_BASE")
+		).build();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -48,7 +48,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @RunWith(Arquillian.class)
 @Sync
 public class ViewContentsSectionDisplayContextTest
-	extends BaseDisplayContextTestCase {
+	extends BaseSectionDisplayContextTestCase {
 
 	@ClassRule
 	@Rule
@@ -71,12 +71,7 @@ public class ViewContentsSectionDisplayContextTest
 						"L_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId()))
 		).build();
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewContentsSectionDisplayContext(
-					getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 
 		ObjectFolder objectFolder =
 			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
@@ -114,12 +109,7 @@ public class ViewContentsSectionDisplayContextTest
 			ObjectDefinitionConstants.SCOPE_SITE,
 			WorkflowConstants.STATUS_DRAFT);
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewContentsSectionDisplayContext(
-					getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 	}
 
 	@Test
@@ -148,6 +138,33 @@ public class ViewContentsSectionDisplayContextTest
 			"delete", "item");
 	}
 
+	@Override
+	protected String getObjectFolderExternalReferenceCode() {
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+	}
+
+	@Override
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
+	}
+
+	@Override
+	protected Object getSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object contentsSectionDisplayContext = httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewContentsSectionDisplayContext");
+
+		Assert.assertNotNull(contentsSectionDisplayContext);
+
+		return contentsSectionDisplayContext;
+	}
+
 	private void _assertFDSActionDropdownItem(
 		FDSActionDropdownItem fdsActionDropdownItem, String icon, String id,
 		String label, String method, String type) {
@@ -169,24 +186,8 @@ public class ViewContentsSectionDisplayContextTest
 		throws Exception {
 
 		return ReflectionTestUtil.invoke(
-			_getViewContentsSectionDisplayContext(getMockHttpServletRequest()),
+			getSectionDisplayContext(getMockHttpServletRequest()),
 			"getFDSActionDropdownItems", new Class<?>[0]);
-	}
-
-	private Object _getViewContentsSectionDisplayContext(
-			HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		_fragmentRenderer.render(
-			null, httpServletRequest, new MockHttpServletResponse());
-
-		Object contentsSectionDisplayContext = httpServletRequest.getAttribute(
-			"com.liferay.site.cms.site.initializer.internal.display.context." +
-				"ViewContentsSectionDisplayContext");
-
-		Assert.assertNotNull(contentsSectionDisplayContext);
-
-		return contentsSectionDisplayContext;
 	}
 
 	@Inject(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -9,14 +9,12 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
-import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -29,7 +27,6 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -37,10 +34,8 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -53,7 +48,6 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,60 +69,6 @@ public class ViewFilesSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Ignore
-	@Test
-	@TestInfo("LPD-50664")
-	public void testGetCreationMenu() throws Exception {
-		Map<String, String> expectedResultMap = LinkedHashMapBuilder.put(
-			"folder", StringPool.BLANK
-		).put(
-			"Basic Document",
-			getHref(
-				objectDefinitionLocalService.
-					fetchObjectDefinitionByExternalReferenceCode(
-						"L_BASIC_DOCUMENT", TestPropsValues.getCompanyId()))
-		).build();
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
-
-		ObjectFolder objectFolder =
-			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
-				TestPropsValues.getCompanyId());
-
-		ObjectDefinition objectDefinition = addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-
-		expectedResultMap.put(
-			objectDefinition.getLabel(LocaleUtil.US),
-			getHref(objectDefinition));
-
-		addCustomObjectDefinition(
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			false, true, ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), false, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, false,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_COMPANY,
-			WorkflowConstants.STATUS_APPROVED);
-		addCustomObjectDefinition(
-			objectFolder.getObjectFolderId(), true, true,
-			ObjectDefinitionConstants.SCOPE_SITE,
-			WorkflowConstants.STATUS_DRAFT);
-
-		testGetCreationMenu(getCreationMenu(), expectedResultMap);
-	}
 
 	@Test
 	public void testGetCreationMenuWithAddEntryPermission() throws Exception {
@@ -178,6 +118,21 @@ public class ViewFilesSectionDisplayContextTest
 			PermissionThreadLocal.setPermissionChecker(
 				originalPermissionChecker);
 		}
+	}
+
+	@Override
+	protected Map<String, String> getExpectedCreationMenuItems()
+		throws PortalException {
+
+		return HashMapBuilder.put(
+			"Basic Document", getRedirect("L_BASIC_DOCUMENT")
+		).put(
+			"External Video", getRedirect("L_EXTERNAL_VIDEO")
+		).put(
+			"folder", StringPool.BLANK
+		).put(
+			"multiple-files", StringPool.BLANK
+		).build();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
@@ -69,7 +67,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @RunWith(Arquillian.class)
 @Sync
 public class ViewFilesSectionDisplayContextTest
-	extends BaseDisplayContextTestCase {
+	extends BaseSectionDisplayContextTestCase {
 
 	@ClassRule
 	@Rule
@@ -92,11 +90,7 @@ public class ViewFilesSectionDisplayContextTest
 						"L_BASIC_DOCUMENT", TestPropsValues.getCompanyId()))
 		).build();
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewFilesSectionDisplayContext(getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 
 		ObjectFolder objectFolder =
 			objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
@@ -133,11 +127,7 @@ public class ViewFilesSectionDisplayContextTest
 			ObjectDefinitionConstants.SCOPE_SITE,
 			WorkflowConstants.STATUS_DRAFT);
 
-		testGetCreationMenu(
-			ReflectionTestUtil.invoke(
-				_getViewFilesSectionDisplayContext(getMockHttpServletRequest()),
-				"getCreationMenu", new Class<?>[0]),
-			expectedResultMap);
+		testGetCreationMenu(getCreationMenu(), expectedResultMap);
 	}
 
 	@Test
@@ -148,7 +138,7 @@ public class ViewFilesSectionDisplayContextTest
 		try {
 			ObjectEntryFolder objectEntryFolder =
 				_objectEntryFolderLocalService.addObjectEntryFolder(
-					null, TestPropsValues.getUserId(), group.getGroupId(),
+					null, group.getGroupId(), TestPropsValues.getUserId(),
 					ObjectEntryFolderConstants.
 						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 					RandomTestUtil.randomString(),
@@ -160,7 +150,7 @@ public class ViewFilesSectionDisplayContextTest
 
 			_setUser(UserTestUtil.addUser());
 
-			CreationMenu creationMenu = _getCreationMenu(objectEntryFolder);
+			CreationMenu creationMenu = getCreationMenu(objectEntryFolder);
 
 			List<DropdownItem> primaryItems =
 				(List<DropdownItem>)creationMenu.get("primaryItems");
@@ -178,7 +168,7 @@ public class ViewFilesSectionDisplayContextTest
 				String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
 				role.getRoleId(), new String[] {ActionKeys.ADD_ENTRY});
 
-			creationMenu = _getCreationMenu(objectEntryFolder);
+			creationMenu = getCreationMenu(objectEntryFolder);
 
 			primaryItems = (List<DropdownItem>)creationMenu.get("primaryItems");
 
@@ -190,28 +180,18 @@ public class ViewFilesSectionDisplayContextTest
 		}
 	}
 
-	private CreationMenu _getCreationMenu(ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		return ReflectionTestUtil.invoke(
-			_getViewFilesSectionDisplayContext(
-				_getMockHttpServletRequest(objectEntryFolder)),
-			"getCreationMenu", new Class<?>[0]);
+	@Override
+	protected String getObjectFolderExternalReferenceCode() {
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
 	}
 
-	private HttpServletRequest _getMockHttpServletRequest(
-			ObjectEntryFolder objectEntryFolder)
-		throws Exception {
-
-		HttpServletRequest httpServletRequest = getMockHttpServletRequest();
-
-		httpServletRequest.setAttribute(
-			InfoDisplayWebKeys.INFO_ITEM, objectEntryFolder);
-
-		return httpServletRequest;
+	@Override
+	protected String getRootObjectEntryFolderExternalReferenceCode() {
+		return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
 	}
 
-	private Object _getViewFilesSectionDisplayContext(
+	@Override
+	protected Object getSectionDisplayContext(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
@@ -227,7 +207,7 @@ public class ViewFilesSectionDisplayContextTest
 		return filesSectionDisplayContext;
 	}
 
-	private void _setUser(User user) throws Exception {
+	private void _setUser(User user) {
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -308,14 +308,14 @@ public abstract class BaseSectionDisplayContext {
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
-	private List<Long> _getAcceptedGroupIds(ObjectDefinition objectDefinition) {
+	private boolean _acceptAllGroups(ObjectDefinition objectDefinition) {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
 				objectDefinition.getObjectDefinitionId(),
 				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS);
 
 		if (objectDefinitionSetting != null) {
-			return null;
+			return true;
 		}
 
 		objectDefinitionSetting =
@@ -326,10 +326,19 @@ public abstract class BaseSectionDisplayContext {
 		if ((objectDefinitionSetting == null) ||
 			Validator.isNull(objectDefinitionSetting.getValue())) {
 
-			return null;
+			return true;
 		}
 
+		return false;
+	}
+
+	private List<Long> _getAcceptedGroupIds(ObjectDefinition objectDefinition) {
 		List<Long> acceptedGroupIds = new ArrayList<>();
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS);
 
 		for (String groupId :
 				StringUtil.split(objectDefinitionSetting.getValue())) {
@@ -375,11 +384,11 @@ public abstract class BaseSectionDisplayContext {
 	private JSONArray _getDepotEntriesJSONArray(
 		ObjectDefinition objectDefinition) {
 
-		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinition);
-
-		if (acceptedGroupIds == null) {
+		if (_acceptAllGroups(objectDefinition)) {
 			return _getDepotEntriesJSONArray();
 		}
+
+		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinition);
 
 		if (acceptedGroupIds.isEmpty()) {
 			return null;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -19,7 +19,6 @@ import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -52,6 +51,8 @@ import jakarta.portlet.ActionRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -257,12 +258,18 @@ public abstract class BaseSectionDisplayContext {
 					themeDisplay.getCompanyId(),
 					getObjectFolderExternalReferenceCodes())) {
 
+			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
+				objectDefinition);
+
+			if (depotEntriesJSONArray == null) {
+				continue;
+			}
+
 			creationMenu.addPrimaryDropdownItem(
 				dropdownItem -> {
 					dropdownItem.putData("action", "createAsset");
 					dropdownItem.putData(
-						"assetLibraries",
-						_getDepotEntriesJSONArray(objectDefinition));
+						"assetLibraries", depotEntriesJSONArray);
 					dropdownItem.putData(
 						"redirect",
 						StringBundler.concat(
@@ -289,22 +296,6 @@ public abstract class BaseSectionDisplayContext {
 
 	protected abstract String getCMSSectionFilterString();
 
-	protected JSONArray getDepotEntriesJSONArray(
-		List<DepotEntry> depotEntries) {
-
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
-
-		for (DepotEntry depotEntry : depotEntries) {
-			JSONObject jsonObject = _getJSONObject(depotEntry.getGroupId());
-
-			if (jsonObject != null) {
-				jsonArray.put(jsonObject);
-			}
-		}
-
-		return jsonArray;
-	}
-
 	protected abstract String[] getObjectFolderExternalReferenceCodes();
 
 	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
@@ -317,27 +308,8 @@ public abstract class BaseSectionDisplayContext {
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
-	private JSONArray _getAllDepotEntriesJSONArray() {
-		return getDepotEntriesJSONArray(
-			depotEntryLocalService.getDepotEntries(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS));
-	}
-
-	private JSONArray _getDepotEntriesJSONArray() {
-		if (objectEntryFolder == null) {
-			return _getAllDepotEntriesJSONArray();
-		}
-
-		return JSONUtil.putAll(_getJSONObject(objectEntryFolder.getGroupId()));
-	}
-
-	private JSONArray _getDepotEntriesJSONArray(
-		ObjectDefinition objectDefinition) {
-
-		if (objectEntryFolder != null) {
-			return JSONUtil.putAll(
-				_getJSONObject(objectEntryFolder.getGroupId()));
-		}
+	private List<Long> _getAcceptedGroupIds(ObjectDefinition objectDefinition) {
+		List<Long> acceptedGroupIds = new ArrayList<>();
 
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
@@ -345,7 +317,7 @@ public abstract class BaseSectionDisplayContext {
 				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS);
 
 		if (objectDefinitionSetting != null) {
-			return _getAllDepotEntriesJSONArray();
+			return acceptedGroupIds;
 		}
 
 		objectDefinitionSetting =
@@ -356,14 +328,81 @@ public abstract class BaseSectionDisplayContext {
 		if ((objectDefinitionSetting == null) ||
 			Validator.isNull(objectDefinitionSetting.getValue())) {
 
-			return _getAllDepotEntriesJSONArray();
+			return acceptedGroupIds;
 		}
 
-		return getDepotEntriesJSONArray(
-			TransformUtil.transform(
-				StringUtil.split(objectDefinitionSetting.getValue()),
-				groupId -> depotEntryLocalService.fetchGroupDepotEntry(
-					GetterUtil.getLong(groupId))));
+		for (String groupId :
+				StringUtil.split(objectDefinitionSetting.getValue())) {
+
+			DepotEntry depotEntry = depotEntryLocalService.fetchGroupDepotEntry(
+				GetterUtil.getLong(groupId));
+
+			if (depotEntry != null) {
+				acceptedGroupIds.add(depotEntry.getGroupId());
+			}
+		}
+
+		if (acceptedGroupIds.isEmpty()) {
+			return null;
+		}
+
+		return acceptedGroupIds;
+	}
+
+	private JSONArray _getDepotEntriesJSONArray() {
+		List<Long> groupIds = new ArrayList<>();
+
+		if (objectEntryFolder != null) {
+			groupIds.add(objectEntryFolder.getGroupId());
+		}
+
+		return _getDepotEntriesJSONArray(groupIds);
+	}
+
+	private JSONArray _getDepotEntriesJSONArray(List<Long> groupIds) {
+		if (groupIds.isEmpty()) {
+			for (DepotEntry depotEntry :
+					depotEntryLocalService.getDepotEntries(
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+				groupIds.add(depotEntry.getGroupId());
+			}
+		}
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		for (Long groupId : groupIds) {
+			JSONObject jsonObject = _getJSONObject(groupId);
+
+			if (jsonObject != null) {
+				jsonArray.put(jsonObject);
+			}
+		}
+
+		return jsonArray;
+	}
+
+	private JSONArray _getDepotEntriesJSONArray(
+		ObjectDefinition objectDefinition) {
+
+		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinition);
+
+		if (acceptedGroupIds == null) {
+			return null;
+		}
+
+		if (objectEntryFolder != null) {
+			if (!acceptedGroupIds.isEmpty() &&
+				!acceptedGroupIds.contains(objectEntryFolder.getGroupId())) {
+
+				return null;
+			}
+
+			return _getDepotEntriesJSONArray(
+				Arrays.asList(objectEntryFolder.getGroupId()));
+		}
+
+		return _getDepotEntriesJSONArray(acceptedGroupIds);
 	}
 
 	private JSONObject _getJSONObject(long groupId) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -334,6 +334,11 @@ public abstract class BaseSectionDisplayContext {
 	private JSONArray _getDepotEntriesJSONArray(
 		ObjectDefinition objectDefinition) {
 
+		if (objectEntryFolder != null) {
+			return JSONUtil.putAll(
+				_getJSONObject(objectEntryFolder.getGroupId()));
+		}
+
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
 				objectDefinition.getObjectDefinitionId(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -294,15 +295,10 @@ public abstract class BaseSectionDisplayContext {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (DepotEntry depotEntry : depotEntries) {
-			Group group = groupLocalService.fetchGroup(depotEntry.getGroupId());
+			JSONObject jsonObject = _getJSONObject(depotEntry.getGroupId());
 
-			if (group != null) {
-				jsonArray.put(
-					JSONUtil.put(
-						"groupId", group.getGroupId()
-					).put(
-						"name", group.getName(themeDisplay.getLocale())
-					));
+			if (jsonObject != null) {
+				jsonArray.put(jsonObject);
 			}
 		}
 
@@ -321,22 +317,18 @@ public abstract class BaseSectionDisplayContext {
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
+	private JSONArray _getAllDepotEntriesJSONArray() {
+		return getDepotEntriesJSONArray(
+			depotEntryLocalService.getDepotEntries(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+	}
+
 	private JSONArray _getDepotEntriesJSONArray() {
 		if (objectEntryFolder == null) {
-			return getDepotEntriesJSONArray(
-				depotEntryLocalService.getDepotEntries(
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+			return _getAllDepotEntriesJSONArray();
 		}
 
-		Group group = groupLocalService.fetchGroup(
-			objectEntryFolder.getGroupId());
-
-		return JSONUtil.putAll(
-			JSONUtil.put(
-				"groupId", group.getGroupId()
-			).put(
-				"name", group.getName(themeDisplay.getLocale())
-			));
+		return JSONUtil.putAll(_getJSONObject(objectEntryFolder.getGroupId()));
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(
@@ -348,9 +340,7 @@ public abstract class BaseSectionDisplayContext {
 				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS);
 
 		if (objectDefinitionSetting != null) {
-			return getDepotEntriesJSONArray(
-				depotEntryLocalService.getDepotEntries(
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+			return _getAllDepotEntriesJSONArray();
 		}
 
 		objectDefinitionSetting =
@@ -361,9 +351,7 @@ public abstract class BaseSectionDisplayContext {
 		if ((objectDefinitionSetting == null) ||
 			Validator.isNull(objectDefinitionSetting.getValue())) {
 
-			return getDepotEntriesJSONArray(
-				depotEntryLocalService.getDepotEntries(
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+			return _getAllDepotEntriesJSONArray();
 		}
 
 		return getDepotEntriesJSONArray(
@@ -371,6 +359,20 @@ public abstract class BaseSectionDisplayContext {
 				StringUtil.split(objectDefinitionSetting.getValue()),
 				groupId -> depotEntryLocalService.fetchGroupDepotEntry(
 					GetterUtil.getLong(groupId))));
+	}
+
+	private JSONObject _getJSONObject(long groupId) {
+		Group group = groupLocalService.fetchGroup(groupId);
+
+		if (group == null) {
+			return null;
+		}
+
+		return JSONUtil.put(
+			"groupId", group.getGroupId()
+		).put(
+			"name", group.getName(themeDisplay.getLocale())
+		);
 	}
 
 	private String _getObjectEntryFolderExternalReferenceCode(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -52,7 +53,6 @@ import jakarta.portlet.ActionRequest;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -309,15 +309,13 @@ public abstract class BaseSectionDisplayContext {
 	protected final ThemeDisplay themeDisplay;
 
 	private List<Long> _getAcceptedGroupIds(ObjectDefinition objectDefinition) {
-		List<Long> acceptedGroupIds = new ArrayList<>();
-
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
 				objectDefinition.getObjectDefinitionId(),
 				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS);
 
 		if (objectDefinitionSetting != null) {
-			return acceptedGroupIds;
+			return null;
 		}
 
 		objectDefinitionSetting =
@@ -328,8 +326,10 @@ public abstract class BaseSectionDisplayContext {
 		if ((objectDefinitionSetting == null) ||
 			Validator.isNull(objectDefinitionSetting.getValue())) {
 
-			return acceptedGroupIds;
+			return null;
 		}
+
+		List<Long> acceptedGroupIds = new ArrayList<>();
 
 		for (String groupId :
 				StringUtil.split(objectDefinitionSetting.getValue())) {
@@ -342,33 +342,23 @@ public abstract class BaseSectionDisplayContext {
 			}
 		}
 
-		if (acceptedGroupIds.isEmpty()) {
-			return null;
-		}
-
 		return acceptedGroupIds;
 	}
 
 	private JSONArray _getDepotEntriesJSONArray() {
-		List<Long> groupIds = new ArrayList<>();
-
 		if (objectEntryFolder != null) {
-			groupIds.add(objectEntryFolder.getGroupId());
+			return _getDepotEntriesJSONArray(
+				List.of(objectEntryFolder.getGroupId()));
 		}
 
-		return _getDepotEntriesJSONArray(groupIds);
+		return _getDepotEntriesJSONArray(
+			TransformUtil.transform(
+				depotEntryLocalService.getDepotEntries(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				DepotEntry::getGroupId));
 	}
 
 	private JSONArray _getDepotEntriesJSONArray(List<Long> groupIds) {
-		if (groupIds.isEmpty()) {
-			for (DepotEntry depotEntry :
-					depotEntryLocalService.getDepotEntries(
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
-
-				groupIds.add(depotEntry.getGroupId());
-			}
-		}
-
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (Long groupId : groupIds) {
@@ -388,18 +378,20 @@ public abstract class BaseSectionDisplayContext {
 		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinition);
 
 		if (acceptedGroupIds == null) {
+			return _getDepotEntriesJSONArray();
+		}
+
+		if (acceptedGroupIds.isEmpty()) {
 			return null;
 		}
 
 		if (objectEntryFolder != null) {
-			if (!acceptedGroupIds.isEmpty() &&
-				!acceptedGroupIds.contains(objectEntryFolder.getGroupId())) {
-
+			if (!acceptedGroupIds.contains(objectEntryFolder.getGroupId())) {
 				return null;
 			}
 
 			return _getDepotEntriesJSONArray(
-				Arrays.asList(objectEntryFolder.getGroupId()));
+				List.of(objectEntryFolder.getGroupId()));
 		}
 
 		return _getDepotEntriesJSONArray(acceptedGroupIds);

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -21,6 +21,7 @@ import {HeadlessAdminContentApiHelper} from './HeadlessAdminContentApiHelper';
 import {HeadlessAdminTaxonomyApiHelper} from './HeadlessAdminTaxonomyApiHelper';
 import {HeadlessAdminUserApiHelper} from './HeadlessAdminUserApiHelper';
 import {HeadlessAdminWorkflowApiHelper} from './HeadlessAdminWorkflowApiHelper';
+import {HeadlessAssetLibraryApiHelper} from './HeadlessAssetLibraryApiHelper';
 import {HeadlessBatchEngineApiHelper} from './HeadlessBatchEngineApiHelper';
 import {HeadlessChangeTrackingApiHelper} from './HeadlessChangeTrackingApiHelper';
 import {HeadlessCommerceAdminAccountApiHelper} from './HeadlessCommerceAdminAccountApiHelper';
@@ -120,6 +121,7 @@ export class ApiHelpers {
 	readonly headlessAdminTaxonomy: HeadlessAdminTaxonomyApiHelper;
 	readonly headlessAdminUser: HeadlessAdminUserApiHelper;
 	readonly headlessAdminWorkflow: HeadlessAdminWorkflowApiHelper;
+	readonly headlessAssetLibrary: HeadlessAssetLibraryApiHelper;
 	readonly headlessBatchEngine: HeadlessBatchEngineApiHelper;
 	readonly headlessChangeTracking: HeadlessChangeTrackingApiHelper;
 	readonly headlessCommerceAdminAccount: HeadlessCommerceAdminAccountApiHelper;
@@ -190,6 +192,7 @@ export class ApiHelpers {
 		this.headlessAdminTaxonomy = new HeadlessAdminTaxonomyApiHelper(this);
 		this.headlessAdminUser = new HeadlessAdminUserApiHelper(this);
 		this.headlessAdminWorkflow = new HeadlessAdminWorkflowApiHelper(this);
+		this.headlessAssetLibrary = new HeadlessAssetLibraryApiHelper(this);
 		this.headlessBatchEngine = new HeadlessBatchEngineApiHelper(this);
 		this.headlessChangeTracking = new HeadlessChangeTrackingApiHelper(this);
 		this.headlessCommerceAdminAccount =

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ApiHelpers} from './ApiHelpers';
+
+export class HeadlessAssetLibraryApiHelper {
+	apiHelpers: ApiHelpers;
+	basePath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = 'headless-asset-library/v1.0';
+	}
+
+	async getAssetLibrariesPage() {
+		const response = await this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries`
+		);
+
+		return response?.items;
+	}
+}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -10,6 +10,7 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -67,5 +68,163 @@ test(
 				String(objectEntry.id)
 			);
 		}
+	}
+);
+
+test(
+	'The Space selector dialog is not shown when creating a Basic Document when only the default Space exists',
+	{tag: '@LPD-57827'},
+	async ({apiHelpers, filesPage, page}) => {
+		await test.step('Check number of existing Spaces', async () => {
+			const assetLibraries =
+				await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage();
+
+			expect(
+				assetLibraries.length,
+				'Only the default Space should exist'
+			).toBe(1);
+		});
+
+		await test.step('Create a Basic Document', async () => {
+			await filesPage.goto();
+
+			await filesPage.createContent('Basic Document');
+		});
+
+		await test.step('Check the Space selector dialog', async () => {
+			await expect(page.getByRole('dialog')).not.toBeVisible();
+		});
+
+		await test.step('Check the Space name in the Basic Document creation page', async () => {
+			await page
+				.getByRole('heading', {name: 'New Basic Document'})
+				.waitFor();
+
+			const spaceSpan = page.locator(
+				'//span[contains(@class,"sticker")]//following-sibling::span[1]'
+			);
+
+			await expect(spaceSpan).toContainText('Default');
+		});
+	}
+);
+
+test(
+	'The Space selector dialog is shown when creating a Basic Document when multiple Spaces exist',
+	{tag: '@LPD-57827'},
+	async ({apiHelpers, filesPage, page}) => {
+		const depotName = getRandomString();
+
+		const depotEntryId = await test.step('Create a new Space', async () => {
+			const depot =
+				await apiHelpers.jsonWebServicesDepot.addDepotEntry(depotName);
+
+			return depot.depotEntryId;
+		});
+
+		await test.step('Check number of existing Spaces', async () => {
+			const assetLibraries =
+				await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage();
+
+			expect(
+				assetLibraries.length,
+				'At least 2 Spaces should exist'
+			).toBeGreaterThan(1);
+		});
+
+		await test.step('Create a Basic Document', async () => {
+			await filesPage.goto();
+
+			await filesPage.createContent('Basic Document');
+		});
+
+		await test.step('Check the Space selector dialog', async () => {
+			await page.getByRole('dialog').waitFor();
+
+			await page.getByLabel('SpaceRequired').click();
+
+			await page.getByRole('option', {name: depotName}).click();
+
+			await page.getByRole('button', {name: 'Save'}).click();
+		});
+
+		await test.step('Check the Space name in the Basic Document creation page', async () => {
+			await page
+				.getByRole('heading', {name: 'New Basic Document'})
+				.waitFor();
+
+			const spaceSpan = page.locator(
+				'//span[contains(@class,"sticker")]//following-sibling::span[1]'
+			);
+
+			await expect(spaceSpan).toContainText(depotName);
+		});
+
+		await apiHelpers.jsonWebServicesDepot.deleteDepotEntry(depotEntryId);
+	}
+);
+
+test(
+	'The Space selector dialog is not shown when creating a Basic Document inside a folder when multiple Spaces exist',
+	{tag: '@LPD-57827'},
+	async ({apiHelpers, filesPage, page}) => {
+		const depotName = getRandomString();
+
+		const depotEntryId = await test.step('Create a new Space', async () => {
+			const depot =
+				await apiHelpers.jsonWebServicesDepot.addDepotEntry(depotName);
+
+			return depot.depotEntryId;
+		});
+
+		await test.step('Check number of existing Spaces', async () => {
+			const assetLibraries =
+				await apiHelpers.headlessAssetLibrary.getAssetLibrariesPage();
+
+			expect(
+				assetLibraries.length,
+				'At least 2 Spaces should exist'
+			).toBeGreaterThan(1);
+		});
+
+		const folderData = await test.step('Create a folder', async () => {
+			return await apiHelpers.objectFolder.createObjectEntryFolder({
+				scopeKey: depotName,
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Navigate into the folder', async () => {
+			const className =
+				await apiHelpers.jsonWebServicesClassName.fetchClassName(
+					'com.liferay.object.model.ObjectEntryFolder'
+				);
+
+			await page.goto(
+				`${PORTLET_URLS.cmsViewFolder}/${className.classNameId}/${folderData.id}`
+			);
+		});
+
+		await test.step('Create a Basic Document', async () => {
+			await filesPage.createContent('Basic Document');
+		});
+
+		await test.step('Check the Space selector dialog', async () => {
+			await expect(page.getByRole('dialog')).not.toBeVisible();
+		});
+
+		await test.step('Check the Space name in the Basic Document creation page', async () => {
+			await page
+				.getByRole('heading', {name: 'New Basic Document'})
+				.waitFor();
+
+			const spaceSpan = page.locator(
+				'//span[contains(@class,"sticker")]//following-sibling::span[1]'
+			);
+
+			await expect(spaceSpan).toContainText(depotName);
+		});
+
+		await apiHelpers.jsonWebServicesDepot.deleteDepotEntry(depotEntryId);
 	}
 );

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FilesPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/FilesPage.ts
@@ -3,23 +3,36 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {DataSetPage} from './DataSetPage';
 
 export class FilesPage {
 	readonly page: Page;
+
 	readonly dataSetFragmentPage: DataSetPage;
+	readonly newButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+
 		this.dataSetFragmentPage = new DataSetPage(page);
+		this.newButton = page.getByLabel('New');
 	}
 
 	async goto() {
 		await this.page.goto(PORTLET_URLS.cmsFiles);
 		await this.page.getByRole('heading', {name: 'Files'}).waitFor();
+	}
+
+	async createContent(type: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: type}),
+			trigger: this.newButton,
+		});
 	}
 
 	getItem(filter: string) {

--- a/modules/test/playwright/types/asset-library.d.ts
+++ b/modules/test/playwright/types/asset-library.d.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type AssetLibrary = {
+	externalReferenceCode: string;
+	id: string;
+	name: string;
+};

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -22,6 +22,7 @@ export const PORTLET_URLS = {
 	cmsStructureBuilder: 'web/cms/structure-builder',
 	cmsStructures: 'web/cms/structures',
 	cmsTags: 'web/cms/categorization/view-tags',
+	cmsViewFolder: 'web/cms/e/view-folder/',
 	cmsVocabularies: 'web/cms/categorization/view-vocabularies',
 	collections:
 		'/~/control_panel/manage?p_p_id=com_liferay_asset_list_web_portlet_AssetListPortlet',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-57827

1) In the CMS, when we are inside a folder (from Contents or Files) and we click on New to create a new asset, the Space selector should not be shown, because we should use the folder's Space.

2) Also, when showing the possible asset types (object definition) from the creation menu, we should remove those not allowed in the available Spaces. In the object definition settings we can configure in which spaces it is available.

# How am I fixing it?

Fixing and refactor the methods `BaseSectionDisplayContext._getDepotEntriesJSONArray`.

# How can you verify that it works?

Follow steps in issue.

Integration tests:

`cd modules/apps/site/site-cms-site-initializer-test`
`gw tI --tests 'ViewAllSectionDisplayContextTest.testGetDepotEntriesJSONArray*' -a`
`gw tI --tests 'ViewContentsSectionDisplayContextTest.testGetDepotEntriesJSONArray*' -a`
`gw tI --tests 'ViewFilesSectionDisplayContextTest.testGetDepotEntriesJSONArray*' -a`

Functional tests:

`cd modules/test/playwright`
`npm run playwright -- test -g 'The Space selector dialog'`
