### PR TITLE
LPD-57587 Validate with Space Settings/System Settings

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -390,7 +390,17 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			}
 		}
 
-		_dlValidator.validateFileSize(groupId, sourceFileName, mimeType, size);
+		try {
+			_dlValidator.validateFileSize(
+				groupId, sourceFileName, mimeType, size);
+		}
+		catch (FileSizeException fileSizeException) {
+			throw new FileSizeException(
+				StringBundler.concat(
+					"File ", sourceFileName,
+					" exceeds the maximum permitted size of ",
+					fileSizeException.getMaxSize() / _FILE_LENGTH_MB, " MB"));
+		}
 	}
 
 	private void _validateObjectDefinitionSettings(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MimeTypes;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portlet.documentlibrary.util.DLAppUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -153,17 +154,25 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			serviceContext.getUserId());
 
 		try (InputStream inputStream = new ByteArrayInputStream(fileContent)) {
+			String title = DLUtil.getUniqueTitle(
+				groupId, dlFolder.getFolderId(),
+				FileUtil.stripExtension(fileName));
+
+			String sourceFileName = DLUtil.getUniqueFileName(
+				groupId, dlFolder.getFolderId(), fileName, true);
+
+			String mimeType = _mimeTypes.getContentType(inputStream, fileName);
+
+			_validateDLFile(
+				companyId, groupId,
+				DLAppUtil.getExtension(title, sourceFileName), mimeType,
+				fileContent.length, sourceFileName);
+
 			return _dlAppLocalService.addFileEntry(
 				externalReferenceCode, serviceContext.getUserId(),
 				dlFolder.getRepositoryId(), dlFolder.getFolderId(),
-				DLUtil.getUniqueFileName(
-					groupId, dlFolder.getFolderId(), fileName, true),
-				_mimeTypes.getContentType(inputStream, fileName),
-				DLUtil.getUniqueTitle(
-					groupId, dlFolder.getFolderId(),
-					FileUtil.stripExtension(fileName)),
-				StringPool.BLANK, null, null, inputStream, fileContent.length,
-				null, null, null, serviceContext);
+				sourceFileName, mimeType, title, StringPool.BLANK, null, null,
+				fileContent, null, null, null, serviceContext);
 		}
 	}
 
@@ -207,18 +216,22 @@ public class AttachmentManagerImpl implements AttachmentManager {
 		cloneServiceContext.setCompanyId(companyId);
 
 		try (InputStream inputStream = new ByteArrayInputStream(fileContent)) {
-			_dlValidator.validateFileSize(
-				groupId, fileName,
-				_mimeTypes.getContentType(inputStream, fileName),
-				fileContent.length);
+			String title = DLUtil.getUniqueTitle(
+				groupId, folderId, FileUtil.stripExtension(fileName));
+
+			String sourceFileName = DLUtil.getUniqueFileName(
+				groupId, folderId, fileName, true);
+
+			String mimeType = _mimeTypes.getContentType(inputStream, fileName);
+
+			_validateDLFile(
+				companyId, groupId,
+				DLAppUtil.getExtension(title, sourceFileName), mimeType,
+				fileContent.length, sourceFileName);
 
 			return _dlAppService.addFileEntry(
-				externalReferenceCode, repositoryId, folderId,
-				DLUtil.getUniqueFileName(groupId, folderId, fileName, true),
-				_mimeTypes.getContentType(inputStream, fileName),
-				DLUtil.getUniqueTitle(
-					groupId, folderId, FileUtil.stripExtension(fileName)),
-				StringPool.BLANK, null, null, inputStream, fileContent.length,
+				externalReferenceCode, repositoryId, folderId, sourceFileName,
+				mimeType, title, StringPool.BLANK, null, null, fileContent,
 				null, null, null, cloneServiceContext);
 		}
 	}
@@ -357,6 +370,27 @@ public class AttachmentManagerImpl implements AttachmentManager {
 		}
 
 		return storageDLFolderId;
+	}
+
+	private void _validateDLFile(
+			long companyId, long groupId, String fileExtension, String mimeType,
+			long size, String sourceFileName)
+		throws PortalException {
+
+		if (Validator.isNotNull(sourceFileName)) {
+			_dlValidator.validateFileName(sourceFileName);
+
+			_dlValidator.validateFileExtension(sourceFileName);
+
+			_dlValidator.validateSourceFileExtension(
+				fileExtension, sourceFileName);
+
+			if (size != 0) {
+				_dlValidator.validateFileMimeType(companyId, mimeType);
+			}
+		}
+
+		_dlValidator.validateFileSize(groupId, sourceFileName, mimeType, size);
 	}
 
 	private void _validateFile(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -377,17 +377,12 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			long size, String sourceFileName)
 		throws PortalException {
 
-		if (Validator.isNotNull(sourceFileName)) {
-			_dlValidator.validateFileName(sourceFileName);
+		_dlValidator.validateFileName(sourceFileName);
 
-			_dlValidator.validateFileExtension(sourceFileName);
+		_dlValidator.validateFileExtension(sourceFileName);
 
-			_dlValidator.validateSourceFileExtension(
-				fileExtension, sourceFileName);
-
-			if (size != 0) {
-				_dlValidator.validateFileMimeType(companyId, mimeType);
-			}
+		if (size != 0) {
+			_dlValidator.validateFileMimeType(companyId, mimeType);
 		}
 
 		try {
@@ -401,6 +396,8 @@ public class AttachmentManagerImpl implements AttachmentManager {
 					" exceeds the maximum permitted size of ",
 					fileSizeException.getMaxSize() / _FILE_LENGTH_MB, " MB"));
 		}
+
+		_dlValidator.validateSourceFileExtension(fileExtension, sourceFileName);
 	}
 
 	private void _validateObjectDefinitionSettings(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -146,7 +146,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			return fileEntry;
 		}
 
-		_validateFile(
+		_validateObjectDefinitionSettings(
 			fileContent, fileName, objectFieldId, serviceContext.getUserId());
 
 		DLFolder dlFolder = getDLFolder(
@@ -163,7 +163,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 
 			String mimeType = _mimeTypes.getContentType(inputStream, fileName);
 
-			_validateDLFile(
+			_validateDLSettings(
 				companyId, groupId,
 				DLAppUtil.getExtension(title, sourceFileName), mimeType,
 				fileContent.length, sourceFileName);
@@ -191,7 +191,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			return fileEntry;
 		}
 
-		_validateFile(
+		_validateObjectDefinitionSettings(
 			fileContent, fileName, objectFieldId, serviceContext.getUserId());
 
 		long repositoryId = groupId;
@@ -224,7 +224,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 
 			String mimeType = _mimeTypes.getContentType(inputStream, fileName);
 
-			_validateDLFile(
+			_validateDLSettings(
 				companyId, groupId,
 				DLAppUtil.getExtension(title, sourceFileName), mimeType,
 				fileContent.length, sourceFileName);
@@ -372,7 +372,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 		return storageDLFolderId;
 	}
 
-	private void _validateDLFile(
+	private void _validateDLSettings(
 			long companyId, long groupId, String fileExtension, String mimeType,
 			long size, String sourceFileName)
 		throws PortalException {
@@ -393,7 +393,7 @@ public class AttachmentManagerImpl implements AttachmentManager {
 		_dlValidator.validateFileSize(groupId, sourceFileName, mimeType, size);
 	}
 
-	private void _validateFile(
+	private void _validateObjectDefinitionSettings(
 			byte[] fileContent, String fileName, long objectFieldId,
 			long userId)
 		throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -134,11 +134,26 @@ public class AttachmentManagerTest {
 
 		Assert.assertEquals(
 			externalReferenceCode, fileEntry.getExternalReferenceCode());
-	}
 
-	@Test(expected = FileExtensionException.class)
-	public void testGetOrAddFileEntryShouldFailIfDLConfigurationFileExtensionNotSupported()
-		throws Exception {
+		try {
+			tempFileEntry = _addTempFileEntry(
+				RandomTestUtil.randomString(), ".bmp",
+				RandomTestUtil.randomString(), ContentTypes.IMAGE_BMP);
+
+			folder = tempFileEntry.getFolder();
+
+			_attachmentManager.getOrAddFileEntry(
+				_objectField.getCompanyId(), RandomTestUtil.randomString(),
+				StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+				ServiceContextTestUtil.getServiceContext());
+
+			Assert.fail();
+		}
+		catch (FileExtensionException fileExtensionException) {
+			Assert.assertNotNull(fileExtensionException);
+		}
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
@@ -147,11 +162,11 @@ public class AttachmentManagerTest {
 						"fileExtensions", new String[] {".doc"}
 					).build())) {
 
-			FileEntry tempFileEntry = _addTempFileEntry(
+			tempFileEntry = _addTempFileEntry(
 				RandomTestUtil.randomString(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
 
-			Folder folder = tempFileEntry.getFolder();
+			folder = tempFileEntry.getFolder();
 
 			_attachmentManager.getOrAddFileEntry(
 				_objectField.getCompanyId(), RandomTestUtil.randomString(),
@@ -159,12 +174,12 @@ public class AttachmentManagerTest {
 				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
 				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
 				ServiceContextTestUtil.getServiceContext());
-		}
-	}
 
-	@Test(expected = FileMimeTypeException.class)
-	public void testGetOrAddFileEntryShouldFailIfDLConfigurationMimeTypeNotSupported()
-		throws Exception {
+			Assert.fail();
+		}
+		catch (FileExtensionException fileExtensionException) {
+			Assert.assertNotNull(fileExtensionException);
+		}
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -175,11 +190,11 @@ public class AttachmentManagerTest {
 							"fileMimeTypes", new String[] {"text/html"}
 						).build())) {
 
-			FileEntry tempFileEntry = _addTempFileEntry(
+			tempFileEntry = _addTempFileEntry(
 				RandomTestUtil.randomString(), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
 
-			Folder folder = tempFileEntry.getFolder();
+			folder = tempFileEntry.getFolder();
 
 			_attachmentManager.getOrAddFileEntry(
 				_objectField.getCompanyId(), RandomTestUtil.randomString(),
@@ -187,12 +202,12 @@ public class AttachmentManagerTest {
 				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
 				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
 				ServiceContextTestUtil.getServiceContext());
-		}
-	}
 
-	@Test(expected = FileSizeException.class)
-	public void testGetOrAddFileEntryShouldFailIfDLSizeLimitConfigurationMimeTypeLimitExceeded()
-		throws Exception {
+			Assert.fail();
+		}
+		catch (FileMimeTypeException fileMimeTypeException) {
+			Assert.assertNotNull(fileMimeTypeException);
+		}
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
@@ -202,11 +217,11 @@ public class AttachmentManagerTest {
 						"mimeTypeSizeLimit", new String[] {"text/plain:1"}
 					).build())) {
 
-			FileEntry tempFileEntry = _addTempFileEntry(
+			tempFileEntry = _addTempFileEntry(
 				RandomTestUtil.randomString(1000), ".txt",
 				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
 
-			Folder folder = tempFileEntry.getFolder();
+			folder = tempFileEntry.getFolder();
 
 			_attachmentManager.getOrAddFileEntry(
 				_objectField.getCompanyId(), RandomTestUtil.randomString(),
@@ -214,25 +229,12 @@ public class AttachmentManagerTest {
 				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
 				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
 				ServiceContextTestUtil.getServiceContext());
+
+			Assert.fail();
 		}
-	}
-
-	@Test(expected = FileExtensionException.class)
-	public void testGetOrAddFileEntryShouldFailIfObjectDefinitionExtensionNotSupported()
-		throws Exception {
-
-		FileEntry tempFileEntry = _addTempFileEntry(
-			RandomTestUtil.randomString(), ".bmp",
-			RandomTestUtil.randomString(), ContentTypes.IMAGE_BMP);
-
-		Folder folder = tempFileEntry.getFolder();
-
-		_attachmentManager.getOrAddFileEntry(
-			_objectField.getCompanyId(), RandomTestUtil.randomString(),
-			StreamUtil.toByteArray(tempFileEntry.getContentStream()),
-			tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
-			TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
-			ServiceContextTestUtil.getServiceContext());
+		catch (FileSizeException fileSizeException) {
+			Assert.assertNotNull(fileSizeException);
+		}
 	}
 
 	private FileEntry _addTempFileEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -1,0 +1,262 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.field.attachment.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.configuration.DLConfiguration;
+import com.liferay.document.library.configuration.DLFileEntryMimeTypeConfiguration;
+import com.liferay.document.library.kernel.exception.FileExtensionException;
+import com.liferay.document.library.kernel.exception.FileMimeTypeException;
+import com.liferay.document.library.kernel.exception.FileSizeException;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.attachment.AttachmentManager;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.io.StreamUtil;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class AttachmentManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = ObjectDefinitionTestUtil.addCustomObjectDefinition(
+			false,
+			Arrays.asList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+					RandomTestUtil.randomString(), "attachment",
+					Arrays.asList(
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.
+								NAME_ACCEPTED_FILE_EXTENSIONS
+						).value(
+							"txt, png"
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_FILE_SOURCE
+						).value(
+							ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+						).value(
+							"100"
+						).build()),
+					false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					ObjectFieldConstants.DB_TYPE_INTEGER, true, false, null,
+					RandomTestUtil.randomString(), "integer", false)));
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId());
+
+		_objectField = _objectFieldLocalService.getObjectField(
+			_objectDefinition.getObjectDefinitionId(), "attachment");
+	}
+
+	@Test
+	public void testGetOrAddFileEntry() throws Exception {
+		FileEntry tempFileEntry = _addTempFileEntry(
+			RandomTestUtil.randomString(), ".txt",
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
+
+		Folder folder = tempFileEntry.getFolder();
+
+		FileEntry fileEntry = _attachmentManager.getOrAddFileEntry(
+			_objectField.getCompanyId(),
+			tempFileEntry.getExternalReferenceCode(),
+			StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+			tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+			TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			tempFileEntry.getExternalReferenceCode(),
+			fileEntry.getExternalReferenceCode());
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		fileEntry = _attachmentManager.getOrAddFileEntry(
+			_objectField.getCompanyId(), externalReferenceCode,
+			StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+			tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+			TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			externalReferenceCode, fileEntry.getExternalReferenceCode());
+	}
+
+	@Test(expected = FileExtensionException.class)
+	public void testGetOrAddFileEntryShouldFailIfDLConfigurationFileExtensionNotSupported()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					DLConfiguration.class.getName(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"fileExtensions", new String[] {".doc"}
+					).build())) {
+
+			FileEntry tempFileEntry = _addTempFileEntry(
+				RandomTestUtil.randomString(), ".txt",
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
+
+			Folder folder = tempFileEntry.getFolder();
+
+			_attachmentManager.getOrAddFileEntry(
+				_objectField.getCompanyId(), RandomTestUtil.randomString(),
+				StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+	}
+
+	@Test(expected = FileMimeTypeException.class)
+	public void testGetOrAddFileEntryShouldFailIfDLConfigurationMimeTypeNotSupported()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						DLFileEntryMimeTypeConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"fileMimeTypes", new String[] {"text/html"}
+						).build())) {
+
+			FileEntry tempFileEntry = _addTempFileEntry(
+				RandomTestUtil.randomString(), ".txt",
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
+
+			Folder folder = tempFileEntry.getFolder();
+
+			_attachmentManager.getOrAddFileEntry(
+				_objectField.getCompanyId(), RandomTestUtil.randomString(),
+				StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+	}
+
+	@Test(expected = FileSizeException.class)
+	public void testGetOrAddFileEntryShouldFailIfDLSizeLimitConfigurationMimeTypeLimitExceeded()
+		throws Exception {
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.document.library.internal.configuration." +
+						"DLSizeLimitConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"mimeTypeSizeLimit", new String[] {"text/plain:1"}
+					).build())) {
+
+			FileEntry tempFileEntry = _addTempFileEntry(
+				RandomTestUtil.randomString(1000), ".txt",
+				RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN);
+
+			Folder folder = tempFileEntry.getFolder();
+
+			_attachmentManager.getOrAddFileEntry(
+				_objectField.getCompanyId(), RandomTestUtil.randomString(),
+				StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+				tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+				TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+	}
+
+	@Test(expected = FileExtensionException.class)
+	public void testGetOrAddFileEntryShouldFailIfObjectDefinitionExtensionNotSupported()
+		throws Exception {
+
+		FileEntry tempFileEntry = _addTempFileEntry(
+			RandomTestUtil.randomString(), ".bmp",
+			RandomTestUtil.randomString(), ContentTypes.IMAGE_BMP);
+
+		Folder folder = tempFileEntry.getFolder();
+
+		_attachmentManager.getOrAddFileEntry(
+			_objectField.getCompanyId(), RandomTestUtil.randomString(),
+			StreamUtil.toByteArray(tempFileEntry.getContentStream()),
+			tempFileEntry.getFileName(), folder.getExternalReferenceCode(),
+			TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private FileEntry _addTempFileEntry(
+			String content, String extension, String fileName, String mimeType)
+		throws Exception {
+
+		return TempFileEntryUtil.addTempFileEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getPortletId(),
+			TempFileEntryUtil.getTempFileName(fileName + extension),
+			FileUtil.createTempFile(content.getBytes()), mimeType);
+	}
+
+	@Inject
+	private AttachmentManager _attachmentManager;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectField _objectField;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+}


### PR DESCRIPTION
LPD-57587 [BE] Validate with Space Settings/System Settings

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51507

Support validations for the multiple file uploader

As a content manager I want the multiple file uploader to have validations for files being uploaded so that I can maintain quality standards by preventing undesired files from existing in the CMS

# How am I fixing it?

I'm adding the dlValidation to the creation of the attachment that is the place where the basic document is created when is called by the multiple upload.

# How can you verify that it works?

Run the included automated tests.

# Commits

- **LPD-57587 make the validations of DL (document library)**
- **LPD-57587 rename**
- **LPD-57587 unify file limit message**
- **LPD-57587 add tests to check the validations from the object definition and the dl configuration**
- **LPD-57587 sort**
- **LPD-57587 group all the test on only one case**
