### PR TITLE
LPD-59259 Web Content Article - Revert Version

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 39.0.1
+Bundle-Version: 39.1.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -2193,6 +2193,21 @@ public interface JournalArticleLocalService
 			long userId, JournalArticle article)
 		throws PortalException;
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param userId the primary key of the user performing the revert
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	public JournalArticle revertArticle(
+			long userId, long groupId, String articleId, double version)
+		throws PortalException;
+
 	public void setTreePaths(long folderId, String treePath, boolean reindex)
 		throws PortalException;
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -2608,6 +2608,24 @@ public class JournalArticleLocalServiceUtil {
 		return getService().restoreArticleFromTrash(userId, article);
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param userId the primary key of the user performing the revert
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	public static JournalArticle revertArticle(
+			long userId, long groupId, String articleId, double version)
+		throws PortalException {
+
+		return getService().revertArticle(userId, groupId, articleId, version);
+	}
+
 	public static void setTreePaths(
 			long folderId, String treePath, boolean reindex)
 		throws PortalException {

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -2809,6 +2809,26 @@ public class JournalArticleLocalServiceWrapper
 			userId, article);
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param userId the primary key of the user performing the revert
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	@Override
+	public JournalArticle revertArticle(
+			long userId, long groupId, String articleId, double version)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.revertArticle(
+			userId, groupId, articleId, version);
+	}
+
 	@Override
 	public void setTreePaths(long folderId, String treePath, boolean reindex)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -1288,6 +1288,20 @@ public interface JournalArticleService extends BaseService {
 	public void restoreArticleFromTrash(long groupId, String articleId)
 		throws PortalException;
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	public JournalArticle revertArticle(
+			long groupId, String articleId, double version)
+		throws PortalException;
+
 	public void subscribe(long groupId, long articleId) throws PortalException;
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -1492,6 +1492,23 @@ public class JournalArticleServiceUtil {
 		getService().restoreArticleFromTrash(groupId, articleId);
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	public static JournalArticle revertArticle(
+			long groupId, String articleId, double version)
+		throws PortalException {
+
+		return getService().revertArticle(groupId, articleId, version);
+	}
+
 	public static void subscribe(long groupId, long articleId)
 		throws PortalException {
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -1572,6 +1572,25 @@ public class JournalArticleServiceWrapper
 		_journalArticleService.restoreArticleFromTrash(groupId, articleId);
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param articleId the primary key of the web content article to revert
+	 * @param version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	@Override
+	public JournalArticle revertArticle(
+			long groupId, String articleId, double version)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.revertArticle(
+			groupId, articleId, version);
+	}
+
 	@Override
 	public void subscribe(long groupId, long articleId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 18.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
@@ -2604,6 +2604,47 @@ public class JournalArticleServiceHttp {
 		}
 	}
 
+	public static com.liferay.journal.model.JournalArticle revertArticle(
+			HttpPrincipal httpPrincipal, long groupId, String articleId,
+			double version)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class, "revertArticle",
+				_revertArticleParameterTypes65);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, articleId, version);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void subscribe(
 			HttpPrincipal httpPrincipal, long groupId, long articleId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -2611,7 +2652,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribe",
-				_subscribeParameterTypes65);
+				_subscribeParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2648,7 +2689,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribeStructure",
-				_subscribeStructureParameterTypes66);
+				_subscribeStructureParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2684,7 +2725,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes67);
+				_unsubscribeParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2721,7 +2762,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribeStructure",
-				_unsubscribeStructureParameterTypes68);
+				_unsubscribeStructureParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2762,7 +2803,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes69);
+				_updateArticleParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, groupId, folderId, articleId, version,
@@ -2819,7 +2860,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes70);
+				_updateArticleParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, titleMap,
@@ -2870,7 +2911,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes71);
+				_updateArticleParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, content,
@@ -2926,7 +2967,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleDefaultValues",
-				_updateArticleDefaultValuesParameterTypes72);
+				_updateArticleDefaultValuesParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, titleMap, descriptionMap,
@@ -2979,7 +3020,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleTranslation",
-				_updateArticleTranslationParameterTypes73);
+				_updateArticleTranslationParameterTypes74);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, locale, title,
@@ -3022,7 +3063,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes74);
+				_updateStatusParameterTypes75);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, status, articleURL,
@@ -3314,23 +3355,25 @@ public class JournalArticleServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _restoreArticleFromTrashParameterTypes64 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _subscribeParameterTypes65 = new Class[] {
+	private static final Class<?>[] _revertArticleParameterTypes65 =
+		new Class[] {long.class, String.class, double.class};
+	private static final Class<?>[] _subscribeParameterTypes66 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _subscribeStructureParameterTypes66 =
+	private static final Class<?>[] _subscribeStructureParameterTypes67 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _unsubscribeParameterTypes67 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes68 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _unsubscribeStructureParameterTypes68 =
+	private static final Class<?>[] _unsubscribeStructureParameterTypes69 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _updateArticleParameterTypes69 =
+	private static final Class<?>[] _updateArticleParameterTypes70 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes70 =
+	private static final Class<?>[] _updateArticleParameterTypes71 =
 		new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
@@ -3342,13 +3385,13 @@ public class JournalArticleServiceHttp {
 			java.io.File.class, java.util.Map.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes71 =
+	private static final Class<?>[] _updateArticleParameterTypes72 =
 		new Class[] {
 			long.class, long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateArticleDefaultValuesParameterTypes72 = new Class[] {
+		_updateArticleDefaultValuesParameterTypes73 = new Class[] {
 			long.class, String.class, java.util.Map.class, java.util.Map.class,
 			String.class, String.class, String.class, int.class, int.class,
 			int.class, int.class, int.class, int.class, int.class, int.class,
@@ -3358,13 +3401,13 @@ public class JournalArticleServiceHttp {
 			java.io.File.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleTranslationParameterTypes73 =
+	private static final Class<?>[] _updateArticleTranslationParameterTypes74 =
 		new Class[] {
 			long.class, String.class, double.class, java.util.Locale.class,
 			String.class, String.class, String.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes74 =
+	private static final Class<?>[] _updateStatusParameterTypes75 =
 		new Class[] {
 			long.class, String.class, double.class, int.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4395,6 +4395,25 @@ public class JournalArticleLocalServiceImpl
 		return article;
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param  userId the primary key of the user performing the revert
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  articleId the primary key of the web content article to revert
+	 * @param  version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	@Override
+	public JournalArticle revertArticle(
+			long userId, long groupId, String articleId, double version)
+		throws PortalException {
+
+		return _copyArticle(userId, groupId, articleId, articleId, version);
+	}
+
 	@Override
 	public void setTreePaths(long folderId, String treePath, boolean reindex)
 		throws PortalException {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -968,217 +968,9 @@ public class JournalArticleLocalServiceImpl
 			String targetArticleId, boolean autoArticleId, double version)
 		throws PortalException {
 
-		// Article
-
-		sourceArticleId = StringUtil.toUpperCase(
-			StringUtil.trim(sourceArticleId));
-		targetArticleId = StringUtil.toUpperCase(
-			StringUtil.trim(targetArticleId));
-
-		JournalArticle sourceArticle = journalArticlePersistence.findByG_A_V(
-			groupId, sourceArticleId, version);
-
-		if (autoArticleId) {
-			targetArticleId = String.valueOf(counterLocalService.increment());
-		}
-		else {
-			validate(targetArticleId);
-
-			if (journalArticlePersistence.countByG_A(groupId, targetArticleId) >
-					0) {
-
-				throw new DuplicateArticleIdException(
-					StringBundler.concat(
-						"{groupId=", groupId, ", articleId=", targetArticleId,
-						"}"));
-			}
-		}
-
-		User user = _userLocalService.getUser(userId);
-
-		long id = counterLocalService.increment();
-
-		long resourcePrimKey =
-			_journalArticleResourceLocalService.getArticleResourcePrimKey(
-				groupId, targetArticleId);
-
-		JournalArticle targetArticle = journalArticlePersistence.create(id);
-
-		targetArticle.setResourcePrimKey(resourcePrimKey);
-		targetArticle.setGroupId(groupId);
-		targetArticle.setCompanyId(user.getCompanyId());
-		targetArticle.setUserId(user.getUserId());
-		targetArticle.setUserName(user.getFullName());
-
-		Date modifiedDate = new Date();
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext == null) {
-			serviceContext = new ServiceContext();
-		}
-
-		modifiedDate = serviceContext.getModifiedDate(modifiedDate);
-
-		targetArticle.setModifiedDate(modifiedDate);
-
-		targetArticle.setExternalReferenceCode(targetArticleId);
-		targetArticle.setFolderId(sourceArticle.getFolderId());
-		targetArticle.setTreePath(sourceArticle.getTreePath());
-		targetArticle.setArticleId(targetArticleId);
-		targetArticle.setVersion(JournalArticleConstants.VERSION_DEFAULT);
-		targetArticle.setDDMStructureId(sourceArticle.getDDMStructureId());
-		targetArticle.setDDMTemplateKey(sourceArticle.getDDMTemplateKey());
-		targetArticle.setDefaultLanguageId(
-			sourceArticle.getDefaultLanguageId());
-		targetArticle.setLayoutUuid(sourceArticle.getLayoutUuid());
-		targetArticle.setDisplayDate(sourceArticle.getDisplayDate());
-		targetArticle.setExpirationDate(sourceArticle.getExpirationDate());
-		targetArticle.setReviewDate(sourceArticle.getReviewDate());
-		targetArticle.setIndexable(sourceArticle.isIndexable());
-		targetArticle.setSmallImage(sourceArticle.isSmallImage());
-		targetArticle.setSmallImageId(counterLocalService.increment());
-		targetArticle.setSmallImageSource(sourceArticle.getSmallImageSource());
-		targetArticle.setSmallImageURL(sourceArticle.getSmallImageURL());
-
-		WorkflowHandler<?> workflowHandler =
-			WorkflowHandlerRegistryUtil.getWorkflowHandler(
-				JournalArticle.class.getName());
-
-		WorkflowDefinitionLink workflowDefinitionLink =
-			workflowHandler.getWorkflowDefinitionLink(
-				sourceArticle.getCompanyId(), sourceArticle.getGroupId(),
-				sourceArticle.getId());
-
-		if (sourceArticle.isPending() || (workflowDefinitionLink != null)) {
-			targetArticle.setStatus(WorkflowConstants.STATUS_DRAFT);
-		}
-		else {
-			targetArticle.setStatus(sourceArticle.getStatus());
-		}
-
-		targetArticle.setStatusByUserId(user.getUserId());
-		targetArticle.setStatusByUserName(user.getFullName());
-		targetArticle.setStatusDate(modifiedDate);
-
-		Map<Locale, String> newTitleMap = sourceArticle.getTitleMap();
-		Map<Locale, String> newUniqueURLTitleMap = new HashMap<>();
-
-		for (Map.Entry<Locale, String> entry : newTitleMap.entrySet()) {
-			Locale locale = entry.getKey();
-
-			String uniqueUrlTitle = _getUniqueUrlTitle(
-				groupId, targetArticleId, entry.getValue());
-
-			newTitleMap.put(locale, uniqueUrlTitle);
-			newUniqueURLTitleMap.put(
-				locale, JournalUtil.getUrlTitle(id, uniqueUrlTitle));
-		}
-
-		DDMFormValues ddmFormValues = sourceArticle.getDDMFormValues();
-
-		Locale locale = ddmFormValues.getDefaultLocale();
-
-		String newURLTitle = newUniqueURLTitleMap.get(locale);
-
-		while (fetchArticleByUrlTitle(groupId, newURLTitle) != null) {
-			newURLTitle = getUniqueUrlTitle(
-				id, groupId, targetArticleId, newURLTitle);
-		}
-
-		targetArticle.setUrlTitle(newURLTitle);
-
-		ExpandoBridgeUtil.copyExpandoBridgeAttributes(
-			sourceArticle.getExpandoBridge(), targetArticle.getExpandoBridge());
-
-		targetArticle = journalArticlePersistence.update(targetArticle);
-
-		// Article localization
-
-		Map<Locale, String> friendlyURLMap = _checkFriendlyURLMap(
-			locale, new HashMap(), newUniqueURLTitleMap);
-
-		Map<String, String> newUrlTitleMap = _getURLTitleMap(
-			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap);
-
-		updateFriendlyURLs(targetArticle, newUrlTitleMap, serviceContext);
-
-		_addArticleLocalizedFields(
-			targetArticle.getCompanyId(), targetArticle.getId(), newTitleMap,
-			sourceArticle.getDescriptionMap());
-
-		// Resources
-
-		_resourceLocalService.copyModelResources(
-			sourceArticle.getCompanyId(), JournalArticle.class.getName(),
-			sourceArticle.getResourcePrimKey(), resourcePrimKey);
-
-		// Small image
-
-		if (sourceArticle.isSmallImage()) {
-			Image image = _imageLocalService.fetchImage(
-				sourceArticle.getSmallImageId());
-
-			if (image != null) {
-				byte[] smallImageBytes = image.getTextObj();
-
-				_imageLocalService.updateImage(
-					targetArticle.getCompanyId(),
-					targetArticle.getSmallImageId(), smallImageBytes);
-			}
-		}
-
-		// Asset
-
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			JournalArticle.class.getName(), sourceArticle.getId());
-
-		if (assetEntry == null) {
-			assetEntry = _assetEntryLocalService.getEntry(
-				JournalArticle.class.getName(),
-				sourceArticle.getResourcePrimKey());
-		}
-
-		long[] assetCategoryIds = _assetCategoryLocalService.getCategoryIds(
-			JournalArticle.class.getName(), assetEntry.getClassPK());
-		String[] assetTagNames = _assetTagLocalService.getTagNames(
-			JournalArticle.class.getName(), assetEntry.getClassPK());
-
-		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
-			assetEntry.getEntryId(), false);
-
-		long[] assetLinkEntryIds = ListUtil.toLongArray(
-			assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
-
-		updateAsset(
-			userId, targetArticle, assetCategoryIds, assetTagNames,
-			assetLinkEntryIds, assetEntry.getPriority());
-
-		AssetDisplayPageEntry assetDisplayPageEntry =
-			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
-				groupId, _portal.getClassNameId(JournalArticle.class.getName()),
-				sourceArticle.getResourcePrimKey());
-
-		if (assetDisplayPageEntry != null) {
-			_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
-				userId, groupId,
-				_portal.getClassNameId(JournalArticle.class.getName()),
-				targetArticle.getResourcePrimKey(),
-				assetDisplayPageEntry.getLayoutPageTemplateEntryId(),
-				assetDisplayPageEntry.getType(), serviceContext);
-		}
-
-		// Dynamic data mapping
-
-		updateDDMFields(
-			targetArticle, copyArticleImages(sourceArticle, targetArticle));
-
-		updateDDMLinks(
-			id, groupId, sourceArticle.getDDMStructureId(),
-			sourceArticle.getDDMTemplateKey(), true);
-
-		return targetArticle;
+		return _copyArticle(
+			userId, groupId, sourceArticleId, targetArticleId, autoArticleId,
+			version);
 	}
 
 	/**
@@ -7603,6 +7395,224 @@ public class JournalArticleLocalServiceImpl
 		).put(
 			defaultLocale, _removeTrailingSlashes(titleMap.get(defaultLocale))
 		).build();
+	}
+
+	private JournalArticle _copyArticle(
+			long userId, long groupId, String sourceArticleId,
+			String targetArticleId, boolean autoArticleId, double version)
+		throws PortalException {
+
+		// Article
+
+		sourceArticleId = StringUtil.toUpperCase(
+			StringUtil.trim(sourceArticleId));
+		targetArticleId = StringUtil.toUpperCase(
+			StringUtil.trim(targetArticleId));
+
+		JournalArticle sourceArticle = journalArticlePersistence.findByG_A_V(
+			groupId, sourceArticleId, version);
+
+		if (autoArticleId) {
+			targetArticleId = String.valueOf(counterLocalService.increment());
+		}
+		else {
+			validate(targetArticleId);
+
+			if (journalArticlePersistence.countByG_A(groupId, targetArticleId) >
+					0) {
+
+				throw new DuplicateArticleIdException(
+					StringBundler.concat(
+						"{groupId=", groupId, ", articleId=", targetArticleId,
+						"}"));
+			}
+		}
+
+		User user = _userLocalService.getUser(userId);
+
+		long id = counterLocalService.increment();
+
+		long resourcePrimKey =
+			_journalArticleResourceLocalService.getArticleResourcePrimKey(
+				groupId, targetArticleId);
+
+		JournalArticle targetArticle = journalArticlePersistence.create(id);
+
+		targetArticle.setResourcePrimKey(resourcePrimKey);
+		targetArticle.setGroupId(groupId);
+		targetArticle.setCompanyId(user.getCompanyId());
+		targetArticle.setUserId(user.getUserId());
+		targetArticle.setUserName(user.getFullName());
+
+		Date modifiedDate = new Date();
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+		}
+
+		modifiedDate = serviceContext.getModifiedDate(modifiedDate);
+
+		targetArticle.setModifiedDate(modifiedDate);
+
+		targetArticle.setExternalReferenceCode(targetArticleId);
+		targetArticle.setFolderId(sourceArticle.getFolderId());
+		targetArticle.setTreePath(sourceArticle.getTreePath());
+		targetArticle.setArticleId(targetArticleId);
+		targetArticle.setVersion(JournalArticleConstants.VERSION_DEFAULT);
+		targetArticle.setDDMStructureId(sourceArticle.getDDMStructureId());
+		targetArticle.setDDMTemplateKey(sourceArticle.getDDMTemplateKey());
+		targetArticle.setDefaultLanguageId(
+			sourceArticle.getDefaultLanguageId());
+		targetArticle.setLayoutUuid(sourceArticle.getLayoutUuid());
+		targetArticle.setDisplayDate(sourceArticle.getDisplayDate());
+		targetArticle.setExpirationDate(sourceArticle.getExpirationDate());
+		targetArticle.setReviewDate(sourceArticle.getReviewDate());
+		targetArticle.setIndexable(sourceArticle.isIndexable());
+		targetArticle.setSmallImage(sourceArticle.isSmallImage());
+		targetArticle.setSmallImageId(counterLocalService.increment());
+		targetArticle.setSmallImageSource(sourceArticle.getSmallImageSource());
+		targetArticle.setSmallImageURL(sourceArticle.getSmallImageURL());
+
+		WorkflowHandler<?> workflowHandler =
+			WorkflowHandlerRegistryUtil.getWorkflowHandler(
+				JournalArticle.class.getName());
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			workflowHandler.getWorkflowDefinitionLink(
+				sourceArticle.getCompanyId(), sourceArticle.getGroupId(),
+				sourceArticle.getId());
+
+		if (sourceArticle.isPending() || (workflowDefinitionLink != null)) {
+			targetArticle.setStatus(WorkflowConstants.STATUS_DRAFT);
+		}
+		else {
+			targetArticle.setStatus(sourceArticle.getStatus());
+		}
+
+		targetArticle.setStatusByUserId(user.getUserId());
+		targetArticle.setStatusByUserName(user.getFullName());
+		targetArticle.setStatusDate(modifiedDate);
+
+		Map<Locale, String> newTitleMap = sourceArticle.getTitleMap();
+		Map<Locale, String> newUniqueURLTitleMap = new HashMap<>();
+
+		for (Map.Entry<Locale, String> entry : newTitleMap.entrySet()) {
+			Locale locale = entry.getKey();
+
+			String uniqueUrlTitle = _getUniqueUrlTitle(
+				groupId, targetArticleId, entry.getValue());
+
+			newTitleMap.put(locale, uniqueUrlTitle);
+			newUniqueURLTitleMap.put(
+				locale, JournalUtil.getUrlTitle(id, uniqueUrlTitle));
+		}
+
+		DDMFormValues ddmFormValues = sourceArticle.getDDMFormValues();
+
+		Locale locale = ddmFormValues.getDefaultLocale();
+
+		String newURLTitle = newUniqueURLTitleMap.get(locale);
+
+		while (fetchArticleByUrlTitle(groupId, newURLTitle) != null) {
+			newURLTitle = getUniqueUrlTitle(
+				id, groupId, targetArticleId, newURLTitle);
+		}
+
+		targetArticle.setUrlTitle(newURLTitle);
+
+		ExpandoBridgeUtil.copyExpandoBridgeAttributes(
+			sourceArticle.getExpandoBridge(), targetArticle.getExpandoBridge());
+
+		targetArticle = journalArticlePersistence.update(targetArticle);
+
+		// Article localization
+
+		Map<Locale, String> friendlyURLMap = _checkFriendlyURLMap(
+			locale, new HashMap(), newUniqueURLTitleMap);
+
+		Map<String, String> newUrlTitleMap = _getURLTitleMap(
+			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap);
+
+		updateFriendlyURLs(targetArticle, newUrlTitleMap, serviceContext);
+
+		_addArticleLocalizedFields(
+			targetArticle.getCompanyId(), targetArticle.getId(), newTitleMap,
+			sourceArticle.getDescriptionMap());
+
+		// Resources
+
+		_resourceLocalService.copyModelResources(
+			sourceArticle.getCompanyId(), JournalArticle.class.getName(),
+			sourceArticle.getResourcePrimKey(), resourcePrimKey);
+
+		// Small image
+
+		if (sourceArticle.isSmallImage()) {
+			Image image = _imageLocalService.fetchImage(
+				sourceArticle.getSmallImageId());
+
+			if (image != null) {
+				byte[] smallImageBytes = image.getTextObj();
+
+				_imageLocalService.updateImage(
+					targetArticle.getCompanyId(),
+					targetArticle.getSmallImageId(), smallImageBytes);
+			}
+		}
+
+		// Asset
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			JournalArticle.class.getName(), sourceArticle.getId());
+
+		if (assetEntry == null) {
+			assetEntry = _assetEntryLocalService.getEntry(
+				JournalArticle.class.getName(),
+				sourceArticle.getResourcePrimKey());
+		}
+
+		long[] assetCategoryIds = _assetCategoryLocalService.getCategoryIds(
+			JournalArticle.class.getName(), assetEntry.getClassPK());
+		String[] assetTagNames = _assetTagLocalService.getTagNames(
+			JournalArticle.class.getName(), assetEntry.getClassPK());
+
+		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
+			assetEntry.getEntryId(), false);
+
+		long[] assetLinkEntryIds = ListUtil.toLongArray(
+			assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
+
+		updateAsset(
+			userId, targetArticle, assetCategoryIds, assetTagNames,
+			assetLinkEntryIds, assetEntry.getPriority());
+
+		AssetDisplayPageEntry assetDisplayPageEntry =
+			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				groupId, _portal.getClassNameId(JournalArticle.class.getName()),
+				sourceArticle.getResourcePrimKey());
+
+		if (assetDisplayPageEntry != null) {
+			_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
+				userId, groupId,
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				targetArticle.getResourcePrimKey(),
+				assetDisplayPageEntry.getLayoutPageTemplateEntryId(),
+				assetDisplayPageEntry.getType(), serviceContext);
+		}
+
+		// Dynamic data mapping
+
+		updateDDMFields(
+			targetArticle, copyArticleImages(sourceArticle, targetArticle));
+
+		updateDDMLinks(
+			id, groupId, sourceArticle.getDDMStructureId(),
+			sourceArticle.getDDMTemplateKey(), true);
+
+		return targetArticle;
 	}
 
 	private void _copyArticleImages(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7591,9 +7591,11 @@ public class JournalArticleLocalServiceImpl
 
 		// Resources
 
-		_resourceLocalService.copyModelResources(
-			sourceArticle.getCompanyId(), JournalArticle.class.getName(),
-			sourceArticle.getResourcePrimKey(), resourcePrimKey);
+		if (newArticle) {
+			_resourceLocalService.copyModelResources(
+				sourceArticle.getCompanyId(), JournalArticle.class.getName(),
+				sourceArticle.getResourcePrimKey(), resourcePrimKey);
+		}
 
 		// Small image
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -985,7 +985,7 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return _copyArticle(
-			userId, groupId, sourceArticleId, targetArticleId, version);
+			userId, groupId, sourceArticleId, targetArticleId, version, true);
 	}
 
 	/**
@@ -4411,7 +4411,8 @@ public class JournalArticleLocalServiceImpl
 			long userId, long groupId, String articleId, double version)
 		throws PortalException {
 
-		return _copyArticle(userId, groupId, articleId, articleId, version);
+		return _copyArticle(
+			userId, groupId, articleId, articleId, version, false);
 	}
 
 	@Override
@@ -7433,7 +7434,7 @@ public class JournalArticleLocalServiceImpl
 
 	private JournalArticle _copyArticle(
 			long userId, long groupId, String sourceArticleId,
-			String targetArticleId, double version)
+			String targetArticleId, double version, boolean newArticle)
 		throws PortalException {
 
 		// Article

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7654,8 +7654,13 @@ public class JournalArticleLocalServiceImpl
 
 		// Dynamic data mapping
 
-		updateDDMFields(
-			targetArticle, copyArticleImages(sourceArticle, targetArticle));
+		if (newArticle) {
+			updateDDMFields(
+				targetArticle, copyArticleImages(sourceArticle, targetArticle));
+		}
+		else {
+			updateDDMFields(targetArticle, sourceArticle.getDDMFormValues());
+		}
 
 		updateDDMLinks(
 			id, groupId, sourceArticle.getDDMStructureId(),

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7479,7 +7479,17 @@ public class JournalArticleLocalServiceImpl
 		targetArticle.setFolderId(sourceArticle.getFolderId());
 		targetArticle.setTreePath(sourceArticle.getTreePath());
 		targetArticle.setArticleId(targetArticleId);
-		targetArticle.setVersion(JournalArticleConstants.VERSION_DEFAULT);
+
+		if (newArticle) {
+			version = JournalArticleConstants.VERSION_DEFAULT;
+		}
+		else {
+			version = getNextVersion(
+				getLatestArticle(
+					groupId, sourceArticleId, WorkflowConstants.STATUS_ANY));
+		}
+
+		targetArticle.setVersion(version);
 		targetArticle.setDDMStructureId(sourceArticle.getDDMStructureId());
 		targetArticle.setDDMTemplateKey(sourceArticle.getDDMTemplateKey());
 		targetArticle.setDefaultLanguageId(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7534,29 +7534,38 @@ public class JournalArticleLocalServiceImpl
 		targetArticle.setStatusByUserName(user.getFullName());
 		targetArticle.setStatusDate(modifiedDate);
 
-		Map<Locale, String> newTitleMap = sourceArticle.getTitleMap();
-		Map<Locale, String> newUniqueURLTitleMap = new HashMap<>();
+		Map<Locale, String> titleMap = sourceArticle.getTitleMap();
+		Map<Locale, String> uniqueURLTitleMap = new HashMap<>();
 
-		for (Map.Entry<Locale, String> entry : newTitleMap.entrySet()) {
-			Locale locale = entry.getKey();
+		if (newArticle) {
+			titleMap = new HashMap<>(sourceArticle.getTitleMap());
 
-			String uniqueUrlTitle = _getUniqueUrlTitle(
-				groupId, targetArticleId, entry.getValue());
+			for (Map.Entry<Locale, String> entry : titleMap.entrySet()) {
+				Locale locale = entry.getKey();
 
-			newTitleMap.put(locale, uniqueUrlTitle);
-			newUniqueURLTitleMap.put(
-				locale, JournalUtil.getUrlTitle(id, uniqueUrlTitle));
+				String uniqueUrlTitle = _getUniqueUrlTitle(
+					groupId, targetArticleId, entry.getValue());
+
+				titleMap.put(locale, uniqueUrlTitle);
+
+				uniqueURLTitleMap.put(
+					locale, JournalUtil.getUrlTitle(id, uniqueUrlTitle));
+			}
 		}
 
 		DDMFormValues ddmFormValues = sourceArticle.getDDMFormValues();
 
 		Locale locale = ddmFormValues.getDefaultLocale();
 
-		String newURLTitle = newUniqueURLTitleMap.get(locale);
+		String newURLTitle = sourceArticle.getUrlTitle();
 
-		while (fetchArticleByUrlTitle(groupId, newURLTitle) != null) {
-			newURLTitle = getUniqueUrlTitle(
-				id, groupId, targetArticleId, newURLTitle);
+		if (newArticle) {
+			newURLTitle = uniqueURLTitleMap.get(locale);
+
+			while (fetchArticleByUrlTitle(groupId, newURLTitle) != null) {
+				newURLTitle = getUniqueUrlTitle(
+					id, groupId, targetArticleId, newURLTitle);
+			}
 		}
 
 		targetArticle.setUrlTitle(newURLTitle);
@@ -7569,15 +7578,15 @@ public class JournalArticleLocalServiceImpl
 		// Article localization
 
 		Map<Locale, String> friendlyURLMap = _checkFriendlyURLMap(
-			locale, new HashMap(), newUniqueURLTitleMap);
+			locale, new HashMap<>(), uniqueURLTitleMap);
 
 		Map<String, String> newUrlTitleMap = _getURLTitleMap(
-			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap);
+			groupId, resourcePrimKey, friendlyURLMap, uniqueURLTitleMap);
 
 		updateFriendlyURLs(targetArticle, newUrlTitleMap, serviceContext);
 
 		_addArticleLocalizedFields(
-			targetArticle.getCompanyId(), targetArticle.getId(), newTitleMap,
+			targetArticle.getCompanyId(), targetArticle.getId(), titleMap,
 			sourceArticle.getDescriptionMap());
 
 		// Resources

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7500,7 +7500,17 @@ public class JournalArticleLocalServiceImpl
 		targetArticle.setReviewDate(sourceArticle.getReviewDate());
 		targetArticle.setIndexable(sourceArticle.isIndexable());
 		targetArticle.setSmallImage(sourceArticle.isSmallImage());
-		targetArticle.setSmallImageId(counterLocalService.increment());
+
+		if (newArticle) {
+			targetArticle.setSmallImageId(counterLocalService.increment());
+		}
+		else {
+			JournalArticle latestArticle = getLatestArticle(
+				groupId, targetArticleId, WorkflowConstants.STATUS_ANY);
+
+			targetArticle.setSmallImageId(latestArticle.getSmallImageId());
+		}
+
 		targetArticle.setSmallImageSource(sourceArticle.getSmallImageSource());
 		targetArticle.setSmallImageURL(sourceArticle.getSmallImageURL());
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7451,9 +7451,8 @@ public class JournalArticleLocalServiceImpl
 
 		long id = counterLocalService.increment();
 
-		long resourcePrimKey =
-			_journalArticleResourceLocalService.getArticleResourcePrimKey(
-				groupId, targetArticleId);
+		long resourcePrimKey = _getResourcePrimKey(
+			groupId, targetArticleId, newArticle);
 
 		JournalArticle targetArticle = journalArticlePersistence.create(id);
 
@@ -8145,6 +8144,21 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return null;
+	}
+
+	private long _getResourcePrimKey(
+			long groupId, String targetArticleId, boolean newArticle)
+		throws PortalException {
+
+		if (newArticle) {
+			return _journalArticleResourceLocalService.
+				getArticleResourcePrimKey(groupId, targetArticleId);
+		}
+
+		JournalArticle latestArticle = getLatestArticle(
+			groupId, targetArticleId, WorkflowConstants.STATUS_ANY);
+
+		return latestArticle.getResourcePrimKey();
 	}
 
 	private int _getSmallImageSource(boolean smallImage, String smallImageURL) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -968,9 +968,24 @@ public class JournalArticleLocalServiceImpl
 			String targetArticleId, boolean autoArticleId, double version)
 		throws PortalException {
 
+		if (autoArticleId) {
+			targetArticleId = String.valueOf(counterLocalService.increment());
+		}
+		else {
+			validate(targetArticleId);
+
+			if (journalArticlePersistence.countByG_A(groupId, targetArticleId) >
+					0) {
+
+				throw new DuplicateArticleIdException(
+					StringBundler.concat(
+						"{groupId=", groupId, ", articleId=", targetArticleId,
+						"}"));
+			}
+		}
+
 		return _copyArticle(
-			userId, groupId, sourceArticleId, targetArticleId, autoArticleId,
-			version);
+			userId, groupId, sourceArticleId, targetArticleId, version);
 	}
 
 	/**
@@ -7399,7 +7414,7 @@ public class JournalArticleLocalServiceImpl
 
 	private JournalArticle _copyArticle(
 			long userId, long groupId, String sourceArticleId,
-			String targetArticleId, boolean autoArticleId, double version)
+			String targetArticleId, double version)
 		throws PortalException {
 
 		// Article
@@ -7411,22 +7426,6 @@ public class JournalArticleLocalServiceImpl
 
 		JournalArticle sourceArticle = journalArticlePersistence.findByG_A_V(
 			groupId, sourceArticleId, version);
-
-		if (autoArticleId) {
-			targetArticleId = String.valueOf(counterLocalService.increment());
-		}
-		else {
-			validate(targetArticleId);
-
-			if (journalArticlePersistence.countByG_A(groupId, targetArticleId) >
-					0) {
-
-				throw new DuplicateArticleIdException(
-					StringBundler.concat(
-						"{groupId=", groupId, ", articleId=", targetArticleId,
-						"}"));
-			}
-		}
 
 		User user = _userLocalService.getUser(userId);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -1845,6 +1845,31 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 		restoreArticleFromTrash(article.getResourcePrimKey());
 	}
 
+	/**
+	 * Reverts the web content article to a specified previous version by creating
+	 * a new version that replicates the content and metadata of the specified older version.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  articleId the primary key of the web content article to revert
+	 * @param  version the specific version of the article to revert to
+	 * @return the newly created web content article based on the specified version
+	 * @throws PortalException if the specified version does not exist or other portal errors occur
+	 */
+	@Override
+	public JournalArticle revertArticle(
+			long groupId, String articleId, double version)
+		throws PortalException {
+
+		JournalArticle article = journalArticlePersistence.findByG_A_V(
+			groupId, articleId, version);
+
+		_journalArticleModelResourcePermission.check(
+			getPermissionChecker(), article, ActionKeys.UPDATE);
+
+		return journalArticleLocalService.revertArticle(
+			getUserId(), groupId, articleId, version);
+	}
+
 	@Override
 	public void subscribe(long groupId, long articleId) throws PortalException {
 		JournalArticle article = getLatestArticle(articleId);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -2047,6 +2047,34 @@ public class JournalArticleLocalServiceTest {
 	}
 
 	@Test
+	public void testRevertArticle() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		JournalArticle updatedJournalArticle = JournalTestUtil.updateArticle(
+			journalArticle, RandomTestUtil.randomString());
+
+		_journalArticleLocalService.revertArticle(
+			journalArticle.getUserId(), _group.getGroupId(),
+			journalArticle.getArticleId(), journalArticle.getVersion());
+
+		JournalArticle latestArticle =
+			_journalArticleLocalService.getLatestArticle(
+				journalArticle.getGroupId(), journalArticle.getArticleId());
+
+		Assert.assertEquals(
+			journalArticle.getTitle(), latestArticle.getTitle());
+		Assert.assertEquals(
+			journalArticle.getContent(), latestArticle.getContent());
+		Assert.assertTrue(
+			updatedJournalArticle.getVersion() < latestArticle.getVersion());
+		Assert.assertEquals(
+			journalArticle.getResourcePrimKey(),
+			latestArticle.getResourcePrimKey());
+	}
+
+	@Test
 	public void testTrashArticleExternalReferenceCode() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/RevertArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/RevertArticleMVCActionCommand.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action;
+
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.service.JournalArticleService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import jakarta.portlet.ActionRequest;
+import jakarta.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Akhash R
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"mvc.command.name=/journal/revert_article"
+	},
+	service = MVCActionCommand.class
+)
+public class RevertArticleMVCActionCommand extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		_journalArticleService.revertArticle(
+			ParamUtil.getLong(actionRequest, "groupId"),
+			ParamUtil.getString(actionRequest, "articleId"),
+			ParamUtil.getDouble(actionRequest, "version"));
+	}
+
+	@Reference
+	private JournalArticleService _journalArticleService;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -293,6 +293,16 @@ public class JournalArticleActionDropdownItemsProvider {
 								 WorkflowConstants.STATUS_SCHEDULED)),
 						_getExpireArticleActionConsumer(
 							articleId, _themeDisplay.getURLCurrent())
+					).add(
+						() ->
+							JournalArticlePermission.contains(
+								_themeDisplay.getPermissionChecker(), _article,
+								ActionKeys.UPDATE) &&
+							!JournalArticleLocalServiceUtil.isLatestVersion(
+								_article.getGroupId(), _article.getArticleId(),
+								_article.getVersion()),
+						_getRevertArticleActionConsumer(
+							_themeDisplay.getURLCurrent())
 					).build());
 				dropdownGroupItem.setSeparator(true);
 			}
@@ -885,6 +895,32 @@ public class JournalArticleActionDropdownItemsProvider {
 			_liferayPortletRequest, "referringPortletResource");
 
 		return _referringPortletResource;
+	}
+
+	private UnsafeConsumer<DropdownItem, Exception>
+		_getRevertArticleActionConsumer(String redirect) {
+
+		return dropdownItem -> {
+			dropdownItem.putData("action", "revertArticle");
+			dropdownItem.putData(
+				"revertURL",
+				PortletURLBuilder.createActionURL(
+					_liferayPortletResponse
+				).setActionName(
+					"/journal/revert_article"
+				).setRedirect(
+					redirect
+				).setParameter(
+					"articleId", _article.getArticleId()
+				).setParameter(
+					"groupId", _article.getGroupId()
+				).setParameter(
+					"version", _article.getVersion()
+				).buildString());
+			dropdownItem.setIcon("undo");
+			dropdownItem.setLabel(
+				LanguageUtil.get(_httpServletRequest, "revert"));
+		};
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -12,6 +12,8 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidationException;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidator;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -40,6 +42,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -1107,6 +1110,24 @@ public class JournalArticleActionDropdownItemsProvider {
 			return false;
 		}
 
+		// Dynamic data mapping
+
+		try {
+			DDMFormValuesValidator ddmFormValuesValidator =
+				_ddmFormValuesValidatorSnapshot.get();
+
+			ddmFormValuesValidator.validate(_article.getDDMFormValues());
+		}
+		catch (DDMFormValuesValidationException
+					ddmFormValuesValidationException) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(ddmFormValuesValidationException);
+			}
+
+			return false;
+		}
+
 		return !JournalArticleLocalServiceUtil.isLatestVersion(
 			_article.getGroupId(), _article.getArticleId(),
 			_article.getVersion());
@@ -1207,6 +1228,11 @@ public class JournalArticleActionDropdownItemsProvider {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleActionDropdownItemsProvider.class);
+
+	private static final Snapshot<DDMFormValuesValidator>
+		_ddmFormValuesValidatorSnapshot = new Snapshot<>(
+			JournalArticleActionDropdownItemsProvider.class,
+			DDMFormValuesValidator.class);
 
 	private final JournalArticle _article;
 	private final AssetDisplayPageFriendlyURLProvider

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -1110,6 +1110,29 @@ public class JournalArticleActionDropdownItemsProvider {
 			return false;
 		}
 
+		// Asset
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			JournalArticle.class.getName(), _article.getResourcePrimKey());
+
+		if (assetEntry == null) {
+			return false;
+		}
+
+		try {
+			AssetEntryLocalServiceUtil.validate(
+				_article.getGroupId(), JournalArticle.class.getName(),
+				assetEntry.getClassTypeId(), assetEntry.getCategoryIds(),
+				assetEntry.getTagNames());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
+
 		// Dynamic data mapping
 
 		try {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -294,13 +294,7 @@ public class JournalArticleActionDropdownItemsProvider {
 						_getExpireArticleActionConsumer(
 							articleId, _themeDisplay.getURLCurrent())
 					).add(
-						() ->
-							JournalArticlePermission.contains(
-								_themeDisplay.getPermissionChecker(), _article,
-								ActionKeys.UPDATE) &&
-							!JournalArticleLocalServiceUtil.isLatestVersion(
-								_article.getGroupId(), _article.getArticleId(),
-								_article.getVersion()),
+						this::_isRevertToVersionActionAvailable,
 						_getRevertArticleActionConsumer(
 							_themeDisplay.getURLCurrent())
 					).build());
@@ -1101,6 +1095,21 @@ public class JournalArticleActionDropdownItemsProvider {
 		}
 
 		return false;
+	}
+
+	private boolean _isRevertToVersionActionAvailable() throws PortalException {
+		if (((_article.getStatus() != WorkflowConstants.STATUS_APPROVED) &&
+			 (_article.getStatus() != WorkflowConstants.STATUS_SCHEDULED)) ||
+			!JournalArticlePermission.contains(
+				_themeDisplay.getPermissionChecker(), _article,
+				ActionKeys.UPDATE)) {
+
+			return false;
+		}
+
+		return !JournalArticleLocalServiceUtil.isLatestVersion(
+			_article.getGroupId(), _article.getArticleId(),
+			_article.getVersion());
 	}
 
 	private boolean _isShowPublishAction() {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultPropsTransformer.js
@@ -143,6 +143,10 @@ const ACTIONS = {
 		});
 	},
 
+	revertArticle({itemData}) {
+		this.send(itemData.revertURL);
+	},
+
 	send(url) {
 		submitForm(document.hrefFm, url);
 	},


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-59259

Introduce a "Revert" action for Journal Articles, allowing users to restore a previous version of an article by creating a new version based on the selected one. 

# How am I fixing it?

1. Add a new public revertArticle(...) method that reuses the logic from copyArticle(...), with adjustments to preserve the original title and article ID.
2. Internally create a new article version using the older version as source, maintaining the resource key and reusing asset/category data.
3. Update dropdown UI to include the revert option and wire it to the appropriate MVCActionCommand.

# How can you verify that it works?

Run the included automated tests.
