### PR TITLE
LPD-58757 Use dash as word separator in categorization friendly urls

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/01_add_vocabulary/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/01_add_vocabulary/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/new_vocabulary",
+	"friendlyURL": "/categorization/new-vocabulary",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Vocabularies"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/02_edit_vocabulary/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/02_edit_vocabulary/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/edit_vocabulary",
+	"friendlyURL": "/categorization/edit-vocabulary",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Vocabularies"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/01_vocabularies/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/view_vocabularies",
+	"friendlyURL": "/categorization/view-vocabularies",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Vocabularies"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/02_tags/01_view_tag_usages/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/02_tags/01_view_tag_usages/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/view_tag_usages",
+	"friendlyURL": "/categorization/view-tag-usages",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Tag Usages"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/02_tags/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/02_tags/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/view_tags",
+	"friendlyURL": "/categorization/view-tags",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Tags"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/01_add_category/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/01_add_category/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/new_category",
+	"friendlyURL": "/categorization/new-category",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Categories"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/02_edit_category/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/02_edit_category/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/edit_category",
+	"friendlyURL": "/categorization/edit-category",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Categories"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/03_view_category_usages/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/03_view_category_usages/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/view_category_usages",
+	"friendlyURL": "/categorization/view-category-usages",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Category Usages"

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/page.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/03_admin/03_categorization/03_categories/page.json
@@ -1,5 +1,5 @@
 {
-	"friendlyURL": "/categorization/view_categories",
+	"friendlyURL": "/categorization/view-categories",
 	"hidden": false,
 	"name_i18n": {
 		"en_US": "Categories"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/EditCategoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/EditCategoryDisplayContext.java
@@ -49,7 +49,7 @@ public class EditCategoryDisplayContext {
 				_portal.getLayoutFullURL(
 					_layoutLocalService.getLayoutByFriendlyURL(
 						_themeDisplay.getScopeGroupId(), false,
-						"/categorization/view_categories"),
+						"/categorization/view-categories"),
 					_themeDisplay),
 				"vocabularyId", getVocabularyId());
 		}
@@ -58,7 +58,7 @@ public class EditCategoryDisplayContext {
 			_portal.getLayoutFullURL(
 				_layoutLocalService.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_categories"),
+					"/categorization/view-categories"),
 				_themeDisplay),
 			"categoryId", getParentCategoryId(), "vocabularyId",
 			getVocabularyId());

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/EditVocabularyDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/EditVocabularyDisplayContext.java
@@ -84,7 +84,7 @@ public class EditVocabularyDisplayContext {
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_vocabularies"),
+					"/categorization/view-vocabularies"),
 				_themeDisplay)
 		).put(
 			"defaultLanguageId",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewCategoriesDisplayContext.java
@@ -108,7 +108,7 @@ public class ViewCategoriesDisplayContext {
 							_portal.getLayoutFullURL(
 								_layoutLocalService.getLayoutByFriendlyURL(
 									_themeDisplay.getScopeGroupId(), false,
-									"/categorization/new_category"),
+									"/categorization/new-category"),
 								_themeDisplay),
 							"vocabularyId", getVocabularyId()));
 
@@ -125,7 +125,7 @@ public class ViewCategoriesDisplayContext {
 						_portal.getLayoutFullURL(
 							_layoutLocalService.getLayoutByFriendlyURL(
 								_themeDisplay.getScopeGroupId(), false,
-								"/categorization/new_category"),
+								"/categorization/new-category"),
 							_themeDisplay),
 						"parentCategoryId", parentCategoryId, "vocabularyId",
 						getVocabularyId()));
@@ -157,7 +157,7 @@ public class ViewCategoriesDisplayContext {
 					_portal.getLayoutFullURL(
 						_layoutLocalService.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/edit_category"),
+							"/categorization/edit-category"),
 						_themeDisplay),
 					"categoryId", "{id}", "parentCategoryId", getCategoryId(),
 					"vocabularyId", "{taxonomyVocabularyId}"),
@@ -168,7 +168,7 @@ public class ViewCategoriesDisplayContext {
 					_portal.getLayoutFullURL(
 						_layoutLocalService.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/edit_category"),
+							"/categorization/edit-category"),
 						_themeDisplay),
 					"parentCategoryId", "{id}", "vocabularyId",
 					"{taxonomyVocabularyId}"),
@@ -180,7 +180,7 @@ public class ViewCategoriesDisplayContext {
 					PortalUtil.getLayoutFullURL(
 						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/view_categories"),
+							"/categorization/view-categories"),
 						_themeDisplay),
 					"categoryId", "{id}", "vocabularyId",
 					"{taxonomyVocabularyId}"),
@@ -192,7 +192,7 @@ public class ViewCategoriesDisplayContext {
 					PortalUtil.getLayoutFullURL(
 						_layoutLocalService.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/view_category_usages"),
+							"/categorization/view-category-usages"),
 						_themeDisplay),
 					"categoryId", "{id}"),
 				null, "view-category-usages",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagUsagesDisplayContext.java
@@ -52,7 +52,7 @@ public class ViewTagUsagesDisplayContext {
 					() -> PortalUtil.getLayoutFullURL(
 						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/view_tags"),
+							"/categorization/view-tags"),
 						_themeDisplay)
 				).put(
 					"label", LanguageUtil.get(_themeDisplay.getLocale(), "tags")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagsDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewTagsDisplayContext.java
@@ -31,21 +31,21 @@ public class ViewTagsDisplayContext {
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_tags"),
+					"/categorization/view-tags"),
 				_themeDisplay)
 		).put(
 			"tagUsagesURL",
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_tag_usages"),
+					"/categorization/view-tag-usages"),
 				_themeDisplay)
 		).put(
 			"vocabulariesURL",
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_vocabularies"),
+					"/categorization/view-vocabularies"),
 				_themeDisplay)
 		).build();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVocabulariesDisplayContext.java
@@ -94,7 +94,7 @@ public class ViewVocabulariesDisplayContext {
 					PortalUtil.getLayoutFullURL(
 						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/new_vocabulary"),
+							"/categorization/new-vocabulary"),
 						_themeDisplay));
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "new-vocabulary"));
@@ -122,7 +122,7 @@ public class ViewVocabulariesDisplayContext {
 		String fullLayoutURL = PortalUtil.getLayoutFullURL(
 			LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 				_themeDisplay.getScopeGroupId(), false,
-				"/categorization/edit_vocabulary"),
+				"/categorization/edit-vocabulary"),
 			_themeDisplay);
 
 		return ListUtil.fromArray(
@@ -139,7 +139,7 @@ public class ViewVocabulariesDisplayContext {
 					PortalUtil.getLayoutFullURL(
 						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 							_themeDisplay.getScopeGroupId(), false,
-							"/categorization/view_categories"),
+							"/categorization/view-categories"),
 						_themeDisplay),
 					"vocabularyId", "{id}"),
 				null, "view-categories",
@@ -165,14 +165,14 @@ public class ViewVocabulariesDisplayContext {
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_tags"),
+					"/categorization/view-tags"),
 				_themeDisplay)
 		).put(
 			"vocabulariesURL",
 			PortalUtil.getLayoutFullURL(
 				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 					_themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_vocabularies"),
+					"/categorization/view-vocabularies"),
 				_themeDisplay)
 		).build();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategorizationJSPSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewCategorizationJSPSectionFragmentRenderer.java
@@ -55,7 +55,7 @@ public class ViewCategorizationJSPSectionFragmentRenderer
 			String redirectURL = PortalUtil.getLayoutFullURL(
 				_layoutLocalService.getLayoutByFriendlyURL(
 					themeDisplay.getScopeGroupId(), false,
-					"/categorization/view_vocabularies"),
+					"/categorization/view-vocabularies"),
 				themeDisplay);
 
 			httpServletResponse.sendRedirect(redirectURL);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/CategorizationBreadcrumbUtil.java
@@ -91,7 +91,7 @@ public class CategorizationBreadcrumbUtil {
 						PortalUtil.getLayoutFullURL(
 							LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 								themeDisplay.getScopeGroupId(), false,
-								"/categorization/view_categories"),
+								"/categorization/view-categories"),
 							themeDisplay),
 						"vocabularyId", category.getVocabularyId(),
 						"categoryId", category.getCategoryId())
@@ -116,7 +116,7 @@ public class CategorizationBreadcrumbUtil {
 				() -> PortalUtil.getLayoutFullURL(
 					LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 						themeDisplay.getScopeGroupId(), false,
-						"/categorization/view_vocabularies"),
+						"/categorization/view-vocabularies"),
 					themeDisplay)
 			).put(
 				"label",
@@ -141,7 +141,7 @@ public class CategorizationBreadcrumbUtil {
 						PortalUtil.getLayoutFullURL(
 							LayoutLocalServiceUtil.getLayoutByFriendlyURL(
 								themeDisplay.getScopeGroupId(), false,
-								"/categorization/view_categories"),
+								"/categorization/view-categories"),
 							themeDisplay),
 						"vocabularyId", assetVocabularyId);
 				}

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -12,17 +12,17 @@ export const PORTLET_URLS = {
 	bookmarks:
 		'/~/control_panel/manage?p_p_id=com_liferay_bookmarks_web_portlet_BookmarksAdminPortlet',
 	categoriesAdmin: '/~/control_panel/manage/-/categories_admin/vocabularies',
-	cmsCategories: 'web/cms/categorization/view_categories',
+	cmsCategories: 'web/cms/categorization/view-categories',
 	cmsContents: 'web/cms/contents',
-	cmsEditCategory: 'web/cms/categorization/edit_category',
+	cmsEditCategory: 'web/cms/categorization/edit-category',
 	cmsFiles: 'web/cms/files',
-	cmsNewCategory: 'web/cms/categorization/new_category',
-	cmsNewVocabulary: 'web/cms/categorization/new_vocabulary',
+	cmsNewCategory: 'web/cms/categorization/new-category',
+	cmsNewVocabulary: 'web/cms/categorization/new-vocabulary',
 	cmsPicklistBuilder: 'web/cms/picklist-builder',
 	cmsStructureBuilder: 'web/cms/structure-builder',
 	cmsStructures: 'web/cms/structures',
-	cmsTags: 'web/cms/categorization/view_tags',
-	cmsVocabularies: 'web/cms/categorization/view_vocabularies',
+	cmsTags: 'web/cms/categorization/view-tags',
+	cmsVocabularies: 'web/cms/categorization/view-vocabularies',
 	collections:
 		'/~/control_panel/manage?p_p_id=com_liferay_asset_list_web_portlet_AssetListPortlet',
 	contentDashboard:


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-58757

Page friendly URLs use dash as a word separator by convention, but categorization pages use the underscore.

# How am I fixing it?

Use the dash consistently for all content pages.

# Why doesn't this include any test?

Existing CMS tests cover this.