### PR TITLE
Lpd 59057 master

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -434,7 +434,14 @@ public class JournalConverterImpl implements JournalConverter {
 			ddmField.addValue(locale, serializable);
 		}
 
-		_addMissingFieldValues(ddmField, defaultLanguageId, missingLanguageIds);
+		String type = ddmField.getType();
+
+		if (!StringUtil.equals(type, DDMFormFieldTypeConstants.RICH_TEXT) &&
+			!StringUtil.equals(type, DDMFormFieldTypeConstants.TEXT)) {
+
+			_addMissingFieldValues(
+				ddmField, defaultLanguageId, missingLanguageIds);
+		}
 
 		return ddmField;
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -391,6 +391,33 @@ public class JournalTransformerTest {
 	}
 
 	@Test
+	public void testLocalTransformerWithPartialTranslation() throws Exception {
+		Assert.assertEquals(
+			"2022-11-26",
+			_transformMethod.invoke(
+				_journalTransformer, _journalArticle, null, _journalHelper,
+				LocaleUtil.toLanguageId(LocaleUtil.BRAZIL),
+				_layoutDisplayPageProviderRegistry,
+				ListUtil.filter(
+					_serviceTrackerList.toList(),
+					TransformerListener::isEnabled),
+				null, false, "${FieldsGroup19507604.birthday.getData()}", null,
+				Constants.VIEW));
+
+		Assert.assertEquals(
+			"",
+			_transformMethod.invoke(
+				_journalTransformer, _journalArticle, null, _journalHelper,
+				LocaleUtil.toLanguageId(LocaleUtil.BRAZIL),
+				_layoutDisplayPageProviderRegistry,
+				ListUtil.filter(
+					_serviceTrackerList.toList(),
+					TransformerListener::isEnabled),
+				null, false, "${FieldsGroup19507604.language.getData()}", null,
+				Constants.VIEW));
+	}
+
+	@Test
 	public void testRandomNamespaceAssetPublisherTemplate() throws Exception {
 		PermissionChecker originalPermissionChecker =
 			PermissionThreadLocal.getPermissionChecker();

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/data_definition.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/data_definition.json
@@ -79,6 +79,12 @@
 									"salary"
 								],
 								"size": 7
+							},
+							{
+								"fields": [
+									"language"
+								],
+								"size": 75
 							}
 						]
 					}
@@ -185,6 +191,40 @@
 					},
 					"localizable": true,
 					"name": "salary",
+					"nestedDataDefinitionFields": [
+					],
+					"readOnly": false,
+					"repeatable": false,
+					"required": false,
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					}
+				},
+				{
+					"customProperties": {
+						"dataType": "text",
+						"fieldNamespace": "",
+						"fieldReference": "language",
+						"labelAtStructureLevel": true,
+						"nativeField": false,
+						"objectFieldName": "",
+						"requiredErrorMessage": {
+							"en_US": ""
+						},
+						"visibilityExpression": ""
+					},
+					"defaultValue": {
+						"en_US": ""
+					},
+					"fieldType": "text",
+					"indexType": "keyword",
+					"indexable": true,
+					"label": {
+						"en_US": "Text"
+					},
+					"localizable": true,
+					"name": "language",
 					"nestedDataDefinitionFields": [
 					],
 					"readOnly": false,

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/journal_article_content.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/transformer/test/dependencies/journal_article_content.xml
@@ -12,5 +12,8 @@
 		<dynamic-element index-type="keyword" instance-id="CWwtPaEO" name="salary" type="numeric">
 			<dynamic-content language-id="en_US"><![CDATA[100]]></dynamic-content>
 		</dynamic-element>
+		<dynamic-element index-type="keyword" instance-id="M2LopT4x" name="language" type="text">
+			<dynamic-content language-id="en_US"><![CDATA[English]]></dynamic-content>
+		</dynamic-element>
 	</dynamic-element>
 </root>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-59057

When adding a partial translation text based fields will be added to the translation with the default locale values. This is needed for many field types, but for text and rich text this is not needed.

# How am I fixing it?

Instead of adding all missing fields, only do so if the fields is not a text or rich text.

# How can you verify that it works?
Run the JournalTransformerTest.testLocalTransformerWithPartialTranslation test
