### PR TITLE
LPD-59702 now siteId is an postTaxonomyCategory valid entry point so if we want to change the vocabulary we can not have both, fix test

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
@@ -140,8 +140,7 @@ public class ExportImportTaskResourceTestUtil {
 		String path = StringBundler.concat(
 			"http://localhost:8080/o/headless-batch-engine/v1.0/import-task/",
 			className, "?createStrategy=", createStrategy,
-			"&importCreatorStrategy=", importCreatorStrategy, "&siteId=",
-			groupId);
+			"&importCreatorStrategy=", importCreatorStrategy);
 
 		if (MapUtil.isNotEmpty(parameters)) {
 			for (Map.Entry<String, String> entry : parameters.entrySet()) {
@@ -149,6 +148,9 @@ public class ExportImportTaskResourceTestUtil {
 					path, StringPool.AMPERSAND, entry.getKey(),
 					StringPool.EQUAL, entry.getValue());
 			}
+		}
+		else {
+			path = StringBundler.concat(path, "&siteId=", groupId);
 		}
 
 		httpInvoker.path(path);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-59702