### PR TITLE
LPD-59436 Append the version to content URLs

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentDocumentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentDocumentUtil.java
@@ -26,7 +26,7 @@ public class ContentDocumentUtil {
 				setContentType(() -> "Document");
 				setContentUrl(
 					() -> dlURLHelper.getPreviewURL(
-						fileEntry, fileEntry.getFileVersion(), null, "", false,
+						fileEntry, fileEntry.getFileVersion(), null, "", true,
 						false));
 				setContentValue(
 					() -> ContentValueUtil.toContentValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
@@ -177,7 +177,7 @@ public class BlogPostingDTOConverter
 				setCaption(blogsEntry::getCoverImageCaption);
 				setContentUrl(
 					() -> _dlURLHelper.getPreviewURL(
-						fileEntry, fileEntry.getFileVersion(), null, "", false,
+						fileEntry, fileEntry.getFileVersion(), null, "", true,
 						false));
 				setContentValue(
 					() -> ContentValueUtil.toContentValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingImageResourceImpl.java
@@ -165,7 +165,8 @@ public class BlogPostingImageResourceImpl
 			{
 				setContentUrl(
 					() -> _dlURLHelper.getPreviewURL(
-						fileEntry, fileEntry.getFileVersion(), null, ""));
+						fileEntry, fileEntry.getFileVersion(), null, "", true,
+						false));
 				setContentValue(
 					() -> ContentValueUtil.toContentValue(
 						"contentValue", fileEntry::getContentStream,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
@@ -204,7 +204,7 @@ public class MessageBoardAttachmentResourceImpl
 			{
 				setContentUrl(
 					() -> _dlURLHelper.getPreviewURL(
-						fileEntry, fileEntry.getFileVersion(), null, "", false,
+						fileEntry, fileEntry.getFileVersion(), null, "", true,
 						false));
 				setContentValue(
 					() -> ContentValueUtil.toContentValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -7,15 +7,22 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.headless.delivery.client.dto.v1_0.BlogPostingImage;
 import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.problem.Problem;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -32,6 +39,28 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class BlogPostingImageResourceTest
 	extends BaseBlogPostingImageResourceTestCase {
+
+	@Test
+	public void testBlogPostingImageContentURL() throws Exception {
+		DLFolder dlFolder = DLTestUtil.addDLFolder(testGroup.getGroupId());
+
+		DLFileEntry dlFileEntry = DLTestUtil.addDLFileEntry(
+			dlFolder.getFolderId());
+
+		FileEntry fileEntry = BlogsEntryLocalServiceUtil.addAttachmentFileEntry(
+			null, dlFileEntry.getUserId(), dlFileEntry.getGroupId(),
+			dlFileEntry.getFileName(), dlFileEntry.getMimeType(),
+			dlFileEntry.getContentStream());
+
+		String previewURL = _dlURLHelper.getPreviewURL(
+			fileEntry, fileEntry.getFileVersion(), null, "", true, false);
+
+		BlogPostingImage getBlogPostingImage =
+			blogPostingImageResource.getBlogPostingImage(
+				fileEntry.getFileEntryId());
+
+		Assert.assertEquals(getBlogPostingImage.getContentUrl(), previewURL);
+	}
 
 	@Override
 	@Test
@@ -198,5 +227,11 @@ public class BlogPostingImageResourceTest
 				randomBlogPostingImage2.getTitle(), 1),
 			blogPostingImage.getTitle());
 	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLURLHelper _dlURLHelper;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -19,8 +19,10 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
@@ -78,6 +80,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -461,6 +464,7 @@ public class StructuredContentResourceTest
 		_testGetStructuredContentWithDifferentFolder();
 		_testGetStructuredContentWithDifferentLocale();
 		_testGetStructuredContentWithDifferentTimeZone();
+		_testGetStructuredContentWithImageContentURL();
 		_testGetStructuredContentWithInvalidImage();
 		_testGetStructuredContentWithRadioField();
 		_testGetStructuredContentWithRoleAdministrator();
@@ -2287,6 +2291,41 @@ public class StructuredContentResourceTest
 		}
 	}
 
+	private void _testGetStructuredContentWithImageContentURL()
+		throws Exception {
+
+		DLFolder dlFolder = DLTestUtil.addDLFolder(testGroup.getGroupId());
+
+		DLFileEntry dlFileEntry = DLTestUtil.addDLFileEntry(
+			dlFolder.getFolderId());
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(
+			dlFileEntry.getFileEntryId());
+
+		String previewURL = _dlURLHelper.getPreviewURL(
+			fileEntry, fileEntry.getFileVersion(), null, "", true, false);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.
+				postStructuredContentFolderStructuredContent(
+					_journalFolder.getFolderId(),
+					_randomCompleteStructuredContent(
+						dlFileEntry.getFileEntryId(), true));
+
+		StructuredContent getStructuredContent =
+			structuredContentResource.getStructuredContent(
+				postStructuredContent.getId());
+
+		ContentField[] contentFields = getStructuredContent.getContentFields();
+
+		ContentFieldValue contentFieldValue =
+			contentFields[8].getContentFieldValue();
+
+		ContentDocument contentDocument = contentFieldValue.getImage();
+
+		Assert.assertEquals(contentDocument.getContentUrl(), previewURL);
+	}
+
 	private void _testGetStructuredContentWithInvalidImage() throws Exception {
 		DLFolder dlFolder = DLTestUtil.addDLFolder(testGroup.getGroupId());
 
@@ -2839,7 +2878,14 @@ public class StructuredContentResourceTest
 	private DDMStructure _ddmStructure;
 	private DDMTemplate _ddmTemplate;
 	private DDMStructure _depotDDMStructure;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private DLURLHelper _dlURLHelper;
 
 	@Inject
 	private ExpandoColumnLocalService _expandoColumnLocalService;


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-59436

The contentURL is not uniform between Documents, StructuredContents, BlogPostings, BlogPostingImages, and MBAttachments in Headless API calls.

# How am I fixing it?
We should append the version of the contentURL to have the same type of contentURL between all the objects listed above.

# Why doesn't this include any test?
The tests already cover these files, this change was only to have uniformity with contentURLs between different object types.