### PR TITLE
LPD-57471 Implement pagination for users and groups

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/package.json
+++ b/modules/apps/site/site-cms-site-initializer/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/alert": "3.129.1",
-		"@clayui/autocomplete": "3.138.0",
+		"@clayui/autocomplete": "3.139.1",
 		"@clayui/breadcrumb": "3.136.0",
 		"@clayui/button": "3.136.0",
 		"@clayui/core": "3.139.1",

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/spaces/SpaceMembersWithList.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/spaces/SpaceMembersWithList.scss
@@ -1,4 +1,4 @@
-.add-space-members {
+.space-members-with-list {
 	padding: 24px;
 
 	.members-list {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -93,7 +93,6 @@ export function AddSpaceMembers({
 			}
 
 			setIsFetchingMembers(true);
-			setUsersPage(newUsersPage);
 
 			try {
 				const spaceUsers = await SpaceService.getSpaceUsers({
@@ -106,6 +105,7 @@ export function AddSpaceMembers({
 					...currentSelectedUsers,
 					...spaceUsers.items,
 				]);
+				setUsersPage(newUsersPage);
 				setUsersLastPage(spaceUsers.lastPage);
 			}
 			catch (error) {
@@ -124,7 +124,6 @@ export function AddSpaceMembers({
 		}
 
 		setIsFetchingMembers(true);
-		setUserGroupsPage(newUserGroupsPage);
 
 		try {
 			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
@@ -137,6 +136,7 @@ export function AddSpaceMembers({
 				...currentSelectedUserGroups,
 				...spaceUserGroups.items,
 			]);
+			setUserGroupsPage(newUserGroupsPage);
 			setUserGroupsLastPage(spaceUserGroups.lastPage);
 		}
 		catch (error) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -7,6 +7,7 @@ import '../../../css/spaces/AddSpaceMembers.scss';
 
 import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
+import LoadingIndicator from '@clayui/loading-indicator';
 import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
@@ -20,7 +21,6 @@ import {
 	SelectOptions,
 	SpaceMembersInputWithSelect,
 } from './SpaceMembersInputWithSelect';
-import LoadingIndicator from '@clayui/loading-indicator';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -38,7 +38,7 @@ export function AddSpaceMembers({
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
-	const [isFetchingMoreMembers, setIsFetchingMoreMembers] = useState(false);
+	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
 	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
 	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
 	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
@@ -71,7 +71,17 @@ export function AddSpaceMembers({
 			setUsersLastPage(spaceUsers.lastPage);
 		};
 
-		fetchMembers();
+		setIsFetchingMembers(true);
+
+		try {
+			fetchMembers();
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
 	}, [assetLibraryId]);
 
 	const loadMoreItems = useCallback(async () => {
@@ -82,7 +92,7 @@ export function AddSpaceMembers({
 				return;
 			}
 
-			setIsFetchingMoreMembers(true);
+			setIsFetchingMembers(true);
 			setUsersPage(newUsersPage);
 
 			try {
@@ -91,14 +101,18 @@ export function AddSpaceMembers({
 					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				});
-	
+
 				setSelectedUsers((currentSelectedUsers) => [
 					...currentSelectedUsers,
 					...spaceUsers.items,
 				]);
 				setUsersLastPage(spaceUsers.lastPage);
-			} finally {
-				setIsFetchingMoreMembers(false);
+			}
+			catch (error) {
+				console.error(error);
+			}
+			finally {
+				setIsFetchingMembers(false);
 			}
 
 			return;
@@ -109,7 +123,7 @@ export function AddSpaceMembers({
 			return;
 		}
 
-		setIsFetchingMoreMembers(true);
+		setIsFetchingMembers(true);
 		setUserGroupsPage(newUserGroupsPage);
 
 		try {
@@ -118,16 +132,27 @@ export function AddSpaceMembers({
 				pageSize: DEFAULT_PAGE_SIZE,
 				spaceId: assetLibraryId,
 			});
-	
+
 			setSelectedUserGroups((currentSelectedUserGroups) => [
 				...currentSelectedUserGroups,
 				...spaceUserGroups.items,
 			]);
 			setUserGroupsLastPage(spaceUserGroups.lastPage);
-		} finally {
-			setIsFetchingMoreMembers(false);
 		}
-	}, [assetLibraryId, selectedOption, userGroupsPage, usersPage, userGroupsLastPage, usersLastPage]);
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [
+		assetLibraryId,
+		selectedOption,
+		userGroupsPage,
+		usersPage,
+		userGroupsLastPage,
+		usersLastPage,
+	]);
 
 	useEffect(() => {
 		if (!sentinelRef.current) {
@@ -348,7 +373,15 @@ export function AddSpaceMembers({
 							/>
 						)}
 
-						{isFetchingMoreMembers && <li className="d-flex justify-content-center"><LoadingIndicator displayType="secondary" size="sm" /></li>}
+						{isFetchingMembers && (
+							<li className="d-flex justify-content-center">
+								<LoadingIndicator
+									displayType="secondary"
+									size="sm"
+								/>
+							</li>
+						)}
+
 						<div ref={sentinelRef} />
 					</ul>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -9,7 +9,7 @@ import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
 import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
-import React, {useEffect, useId, useState} from 'react';
+import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
 
 import SpaceService from '../../services/SpaceService';
 import {UserAccount, UserGroup} from '../../types/UserAccount';
@@ -20,6 +20,7 @@ import {
 	SelectOptions,
 	SpaceMembersInputWithSelect,
 } from './SpaceMembersInputWithSelect';
+import LoadingIndicator from '@clayui/loading-indicator';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -28,6 +29,8 @@ export interface AddSpaceMembersProps {
 	baseAssetLibraryURL: string;
 }
 
+const DEFAULT_PAGE_SIZE = 20;
+
 export function AddSpaceMembers({
 	assetLibraryCreatorUserId,
 	assetLibraryId,
@@ -35,29 +38,119 @@ export function AddSpaceMembers({
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
+	const [isFetchingMoreMembers, setIsFetchingMoreMembers] = useState(false);
 	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
 	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
 	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
 		[]
 	);
+	const [usersLastPage, setUsersLastPage] = useState(0);
+	const [usersPage, setUsersPage] = useState(1);
+	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
+	const [userGroupsPage, setUserGroupsPage] = useState(1);
+	const sentinelRef = useRef(null);
 
 	useEffect(() => {
 		const fetchMembers = async () => {
 			const [spaceUsers, spaceUserGroups] = await Promise.all([
 				SpaceService.getSpaceUsers({
+					page: 1,
+					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				}),
 				SpaceService.getSpaceUserGroups({
+					page: 1,
+					pageSize: DEFAULT_PAGE_SIZE,
 					spaceId: assetLibraryId,
 				}),
 			]);
 
-			setSelectedUsers(spaceUsers);
-			setSelectedUserGroups(spaceUserGroups);
+			setSelectedUsers(spaceUsers.items);
+			setSelectedUserGroups(spaceUserGroups.items);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+			setUsersLastPage(spaceUsers.lastPage);
 		};
 
 		fetchMembers();
 	}, [assetLibraryId]);
+
+	const loadMoreItems = useCallback(async () => {
+		if (selectedOption === SelectOptions.USERS) {
+			const newUsersPage = usersPage + 1;
+
+			if (newUsersPage > usersLastPage) {
+				return;
+			}
+
+			setIsFetchingMoreMembers(true);
+			setUsersPage(newUsersPage);
+
+			try {
+				const spaceUsers = await SpaceService.getSpaceUsers({
+					page: newUsersPage,
+					pageSize: DEFAULT_PAGE_SIZE,
+					spaceId: assetLibraryId,
+				});
+	
+				setSelectedUsers((currentSelectedUsers) => [
+					...currentSelectedUsers,
+					...spaceUsers.items,
+				]);
+				setUsersLastPage(spaceUsers.lastPage);
+			} finally {
+				setIsFetchingMoreMembers(false);
+			}
+
+			return;
+		}
+
+		const newUserGroupsPage = userGroupsPage + 1;
+		if (newUserGroupsPage > userGroupsLastPage) {
+			return;
+		}
+
+		setIsFetchingMoreMembers(true);
+		setUserGroupsPage(newUserGroupsPage);
+
+		try {
+			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
+				page: newUserGroupsPage,
+				pageSize: DEFAULT_PAGE_SIZE,
+				spaceId: assetLibraryId,
+			});
+	
+			setSelectedUserGroups((currentSelectedUserGroups) => [
+				...currentSelectedUserGroups,
+				...spaceUserGroups.items,
+			]);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+		} finally {
+			setIsFetchingMoreMembers(false);
+		}
+	}, [assetLibraryId, selectedOption, userGroupsPage, usersPage, userGroupsLastPage, usersLastPage]);
+
+	useEffect(() => {
+		if (!sentinelRef.current) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting) {
+					loadMoreItems();
+				}
+			},
+			{
+				threshold: 1,
+			}
+		);
+
+		observer.observe(sentinelRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [sentinelRef, loadMoreItems]);
 
 	const onAutocompleteItemSelected = async (
 		item: UserAccount | UserGroup
@@ -220,7 +313,9 @@ export function AddSpaceMembers({
 				>
 					<SpaceMembersInputWithSelect
 						onAutocompleteItemSelected={onAutocompleteItemSelected}
-						onSelectChange={setSelectedOption}
+						onSelectChange={(value) => {
+							setSelectedOption(value);
+						}}
 						selectValue={selectedOption}
 					/>
 
@@ -252,6 +347,9 @@ export function AddSpaceMembers({
 								onRemoveItem={onRemoveItem}
 							/>
 						)}
+
+						{isFetchingMoreMembers && <li className="d-flex justify-content-center"><LoadingIndicator displayType="secondary" size="sm" /></li>}
+						<div ref={sentinelRef} />
 					</ul>
 
 					<ClayButton.Group className="mb-0 w-100" spaced vertical>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers.tsx
@@ -3,24 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import '../../../css/spaces/AddSpaceMembers.scss';
-
 import ClayButton from '@clayui/button';
 import ClayLayout from '@clayui/layout';
-import LoadingIndicator from '@clayui/loading-indicator';
-import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
-import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
+import React, {useState} from 'react';
 
-import SpaceService from '../../services/SpaceService';
-import {UserAccount, UserGroup} from '../../types/UserAccount';
 import {getImage} from '../util/getImage';
-import {MembersListItem} from './MemberListItem';
 import {NewSpaceFormSection} from './NewSpaceFormSection';
-import {
-	SelectOptions,
-	SpaceMembersInputWithSelect,
-} from './SpaceMembersInputWithSelect';
+import {SpaceMembersWithList} from './SpaceMembersWithList';
 
 export interface AddSpaceMembersProps {
 	assetLibraryCreatorUserId: string;
@@ -29,298 +19,17 @@ export interface AddSpaceMembersProps {
 	baseAssetLibraryURL: string;
 }
 
-const DEFAULT_PAGE_SIZE = 20;
-
 export function AddSpaceMembers({
 	assetLibraryCreatorUserId,
 	assetLibraryId,
 	assetLibraryName,
 	baseAssetLibraryURL,
 }: AddSpaceMembersProps) {
-	const currentUserId = Liferay.ThemeDisplay.getUserId();
-	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
-	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
-	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
-	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
-		[]
-	);
-	const [usersLastPage, setUsersLastPage] = useState(0);
-	const [usersPage, setUsersPage] = useState(1);
-	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
-	const [userGroupsPage, setUserGroupsPage] = useState(1);
-	const sentinelRef = useRef(null);
-
-	useEffect(() => {
-		const fetchMembers = async () => {
-			const [spaceUsers, spaceUserGroups] = await Promise.all([
-				SpaceService.getSpaceUsers({
-					page: 1,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				}),
-				SpaceService.getSpaceUserGroups({
-					page: 1,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				}),
-			]);
-
-			setSelectedUsers(spaceUsers.items);
-			setSelectedUserGroups(spaceUserGroups.items);
-			setUserGroupsLastPage(spaceUserGroups.lastPage);
-			setUsersLastPage(spaceUsers.lastPage);
-		};
-
-		setIsFetchingMembers(true);
-
-		try {
-			fetchMembers();
-		}
-		catch (error) {
-			console.error(error);
-		}
-		finally {
-			setIsFetchingMembers(false);
-		}
-	}, [assetLibraryId]);
-
-	const loadMoreItems = useCallback(async () => {
-		if (selectedOption === SelectOptions.USERS) {
-			const newUsersPage = usersPage + 1;
-
-			if (newUsersPage > usersLastPage) {
-				return;
-			}
-
-			setIsFetchingMembers(true);
-
-			try {
-				const spaceUsers = await SpaceService.getSpaceUsers({
-					page: newUsersPage,
-					pageSize: DEFAULT_PAGE_SIZE,
-					spaceId: assetLibraryId,
-				});
-
-				setSelectedUsers((currentSelectedUsers) => [
-					...currentSelectedUsers,
-					...spaceUsers.items,
-				]);
-				setUsersPage(newUsersPage);
-				setUsersLastPage(spaceUsers.lastPage);
-			}
-			catch (error) {
-				console.error(error);
-			}
-			finally {
-				setIsFetchingMembers(false);
-			}
-
-			return;
-		}
-
-		const newUserGroupsPage = userGroupsPage + 1;
-		if (newUserGroupsPage > userGroupsLastPage) {
-			return;
-		}
-
-		setIsFetchingMembers(true);
-
-		try {
-			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
-				page: newUserGroupsPage,
-				pageSize: DEFAULT_PAGE_SIZE,
-				spaceId: assetLibraryId,
-			});
-
-			setSelectedUserGroups((currentSelectedUserGroups) => [
-				...currentSelectedUserGroups,
-				...spaceUserGroups.items,
-			]);
-			setUserGroupsPage(newUserGroupsPage);
-			setUserGroupsLastPage(spaceUserGroups.lastPage);
-		}
-		catch (error) {
-			console.error(error);
-		}
-		finally {
-			setIsFetchingMembers(false);
-		}
-	}, [
-		assetLibraryId,
-		selectedOption,
-		userGroupsPage,
-		usersPage,
-		userGroupsLastPage,
-		usersLastPage,
-	]);
-
-	useEffect(() => {
-		if (!sentinelRef.current) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (entries[0].isIntersecting) {
-					loadMoreItems();
-				}
-			},
-			{
-				threshold: 1,
-			}
-		);
-
-		observer.observe(sentinelRef.current);
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [sentinelRef, loadMoreItems]);
-
-	const onAutocompleteItemSelected = async (
-		item: UserAccount | UserGroup
-	) => {
-		if (selectedOption === SelectOptions.USERS) {
-			if (selectedUsers.some((user) => user.id === item.id)) {
-				return;
-			}
-
-			setSelectedUsers([item as UserAccount, ...selectedUsers]);
-
-			const {error} = await SpaceService.linkUserToSpace({
-				spaceId: assetLibraryId,
-				userId: item.id,
-			});
-
-			if (error) {
-				openToast({
-					message: sub(
-						Liferay.Language.get('failed-to-add-user-x-to-space'),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'danger',
-				});
-			}
-			else {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'user-x-successfully-added-to-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'success',
-				});
-			}
-
-			return;
-		}
-
-		if (selectedUserGroups.some((group) => group.id === item.id)) {
-			return;
-		}
-
-		setSelectedUserGroups([item, ...selectedUserGroups]);
-
-		const {error} = await SpaceService.linkUserGroupToSpace({
-			spaceId: assetLibraryId,
-			userGroupId: item.id,
-		});
-
-		if (error) {
-			openToast({
-				message: sub(
-					Liferay.Language.get('failed-to-add-group-x-to-space'),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'danger',
-			});
-		}
-		else {
-			openToast({
-				message: sub(
-					Liferay.Language.get('group-x-successfully-added-to-space'),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-	};
-
-	const onRemoveItem = async (item: UserAccount | UserGroup) => {
-		if (selectedOption === SelectOptions.USERS) {
-			setSelectedUsers(selectedUsers.filter((u) => u.id !== item.id));
-
-			const {error} = await SpaceService.unlinkUserFromSpace({
-				spaceId: assetLibraryId,
-				userId: item.id,
-			});
-
-			if (error) {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'unable-to-remove-user-x-from-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'danger',
-				});
-			}
-			else {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'user-x-successfully-removed-from-space'
-						),
-						[`<strong>${item.name}</strong>`]
-					),
-					type: 'success',
-				});
-			}
-
-			return;
-		}
-
-		setSelectedUserGroups(
-			selectedUserGroups.filter((u) => u.id !== item.id)
-		);
-
-		const {error} = await SpaceService.unlinkUserGroupFromSpace({
-			spaceId: assetLibraryId,
-			userGroupId: item.id,
-		});
-
-		if (error) {
-			openToast({
-				message: sub(
-					Liferay.Language.get(
-						'unable-to-remove-group-x-from-space-x'
-					),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-		else {
-			openToast({
-				message: sub(
-					Liferay.Language.get(
-						'group-x-successfully-removed-from-space-x'
-					),
-					[`<strong>${item.name}</strong>`]
-				),
-				type: 'success',
-			});
-		}
-	};
+	const [hasSelectedMembers, setHasSelectedMembers] = useState(false);
 
 	const onContinueBtnClick = () => {
 		navigate(baseAssetLibraryURL + assetLibraryId);
 	};
-
-	const hasMembers = selectedUsers?.length > 1 || selectedUserGroups?.length;
-	const listLabelId = useId();
 
 	return (
 		<ClayLayout.Row className="add-space-members">
@@ -336,61 +45,18 @@ export function AddSpaceMembers({
 					)}
 					withForm={false}
 				>
-					<SpaceMembersInputWithSelect
-						onAutocompleteItemSelected={onAutocompleteItemSelected}
-						onSelectChange={(value) => {
-							setSelectedOption(value);
-						}}
-						selectValue={selectedOption}
+					<SpaceMembersWithList
+						assetLibraryCreatorUserId={assetLibraryCreatorUserId}
+						assetLibraryId={assetLibraryId}
+						onHasSelectedMembersChange={setHasSelectedMembers}
 					/>
-
-					<label className="d-block" id={listLabelId}>
-						{Liferay.Language.get('who-has-access')}
-					</label>
-
-					<ul aria-labelledby={listLabelId} className="members-list">
-						{selectedOption === SelectOptions.USERS ? (
-							<MembersListItem
-								assetLibraryCreatorUserId={
-									assetLibraryCreatorUserId
-								}
-								currentUserId={currentUserId}
-								emptyMessage={Liferay.Language.get(
-									'this-space-has-no-user-yet'
-								)}
-								itemType="user"
-								items={selectedUsers}
-								onRemoveItem={onRemoveItem}
-							/>
-						) : (
-							<MembersListItem
-								emptyMessage={Liferay.Language.get(
-									'this-space-has-no-group-yet'
-								)}
-								itemType="group"
-								items={selectedUserGroups}
-								onRemoveItem={onRemoveItem}
-							/>
-						)}
-
-						{isFetchingMembers && (
-							<li className="d-flex justify-content-center">
-								<LoadingIndicator
-									displayType="secondary"
-									size="sm"
-								/>
-							</li>
-						)}
-
-						<div ref={sentinelRef} />
-					</ul>
 
 					<ClayButton.Group className="mb-0 w-100" spaced vertical>
 						<ClayButton
 							className="mt-4"
 							onClick={onContinueBtnClick}
 						>
-							{hasMembers
+							{hasSelectedMembers
 								? Liferay.Language.get('continue')
 								: Liferay.Language.get(
 										'continue-without-members'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
@@ -1,0 +1,372 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '../../../css/spaces/SpaceMembersWithList.scss';
+
+import LoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
+import React, {useCallback, useEffect, useId, useRef, useState} from 'react';
+
+import SpaceService from '../../services/SpaceService';
+import {UserAccount, UserGroup} from '../../types/UserAccount';
+import {MembersListItem} from './MemberListItem';
+import {
+	SelectOptions,
+	SpaceMembersInputWithSelect,
+} from './SpaceMembersInputWithSelect';
+
+interface SpaceMembersWithListProps {
+	assetLibraryCreatorUserId: string;
+	assetLibraryId: string;
+	className?: string;
+	onHasSelectedMembersChange?: (hasSelectedMembers: boolean) => void;
+  pageSize?: number;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export function SpaceMembersWithList({
+	assetLibraryCreatorUserId,
+	assetLibraryId,
+	className,
+	onHasSelectedMembersChange,
+  pageSize = DEFAULT_PAGE_SIZE,
+}: SpaceMembersWithListProps) {
+	const currentUserId = Liferay.ThemeDisplay.getUserId();
+	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
+	const [selectedOption, setSelectedOption] = useState(SelectOptions.USERS);
+	const [selectedUsers, setSelectedUsers] = useState<UserAccount[]>([]);
+	const [selectedUserGroups, setSelectedUserGroups] = useState<UserGroup[]>(
+		[]
+	);
+	const [usersLastPage, setUsersLastPage] = useState(0);
+	const [usersPage, setUsersPage] = useState(1);
+	const [userGroupsLastPage, setUserGroupsLastPage] = useState(0);
+	const [userGroupsPage, setUserGroupsPage] = useState(1);
+	const sentinelRef = useRef(null);
+
+	useEffect(() => {
+		const fetchMembers = async () => {
+			const [spaceUsers, spaceUserGroups] = await Promise.all([
+				SpaceService.getSpaceUsers({
+					page: 1,
+					pageSize,
+					spaceId: assetLibraryId,
+				}),
+				SpaceService.getSpaceUserGroups({
+					page: 1,
+					pageSize,
+					spaceId: assetLibraryId,
+				}),
+			]);
+
+			setSelectedUsers(spaceUsers.items);
+			setSelectedUserGroups(spaceUserGroups.items);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+			setUsersLastPage(spaceUsers.lastPage);
+		};
+
+		setIsFetchingMembers(true);
+
+		try {
+			fetchMembers();
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [assetLibraryId]);
+
+	useEffect(() => {
+		const hasMembers =
+			selectedUsers?.length > 1 || selectedUserGroups?.length;
+		onHasSelectedMembersChange?.(Boolean(hasMembers));
+	}, [onHasSelectedMembersChange, selectedUsers, selectedUserGroups]);
+
+	const loadMoreItems = useCallback(async () => {
+		if (selectedOption === SelectOptions.USERS) {
+			const newUsersPage = usersPage + 1;
+
+			if (newUsersPage > usersLastPage) {
+				return;
+			}
+
+			setIsFetchingMembers(true);
+
+			try {
+				const spaceUsers = await SpaceService.getSpaceUsers({
+					page: newUsersPage,
+					pageSize,
+					spaceId: assetLibraryId,
+				});
+
+				setSelectedUsers((currentSelectedUsers) => [
+					...currentSelectedUsers,
+					...spaceUsers.items,
+				]);
+				setUsersPage(newUsersPage);
+				setUsersLastPage(spaceUsers.lastPage);
+			}
+			catch (error) {
+				console.error(error);
+			}
+			finally {
+				setIsFetchingMembers(false);
+			}
+
+			return;
+		}
+
+		const newUserGroupsPage = userGroupsPage + 1;
+		if (newUserGroupsPage > userGroupsLastPage) {
+			return;
+		}
+
+		setIsFetchingMembers(true);
+
+		try {
+			const spaceUserGroups = await SpaceService.getSpaceUserGroups({
+				page: newUserGroupsPage,
+				pageSize,
+				spaceId: assetLibraryId,
+			});
+
+			setSelectedUserGroups((currentSelectedUserGroups) => [
+				...currentSelectedUserGroups,
+				...spaceUserGroups.items,
+			]);
+			setUserGroupsPage(newUserGroupsPage);
+			setUserGroupsLastPage(spaceUserGroups.lastPage);
+		}
+		catch (error) {
+			console.error(error);
+		}
+		finally {
+			setIsFetchingMembers(false);
+		}
+	}, [
+		assetLibraryId,
+		selectedOption,
+		userGroupsPage,
+		usersPage,
+		userGroupsLastPage,
+		usersLastPage,
+	]);
+
+	useEffect(() => {
+		if (!sentinelRef.current) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting) {
+					loadMoreItems();
+				}
+			},
+			{
+				threshold: 1,
+			}
+		);
+
+		observer.observe(sentinelRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [sentinelRef, loadMoreItems]);
+
+	const onAutocompleteItemSelected = async (
+		item: UserAccount | UserGroup
+	) => {
+		if (selectedOption === SelectOptions.USERS) {
+			if (selectedUsers.some((user) => user.id === item.id)) {
+				return;
+			}
+
+			setSelectedUsers([item as UserAccount, ...selectedUsers]);
+
+			const {error} = await SpaceService.linkUserToSpace({
+				spaceId: assetLibraryId,
+				userId: item.id,
+			});
+
+			if (error) {
+				openToast({
+					message: sub(
+						Liferay.Language.get('failed-to-add-user-x-to-space'),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'danger',
+				});
+			}
+			else {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'user-x-successfully-added-to-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'success',
+				});
+			}
+
+			return;
+		}
+
+		if (selectedUserGroups.some((group) => group.id === item.id)) {
+			return;
+		}
+
+		setSelectedUserGroups([item, ...selectedUserGroups]);
+
+		const {error} = await SpaceService.linkUserGroupToSpace({
+			spaceId: assetLibraryId,
+			userGroupId: item.id,
+		});
+
+		if (error) {
+			openToast({
+				message: sub(
+					Liferay.Language.get('failed-to-add-group-x-to-space'),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'danger',
+			});
+		}
+		else {
+			openToast({
+				message: sub(
+					Liferay.Language.get('group-x-successfully-added-to-space'),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+	};
+
+	const onRemoveItem = async (item: UserAccount | UserGroup) => {
+		if (selectedOption === SelectOptions.USERS) {
+			setSelectedUsers(selectedUsers.filter((u) => u.id !== item.id));
+
+			const {error} = await SpaceService.unlinkUserFromSpace({
+				spaceId: assetLibraryId,
+				userId: item.id,
+			});
+
+			if (error) {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'unable-to-remove-user-x-from-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'danger',
+				});
+			}
+			else {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'user-x-successfully-removed-from-space'
+						),
+						[`<strong>${item.name}</strong>`]
+					),
+					type: 'success',
+				});
+			}
+
+			return;
+		}
+
+		setSelectedUserGroups(
+			selectedUserGroups.filter((u) => u.id !== item.id)
+		);
+
+		const {error} = await SpaceService.unlinkUserGroupFromSpace({
+			spaceId: assetLibraryId,
+			userGroupId: item.id,
+		});
+
+		if (error) {
+			openToast({
+				message: sub(
+					Liferay.Language.get(
+						'unable-to-remove-group-x-from-space-x'
+					),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+		else {
+			openToast({
+				message: sub(
+					Liferay.Language.get(
+						'group-x-successfully-removed-from-space-x'
+					),
+					[`<strong>${item.name}</strong>`]
+				),
+				type: 'success',
+			});
+		}
+	};
+
+	const listLabelId = useId();
+
+	return (
+		<div className={classNames('space-members-with-list', className)}>
+			<SpaceMembersInputWithSelect
+				onAutocompleteItemSelected={onAutocompleteItemSelected}
+				onSelectChange={(value) => {
+					setSelectedOption(value);
+				}}
+				selectValue={selectedOption}
+			/>
+
+			<label className="d-block" id={listLabelId}>
+				{Liferay.Language.get('who-has-access')}
+			</label>
+
+			<ul aria-labelledby={listLabelId} className="members-list">
+				{selectedOption === SelectOptions.USERS ? (
+					<MembersListItem
+						assetLibraryCreatorUserId={assetLibraryCreatorUserId}
+						currentUserId={currentUserId}
+						emptyMessage={Liferay.Language.get(
+							'this-space-has-no-user-yet'
+						)}
+						itemType="user"
+						items={selectedUsers}
+						onRemoveItem={onRemoveItem}
+					/>
+				) : (
+					<MembersListItem
+						emptyMessage={Liferay.Language.get(
+							'this-space-has-no-group-yet'
+						)}
+						itemType="group"
+						items={selectedUserGroups}
+						onRemoveItem={onRemoveItem}
+					/>
+				)}
+
+				{isFetchingMembers && (
+					<li className="d-flex justify-content-center">
+						<LoadingIndicator displayType="secondary" size="sm" />
+					</li>
+				)}
+
+				<div ref={sentinelRef} />
+			</ul>
+		</div>
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces/SpaceMembersWithList.tsx
@@ -24,7 +24,7 @@ interface SpaceMembersWithListProps {
 	assetLibraryId: string;
 	className?: string;
 	onHasSelectedMembersChange?: (hasSelectedMembers: boolean) => void;
-  pageSize?: number;
+	pageSize?: number;
 }
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -34,7 +34,7 @@ export function SpaceMembersWithList({
 	assetLibraryId,
 	className,
 	onHasSelectedMembersChange,
-  pageSize = DEFAULT_PAGE_SIZE,
+	pageSize = DEFAULT_PAGE_SIZE,
 }: SpaceMembersWithListProps) {
 	const currentUserId = Liferay.ThemeDisplay.getUserId();
 	const [isFetchingMembers, setIsFetchingMembers] = useState(false);
@@ -81,7 +81,7 @@ export function SpaceMembersWithList({
 		finally {
 			setIsFetchingMembers(false);
 		}
-	}, [assetLibraryId]);
+	}, [assetLibraryId, pageSize]);
 
 	useEffect(() => {
 		const hasMembers =
@@ -152,6 +152,7 @@ export function SpaceMembersWithList({
 		}
 	}, [
 		assetLibraryId,
+		pageSize,
 		selectedOption,
 		userGroupsPage,
 		usersPage,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
@@ -55,7 +55,12 @@ async function getSpaceUserGroups({
 	page?: number;
 	pageSize?: number;
 	spaceId: string;
-}): Promise<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}> {
+}): Promise<{
+	items: UserGroup[];
+	lastPage: number;
+	page: number;
+	totalCount: number;
+}> {
 	const urlParams = new URLSearchParams();
 
 	if (page) {
@@ -66,7 +71,12 @@ async function getSpaceUserGroups({
 		urlParams.set('pageSize', String(pageSize));
 	}
 
-	const {data, error} = await ApiHelper.get<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}>(
+	const {data, error} = await ApiHelper.get<{
+		items: UserGroup[];
+		lastPage: number;
+		page: number;
+		totalCount: number;
+	}>(
 		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups?${urlParams.toString()}`
 	);
 
@@ -85,7 +95,12 @@ async function getSpaceUsers({
 	page?: number;
 	pageSize?: number;
 	spaceId: string;
-}): Promise<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}> {
+}): Promise<{
+	items: UserAccount[];
+	lastPage: number;
+	page: number;
+	totalCount: number;
+}> {
 	const urlParams = new URLSearchParams();
 
 	if (page) {
@@ -96,7 +111,12 @@ async function getSpaceUsers({
 		urlParams.set('pageSize', String(pageSize));
 	}
 
-	const {data, error} = await ApiHelper.get<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}>(
+	const {data, error} = await ApiHelper.get<{
+		items: UserAccount[];
+		lastPage: number;
+		page: number;
+		totalCount: number;
+	}>(
 		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts?${urlParams.toString()}`
 	);
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/services/SpaceService.ts
@@ -48,32 +48,60 @@ async function getSpace({
 }
 
 async function getSpaceUserGroups({
+	page,
+	pageSize,
 	spaceId,
 }: {
+	page?: number;
+	pageSize?: number;
 	spaceId: string;
-}): Promise<UserGroup[]> {
-	const {data, error} = await ApiHelper.get<{items: UserGroup[]}>(
-		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups`
+}): Promise<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}> {
+	const urlParams = new URLSearchParams();
+
+	if (page) {
+		urlParams.set('page', String(page));
+	}
+
+	if (pageSize) {
+		urlParams.set('pageSize', String(pageSize));
+	}
+
+	const {data, error} = await ApiHelper.get<{items: UserGroup[]; page: number; lastPage: number; totalCount: number;}>(
+		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-groups?${urlParams.toString()}`
 	);
 
 	if (data) {
-		return data.items;
+		return data;
 	}
 
 	throw new Error(error);
 }
 
 async function getSpaceUsers({
+	page,
+	pageSize,
 	spaceId,
 }: {
+	page?: number;
+	pageSize?: number;
 	spaceId: string;
-}): Promise<UserAccount[]> {
-	const {data, error} = await ApiHelper.get<{items: UserAccount[]}>(
-		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts`
+}): Promise<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}> {
+	const urlParams = new URLSearchParams();
+
+	if (page) {
+		urlParams.set('page', String(page));
+	}
+
+	if (pageSize) {
+		urlParams.set('pageSize', String(pageSize));
+	}
+
+	const {data, error} = await ApiHelper.get<{items: UserAccount[]; page: number; lastPage: number; totalCount: number;}>(
+		`/o/headless-asset-library/v1.0/asset-libraries/${spaceId}/user-accounts?${urlParams.toString()}`
 	);
 
 	if (data) {
-		return data.items;
+		return data;
 	}
 
 	throw new Error(error);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -4,8 +4,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {act, render, screen, waitFor, within} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {act, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -14,10 +13,6 @@ import {
 } from '../../../../src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers';
 import SpaceService from '../../../../src/main/resources/META-INF/resources/js/services/SpaceService';
 import {Space} from '../../../../src/main/resources/META-INF/resources/js/types/Space';
-import {
-	UserAccount,
-	UserGroup,
-} from '../../../../src/main/resources/META-INF/resources/js/types/UserAccount';
 
 describe('AddSpaceMembers', () => {
 	const testSpace = {
@@ -25,60 +20,31 @@ describe('AddSpaceMembers', () => {
 		name: 'Test Space',
 	};
 
-	const testUsers = [
-		{
-			emailAddress: 'john.doe@example.com',
-			id: '1',
-			image: '/image/user_portrait',
-			name: 'John Doe',
-		},
-		{
-			emailAddress: 'jane.smith@example.com',
-			id: '2',
-			image: '/image/user_portrait',
-			name: 'Jane Smith',
-		},
-	] as UserAccount[];
-
 	const testUsersResponse = {
-		items: testUsers,
+		items: [],
 		lastPage: 1,
 		page: 1,
-		totalCount: testUsers.length,
+		totalCount: 0,
 	};
 
-	const testUserGroups = [
-		{
-			id: '1',
-			name: 'Group 1',
-		},
-		{
-			id: '2',
-			name: 'Group 2',
-		},
-	] as UserGroup[];
-
 	const testUserGroupsResponse = {
-		items: testUserGroups,
+		items: [],
 		lastPage: 1,
 		page: 1,
-		totalCount: testUserGroups.length,
+		totalCount: 0,
 	};
 
 	const props: AddSpaceMembersProps = {
-		assetLibraryCreatorUserId: testUsers[0].id,
+		assetLibraryCreatorUserId: '0',
 		assetLibraryId: testSpace.id,
 		assetLibraryName: testSpace.name,
 		baseAssetLibraryURL: '/web/cms/e/space/28632',
 	};
 
 	const LiferayOriginal = global.Liferay;
-	const {ResizeObserver: ResizeObserverOriginal} = window;
-
 	let getSpaceSpy: jest.SpyInstance;
 	let getSpaceUsersSpy: jest.SpyInstance;
 	let getSpaceUserGroupsSpy: jest.SpyInstance;
-	let intersectionObserverMock: jest.Mock;
 
 	beforeEach(() => {
 		getSpaceSpy = jest
@@ -90,17 +56,6 @@ describe('AddSpaceMembers', () => {
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
 			.mockResolvedValue(testUserGroupsResponse);
-
-		intersectionObserverMock = jest.fn((callback) => {
-			(intersectionObserverMock as any).mockCallback = callback;
-
-			return {
-				disconnect: jest.fn(),
-				observe: jest.fn(),
-				unobserve: jest.fn(),
-			};
-		});
-		global.IntersectionObserver = intersectionObserverMock;
 	});
 
 	beforeAll(() => {
@@ -113,12 +68,6 @@ describe('AddSpaceMembers', () => {
 				getUserId: jest.fn(() => '1'),
 			},
 		} as any;
-
-		window.ResizeObserver = jest.fn().mockImplementation(() => ({
-			disconnect: jest.fn(),
-			observe: jest.fn(),
-			unobserve: jest.fn(),
-		}));
 	});
 
 	afterEach(() => {
@@ -130,8 +79,6 @@ describe('AddSpaceMembers', () => {
 	});
 
 	afterAll(() => {
-		window.ResizeObserver = ResizeObserverOriginal;
-		delete (global as any).IntersectionObserver;
 		jest.restoreAllMocks();
 	});
 
@@ -152,145 +99,5 @@ describe('AddSpaceMembers', () => {
 				name: 'continue',
 			})
 		).toBeInTheDocument();
-	});
-
-	it('lists users from a space', async () => {
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		const usersList = screen.getByLabelText('who-has-access');
-		expect(usersList).toBeInTheDocument();
-
-		await waitFor(() => {
-			const usersListItems = within(usersList).getAllByRole('listitem');
-			expect(usersListItems).toHaveLength(testUsers.length);
-
-			usersListItems.forEach((item, index) => {
-				expect(item).toHaveTextContent(testUsers[index].name);
-			});
-		});
-	});
-
-	it('lists user groups from a space', async () => {
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await userEvent.click(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
-		);
-
-		await userEvent.click(screen.getByRole('option', {name: 'groups'}));
-
-		const userGroupsList = screen.getByLabelText('who-has-access');
-		expect(userGroupsList).toBeInTheDocument();
-
-		await waitFor(() => {
-			const userGroupsListItems =
-				within(userGroupsList).getAllByRole('listitem');
-			expect(userGroupsListItems).toHaveLength(testUsers.length);
-
-			userGroupsListItems.forEach((item, index) => {
-				expect(item).toHaveTextContent(testUsers[index].name);
-			});
-		});
-	});
-
-	it('loads more users when scrolling down', async () => {
-		const moreUsers = [
-			{
-				emailAddress: 'user3@example.com',
-				id: '3',
-				name: 'User Three',
-			},
-		];
-		const moreUsersResponse = {
-			items: moreUsers,
-			lastPage: 2,
-			page: 2,
-			totalCount: 1,
-		};
-
-		getSpaceUsersSpy.mockResolvedValueOnce({
-			...testUsersResponse,
-			lastPage: 2,
-		});
-
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUsers.length);
-		});
-
-		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
-
-		act(() => {
-			(intersectionObserverMock as any).mockCallback([
-				{isIntersecting: true},
-			]);
-		});
-
-		await waitFor(() => {
-			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
-			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
-				expect.objectContaining({page: 2})
-			);
-		});
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUsers.length + moreUsers.length);
-		});
-
-		expect(screen.queryByRole('status')).not.toBeInTheDocument();
-	});
-
-	it('loads more user groups when scrolling down', async () => {
-		const moreGroups = [{id: '3', name: 'Group Three'}];
-		const moreGroupsResponse = {
-			items: moreGroups,
-			lastPage: 2,
-			page: 2,
-			totalCount: 1,
-		};
-
-		getSpaceUserGroupsSpy.mockResolvedValueOnce({
-			...testUserGroupsResponse,
-			lastPage: 2,
-		});
-
-		await act(async () => render(<AddSpaceMembers {...props} />));
-
-		await userEvent.selectOptions(
-			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
-			'groups'
-		);
-
-		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
-
-		act(() => {
-			(intersectionObserverMock as any).mockCallback([
-				{isIntersecting: true},
-			]);
-		});
-
-		await waitFor(() => {
-			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
-			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
-				expect.objectContaining({page: 2})
-			);
-		});
-
-		await waitFor(() => {
-			expect(
-				within(screen.getByLabelText('who-has-access')).getAllByRole(
-					'listitem'
-				)
-			).toHaveLength(testUserGroups.length + moreGroups.length);
-		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -38,7 +38,14 @@ describe('AddSpaceMembers', () => {
 			image: '/image/user_portrait',
 			name: 'Jane Smith',
 		},
-	];
+	] as UserAccount[];
+
+	const testUsersResponse = {
+		items: testUsers,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUsers.length,
+	};
 
 	const testUserGroups = [
 		{
@@ -49,13 +56,20 @@ describe('AddSpaceMembers', () => {
 			id: '2',
 			name: 'Group 2',
 		},
-	];
+	] as UserGroup[];
+
+	const testUserGroupsResponse = {
+		items: testUserGroups,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUserGroups.length,
+	};
 
 	const props: AddSpaceMembersProps = {
 		assetLibraryCreatorUserId: testUsers[0].id,
 		assetLibraryId: testSpace.id,
 		assetLibraryName: testSpace.name,
-		baseAssetLibraryURL: '/web/cms/e/space/28632/',
+		baseAssetLibraryURL: '/web/cms/e/space/28632',
 	};
 
 	const LiferayOriginal = global.Liferay;
@@ -64,6 +78,7 @@ describe('AddSpaceMembers', () => {
 	let getSpaceSpy: jest.SpyInstance;
 	let getSpaceUsersSpy: jest.SpyInstance;
 	let getSpaceUserGroupsSpy: jest.SpyInstance;
+	let intersectionObserverMock: jest.Mock;
 
 	beforeEach(() => {
 		getSpaceSpy = jest
@@ -71,19 +86,24 @@ describe('AddSpaceMembers', () => {
 			.mockResolvedValue(testSpace as Space);
 		getSpaceUsersSpy = jest
 			.spyOn(SpaceService, 'getSpaceUsers')
-			.mockResolvedValue(testUsers as UserAccount[]);
+			.mockResolvedValue(testUsersResponse);
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
-			.mockResolvedValue(testUserGroups as UserGroup[]);
+			.mockResolvedValue(testUserGroupsResponse);
+
+		intersectionObserverMock = jest.fn((callback) => {
+			(intersectionObserverMock as any).mockCallback = callback;
+
+			return {
+				disconnect: jest.fn(),
+				observe: jest.fn(),
+				unobserve: jest.fn(),
+			};
+		});
+		global.IntersectionObserver = intersectionObserverMock;
 	});
 
 	beforeAll(() => {
-		window.ResizeObserver = jest.fn().mockImplementation(() => ({
-			disconnect: jest.fn(),
-			observe: jest.fn(),
-			unobserve: jest.fn(),
-		}));
-
 		global.Liferay = {
 			Language: {
 				get: jest.fn((key) => key),
@@ -93,6 +113,12 @@ describe('AddSpaceMembers', () => {
 				getUserId: jest.fn(() => '1'),
 			},
 		} as any;
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
 	});
 
 	afterEach(() => {
@@ -105,6 +131,7 @@ describe('AddSpaceMembers', () => {
 
 	afterAll(() => {
 		window.ResizeObserver = ResizeObserverOriginal;
+		delete (global as any).IntersectionObserver;
 		jest.restoreAllMocks();
 	});
 
@@ -163,6 +190,107 @@ describe('AddSpaceMembers', () => {
 			userGroupsListItems.forEach((item, index) => {
 				expect(item).toHaveTextContent(testUsers[index].name);
 			});
+		});
+	});
+
+	it('loads more users when scrolling down', async () => {
+		const moreUsers = [
+			{
+				emailAddress: 'user3@example.com',
+				id: '3',
+				name: 'User Three',
+			},
+		];
+		const moreUsersResponse = {
+			items: moreUsers,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUsersSpy.mockResolvedValueOnce({
+			...testUsersResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length);
+		});
+
+		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length + moreUsers.length);
+		});
+
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+
+	it('loads more user groups when scrolling down', async () => {
+		const moreGroups = [{id: '3', name: 'Group Three'}];
+		const moreGroupsResponse = {
+			items: moreGroups,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce({
+			...testUserGroupsResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.selectOptions(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
+			'groups'
+		);
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUserGroups.length + moreGroups.length);
 		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/AddSpaceMembers.test.tsx
@@ -56,6 +56,12 @@ describe('AddSpaceMembers', () => {
 		getSpaceUserGroupsSpy = jest
 			.spyOn(SpaceService, 'getSpaceUserGroups')
 			.mockResolvedValue(testUserGroupsResponse);
+
+		global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
 	});
 
 	beforeAll(() => {
@@ -80,6 +86,7 @@ describe('AddSpaceMembers', () => {
 
 	afterAll(() => {
 		jest.restoreAllMocks();
+		delete (global as any).IntersectionObserver;
 	});
 
 	it('renders with correct title, description, buttons', async () => {
@@ -96,7 +103,7 @@ describe('AddSpaceMembers', () => {
 
 		expect(
 			screen.getByRole('button', {
-				name: 'continue',
+				name: 'continue-without-members',
 			})
 		).toBeInTheDocument();
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/SpaceMembersWithList.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main/spaces/SpaceMembersWithList.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {act, render, screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+	AddSpaceMembers,
+	AddSpaceMembersProps,
+} from '../../../../src/main/resources/META-INF/resources/js/main/spaces/AddSpaceMembers';
+import SpaceService from '../../../../src/main/resources/META-INF/resources/js/services/SpaceService';
+import {Space} from '../../../../src/main/resources/META-INF/resources/js/types/Space';
+import {
+	UserAccount,
+	UserGroup,
+} from '../../../../src/main/resources/META-INF/resources/js/types/UserAccount';
+
+describe('SpaceMembersWithList', () => {
+	const testSpace = {
+		id: '123',
+		name: 'Test Space',
+	};
+
+	const testUsers = [
+		{
+			emailAddress: 'john.doe@example.com',
+			id: '1',
+			image: '/image/user_portrait',
+			name: 'John Doe',
+		},
+		{
+			emailAddress: 'jane.smith@example.com',
+			id: '2',
+			image: '/image/user_portrait',
+			name: 'Jane Smith',
+		},
+	] as UserAccount[];
+
+	const testUsersResponse = {
+		items: testUsers,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUsers.length,
+	};
+
+	const testUserGroups = [
+		{
+			id: '1',
+			name: 'Group 1',
+		},
+		{
+			id: '2',
+			name: 'Group 2',
+		},
+	] as UserGroup[];
+
+	const testUserGroupsResponse = {
+		items: testUserGroups,
+		lastPage: 1,
+		page: 1,
+		totalCount: testUserGroups.length,
+	};
+
+	const props: AddSpaceMembersProps = {
+		assetLibraryCreatorUserId: testUsers[0].id,
+		assetLibraryId: testSpace.id,
+		assetLibraryName: testSpace.name,
+		baseAssetLibraryURL: '/web/cms/e/space/28632',
+	};
+
+	const LiferayOriginal = global.Liferay;
+	const {ResizeObserver: ResizeObserverOriginal} = window;
+
+	let getSpaceSpy: jest.SpyInstance;
+	let getSpaceUsersSpy: jest.SpyInstance;
+	let getSpaceUserGroupsSpy: jest.SpyInstance;
+	let intersectionObserverMock: jest.Mock;
+
+	beforeEach(() => {
+		getSpaceSpy = jest
+			.spyOn(SpaceService, 'getSpace')
+			.mockResolvedValue(testSpace as Space);
+		getSpaceUsersSpy = jest
+			.spyOn(SpaceService, 'getSpaceUsers')
+			.mockResolvedValue(testUsersResponse);
+		getSpaceUserGroupsSpy = jest
+			.spyOn(SpaceService, 'getSpaceUserGroups')
+			.mockResolvedValue(testUserGroupsResponse);
+
+		intersectionObserverMock = jest.fn((callback) => {
+			(intersectionObserverMock as any).mockCallback = callback;
+
+			return {
+				disconnect: jest.fn(),
+				observe: jest.fn(),
+				unobserve: jest.fn(),
+			};
+		});
+		global.IntersectionObserver = intersectionObserverMock;
+	});
+
+	beforeAll(() => {
+		global.Liferay = {
+			Language: {
+				get: jest.fn((key) => key),
+			},
+			ThemeDisplay: {
+				...LiferayOriginal.ThemeDisplay,
+				getUserId: jest.fn(() => '1'),
+			},
+		} as any;
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		getSpaceSpy.mockClear();
+		getSpaceUsersSpy.mockClear();
+		getSpaceUserGroupsSpy.mockClear();
+
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		window.ResizeObserver = ResizeObserverOriginal;
+		delete (global as any).IntersectionObserver;
+		jest.restoreAllMocks();
+	});
+
+	it('lists users from a space', async () => {
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		const usersList = screen.getByLabelText('who-has-access');
+		expect(usersList).toBeInTheDocument();
+
+		await waitFor(() => {
+			const usersListItems = within(usersList).getAllByRole('listitem');
+			expect(usersListItems).toHaveLength(testUsers.length);
+
+			usersListItems.forEach((item, index) => {
+				expect(item).toHaveTextContent(testUsers[index].name);
+			});
+		});
+	});
+
+	it('lists user groups from a space', async () => {
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.click(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'})
+		);
+
+		await userEvent.click(screen.getByRole('option', {name: 'groups'}));
+
+		const userGroupsList = screen.getByLabelText('who-has-access');
+		expect(userGroupsList).toBeInTheDocument();
+
+		await waitFor(() => {
+			const userGroupsListItems =
+				within(userGroupsList).getAllByRole('listitem');
+			expect(userGroupsListItems).toHaveLength(testUsers.length);
+
+			userGroupsListItems.forEach((item, index) => {
+				expect(item).toHaveTextContent(testUsers[index].name);
+			});
+		});
+	});
+
+	it('loads more users when scrolling down', async () => {
+		const moreUsers = [
+			{
+				emailAddress: 'user3@example.com',
+				id: '3',
+				name: 'User Three',
+			},
+		];
+		const moreUsersResponse = {
+			items: moreUsers,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUsersSpy.mockResolvedValueOnce({
+			...testUsersResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length);
+		});
+
+		getSpaceUsersSpy.mockResolvedValueOnce(moreUsersResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUsersSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUsersSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUsers.length + moreUsers.length);
+		});
+
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+	});
+
+	it('loads more user groups when scrolling down', async () => {
+		const moreGroups = [{id: '3', name: 'Group Three'}];
+		const moreGroupsResponse = {
+			items: moreGroups,
+			lastPage: 2,
+			page: 2,
+			totalCount: 1,
+		};
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce({
+			...testUserGroupsResponse,
+			lastPage: 2,
+		});
+
+		await act(async () => render(<AddSpaceMembers {...props} />));
+
+		await userEvent.selectOptions(
+			screen.getByRole('combobox', {name: 'add-people-to-collaborate'}),
+			'groups'
+		);
+
+		getSpaceUserGroupsSpy.mockResolvedValueOnce(moreGroupsResponse);
+
+		act(() => {
+			(intersectionObserverMock as any).mockCallback([
+				{isIntersecting: true},
+			]);
+		});
+
+		await waitFor(() => {
+			expect(getSpaceUserGroupsSpy).toHaveBeenCalledTimes(2);
+			expect(getSpaceUserGroupsSpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({page: 2})
+			);
+		});
+
+		await waitFor(() => {
+			expect(
+				within(screen.getByLabelText('who-has-access')).getAllByRole(
+					'listitem'
+				)
+			).toHaveLength(testUserGroups.length + moreGroups.length);
+		});
+	});
+});


### PR DESCRIPTION
- **LPD-57772 Add BlockToolbar plugin**
- **LPD-57772 Add blockToolbar params to the rich text config**
- **LPD-57772 Add plugin to set the correct attributes for the block toolbar button**
- **LPD-57772 Add styles for the block toolbar button**
- **LPD-57772 Extract chooseFileFromDocumentLibrary to reuse it**
- **LPD-57772 Do not block the arrow keys in the text editable**
- **LPD-57772 Take into account the extra plugins when a CX is loaded**
- **LPD-57772 Avoid showing the drag preview when dragging text inside the CKEditor 5**
- **LPD-57772 Add test to check that the images inserted in editables have an empty alt by default**
- **LPD-57772 Add test to check that a rich text editable accepts rich text and a text editable does not**
- **LPD-57772 Add test to check the keyboard interactions inside the editor and the blur behavior**
- **LPD-57772 Allow checking an action when dragging an element**
- **LPD-57772 Add test to prevent the drag preview from appearing when dragging text inside the editor**
- **LPD-57772 Adapt tests to the block toolbar**
- **LPD-57772 Generate global config**
- **LPD-58199 Update to CKEditor 5 in the comments panel**
- **LPD-58199 Avoid to remove the fragment the backspace key is pressed inside the editor**
- **LPD-58199 Add test to prevent fragment deletion by pressing the Backspace key while editing a comment**
- **LPD-58199 Adapt styles**
- **LPD-57811 Update test logic**
- **LPD-56632 Transitions names only need to be unique at source node level**
- **LPD-56632 Transitions can have the same name as a node**
- **LPD-56632 Application data belongs in the data property of a React Flow element, so we are moving transitionName there and using a random id**
- **LPD-56632 Since transition name now lives in the data property, we need to look there when serializing the definition**
- **LPD-56632 Create util function to check if a transision name is unique among transitions from the same source node**
- **LPD-56632 We're introducing a new selectedTransitionNewName state. This is crucial for separating transition name updates from node name updates. Unlike node names and React Flow IDs (which are currently coupled and require global uniqueness) transition names only need to be unique to their source node. This distinction necessitates completely isolating the update logic for transition names from that of node names/IDs, which will continue to use the selectedItemNewId state.**
- **LPD-56632 Adapts the update logic for the Transition Name field in the Transition Information sidebar: - Introduced a transitionName local state to separate the displayed input from React Flow's elements object. This ensures the user always sees their current input, even when validation temporarily prevents the underlying elements object from updating. - Created handleTransitionNameChange to manage value changes. setSelectedTransitionNewName is now only called when input validation passes. - Added a useEffect hook to keep the local transitionName state synchronized with selectedItem after successful updates.**
- **LPD-56632 Add update logic specific for selectedTransitionNewName when elements and selectedItems names are updated, separating it from node name updates**
- **LPD-56632 Change clean-up logic to account for setSelectedTransitionNewName**
- **LPD-57894 Fix Poshi tests by simulating onblur**
- **LPD-57894 Add case 'Assert that the Revision History tab displays a list of versions in descending order' to revisionHistory.spec.ts and organize test in steps**
- **LPD-57894 Delete Poshi tests already covered by Playwright test in revisionHistory.spec.ts**
- **LPD-56632 Add unit test to assert that DeserializeUtil.getElements makes transition names unique only when they share the same source node**
- **LPD-56632 Add Playwright test to assert that: - transitions with different source nodes can have the same name - transitions with the same source node cannot have the same name - a repeated name is reverted to a previously valid name after navigating back**
- **LPD-56632 SF**
- **LPD-49422 Add endpoints to extend test module coverage**
- **LPD-49422 buildREST**
- **LPD-49422 Fix operationId calculation for site/assetLibrary-scoped entities with names starting with multiple uppercase letters**
- **LPD-49422 buildREST**
- **LPD-46121 Make isParameterNameSchemaRelated more robust to fix and simplify generated code.**
- **LPD-46121 buildREST**
- **LPD-46121 Check if keys from different scopes are present within the importTask**
- **LPD-46121 Extend delete to support deletion by ERC for site/assetLibrary scoped entities**
- **LPD-46121 buildREST**
- **LPD-46121 Refactor: use getterMethodName and idParameterName. Check if schema related. Use ERC all across, same as with ID. Simplify using macros.**
- **LPD-46121 buildREST**
- **LPD-46121 Override objects batch delete method for site/assetLibrary scoped objects**
- **LPD-46121 Add new ERCScopedTestEntity, scoped either by assetLibrary or site**
- **LPD-46121 buildREST**
- **LPD-46121 Autogenerate tests for batch delete by ERC for site/assetLibrary scoped entities**
- **LPD-46121 Add testDeleteImportTask to test directly through the batch engine, as the delete{schemaName}Batch() method is only generated if deleteById exists.**
- **LPD-46121 Batch engine returns the importTask which is a 200**
- **LPD-46121 Separate in importTaskResource and ScopedimportTaskResource to avoid overriding the same resource**
- **LPD-46121 Only generate add method if needed**
- **LPD-46121 Use parameter as argument if parameterName is present in schema's properties**
- **LPD-46121 Simplify macros**
- **LPD-46121 Allow to use null for body parameters**
- **LPD-46121 Check if path parameters exists to avoid generating empty put()**
- **LPD-46121 Reset variable**
- **LPD-46121 Needed**
- **LPD-46121 buildREST**
- **LPD-46121 Fix tests**
- **LPD-46121 Ignore tests**
- **LPD-46121 Add DeleteImportTask test for objects as we do not autogenerate it**
- **LPD-46121 Add dependency because I need to use the importTaskResource client as HTTPTestUtil does not allow a body for DELETE method**
- **LPD-46121 Use schema variable if needed**
- **LPD-46121 Check is ERC is required before including it to validation. ERC is additional assert field**
- **LPD-46121 buildREST**
- **LPD-46121 Take into account all site/assetLibrary keys and SF**
- **LPD-46121 buildREST**
- **LPD-46121 Delete overridden methods as now those are correctly generated**
- **LPD-46121 Make GraphQL tests consistent by also using externalReferenceCode. Also take into account all site and assetLibrary keys.**
- **LPD-46121 Make site and assetLibrary ERC required**
- **LPD-46121 buildREST**
- **LPD-46121 Fix tests, either ignoring if lacking some implementation or deleting overridden method that is no longer needed**
- **LPD-46121 Unify**
- **LPD-46121 Rename, keep existing pattern (irrelevantGroup VS testGroup)**
- **LPD-46121 Avoid chaining**
- **LPD-46121 SF**
- **LPD-46121 Unify, all the values should be the same**
- **LPD-46121 Rename, same name can be used as it is inside the method's scope**
- **LPD-46121 Associate to correct depotEntry and new user**
- **LPD-46121 Use the provided assetLibraryId**
- **LPD-46121 Use correct group class**
- **LPD-46121 buildREST**
- **LPD-46121 SF**
- **LPD-46121 SF**
- **LPD-46121 SF**
- **LPD-46121 SF**
- **LPD-46121 Sort**
- **LPD-46121 SF**
- **LPD-46121 Sort**
- **LPD-46121 SF**
- **LPD-46121 Regen**
- **LPD-46121 prep next**
- **LPD-46121 prep next**
- **LPD-57500 Add groupId to incomplete entry**
- **LPD-57500 Apply usage**
- **LPD-57500 buildService**
- **LPD-57500 Apply to tests**
- **LPD-57500 Rename**
- **LPD-57500 SF**
- **LPD-57500 Fix test compile errors**
- **LPD-57500 Prevent NPE**
- **LPD-57500 Sort following service.xml order**
- **LPD-57500 buildService**
- **LPD-57500 Fix usages**
- **LPD-57861 SF**
- **LPD-55260 migrate control menu tests to Playwright**
- **LPD-55260 remove poshi tests**
- **LPD-56873 Auto SF**
- **LPD-57848 Remove FF**
- **LPD-57848 buildLang**
- **LPD-57848 Adapt tests**
- **LPD-57848 Adapt test to make it more robust**
- **LPD-57848 SF**
- **LPD-52638 Remove nonexistent path, see 801766dc**
- **LPD-44846 Auto SF**
- **LPD-57819 Refactor LocalFile.UsersAdmin test to Playwright**
- **LPD-57819 Delete Poshi tests**
- **LPD-57726 Prevent button to be displayed until visited status is handled**
- **LPD-57726 Remove has selector cause is causing scroll to disappear in fragments sidebar**
- **LPD-57726 Add a common div parent with flex-shrink-0**
- **LPD-57726 Adapt tests**
- **LPD-58185 Copy key to incomplete entry name**
- **LPD-58185 Prevent creation of entries with empty key**
- **LPD-58185 Add tests**
- **LPD-58185 Simplify**
- **LPD-55716 Add deprecation feature flag**
- **LPD-55716 Apply the deprecation feature flag**
- **LPD-55716 Fix current playwright test**
- **LPD-55716 Add test**
- **LPD-55716 Fix XPath to find text inside children of .list-group-title**
- **LPD-55716 Enable deprecation feature flag in poshi test**
- **LPD-55716 Update poshi macros when copyAsNew is enabled**
- **LPD-55716 Remove unused macro LAR.importTeam**
- **LPD-55716 Adapt rebased test to work with deprecation FF**
- **LPD-55716 Simplify test definition**
- **LPD-55716 Remove redundant enabling of feature flag**
- **LPD-55716 Auto SF**
- **LPD-55716 Unify tests**
- **LPD-55716 Wordsmith**
- **LPD-55716 Regen**
- **LPD-56906 Check ADD_ENTRY permission in order to show some creation menu items**
- **LPD-56906 Typo**
- **LPD-56906 Not need**
- **LPD-56906 Add test**
- **LPD-56906 Prevent NullPointerException**
- **LPD-58194 Update SampleSQLBuilder to generate correct groupkey for the global group according to LPD-57902**
- **LPD-49899 Add methods to add and get entries**
- **LPD-49899 buildService**
- **LPD-49899 Create new interface to manage the Incomplete Models**
- **LPD-49899 Add method and set the id to be able to get it when the record is inserted**
- **LPD-49899 Implement the interface and create a new ThreadLocal just to be used internally, we don't need to expose those methods**
- **LPD-49899 Remove methods from the ThreadLocal**
- **LPD-49899 Update usages**
- **LPD-49899 Create extension point to handle exceptions when happened while importing data using Batch Engine**
- **LPD-49899 Add the Delegate that is handling the Import, we will need this to know the scope of the request**
- **LPD-49899 Implement handler and updates the arguments to pass the BatchEngineTaskItemDelegate**
- **LPD-49899 baseline**
- **LPD-49899 Create Util and use from portal-impl classes**
- **LPD-49899 Add integration test**
- **LPD-49899 Add unit tests**
- **LPD-49899 Add unit test**
- **LPD-49899 Baseline**
- **LPD-49899 Applying IncompleteModelManager**
- **LPD-49899 Add integration test**
- **LPD-49899 Pass the BatchEngineTaskItemDelegate as an argument to call the Handler in case of an error**
- **LPD-49899 Use the method using the groupId**
- **LPD-49899 Sort parameters**
- **LPD-49899 Rename**
- **LPD-49899 buildService**
- **LPD-49899 Update invocations**
- **LPD-49899 Not needed**
- **LPD-49899 Match order in service.xml**
- **LPD-57792 Add build test batches**
- **LPD-57792 Add new playwright smoke batches and remove poshi ones**
- **LPD-57792 Scope playwright smoke**
- **LPD-52709 Add the frontend caching configuration interface**
- **LPD-52709 Add FrontendResource and FrontendResourceRequestHandler interfaces**
- **LPD-52709 Implement FrontendResource and handler for hashed files**
- **LPD-52709 Add tests for previous commit**
- **LPD-52709 Create a JEE filter to handle frontend resources**
- **LPD-52709 Add dependencies**
- **LPD-52709 Fix flaky test**
- **LPD-52709 Reword language labels**
- **LPD-52709 Sort by ContentTypes.***
- **LPD-52709 Sort***
- **LPD-52709 Can we sort this?**
- **LPD-52709 Don't use magic number**
- **LPD-52709 Wordsmith**
- **LPD-52709 Move things out of the setUp method that don't need to be in there**
- **LPD-52709 Regen**
- **LPD-52709 Rename. Also, is the before-filter correct?**
- **LPD-52709 Rename**
- **LPD-52709 Wordsmith**
- **LPD-52709 Sort/simplify**
- **LPD-52709 Rename**
- **LPD-52709 Rename**
- **LPD-52709 auto SF**
- **LPD-57523 Adding :  - liferay-streamhub-batch**
- **LPD-57523 liferay-streamhub-batch, fixing prefix and  inconsistent names**
- **LPD-57523 liferay-streamhub-batch, Fixing rest context path**
- **LPD-57523 liferay-streamhub-batch, Fixing rest context path with prefix**
- **LPD-57523 liferay-streamhub-batch, Fixing rest context path with prefix**
- **LPD-57523 liferay-streamhub-batch, Fixing rest context path with prefix**
- **LPD-57523 SF**
- **LPD-57523 Consistency**
- **LPD-57523 Sort**
- **LPD-57523 Shouldn't this be an ERC? If it's an ID it should be a number.**
- **LPD-57523 liferay-streamhub-batch, Fixing rest context path with prefix**
- **LPD-57523 liferay-streamhub-batch, fix object actions names, mapping and error message for standalone action**
- **LPD-57523 Wordsmith**
- **Revert "LPD-57803 Export packages"**
- **Revert "LPD-57803 Copy email files from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/dependencies, no logic changes"**
- **Revert "LPD-57803 SF - Manual source formatting"**
- **Revert "LPD-57803 Auto SF"**
- **Revert "LPD-57803 Creates PatcherPortlet component instead using the old way of defining portlets"**
- **Revert "LPD-57803 Rename to match base name"**
- **Revert "LPD-57803 Convert into component, extends BasePortalInstanceLifecycleListener, fix source formating issues and compile errors"**
- **Revert "LPD-57803 Update copyright"**
- **Revert "LPD-57803 Auto SF"**
- **Revert "LPD-57803 Copy ServletContextListener from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/servlet, no logic changes"**
- **Revert "LPD-57803 Copy roles.xml from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/dependencies, no logic changes"**
- **Revert "LPD-57803 Resource Actions - SF reorder"**
- **Revert "LPD-57803 Copy resource-actions from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/resource-actions, no logic changes"**
- **Revert "LPD-57803 Portlet Properties - Moves all properties to configuration class"**
- **Revert "LPD-57803 Portlet Properties - Sort"**
- **Revert "LPD-57803 Portlet Properties - Copy portlet properties without default values from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src, no logic changes"**
- **Revert "LPD-57803 buildLang"**
- **Revert "LPD-57803 Update portlet title"**
- **LRSD-9421 Fix home page experience**
- **LPD-46121 buildREST**
- **LPD-52638 Revert "LPD-52638 Please resend"**
- **LPD-52638 Moving to proper package**
- **LPD-52638 Sort**
- **LPD-52638 Adding SF supression as this is a test module**
- **LPD-52638 Dependencies should be relative to the test that uses them**
- **LPD-52638 Unless we have more, this is enough**
- **LPD-52638 Assume it works**
- **LPD-52638 The package path is still needed**
- **LPD-52638 Here order matters**
- **LPD-52638 Here order does not matter**
- **LPD-52638 This should allow us to remove the package path**
- **LPD-58377 Shortcut on size 1.**
- **LRCI-5831 Store the build-database.json files in Testray**
- **LRCI-5831 Record build-database.json files at the top level builds**
- **LRCI-5831 prep next**
- **LPD-57643 Set active CSS classes on item selection**
- **LPD-57643 Set "selectable" CSS class on visualization mode level**
- **LPD-57643 Standardize hover and active styles for all visualization modes**
- **LPD-57643 Add a sample of list visualization mode to the react "sample", to showcase non-interactive hover behavior**
- **LPD-57643 Extend selection tests with checks for "active" CSS classes**
- **LPD-57643 Migrate main exports to TS, move TS types to standard location**
- **LPD-57643 Revert code removed by mistake**
- **LPD-57643 Deduplicate types**
- **LPD-58378 Drop jdk8 support**
- **LPD-58378 Fix unit test**
- **LPD-58262 Add gradle deps**
- **LPD-58262 Update Cronjob to retrieve projects using Marketplace Apps**
- **LPD-58262 Create Koroneiki Contact endpoint to be called by the CronJob (only)**
- **LPD-58262 SF**
- **LPD-58262 Add Scope**
- **LPD-58262 Update filter**
- **LPD-58262 SF**
- **LRDOCS-15307 remove /search-experiences/ from links to documentation**
- **LPD-55765 Update testray team to the correct team for Rest Builder tests**
- **LPD-57764 Fix pattern**
- **LRSD-9421 Styling fixes**
- **Reapply "LPD-57803 Update portlet title"**
- **Reapply "LPD-57803 buildLang"**
- **Reapply "LPD-57803 Portlet Properties - Copy portlet properties without default values from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src, no logic changes"**
- **Reapply "LPD-57803 Portlet Properties - Sort"**
- **Reapply "LPD-57803 Portlet Properties - Moves all properties to configuration class"**
- **Reapply "LPD-57803 Copy resource-actions from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/resource-actions, no logic changes"**
- **Reapply "LPD-57803 Resource Actions - SF reorder"**
- **Reapply "LPD-57803 Copy roles.xml from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/dependencies, no logic changes"**
- **Reapply "LPD-57803 Copy ServletContextListener from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/servlet, no logic changes"**
- **Reapply "LPD-57803 Auto SF"**
- **Reapply "LPD-57803 Update copyright"**
- **Reapply "LPD-57803 Convert into component, extends BasePortalInstanceLifecycleListener, fix source formating issues and compile errors"**
- **Reapply "LPD-57803 Rename to match base name"**
- **Reapply "LPD-57803 Creates PatcherPortlet component instead using the old way of defining portlets"**
- **Reapply "LPD-57803 Auto SF"**
- **Reapply "LPD-57803 SF - Manual source formatting"**
- **Reapply "LPD-57803 Copy email files from https://github.com/liferay/liferay-plugins-ee/tree/ee-6.2.x/portlets/osb-patcher-portlet/docroot/WEB-INF/src/com/liferay/osb/patcher/dependencies, no logic changes"**
- **Reapply "LPD-57803 Export packages"**
- **LPD-58282 Removing the cause of the startup regression**
- **LRSD-10141 Fix overdue business events notification template placeholders**
- **LPD-58424 Merge CreateSnapshotRequestExecutor/CreateSnapshotRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LPD-58424 Merge RestoreSnapshotRequestExecutor/RestoreSnapshotRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LPD-58424 Merge GetSnapshotsRequestExecutor/GetSnapshotsRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LPD-58424 Merge GetSnapshotRepositoriesRequestExecutor/GetSnapshotRepositoriesRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LPD-58424 Merge DeleteSnapshotRequestExecutor/DeleteSnapshotRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LPD-58424 Merge CreateSnapshotRepositoryRequestExecutor/CreateSnapshotRepositoryRequestExecutorImpl into pojos**
- **LPD-58424 Fix tests**
- **LRSD-9750 Add Sales Enablement Hub card to Learn (for Internal Employee e Partner)**
- **LRSD-9750 sf**
- **LRSD-9750 sf**
- **LRSD-9750 changing texts to editable**
- **LRSD-9750 SF**
- **LPD-58417 Merge IndicesOptionsTranslator/IndicesOptionsTranslatorImpl into a stateless util.**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge IndexRequestShardFailureTranslator/IndexRequestShardFailureTranslatorImpl into stateless utils.**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge AnalyzeIndexRequestExecutor/AnalyzeIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge GetMappingIndexRequestExecutor/GetMappingIndexRequestExecutorImpl into pojos.**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge OpenIndexRequestExecutor/OpenIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge DeleteIndexRequestExecutor/DeleteIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge IndicesExistsIndexRequestExecutor/IndicesExistsIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge FlushIndexRequestExecutor/FlushIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge UpdateIndexSettingsIndexRequestExecutor/UpdateIndexSettingsIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge CloseIndexRequestExecutor/CloseIndexRequestExecutorImpl into pojos.**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge GetFieldMappingIndexRequestExecutor/GetFieldMappingIndexRequestExecutorImpl into pojos.**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge RefreshIndexRequestExecutor/RefreshIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge PutMappingIndexRequestExecutor/PutMappingIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge CreateIndexRequestExecutor/CreateIndexRequestExecutorImpl into pojos**
- **LPD-58417 Fix tests**
- **LPD-58417 Merge GetIndexIndexRequestExecutor/GetIndexIndexRequestExecutorImpl**
- **LPD-58417 Fix tests**
- **LPD-56043 When adding or updating a user from SAML IdP, save the IdP information**
- **LPD-56043 Fix existing tests**
- **LPD-56043 We should only store IdP info when adding users, not updating them**
- **LPD-56043 Add test to verify expected values**
- **LPD-56043 SF - Sort**
- **LPD-56043 SF - Inline and remove unused code**
- **LPD-56043 Sort**
- **LPD-56043 Burrito**
- **LPD-56043 Match order in service.xml**
- **LPD-57356 Use entry value instead of blank**
- **LPD-57356 Test**
- **LPD-57356 Rename comment and sort**
- **LPD-57356 Rename field name and inline localized values**
- **LPD-57356 Rename**
- **LPD-57356 Not necessary**
- **LPD-57356 Delete the validation**
- **LPD-57356 Stringfy**
- **LPD-57356 SF Use GetterUtil#get**
- **LPD-57356 SF formatting**
- **LPD-57861 Add hCaptcha sample**
- **LPD-57861 SF**
- **LPD-57861 Can I change this?**
- **LPD-57861 Rename**
- **LPD-57792 Auto SF**
- **LPD-57523 Auto SF**
- **LPD-57456 Use Liferay.Util.openModal instead of openWindow**
- **LPD-57456 Unmount the modal to hide it when polling is complete**
- **LPD-57456 Update current tests**
- **LPD-57456 add test that covers the bug**
- **LPD-57851 Move personal menu styles to styled theme**
- **LPD-56917 create FF (LPD-42553) to set the functionality of workflow for folders**
- **LPD-56917 apply the new FF (LPD-42553) on the places where is needed**
- **LPD-56917 buildLang**
- **LPD-57290 Enable change tracking for LayoutSetPrototype**
- **LPD-57290 Regen**
- **LPD-57290 Add upgrade process**
- **LPD-57290 Semver**
- **LPD-57290 Add TableReferenceDefinition for LayoutSetPrototype**
- **LPD-57290 Add test for TableReferenceDefinition**
- **LPD-57290 Add CTDisplayRenderer for LayoutSetPrototype**
- **LPD-57290 Check template propagation separately for each publication to ensure propagation is triggered correctly**
- **LPD-57290 Add test**
- **LPD-57511 - send empty params rather than null so we always add keywords for item selector**
- **LPD-57511 - add test**
- **LPD-57511 As used**
- **LPD-57675 Refactor Marketplace Management Toolbar**
- **LPD-58175 Create Form to display Filters**
- **LPD-58176 Change how we filter on ListView**
- **LPD-58176 update Marketplace Custom Element package.json**
- **LPD-58177 Apply updated ListView to existing tables**
- **LPD-58250 added action button to orders table**
- **LPD-58250 minor improvements and code cleanup**
- **LPD-57673 SF**
- **LPD-57673 add actions to apps tables**
- **LPD-57673 code refactor**
- **LPD-57673 Simplify ManagementToolbar, Filter and Renderer**
- **LPD-57673 Update filter names**
- **LPD-58219 Capture the exception so as not to have a broken view**
- **LPD-58219 Adds tests**
- **LPD-58219 SF**
- **LPD-53882 Add validation rules to the space name field**
- **LPD-53882 buildLang**
- **LPD-53882 Extend invalid characters function**
- **LPD-53882 Add unit tests for space name**
- **LPD-53882 SF**
- **LPD-56190 Add base setup for new space step 2**
- **LPD-49345 Create AddSpaceMember page**
- **LPD-49345 Add tests**
- **LPD-49345 Remove assetLibraryId from tests**
- **LPD-49345 Add tanslations**
- **LPD-49345 Fix rebase issues**
- **LPD-49345 Source formatting**
- **LPD-56418 Integrate autocomplete with useResource response to display user/groups**
- **LPD-56418 Add delete helper to ApiHelper**
- **LPD-56418 Add space functions to link/unlink users/groups with space**
- **LPD-56418 Integrate components with requests**
- **LPD-56418 Add client-side request to retrieve space members**
- **LPD-56418 Rename fetch function**
- **LPD-56418 Support nested fields for AssetLibrary.**
- **LPD-56418 Add properties required by the nested fields framework**
- **LPD-56418 Add the creator user Id to the AssetLibrary**
- **LPD-56418 BuildRest**
- **LPD-56418 Create SpaceService methods to get space members**
- **LPD-56418 Use Server function to fetch space**
- **LPD-56418 Fix space members endpoints**
- **LPD-56418 Fix redirect URL**
- **LPD-56418 Display placeholder message when there is no user/group in a space**
- **LPD-56418 Add translation for placeholders and tests for components**
- **LPD-56418 Add toasts for success/failure actions and improve tests**
- **LPD-56418 Add translations**
- **LPD-56418 Source formatting**
- **LPD-57472 Update color names, button label and move component to space scope**
- **LPD-57472 Update unit tests**
- **LPD-57472 Add new master page for CMS**
- **LPD-57472 Remove redundant header on space creation pages**
- **LPD-57472 Remove frontend query to get space and retrieve data from backend**
- **LPD-57472 Fix broken unit test**
- **LPD-57472 Remove unused service**
- **LPD-57472 Fix logic for catching errors on adding/removing members of a space**
- **LPD-57472 Move code to a single useEffect**
- **LPD-57472 Unify removeUserFromSpace and removeUserGroupFromSpace functions to a single one**
- **LPD-57472 Add tests to MemberListItem**
- **LPD-57472 Add tests to MemberListItem**
- **LPD-57472 Standardize page parameters to use assetLibrary naming convention**
- **LPD-57472 Source formatting**
- **LPD-57472 Add translations**
- **LPD-57472 Fix typescript issue**
- **LPD-57472 Remove unnecessary generic type from component**
- **LPD-57472 Fix return type of react component**
- **LPD-57472 Fix props in unit test**
- **LPD-57472 Fix add space members page not loading after rebase**
- **LPD-57472 Update build rest**
- **LPD-57472 Wordsmith**
- **LCD-46861 Operator scaffolding**
- **LCD-46861 Ordering**
- **LCD-46861 Format Dockerfile**
- **LCD-46861 Move code to resources dir, format code, format Dockerfile**
- **LCD-46861 SF**
- **LPD-58050 make InventoryAnalysisCard filters responsive**
- **LPD-58050 create showLabelInSmallViewport prop in FilterDropdown**
- **LPD-56356 Test-fix**
- **LPD-56356 Modifying build-test**
- **LPD-56356 Remove unnecessary var**
- **LPD-58113 Remove Feature Flag LPD-34938**
- **LPD-58113 Use story task LPD-43455**
- **LPD-58113 Adapt tests**
- **LPD-58113 Mock session util and use the real button**
- **LPD-58113 Unify sub function for all tests**
- **LPD-57833 Add waitFor until the marketplace button is ready and displayed in the dom**
- **LPD-52709 Rename test methods**
- **LPD-52709 Move filter up in the chain**
- **LPD-58219 Fix typo**
- **LPD-8016 Add new imports.txt case**
- **LPD-8016 Improving classStructurePatterns logic to deal with attribute dependencies as well i.e. imports and references**
- **LPD-8016 Supplementary pattern for the case of imports.txt**
- **LPD-8016 Tests for LPD-8016 pattern**
- **LPD-8016 Match line 46**
- **LPD-8041 New classStructure Pattern, dealing with the migration from a method to a method and a reference, directly in the feature, using regex**
- **LPD-8041 Tests for LPD-8041**
- **LPD-58270 Add NestedFieldId annotation**
- **LPD-58270 Integration Test**
- **LPD-8041 prep next**
- **LPD-8041 prep nex**
- **LPD-37878 - move beta to release Flag**
- **LPD-55288 make time range optional**
- **LPD-55288 set title to Unknown when it is null**
- **LPD-55288 create test**
- **LPD-55288 Same thing**
- **LPD-56988 Check first values from portlet preference for email body/subject**
- **LPD-56988 Integration test**
- **LPD-56988 move toLocalizedValuesMap() method to Util class**
- **LPD-56988 add test for LocalizedValueUtil**
- **LPD-56988 baseLine**
- **LPD-56988 Methods are grouped together**
- **LPD-56988 refactoring test to use UnsafeConsumer**
- **LPD-56988 Rename for clarity**
- **LPD-56988 SF**
- **Revert "LPD-55188 Optimize reindex"**
- **Revert "LPD-55188 Integration test"**
- **Revert "LPD-55188 Add module dependencies"**
- **LPD-57472 Update build rest**
- **LPD-53153 Fix unit test errors in PreupgradeVerifyProcessSuiteTest**
- **LPD-53153 Don't use new line character in the exception message, because it is sanitized by the log**
- **LPD-53153 Write the log exceptions inside PreupgradeVerifyProcessSuite to get the complete stacktrace and be able to detect this is a PreupgradeVerifyProcessSuite error**
- **LPD-53153 state upgrade status in upgrade recorder**
- **LPD-53153 exception must be processed where thrown**
- **LPD-53153 state the verification failure message in the preupgradeverification suite**
- **LPD-53153 sf**
- **LPD-53153 just log the exception message**
- **LPD-53153 log the error in the report**
- **LPD-53153 Move message to DBupgrade class**
- **LPD-53153 SF**
- **LPD-53153 Don't remove the 'Stopping the server because' part**
- **LPD-53153 Add 'to the system' that was in the original message from victor**
- **LPD-53153 Add preupgrade validation error information to the upgrade_report.txt file**
- **LPD-53153 Wordsmith**
- **LPD-50383 Add new fragment renderer for space contents abstract section**
- **LPD-50383 Do not add the page and pageSize if not available**
- **LPD-50383 Pass the right page values for Space Abstracts**
- **LPD-50383 Add the Space Abstract Header and show it the space scoped contents as list**
- **LPD-50383 Add a new space contents view**
- **LPD-50383 Add new Fragment Renderer to show the Space Sticker**
- **LPD-50383 Update test**
- **LPD-57328 Apply styles for space card and space page**
- **LPD-57328 Keep previous names**
- **LPD-50383 Add a new master page**
- **LPD-50384 Same for files**
- **LPD-50383 Handle Space display pages for content and files**
- **LPD-50383 Lang properties**
- **LPD-50383 Build lang**
- **LPD-50383 Simplify base class by reusing method**
- **LPD-50383 Add the empty state contents**
- **LPD-50384 Add the empty state files**
- **LPD-50383 Add a util class**
- **LPD-50383 Encapsulate common logic in Base classes and avoid inherit from specific classes**
- **LPD-50383 Use HttpComponentsUtil instead**
- **LPD-50383 Fix test**
- **LPD-50383 Fix Rebase errors**
- **LPD-50383 Set the collection keys**
- **LPD-50383 Sort the filterString**
- **LPD-57803 Switch to a fixed size, not CLOB, since they are going to be used as index fields.**
- **LPD-57803 ant build-services**
- **LPD-8016 Follow up pr - fix testcase**
- **LPD-57523 adding liferay-streamhub-global-js-1 cx**
- **LPD-57523 name change from liferay-streamhub-global-js-1 to liferay-streamhub-global-js**
- **LPD-57523 removing webpack**
- **LPD-57523 auto SF**
- **LRSD-8780 Creating P2S3 Knowledge Article approval workflow**
- **LRSD-9482 Refactoring Article Related Recipes to Knowledge Article object format**
- **LRSD-9482 SF**
- **LRSD-8707 Migrating related How To logic to LEARN ARTICLE template to use Language Override and removing the unused fragment**
- **LRSD-8707 SF**
- **LRSD-8707 Inline**
- **LRSD-8707 Sort**
- **LRSD-8707 Inline**
- **LRSD-8707 Rename**
- **LRSD-8707 Inline**
- **LRSD-8707 SF**
- **LRSD-8707 Simplify**
- **LRSD-8707 Just one request instead two**
- **LRSD-8707 SF**
- **LRSD-8707 Fixing FTL import errors**
- **LRSD-8707 Use getCanonicalURL instead**
- **LRSD-8707 SF**
- **LPD-57523 Java**
- **LPD-44845 Change required asterisk color accordingly to disabled prop**
- **LPD-44844 Add optional disabled prop to seo container features**
- **LPD-44844 Update SeparatorFields component to accept disabled prop**
- **LPD-44844 Delete modal references**
- **LPD-58373 Remove Z from date string so that javascript treats it as a local date and not a utc one**
- **LPD-57471 Fetch data when reaching end of scroll**
- **LPD-57471 Add unit tests for infinite scrolling**
- **LPD-57471 Update page number only if requests succeeds**
- **LPD-57471 Create component to handle reusable space members management**
- **LPD-57471 Update unit tests for SpaceMembersWithList component**
- **LPD-57471 Fix broken unit test after rebase**
- **LPD-57471 AutoSF**
