### PR TITLE
LPD-57456 Onedrive shows empty modal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/commands/openModal.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/commands/openModal.ts
@@ -26,5 +26,5 @@ export default function openModal(props: OpenModalProps) {
 
 	// @ts-ignore
 
-	render(Modal, props, document.createElement('div'));
+	return render(Modal, props, document.createElement('div'));
 }

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
@@ -5,7 +5,7 @@
 
 import {getSpritemap} from '@liferay/frontend-icons-web';
 import {openSimpleInputModal, openToast} from 'frontend-js-components-web';
-import {fetch, getWindow, navigate, openWindow} from 'frontend-js-web';
+import {fetch, getWindow, navigate} from 'frontend-js-web';
 
 const TIME_POLLING = 500;
 const TIME_SHOW_MSG = 2000;
@@ -25,6 +25,7 @@ export class DocumentLibraryOpener {
 
 	_openExternal({externalURL}) {
 		window.open(externalURL);
+
 		this._hideLoading();
 
 		if (this._refreshAfterNavigate) {
@@ -74,23 +75,19 @@ export class DocumentLibraryOpener {
 
 	_showLoading({dialogMessage}) {
 		return new Promise((resolve) => {
-			openWindow(
-				{
-					dialog: {
-						bodyContent: `<p>${dialogMessage}</p><div aria-hidden="true" class="loading-animation"></div>`,
-						cssClass: 'office-365-redirect-modal',
-						height: 172,
-						modal: true,
-						resizable: false,
-						title: '',
-						width: 320,
-					},
-					id: this._dialogLoadingId,
-				},
-				() => {
+			Liferay.Util.openModal({
+				bodyHTML: `<p>${dialogMessage}</p><div aria-hidden="true" class="loading-animation"></div>`,
+				center: true,
+				className: 'office-365-redirect-modal',
+				containerProps: {},
+				height: 172,
+				id: this._dialogLoadingId,
+				onOpen: () => {
 					setTimeout(resolve, TIME_SHOW_MSG);
-				}
-			);
+				},
+				size: 'sm',
+				title: '',
+			});
 		});
 	}
 

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/resources/META-INF/resources/js/index.js
@@ -4,8 +4,12 @@
  */
 
 import {getSpritemap} from '@liferay/frontend-icons-web';
-import {openSimpleInputModal, openToast} from 'frontend-js-components-web';
-import {fetch, getWindow, navigate} from 'frontend-js-web';
+import {
+	openModal,
+	openSimpleInputModal,
+	openToast,
+} from 'frontend-js-components-web';
+import {fetch, navigate} from 'frontend-js-web';
 
 const TIME_POLLING = 500;
 const TIME_SHOW_MSG = 2000;
@@ -17,10 +21,11 @@ export class DocumentLibraryOpener {
 
 		this._dialogLoadingId = `${namespace}OneDriveLoadingDialog`;
 		this._refreshAfterNavigate = false;
+		this._loadingModal = null;
 	}
 
 	_hideLoading() {
-		getWindow(this._dialogLoadingId).hide();
+		this._loadingModal?.unmount();
 	}
 
 	_openExternal({externalURL}) {
@@ -75,7 +80,7 @@ export class DocumentLibraryOpener {
 
 	_showLoading({dialogMessage}) {
 		return new Promise((resolve) => {
-			Liferay.Util.openModal({
+			this._loadingModal = openModal({
 				bodyHTML: `<p>${dialogMessage}</p><div aria-hidden="true" class="loading-animation"></div>`,
 				center: true,
 				className: 'office-365-redirect-modal',

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
@@ -8,21 +8,24 @@ import {openModal} from 'frontend-js-components-web';
 import {DocumentLibraryOpener} from '../../src/main/resources/META-INF/resources/js/index';
 
 const realSetTimeout = setTimeout;
+let mockUnmount;
 
-jest.mock('frontend-js-components-web', () => ({
-	openModal: jest.fn((options) => {
-		setTimeout(() => {
-			if (options.onOpen) {
-				options.onOpen();
-			}
-		}, 0);
+jest.mock('frontend-js-components-web', () => {
+	mockUnmount = jest.fn();
 
-		return {
-			unmount: jest.fn(),
-		};
-	}),
-	openToast: jest.fn(),
-}));
+	return {
+		openModal: jest.fn((options) => {
+			setTimeout(() => {
+				options.onOpen?.();
+			}, 0);
+
+			return {
+				unmount: mockUnmount,
+			};
+		}),
+		openToast: jest.fn(),
+	};
+});
 
 jest.mock('frontend-js-web', () => ({
 	...jest.requireActual('frontend-js-web'),
@@ -109,6 +112,10 @@ describe('DocumentLibraryOpener', () => {
 			it('and, since the task has already finished, navigates to the edit URL', () => {
 				expect(window.open).toHaveBeenCalledTimes(1);
 				expect(window.open.mock.calls[0][0]).toBe(OFFICE365_EDIT_URL);
+			});
+
+			it('and the modal is hidden', () => {
+				expect(mockUnmount).toHaveBeenCalledTimes(1);
 			});
 		});
 
@@ -218,6 +225,10 @@ describe('DocumentLibraryOpener', () => {
 			it('and, since the task has failed, shows an error message', () => {
 				expect(opener._showError).toHaveBeenCalledTimes(1);
 			});
+
+			it('and the modal is hidden', () => {
+				expect(mockUnmount).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 
@@ -260,6 +271,10 @@ describe('DocumentLibraryOpener', () => {
 			it('and the portlet did not refresh', () => {
 				expect(global.Liferay.Portlet.refresh).toHaveBeenCalledTimes(0);
 			});
+
+			it('and the modal is hidden', () => {
+				expect(mockUnmount).toHaveBeenCalledTimes(1);
+			});
 		});
 
 		describe('when the creation background task finishes at the first polling request with refresh', () => {
@@ -300,6 +315,10 @@ describe('DocumentLibraryOpener', () => {
 
 			it('and the portlet did refresh', () => {
 				expect(global.Liferay.Portlet.refresh).toHaveBeenCalledTimes(1);
+			});
+
+			it('and the modal is hidden', () => {
+				expect(mockUnmount).toHaveBeenCalledTimes(1);
 			});
 		});
 	});

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/test/js/DocumentLibraryOpener.es.js
@@ -3,20 +3,29 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openWindow} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 import {DocumentLibraryOpener} from '../../src/main/resources/META-INF/resources/js/index';
 
 const realSetTimeout = setTimeout;
 
 jest.mock('frontend-js-components-web', () => ({
+	openModal: jest.fn((options) => {
+		setTimeout(() => {
+			if (options.onOpen) {
+				options.onOpen();
+			}
+		}, 0);
+
+		return {
+			unmount: jest.fn(),
+		};
+	}),
 	openToast: jest.fn(),
 }));
 
 jest.mock('frontend-js-web', () => ({
 	...jest.requireActual('frontend-js-web'),
-	getWindow: jest.fn(() => ({hide: jest.fn()})),
-	openWindow: jest.fn().mockImplementation((_, callback) => callback()),
 }));
 
 function replyAndWait({body = {}, ms}) {
@@ -83,10 +92,8 @@ describe('DocumentLibraryOpener', () => {
 			});
 
 			it('opens the loading modal', () => {
-				expect(openWindow).toHaveBeenCalledTimes(1);
-				expect(
-					openWindow.mock.calls[0][0].dialog.bodyContent
-				).toContain(
+				expect(openModal).toHaveBeenCalledTimes(1);
+				expect(openModal.mock.calls[0][0].bodyHTML).toContain(
 					'you-are-being-redirected-to-an-external-editor-to-edit-this-document'
 				);
 			});
@@ -136,10 +143,8 @@ describe('DocumentLibraryOpener', () => {
 			});
 
 			it('opens the loading modal', () => {
-				expect(openWindow).toHaveBeenCalledTimes(1);
-				expect(
-					openWindow.mock.calls[0][0].dialog.bodyContent
-				).toContain(
+				expect(openModal).toHaveBeenCalledTimes(1);
+				expect(openModal.mock.calls[0][0].bodyHTML).toContain(
 					'you-are-being-redirected-to-an-external-editor-to-edit-this-document'
 				);
 			});
@@ -192,10 +197,8 @@ describe('DocumentLibraryOpener', () => {
 			});
 
 			it('opens the loading modal', () => {
-				expect(openWindow).toHaveBeenCalledTimes(1);
-				expect(
-					openWindow.mock.calls[0][0].dialog.bodyContent
-				).toContain(
+				expect(openModal).toHaveBeenCalledTimes(1);
+				expect(openModal.mock.calls[0][0].bodyHTML).toContain(
 					'you-are-being-redirected-to-an-external-editor-to-edit-this-document'
 				);
 			});
@@ -239,10 +242,8 @@ describe('DocumentLibraryOpener', () => {
 			});
 
 			it('opens the loading modal with the creation message', () => {
-				expect(openWindow).toHaveBeenCalledTimes(1);
-				expect(
-					openWindow.mock.calls[0][0].dialog.bodyContent
-				).toContain(
+				expect(openModal).toHaveBeenCalledTimes(1);
+				expect(openModal.mock.calls[0][0].bodyHTML).toContain(
 					'you-are-being-redirected-to-an-external-editor-to-create-this-document'
 				);
 			});
@@ -282,10 +283,8 @@ describe('DocumentLibraryOpener', () => {
 			});
 
 			it('opens the loading modal with the creation message', () => {
-				expect(openWindow).toHaveBeenCalledTimes(1);
-				expect(
-					openWindow.mock.calls[0][0].dialog.bodyContent
-				).toContain(
+				expect(openModal).toHaveBeenCalledTimes(1);
+				expect(openModal.mock.calls[0][0].bodyHTML).toContain(
 					'you-are-being-redirected-to-an-external-editor-to-create-this-document'
 				);
 			});


### PR DESCRIPTION
[Link to the issue](https://liferay.atlassian.net/browse/LPD-57456)

# How did I solve it 

`openWindow` should not be used anymore, so I changed it to use `openModal`, like it was done for https://liferay.atlassian.net/browse/LPD-53792. 

Also, it should be hidden when another process finishes, so I used the `unmount` function from react. This was suggested by FI in https://liferay.slack.com/archives/CNBG06JS3/p1749208645266609 

cc/ @bryceosterhaus

# How to test it
follow the reproduction steps, or run `npm run test DocumentLibraryOpener`: 
```
document-library-opener-onedrive-web@3.0.71 test
node-scripts test DocumentLibraryOpener

 PASS  test/js/DocumentLibraryOpener.es.js

Test Suites: 1 passed, 1 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        2.418s
```