### PR TITLE
LPD-58297 | Author of web content article is incorrectly listed when comparing version history on live site (Staging)

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1039,6 +1039,7 @@ public class JournalArticleStagedModelDataHandler
 				}
 			}
 
+			importedArticle.setModifiedDate(article.getModifiedDate());
 			importedArticle.setStatusByUserId(article.getStatusByUserId());
 			importedArticle.setStatusByUserName(article.getStatusByUserName());
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1039,6 +1039,12 @@ public class JournalArticleStagedModelDataHandler
 				}
 			}
 
+			importedArticle.setStatusByUserId(article.getStatusByUserId());
+			importedArticle.setStatusByUserName(article.getStatusByUserName());
+
+			importedArticle = _journalArticleLocalService.updateJournalArticle(
+				importedArticle);
+
 			Map<Long, Long> primaryKeys =
 				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					JournalArticle.class);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
@@ -894,6 +894,52 @@ public class JournalArticleStagedModelDataHandlerTest
 			importJournalArticle.getArticleResourceUuid());
 	}
 
+	@Test
+	public void testStatusByUserIdAndUserName() throws Exception {
+		initExport();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			stagingGroup.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		User user = UserTestUtil.addUser(
+			RandomTestUtil.randomString(4), liveGroup.getGroupId());
+
+		journalArticle.setStatusByUserId(user.getUserId());
+		journalArticle.setStatusByUserName(user.getFullName());
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, journalArticle);
+
+		initImport();
+
+		StagedModel exportedStagedModel = readExportedStagedModel(
+			journalArticle);
+
+		Assert.assertNotNull(exportedStagedModel);
+
+		try {
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+
+		JournalArticle importJournalArticle =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				journalArticle.getUuid(), liveGroup.getGroupId());
+
+		Assert.assertEquals(
+			journalArticle.getStatusByUserName(),
+			importJournalArticle.getStatusByUserName());
+		Assert.assertEquals(
+			journalArticle.getStatusByUserId(),
+			importJournalArticle.getStatusByUserId());
+	}
+
 	public class TestLayoutStagedModelDataHandler
 		implements StagedModelDataHandler<Layout> {
 


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-58297

Author of web content article is incorrectly listed when comparing version history on live site, it is showing the creators name instead of the one who did the last modification

### How am I fixing it?
setting the statusByUserId and statusByUserName for the importend Article, during import process in staging.

### How can you verify that it works?
run integration test:
 JournalArticleStagedModelDataHandlerTest.testStatusByUserIdAndUserName
 
 followup for https://github.com/liferay-content-management/liferay-portal/pull/6776 based on https://liferay.slack.com/archives/GQBCVUPBQ/p1751284473654979