### PR TITLE
LPD-57727 site-cms-site-initializer: Adopt Clay's VerticalNav for spaces navigation menu

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
@@ -4,13 +4,11 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
+import {VerticalNav} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
-import ClayPanel from '@clayui/panel';
+import ClaySticker, {DisplayType} from '@clayui/sticker';
 import {navigate, sub} from 'frontend-js-web';
 import React from 'react';
-
-import SpaceSticker, {LogoColor} from '../components/SpaceSticker';
 
 export interface AssetLibrary {
 	id: number;
@@ -29,6 +27,24 @@ interface SpacesNavigationProps {
 	showAddButton: boolean;
 }
 
+interface VerticalNavItem {
+	active?: boolean;
+	href?: string;
+	icon?: string;
+	itemClass?: string;
+	items?: VerticalNavItem[];
+	label: string;
+	menubarAction?: {
+		'aria-label'?: string;
+		'onClick'?: Function;
+		'title'?: string;
+	};
+	sticker?: {
+		displayType: string;
+		label: string;
+	};
+}
+
 const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 	allSpacesURL,
 	assetLibraries,
@@ -44,66 +60,88 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 		event.stopPropagation();
 	};
 
+	const spacesNavigationItem = {
+		items: [
+			...assetLibraries.map(({name, settings, url}) => ({
+				href: url,
+				label: name,
+				sticker: {
+					displayType: settings?.logoColor as string,
+					label: name.charAt(0).toUpperCase(),
+				},
+			})),
+			{
+				href: allSpacesURL,
+				icon: 'box-container',
+				label: sub(
+					Liferay.Language.get('all-spaces-x'),
+					assetLibrariesCount
+				),
+			},
+		],
+		label: Liferay.Language.get('spaces'),
+	};
+
 	return (
-		<ClayPanel
-			collapsable
-			defaultExpanded
-			displayTitle={
-				<ClayPanel.Title className="align-items-center d-flex font-weight-semi-bold justify-content-between text-2 text-uppercase">
-					<span>{Liferay.Language.get('spaces')}</span>
-
-					{showAddButton && (
-						<span className="float-right mr-2">
-							<ClayButtonWithIcon
-								aria-label={Liferay.Language.get('add-space')}
-								displayType="secondary"
-								onClick={onAddButtonClick}
-								size="xs"
-								symbol="plus"
-								title={Liferay.Language.get('add-space')}
-								type="button"
-							/>
-						</span>
-					)}
-				</ClayPanel.Title>
+		<VerticalNav
+			aria-label="vertical navbar"
+			defaultExpandedKeys={new Set([Liferay.Language.get('spaces')])}
+			displayType="primary"
+			items={
+				showAddButton
+					? [
+							{
+								...spacesNavigationItem,
+								menubarAction: {
+									'aria-label':
+										Liferay.Language.get('add-space'),
+									'onClick': onAddButtonClick,
+									'title': Liferay.Language.get('add-space'),
+								},
+							},
+						]
+					: [spacesNavigationItem]
 			}
-			showCollapseIcon
 		>
-			<ClayPanel.Body className="p-0">
-				<ul className="menubar-primary nav nav-stacked" role="menu">
-					{assetLibraries.map((assetLibrary) => (
-						<li className="nav-item" key={assetLibrary.id}>
-							<ClayLink
-								className="nav-link"
-								href={assetLibrary.url}
+			{(item: VerticalNavItem) => {
+				return (
+					<VerticalNav.Item
+						href={item.href}
+						items={item.items}
+						key={item.label}
+						menubarAction={
+							item.menubarAction as React.ComponentProps<
+								typeof ClayButtonWithIcon
 							>
-								<SpaceSticker
+						}
+						textValue={item.label}
+					>
+						<div className="autofit-row">
+							{item.sticker && (
+								<ClaySticker
 									displayType={
-										assetLibrary.settings
-											?.logoColor as LogoColor
+										item.sticker.displayType as DisplayType
 									}
-									name={assetLibrary.name}
 									size="sm"
-								/>
-							</ClayLink>
-						</li>
-					))}
-
-					<li className="nav-item" role="none">
-						<ClayLink className="nav-link" href={allSpacesURL}>
-							<span className="mr-2 sticker sticker-sm">
-								<ClayIcon symbol="box-container" />
-							</span>
-
-							{sub(
-								Liferay.Language.get('all-spaces-x'),
-								assetLibrariesCount
+								>
+									{item.sticker.label}
+								</ClaySticker>
 							)}
-						</ClayLink>
-					</li>
-				</ul>
-			</ClayPanel.Body>
-		</ClayPanel>
+
+							{item.icon && (
+								<div className="autofit-col">
+									<ClayIcon symbol={item.icon} />
+								</div>
+							)}
+
+							<div className="autofit-col autofit-col-expand">
+								{item.label}
+							</div>
+						</div>
+					</VerticalNav.Item>
+				);
+			}}
+		</VerticalNav>
 	);
 };
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/spaces_navigation/SpacesNavigation.tsx
@@ -37,6 +37,7 @@ interface VerticalNavItem {
 	menubarAction?: {
 		'aria-label'?: string;
 		'onClick'?: Function;
+		'role'?: string;
 		'title'?: string;
 	};
 	sticker?: {
@@ -96,6 +97,7 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 									'aria-label':
 										Liferay.Language.get('add-space'),
 									'onClick': onAddButtonClick,
+									'role': 'menuitem',
 									'title': Liferay.Language.get('add-space'),
 								},
 							},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57727 - Improve Spaces Menu Area in CMS due to Accessibility

Objective:

> This panel should be a vertical navigation component, just like the previous menu. Otherwise, the user is completely changing the way they navigate between two visually identical elements, and this is happening all in in the same sidebar.

These changes are for the `SpacesNavigation.tsx` component, to adopt `VerticalNav` from Clay core. I ran DevTools and did not see any a11y issues afterward, please let me know what you think! Thank you.

Preview:
<img width="500" alt="Screenshot 2025-06-26 at 4 14 18 PM" src="https://github.com/user-attachments/assets/8e829b70-c3e2-4802-84e6-88f4127e2bf4" />
