### PR TITLE
LPD-44158 No need to clear state on node shutdown

### DIFF
--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialUtil.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/oauth/StoredCredentialUtil.java
@@ -37,10 +37,6 @@ public class StoredCredentialUtil {
 
 	public static void clear() {
 		_clear();
-
-		if (ClusterExecutorUtil.isEnabled()) {
-			_executeOnCluster(new MethodHandler(_clearMethodKey));
-		}
 	}
 
 	public static void clear(long companyId) {
@@ -184,8 +180,6 @@ public class StoredCredentialUtil {
 		StoredCredential.class);
 	private static final MethodKey _clearCompanyMethodKey = new MethodKey(
 		StoredCredentialUtil.class, "_clear", long.class);
-	private static final MethodKey _clearMethodKey = new MethodKey(
-		StoredCredentialUtil.class, "_clear");
 	private static final MethodKey _deleteMethodKey = new MethodKey(
 		StoredCredentialUtil.class, "_delete", long.class, String.class);
 	private static final Map<Long, Map<String, StoredCredential>>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-44158

When a node in a cluster is shutdown, the whole Google Drive state is cleared up in all nodes.  This is not necessary, as the rest of the nodes are consistent among themselves.  Also, if the node is brought up later, and a Google Drive session is requested, that new session will be replicated to all other nodes -- reaching consistency when finished.

# How am I fixing it?

By clearing the local node on component deactivation.

# How can you verify that it works?

Run the `ci:test:core-functional` test suite.

# Why doesn't this include any test?

There were multiple tests failures caused by this in `ci:test:core-functional`.