### PR TITLE
LPD-58387 Remove Poshi tests with Priority 3 and lower from acceptance - Content Management

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
@@ -183,7 +183,7 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanDeleteAttachmentForKnowledgeBaseArticleByExternalReferenceCode {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("When with deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and siteId and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to delete the knwoledgeBaseAttachment") {
 			KnowledgeBaseAttachmentAPI.deleteKBAttachmentByKBArticleErcAndKBAttachmentErc(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
@@ -285,7 +285,7 @@ definition {
 	@description = "Document is not able to delete in an asset library by nonexistent erc"
 	@priority = 3
 	test DocumentDeletionImpossibleByAssetLibraryIdAndNonexistentErc {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
@@ -146,7 +146,7 @@ definition {
 
 	@priority = 3
 	test CanDeleteParentDocumentFolderByErc {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc") {
 			var response = DocumentFolderAPI.addDocumentFolder(
@@ -192,7 +192,7 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanGetDocumentFolderByErc {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("When with GET request, siteId and external reference code to retrieve the document folder") {
 			var response = DocumentFolderAPI.getDocumentFolderBySiteIdAndErc(
@@ -307,7 +307,7 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanReturnErrorWithGetDocumentFolderByNonexistentErc {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("When with GET request, siteId and nonexistent external reference code to retrieve the document folder") {
 			var response = DocumentFolderAPI.getDocumentFolderBySiteIdAndErc(
@@ -354,7 +354,7 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test DocumentFolderDeletionImpossibleByNonexistentErc {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("When I make a DELETE request by siteId and on-existent erc") {
 			DocumentFolderAPI.deleteDocumentFolderBySiteIdAndErc(

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsApplication.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsApplication.testcase
@@ -396,6 +396,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewEntryModifiedDate {
+		property portal.acceptance = "false";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",
 			groupName = "Guest",

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageExportImport.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsContentPageExportImport.testcase
@@ -1250,6 +1250,8 @@ definition {
 	@description = "This is a test for LPS-144152. This ensures that the updated draft translation can be published."
 	@priority = 3
 	test CanPublishUpdatedDraftTranslation {
+		property portal.acceptance = "false";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "TranslationContentPage",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsEntry.testcase
@@ -2,7 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property portal.acceptance = "true";
+	property portal.acceptance = "false";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Blogs";
@@ -107,6 +107,8 @@ definition {
 	@priority = 5
 	@refactorneeded
 	test AddBlogWithFormatting {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openToAddEntry(siteURLKey = "guest");
 
 		BlogsNavigator.gotoSelectFile();
@@ -252,6 +254,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAddHTMLToContentField {
+		property portal.acceptance = "true";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");
@@ -317,6 +321,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAddTitleWithoutEscapingCharacters {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addEntry(
@@ -336,6 +342,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAddWithCustomURL {
+		property portal.acceptance = "true";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");
@@ -386,6 +394,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAddWithEmbeddedVideo {
+		property portal.acceptance = "true";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");
@@ -479,6 +489,7 @@ definition {
 	@refactorneeded
 	test CanAddWithTrackbackURL {
 		property custom.properties = "blogs.trackback.enabled=true";
+		property portal.acceptance = "true";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -521,6 +532,8 @@ definition {
 	@description = "LPS-186698 Confirm that the blog is created via API, check that the console, and the Title and Content fields are faulty."
 	@priority = 4
 	test CanAssertThatTheBlogContentViaAPI {
+		property portal.acceptance = "true";
+
 		task ("Given go to http://localhost:8080/o/api and create a new blog post") {
 			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
 				articleBody = "test",
@@ -568,6 +581,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAutomaticallySaveEntryAsDraft {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addDraftViaAutoSave(
@@ -693,6 +708,8 @@ definition {
 	@priority = 4
 	@refactorneeded
 	test CanDeleteDraft {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addDraft(
@@ -728,6 +745,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanDeleteMultipleEntriesSequentially {
+		property portal.acceptance = "true";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry1 Content",
 			entryTitle = "Blogs Entry1 Title");
@@ -799,6 +818,7 @@ definition {
 	@priority = 4
 	@refactorneeded
 	test CanEditCustomAbstract {
+		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -972,6 +992,8 @@ definition {
 	@priority = 5
 	@refactordone
 	test CanManuallySaveAsDraft {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addDraft(
@@ -1051,6 +1073,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CannotAddWithEmptyContent {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addWithInvalidContent(
@@ -1066,6 +1090,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CannotAddWithEmptyTitle {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addWithInvalidTitle(
@@ -1317,6 +1343,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanPublishDraft {
+		property portal.acceptance = "true";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addDraft(
@@ -1346,6 +1374,7 @@ definition {
 	@refactordone
 	test CanSchedulePost {
 		property custom.properties = "company.default.time.zone=America/Los_Angeles";
+		property portal.acceptance = "true";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -1382,6 +1411,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanSearchByContent {
+		property portal.acceptance = "true";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Search Page");
@@ -1406,6 +1437,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanSearchByTitle {
+		property portal.acceptance = "true";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Search Page");
@@ -1429,6 +1462,8 @@ definition {
 	@description = "This is a test for LPS-80502. It asserts that user can search a draft blog entry."
 	@priority = 4
 	test CanSearchForDraftEntry {
+		property portal.acceptance = "true";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry Content",
 			entrySubtitle = "Blogs Entry Subtitle",
@@ -1453,6 +1488,7 @@ definition {
 	@priority = 4
 	@refactorneeded
 	test CanViewDefaultAbstract {
+		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -1543,6 +1579,7 @@ definition {
 	test CanViewInlineVideoWithPublication {
 		property osgi.module.configuration.file.names = "com.liferay.change.tracking.configuration.CTSettingsConfiguration.config";
 		property osgi.module.configurations = "enabled=B\"true\"";
+		property portal.acceptance = "true";
 
 		JSONPublications.addPublication(publicationName = "Publication Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
@@ -38,6 +38,8 @@ definition {
 	@priority = 4
 	@refactordone
 	test CanAddInlineImage {
+		property portal.acceptance = "false";
+
 		BlogsNavigator.openToAddEntry(siteURLKey = "guest");
 
 		BlogsEntry.addTitle(entryTitle = "Blogs Entry Title");
@@ -273,6 +275,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSaveCoverImageAsDraft {
+		property portal.acceptance = "false";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addEntryWithUploadedCoverImage(
@@ -310,6 +314,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanUploadAndPublishCoverImage {
+		property portal.acceptance = "false";
+
 		Navigator.gotoPage(pageName = "Blogs Page");
 
 		Blogs.addEntryWithUploadedCoverImage(
@@ -373,6 +379,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewCaptionFieldAfterRemovingSmallImage {
+		property portal.acceptance = "false";
+
 		Navigator.gotoPage(pageName = "Blogs Page");
 
 		Blogs.addEntryWithUploadedCoverImage(
@@ -408,6 +416,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewCoverImageDetails {
+		property portal.acceptance = "false";
+
 		var imageId = JSONBlog.uploadBlogImage(
 			groupName = "Guest",
 			sourceFileName = "Document_1.jpg");
@@ -439,6 +449,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewCoverImageUploadedFromDM {
+		property portal.acceptance = "false";
+
 		for (var n : list "1,2") {
 			JSONFolder.addFolder(
 				dmFolderDescription = "DM Folder ${n} Description",
@@ -582,6 +594,8 @@ definition {
 	@description = "This ensures that an image in the Blogs small image can be rendered correctly after moving it to a folder."
 	@priority = 3
 	test CanViewSmallImageAfterMovingToFolder {
+		property portal.acceptance = "false";
+
 		JSONDocument.addFileWithUploadedFile(
 			dmDocumentDescription = "DM Document Description",
 			dmDocumentTitle = "DM Document Title",
@@ -623,6 +637,8 @@ definition {
 	@description = "This is a test for LPS-67276. It ensures that the success message for the cover image does not display after publishing with the empty required fields."
 	@priority = 3
 	test SuccessMessageForCoverImageDoesNotDisplayAfterPublishingWithEmptyRequiredFields {
+		property portal.acceptance = "false";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addEntryWithUploadedCoverImage(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalStaging.testcase
@@ -182,6 +182,8 @@ definition {
 	@description = "This is a test for LPS-136789. It checks that a blog with a layout reference can be published."
 	@priority = 3
 	test CanPublishBlogWithLayoutReference {
+		property portal.acceptance = "false";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		JSONLayoutpagetemplate.addDisplayPageTemplateEntry(
@@ -631,6 +633,7 @@ definition {
 	@refactordone
 	test CanPublishScheduledEntry {
 		property custom.properties = "company.default.time.zone=America/Los_Angeles";
+		property portal.acceptance = "false";
 
 		JSONBlog.addEntry(
 			displayDate = "true",
@@ -1259,6 +1262,8 @@ definition {
 	@description = "This test covers LPS-154411. It ensures that a small image with a custom friendlyURL added in the Blog content field can be rendered properly on a site after its friendlyURL is edited."
 	@priority = 3
 	test CanViewSmallImageAfterFriendlyURLIsUpdated {
+		property portal.acceptance = "false";
+
 		JSONDocument.addFileWithUploadedFile(
 			dmDocumentDescription = "DM Image Description",
 			dmDocumentTitle = "Document_1.jpg",
@@ -1325,6 +1330,8 @@ definition {
 	@description = "This is a use case for LPS-160639. Verify the blog entry can be published via portlet to Live when adding an entry after selecting blog page as the scope."
 	@priority = 3
 	test PublishBlogWithScopeViaPortlet {
+		property portal.acceptance = "false";
+
 		task ("Enable Scope Configuration") {
 			Portlet.enableScopeConfiguration();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsLocalization.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-content-management"
 definition {
 
-	property portal.acceptance = "true";
+	property portal.acceptance = "false";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Blogs";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsNotifications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsNotifications.testcase
@@ -74,6 +74,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewEmailNotificationForFlaggedEntry {
+		property portal.acceptance = "false";
 		property test.smtp.server.enabled = "true";
 
 		var siteName = TestCase.getSiteName(siteName = ${siteName});
@@ -158,6 +159,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewWebsiteNotificationForMention {
+		property portal.acceptance = "false";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPage.testcase
@@ -59,6 +59,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test AbstractDescriptionPersistsWhenTypingInContentField {
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -87,6 +88,7 @@ definition {
 	@priority = 3
 	test CanAddCommentToBlogEntryWhenEntryIsDisplayedWithDPT {
 		property custom.properties = "virtual.hosts.default.site.name=Guest";
+		property portal.acceptance = "false";
 
 		var portalURL = PropsUtil.get("portal.url");
 
@@ -169,6 +171,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanDisplayViewCountForEntry {
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -485,6 +488,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSubscribeToComment {
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -960,6 +964,8 @@ definition {
 	@description = "This test checks that the javascript in the user name will not be executed when viewing an entry on page."
 	@priority = 3
 	test XSSIsNotExecutedWhenViewingUsernameInBlog {
+		property portal.acceptance = "false";
+
 		Navigator.openURL();
 
 		UserBar.gotoDropdownItem(dropdownItem = "Account Settings");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsPermissions.testcase
@@ -107,6 +107,7 @@ definition {
 	@priority = 3
 	test CanDeleteImageWithRegRole {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",
@@ -1200,6 +1201,7 @@ definition {
 	@priority = 3
 	test CannotEditEntryWhenUserHasNoPermissions {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -1241,6 +1243,7 @@ definition {
 	@priority = 3
 	test CannotEditOwnComment {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -1288,6 +1291,8 @@ definition {
 	@description = "This is a test for LPS-136785. It checks that a guest cannot rate an entry without permissions."
 	@priority = 3
 	test CannotRateEntryAsGuest {
+		property portal.acceptance = "false";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");
@@ -1320,6 +1325,7 @@ definition {
 	@priority = 3
 	test CannotReplyToCommentWithoutPermissions {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",
@@ -1375,6 +1381,7 @@ definition {
 	@priority = 3
 	test CannotSubscribeToCommentWithoutPermissions {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONUser.addUser(
 			userEmailAddress = "userea@liferay.com",
@@ -1577,6 +1584,7 @@ definition {
 	@refactordone
 	test CannotViewDraftWithoutPermissions {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsRemoteStaging.testcase
@@ -167,6 +167,7 @@ definition {
 		property custom.properties = "auth.verifier.TunnelAuthVerifier.hosts.allowed=${line.separator}company.default.time.zone=America/Los_Angeles${line.separator}tunneling.servlet.shared.secret=1234567890123456";
 		property databases.size = "1";
 		property minimum.slave.ram = "24";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -229,6 +230,7 @@ definition {
 		property custom.properties = "auth.verifier.TunnelAuthVerifier.hosts.allowed=${line.separator}tunneling.servlet.shared.secret=1234567890123456";
 		property databases.size = "1";
 		property minimum.slave.ram = "24";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsWidget.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsWidget.testcase
@@ -60,6 +60,8 @@ definition {
 	@description = "This is a test for LPS-136766. It checks that comments can be disabled from the widget."
 	@priority = 3
 	test CanDisableComments {
+		property portal.acceptance = "false";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
@@ -91,6 +93,8 @@ definition {
 	@description = "This is a test for LPS-136767. It checks that related assets can be disabled from the widget."
 	@priority = 3
 	test CanDisableRelatedAssets {
+		property portal.acceptance = "false";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry1 Content",
 			entryTitle = "Blogs Entry1 Title");
@@ -230,6 +234,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanSearchForPendingEntry {
+		property portal.acceptance = "false";
+
 		ProductMenu.gotoPortlet(
 			category = "Configuration",
 			panel = "Site Administration",
@@ -260,6 +266,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewBlogWithAbstractDisplay {
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -305,6 +312,7 @@ definition {
 	@description = "This is a test for LPS-136809. It checks that a Blog entry can be viewed with the Menu Display configured."
 	@priority = 3
 	test CanViewBlogWithCardDisplay {
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -361,6 +369,7 @@ definition {
 	@refactorneeded
 	test CanViewBlogWithFutureDisplayDateViaBlogsAggregator {
 		property custom.properties = "company.default.time.zone=America/Los_Angeles";
+		property portal.acceptance = "false";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
@@ -466,6 +475,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewBlogWithTitleDisplay {
+		property portal.acceptance = "false";
+
 		JSONBlog.addEntry(
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
@@ -590,6 +601,8 @@ definition {
 	@description = "This is a test for LPS-136810. It checks that a blog can be viewed with Quote Display in the Aggregator widget."
 	@priority = 3
 	test CanViewEntryInQuoteDisplayStyleViaAggregator {
+		property portal.acceptance = "false";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Aggregator Page");
@@ -622,6 +635,8 @@ definition {
 	@description = "This is a test for LPS-136811. It checks that a blog can be viewed through the Navigations Portlet."
 	@priority = 3
 	test CanViewEntryViaNavigationsPortlet {
+		property portal.acceptance = "false";
+
 		JSONCategory.addVocabulary(
 			groupName = "Guest",
 			title = "Vocabulary Name");
@@ -867,6 +882,8 @@ definition {
 	@ignore = "true"
 	@priority = 3
 	test WidgetsFollowAccessibilityStandards {
+		property portal.acceptance = "false";
+
 		for (var widgetName : list "Blogs Aggregator,Recent Bloggers") {
 			JSONLayout.addWidgetToPublicLayout(
 				column = 1,

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBAdmin.testcase
@@ -46,6 +46,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddSubcategory {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
 			categoryName = "MB Category Name",
@@ -174,6 +176,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanDeleteCategories {
+		property portal.acceptance = "false";
+
 		for (var num : list "1,2,3") {
 			JSONMBMessage.addCategory(
 				categoryDescription = "MB Category Description",
@@ -213,6 +217,8 @@ definition {
 	@description = "This is a test for LPS-136918. It checks that a category can be exported."
 	@priority = 3
 	test CanExportCategory {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
 			categoryName = "MB Category Name",
@@ -228,6 +234,8 @@ definition {
 	@description = "This is a test for LPS-136917. It checks that a category can be imported."
 	@priority = 3
 	test CanImportCategory {
+		property portal.acceptance = "false";
+
 		MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
 
 		LAR.importPortlet(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBLocalization.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-content-management"
 definition {
 
-	property portal.acceptance = "true";
+	property portal.acceptance = "false";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Message Boards";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBPage.testcase
@@ -46,6 +46,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddCategoryWithDescription {
+		property portal.acceptance = "false";
+
 		Navigator.gotoPage(pageName = "Message Boards Page");
 
 		MessageboardsCategory.addPG(
@@ -62,6 +64,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddCategoryWithUTF8Characters {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
 			categoryName = "MB Catègory Name",
@@ -89,6 +93,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddMultipleCategories {
+		property portal.acceptance = "false";
+
 		for (var categoryName : list "MB Category1 Name,MB Category2 Name") {
 			JSONMBMessage.addCategory(
 				categoryDescription = "MB Category Description",
@@ -104,6 +110,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddThreadInCategoryAsQuestion {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
 			categoryName = "MB Category Name",
@@ -252,6 +260,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanReplyAfterDownloadingMBThreadAttachmentTwice {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
 			threadBody = "Message Boards Thread Body",
@@ -456,6 +466,7 @@ definition {
 	@refactordone
 	test CanViewMBThreadReplyViaMoreMessages {
 		property custom.properties = "discussion.comments.delta.value=5";
+		property portal.acceptance = "false";
 
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
@@ -654,6 +665,7 @@ definition {
 	@refactordone
 	test CanViewSubcategorySubscriptionViaMySubscriptionsPage {
 		property database.types = "oracle";
+		property portal.acceptance = "false";
 
 		JSONMBMessage.addCategory(
 			categoryDescription = "MB Category Description",
@@ -777,6 +789,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewThreadStatistics {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
 			threadBody = "MB Thread1 Message Body",
@@ -917,6 +931,8 @@ definition {
 	@description = "This test checks that the javascript in the user name will not be executed when viewing a thread on page."
 	@priority = 3
 	test XSSIsNotExecutedWhenViewingUsernameInThread {
+		property portal.acceptance = "false";
+
 		Navigator.openURL();
 
 		UserBar.gotoDropdownItem(dropdownItem = "Account Settings");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/MBThread.testcase
@@ -40,6 +40,8 @@ definition {
 	@description = "This is a test for LPS-136910. It checks that bold text can be added in the editor."
 	@priority = 3
 	test CanAddBoldText {
+		property portal.acceptance = "false";
+
 		MessageboardsThread.addPG(
 			bold = "true",
 			groupName = "Guest",
@@ -154,6 +156,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddThreadWithUTF8Characters {
+		property portal.acceptance = "false";
+
 		Navigator.gotoPage(pageName = "Message Boards Page");
 
 		MessageboardsThread.addPG(
@@ -176,6 +180,8 @@ definition {
 	@description = "This ensures that a thread with 255 characters in the title can be added."
 	@priority = 3
 	test CanAddTitleWith255Characters {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
 			threadBody = "MB Thread Message Body",
@@ -192,6 +198,8 @@ definition {
 	@description = "This is a test for LPS-136912. It checks that an urgent thread can be added."
 	@priority = 3
 	test CanAddUrgentThread {
+		property portal.acceptance = "false";
+
 		MessageboardsThread.addPG(
 			groupName = "Guest",
 			layoutName = "message-boards-page",
@@ -214,6 +222,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanCancelEditOnThread {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
 			threadBody = "Message Boards Thread Body",
@@ -355,6 +365,8 @@ definition {
 	@description = "This is a test for LPS-136920. It checks that a thread can be exported."
 	@priority = 3
 	test CanExportThread {
+		property portal.acceptance = "false";
+
 		JSONMBMessage.addMessage(
 			groupName = "Guest",
 			threadBody = "MB Thread Message Body",
@@ -370,6 +382,8 @@ definition {
 	@description = "This is a test for LPS-136919. It checks that a thread can be imported."
 	@priority = 3
 	test CanImportThread {
+		property portal.acceptance = "false";
+
 		MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
 
 		LAR.importPortlet(
@@ -595,6 +609,7 @@ definition {
 	@refactordone
 	test CanViewBBCodeNoXSSWithRemoteServices {
 		property custom.properties = "message.boards.message.formats.default=bbcode";
+		property portal.acceptance = "false";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiLocalization.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property custom.properties = "feature.flag.LPD-35013=false";
 	property osgi.modules.includes = "wiki";
-	property portal.acceptance = "true";
+	property portal.acceptance = "false";
 	property portal.release = "false";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Wiki";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPage.testcase
@@ -135,6 +135,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanAddChildPagesToFrontPage {
+		property portal.acceptance = "false";
+
 		JSONWiki.updateWikiPage(
 			groupName = "Guest",
 			wikiNodeName = "Main",
@@ -355,6 +357,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanCancelAddingAPage {
+		property portal.acceptance = "false";
+
 		WikiNavigator.openToAddPage(
 			groupName = "Guest",
 			layoutURLKey = "wiki-test-page",
@@ -376,6 +380,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanCancelEditingAPage {
+		property portal.acceptance = "false";
+
 		JSONWiki.addWikiPage(
 			groupName = "Guest",
 			wikiNodeName = "Main",
@@ -716,6 +722,8 @@ definition {
 	@description = "This test covers LPS-67282. It ensures that a user cannot rename the draft wiki page."
 	@priority = 3
 	test CannotRenameDraftPage {
+		property portal.acceptance = "false";
+
 		JSONWiki.addWikiPage(
 			groupName = "Guest",
 			wikiNodeName = "Main",
@@ -1032,6 +1040,8 @@ definition {
 	@description = "This is a test for LPS-190823. It checks that Javascript will not be executed from the child wiki page content when viewing the parent wiki page."
 	@priority = 3
 	test XSSCannotBeExecutedFromChildWikiPageContent {
+		property portal.acceptance = "false";
+
 		JSONWiki.addWikiPage(
 			groupName = "Guest",
 			wikiNodeName = "Main",
@@ -1058,6 +1068,8 @@ definition {
 	@description = "This test checks that the javascript in the user name will not be executed when viewing a new wiki page on page."
 	@priority = 3
 	test XSSIsNotExecutedWhenViewingUsernameInEntry {
+		property portal.acceptance = "false";
+
 		Navigator.openURL();
 
 		UserBar.gotoDropdownItem(dropdownItem = "Account Settings");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiPermissions.testcase
@@ -285,6 +285,7 @@ definition {
 	@refactordone
 	test CannotAddWikiAssetsWithRegularRoleWithoutPermissions {
 		property custom.properties = "feature.flag.LPS-188058=true${line.separator}jsonws.web.service.paths.excludes=";
+		property portal.acceptance = "false";
 
 		Permissions.setUpRegRoleLoginUserCP(
 			roleTitle = "Regrole Name",
@@ -364,6 +365,8 @@ definition {
 	@description = "This is a test for LPS-162742. It checks that configured permissions will remain after renaming the wiki page."
 	@priority = 3
 	test ConfiguredPermissionsWillRemainAfterRenamingPage {
+		property portal.acceptance = "false";
+
 		WikiNavigator.openToAddPage(
 			groupName = "Guest",
 			siteURLKey = "guest",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiStaging.testcase
@@ -299,6 +299,8 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanViewRenamedChildPageAfterPublishing {
+		property portal.acceptance = "false";
+
 		JSONWiki.addWikiPage(
 			groupName = "Site Name (Staging)",
 			site = "false",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalStaging.testcase
@@ -311,7 +311,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanOnlyCommentOnLiveSite {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		JSONLayout.addWidgetToPublicLayout(
 			column = 1,

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/DMLocalization.testcase
@@ -162,6 +162,8 @@ definition {
 	@description = "This test ensures that multiple Japanese files can be downloaded simultaneously."
 	@priority = 3
 	test CanSimultaneouslyDownloadMultipleJapaneseFiles {
+		property portal.acceptance = "false";
+
 		HeadlessSite.addSite(siteName = "Site_1");
 
 		JSONDocument.addFileWithUploadedFile(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoPreview.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoPreview.testcase
@@ -336,7 +336,7 @@ definition {
 	@priority = 3
 	@refactordone
 	test CanImportExportedKBWithEmbeddedVideo {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/CategoriesOOTB.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/asset/categories/CategoriesOOTB.testcase
@@ -462,7 +462,7 @@ definition {
 	@description = ""
 	@priority = 3
 	test CheckBlogFilterByCategoryAtCollection {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Add a global category") {
 			var categoryId1 = JSONCategory.addCategory(


### PR DESCRIPTION
Hi team, Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on acceptance. 
If you believe any of these tests should not be removed from acceptance, please let us know so we can update the priority and keep the test running on acceptance. 
Thank you!