### PR TITLE
LPD-40725 Hidden Error Message in Invite to Collaborate Modal

### DIFF
--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/sharing/Sharing.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/sharing/Sharing.js
@@ -244,7 +244,9 @@ const Sharing = ({
 									'enter-name-or-email-address'
 								)}
 								sourceItems={
-									multiSelectValue && users
+									multiSelectValue &&
+									!!users.length &&
+									!emailAddressErrorMessages.length
 										? users.map((user) => {
 												return {
 													emailAddress:
@@ -257,7 +259,7 @@ const Sharing = ({
 													value: user.emailAddress,
 												};
 											})
-										: []
+										: undefined
 								}
 								value={multiSelectValue}
 							>

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -163,6 +163,21 @@ export class DocumentLibraryPage {
 		});
 	}
 
+	async goToShareFileEntry(entryTitle: string) {
+		await this.page
+			.getByRole('link', {exact: true, name: entryTitle})
+			.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Share',
+			}),
+			trigger: this.page.getByRole('button', {name: 'Show Actions'}),
+		});
+	}
+
 	async goToEditFileEntry(entryTitle: string) {
 		await this.page
 			.getByRole('link', {exact: true, name: entryTitle})

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -876,3 +876,24 @@ test(
 		await expect(page.getByRole('dialog')).toBeVisible();
 	}
 );
+
+test(
+	'User search is working properly in share modal',
+	{tag: '@LPD-40725'},
+	async ({documentLibraryEditFilePage, documentLibraryPage, page, site}) => {
+		const title = getRandomString();
+		await documentLibraryEditFilePage.publishNewBasicFileEntry(
+			title,
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryPage.goToShareFileEntry(title);
+
+		const iframeLocator = page.frameLocator('iframe[title^="Share"]');
+		await iframeLocator.getByRole('combobox').click();
+
+		await expect(iframeLocator.getByText('No results found')).toHaveCount(
+			0
+		);
+	}
+);


### PR DESCRIPTION
### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-40725

Resolves an issue where custom error messages (e.g., “user does not exist”) were being visually hidden behind the "No results found" dropdown when searching for users in the Share modal.

### **How am I fixing it?**
Added conditions to pass undefined instead of an empty list. This prevents Clay's default "No results found" dropdown from appearing, ensuring that custom error messages (like "User does not exist") are clearly visible and not hidden behind the dropdown.

### **How can you verify that it works?**
By running the following Playwright test:
**npm run playwright -- test -g 'User search is working properly in share modal'**