### PR TITLE
LPD-59105 Only add the reference if it doesn't exists

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
@@ -72,10 +72,18 @@ public class DLOpenerOneDriveManager {
 		BackgroundTask backgroundTask = _addBackgroundTask(
 			userId, fileEntry, locale);
 
-		_dlOpenerFileEntryReferenceLocalService.
-			addPlaceholderDLOpenerFileEntryReference(
-				userId, DLOpenerOneDriveConstants.ONE_DRIVE_REFERENCE_TYPE,
-				fileEntry, DLOpenerFileEntryReferenceConstants.TYPE_EDIT);
+		DLOpenerFileEntryReference dlOpenerFileEntryReference =
+			_dlOpenerFileEntryReferenceLocalService.
+				fetchDLOpenerFileEntryReference(
+					DLOpenerOneDriveConstants.ONE_DRIVE_REFERENCE_TYPE,
+					fileEntry);
+
+		if (dlOpenerFileEntryReference == null) {
+			_dlOpenerFileEntryReferenceLocalService.
+				addPlaceholderDLOpenerFileEntryReference(
+					userId, DLOpenerOneDriveConstants.ONE_DRIVE_REFERENCE_TYPE,
+					fileEntry, DLOpenerFileEntryReferenceConstants.TYPE_EDIT);
+		}
 
 		return new DLOpenerOneDriveFileReference<>(
 			fileEntry.getFileEntryId(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-59105

This issue is very hard to reproduce. There are cases were the reference is not removed based on a race condition, so creating a new reference will lead to a duplicate index exception. The idea is to check if the refence exists, and if it doesn't create it