### PR TITLE
LPD-57850 use fileName instead of the created getSourceFileName

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenCopyingAFileEntryTest.java
@@ -12,6 +12,7 @@ import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppServiceUtil;
 import com.liferay.document.library.test.util.BaseDLAppTestCase;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Before;
@@ -111,8 +113,38 @@ public class DLAppServiceWhenCopyingAFileEntryTest extends BaseDLAppTestCase {
 		_copy(parentFolder, targetParentFolder);
 	}
 
+	@Test
+	public void testShouldSucceedWithDifferentNameAndTitleToDifferentSite()
+		throws Exception {
+
+		String fileName = "test.txt";
+		String fileTitle = "test:Name";
+
+		FileEntry sourceFileEntry = dlAppService.addFileEntry(
+			null, parentFolder.getGroupId(), parentFolder.getFolderId(),
+			fileName, ContentTypes.TEXT_PLAIN, fileTitle, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, null, 0, null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				parentFolder.getGroupId()));
+
+		_copy(
+			sourceFileEntry, targetParentFolder.getGroupId(),
+			targetParentFolder.getFolderId());
+	}
+
 	protected Folder newParentFolder;
 	protected Folder targetParentFolder;
+
+	private void _copy(
+			FileEntry fileEntry, long targetGroupId, long targetFolderId)
+		throws Exception {
+
+		dlAppService.copyFileEntry(
+			fileEntry.getFileEntryId(), targetFolderId, targetGroupId,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			ServiceContextTestUtil.getServiceContext(
+				targetParentFolder.getGroupId()));
+	}
 
 	private void _copy(Folder sourceParentFolder, Folder targetParentFolder)
 		throws Exception {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -3284,7 +3284,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		FileVersion latestFileVersion = fileVersions.get(
 			fileVersions.size() - 1);
 
-		String sourceFileName = DLAppUtil.getSourceFileName(latestFileVersion);
+		String sourceFileName = latestFileVersion.getFileName();
 
 		DLValidatorUtil.validateFileSize(
 			toRepository.getRepositoryId(), sourceFileName,
@@ -3318,7 +3318,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		for (int i = fileVersions.size() - 2; i >= 0; i--) {
 			FileVersion fileVersion = fileVersions.get(i);
 
-			sourceFileName = DLAppUtil.getSourceFileName(fileVersion);
+			sourceFileName = fileVersion.getFileName();
 
 			FileVersion previousFileVersion = fileVersions.get(i + 1);
 


### PR DESCRIPTION
### What is this trying to solve?

Moving file to an external repository is giving an error, if the file name and title are different.

https://liferay.atlassian.net/browse/LPD-57850

### How am I fixing it?

Simply getting the file name attribute from the fileEntry, instead of getting it with the getSourceFileName which is creating the name from title+extension. 

### How can you verify that it works?

run integration test:
--tests=com.liferay.document.library.service.test.DLAppServiceImplTest