### PR TITLE
LPD-57911 Document Version Revert Failure

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -14,8 +14,14 @@ import com.liferay.document.library.display.context.DLUIItemKeys;
 import com.liferay.document.library.kernel.document.conversion.DocumentConversionUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFileShortcutConstants;
+import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.document.library.kernel.versioning.VersioningStrategy;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.document.library.web.internal.display.context.helper.FileEntryDisplayContextHelper;
@@ -23,6 +29,12 @@ import com.liferay.document.library.web.internal.display.context.helper.FileShor
 import com.liferay.document.library.web.internal.helper.DLTrashHelper;
 import com.liferay.document.library.web.internal.util.DLSubscriptionUtil;
 import com.liferay.document.library.web.internal.util.FolderItemSelectorURLProvider;
+import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.dynamic.data.mapping.kernel.StorageEngineManagerUtil;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMBeanTranslatorUtil;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidationException;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidator;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -36,6 +48,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -887,6 +900,10 @@ public class UIItemsBuilder {
 			return false;
 		}
 
+		if (!_isValidDDMFormValues(_fileVersion)) {
+			return false;
+		}
+
 		FileVersion latestFileVersion = _fileEntry.getLatestFileVersion();
 
 		return !Objects.equals(
@@ -1306,7 +1323,75 @@ public class UIItemsBuilder {
 		return _trashEnabled;
 	}
 
+	private boolean _isValidDDMFormValues(FileVersion fileVersion) {
+		try {
+			if (!(fileVersion.getModel() instanceof DLFileVersion)) {
+				return true;
+			}
+
+			DLFileVersion dlFileVersion = (DLFileVersion)fileVersion.getModel();
+
+			if (dlFileVersion.getFileEntryTypeId() ==
+					DLFileEntryTypeConstants.
+						FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT) {
+
+				return true;
+			}
+
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+					dlFileVersion.getFileEntryTypeId());
+
+			for (DDMStructure ddmStructure :
+					dlFileEntryType.getDDMStructures()) {
+
+				DLFileEntryMetadata dlFileEntryMetadata =
+					DLFileEntryMetadataLocalServiceUtil.fetchFileEntryMetadata(
+						ddmStructure.getStructureId(),
+						fileVersion.getFileVersionId());
+
+				if (dlFileEntryMetadata != null) {
+					DDMFormValues translatedDDMFormValues =
+						DDMBeanTranslatorUtil.translate(
+							StorageEngineManagerUtil.getDDMFormValues(
+								dlFileEntryMetadata.getDDMStorageId()));
+
+					if (translatedDDMFormValues != null) {
+						_validate(translatedDDMFormValues);
+					}
+				}
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private void _validate(DDMFormValues ddmFormValues)
+		throws DDMFormValuesValidationException {
+
+		DDMFormValuesValidator ddmFormValuesValidator =
+			_ddmFormValuesValidatorSnapshot.get();
+
+		if (ddmFormValuesValidator == null) {
+			throw new IllegalStateException(
+				"DDMFormValuesValidator service is not available");
+		}
+
+		ddmFormValuesValidator.validate(ddmFormValues);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(UIItemsBuilder.class);
+
+	private static final Snapshot<DDMFormValuesValidator>
+		_ddmFormValuesValidatorSnapshot = new Snapshot<>(
+			UIItemsBuilder.class, DDMFormValuesValidator.class);
 
 	private String _currentURL;
 	private final DLTrashHelper _dlTrashHelper;

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditDocumentTypesPage.ts
@@ -65,4 +65,36 @@ export class DocumentLibraryEditDocumentTypesPage {
 		await fillAndClickOutside(this.page, this.titleSelector, title);
 		await this.saveButton.click();
 	}
+
+	async createNewDLTypeWithTextField(
+		title: string,
+		isRequired: boolean,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
+		await this.addField('Text', siteUrl);
+		await this.page.getByRole('tab', {name: 'Basic'}).click();
+		await fillAndClickOutside(this.page, this.titleSelector, title);
+		if (isRequired) {
+			await this.page.getByLabel('Required Field').check();
+		}
+		await this.saveButton.click();
+		await this.documentLibraryPage.waitForSuccessAlert();
+	}
+
+	async updateDLTypeTextField(
+		title: string,
+		isRequired: boolean,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
+		await this.documentLibraryPage.changeTab('Document Types');
+		await this.page.locator('a', {hasText: title}).click();
+		await this.page.locator('.ddm-drag').first().click();
+		await this.page.getByRole('tab', {name: 'Basic'}).click();
+		if (isRequired) {
+			await this.page.getByLabel('Required Field').check();
+		}
+		await this.saveButton.click();
+	}
 }

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -7,6 +7,7 @@ import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export type TVocabularyCategory = {
 	categoryNames: string[];
@@ -55,6 +56,13 @@ export class DocumentLibraryPage {
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
 		await this.page.goto(
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.documentLibrary}`
+		);
+	}
+
+	async waitForSuccessAlert() {
+		await waitForAlert(
+			this.page,
+			'Success:Your request completed successfully.'
 		);
 	}
 
@@ -112,6 +120,19 @@ export class DocumentLibraryPage {
 			await checkbox.check();
 		}
 		await this.page.getByRole('button', {name: 'Delete'}).click();
+	}
+
+	async clickFileEntryAction(actionName: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: actionName,
+			}),
+			trigger: this.page.getByRole('button', {
+				name: 'Show Actions',
+			}),
+		});
 	}
 
 	async deleteDocumentType(name: string) {

--- a/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/main/fileEntry.spec.ts
@@ -897,3 +897,63 @@ test(
 		);
 	}
 );
+
+test(
+	'Cannot revert to version with missing required fields',
+	{
+		tag: '@LPD-57911',
+	},
+
+	async ({
+		documentLibraryEditDocumentTypesPage,
+		documentLibraryEditFilePage,
+		documentLibraryPage,
+		page,
+		site,
+	}) => {
+		const dlTypeTitle = getRandomString();
+		const fileEntryTitle = getRandomString();
+
+		await documentLibraryEditDocumentTypesPage.createNewDLTypeWithTextField(
+			dlTypeTitle,
+			false,
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryEditFilePage.goToNewFileDifferentType(
+			dlTypeTitle,
+			site.friendlyUrlPath
+		);
+		await page.getByLabel('Title Required').fill(fileEntryTitle);
+		await documentLibraryEditFilePage.publishButton.click();
+		await documentLibraryPage.waitForSuccessAlert();
+
+		await documentLibraryPage.page
+			.getByRole('link', {exact: true, name: fileEntryTitle})
+			.click();
+		await documentLibraryPage.clickFileEntryAction('Edit');
+		await documentLibraryEditFilePage.descriptionInput.fill(fileEntryTitle);
+		await documentLibraryEditFilePage.publishButton.click();
+		await documentLibraryPage.waitForSuccessAlert();
+
+		await documentLibraryEditDocumentTypesPage.updateDLTypeTextField(
+			dlTypeTitle,
+			true,
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.page
+			.getByRole('link', {exact: true, name: fileEntryTitle})
+			.click();
+		await documentLibraryPage.clickFileEntryAction('View History');
+		await page
+			.locator('tr', {hasText: '1.0'})
+			.locator('[aria-label="Actions"], .dropdown-toggle')
+			.click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Revert'})
+		).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
Fixed changes as per Brian's Comment https://github.com/brianchandotcom/liferay-portal/pull/163038#issuecomment-3004740242

### **What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-57911
When attempting to revert a document to an older version that lacked values for fields that have since become required, the system would throw an error

### **How am I fixing it?**
The Revert option is now disabled for versions that do not satisfy the current required field constraints.

### **How can you verify that it works?**
By running the following Playwright test:
**npm run playwright -- test -g 'Cannot revert to version with missing required fields'**