### PR TITLE
Lpd 59048

### DIFF
--- a/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/model/DDMStructureClassType.java
+++ b/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/model/DDMStructureClassType.java
@@ -14,6 +14,7 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -100,7 +101,9 @@ public class DDMStructureClassType implements ClassType {
 				return new ClassTypeField(
 					ddmStructure.getStructureId(),
 					ddmFormField.getFieldReference(),
-					label.getString(LocaleUtil.fromLanguageId(_languageId)),
+					HtmlUtil.escape(
+						label.getString(
+							LocaleUtil.fromLanguageId(_languageId))),
 					ddmFormField.getName(), type);
 			});
 	}

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/model/test/DDMStructureClassTypeTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/model/test/DDMStructureClassTypeTest.java
@@ -6,6 +6,7 @@
 package com.liferay.asset.model.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.ClassTypeField;
 import com.liferay.asset.model.DDMStructureClassType;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -71,6 +73,13 @@ public class DDMStructureClassTypeTest {
 				ddmStructureClassType.getClassTypeFields(),
 				classTypeField -> Objects.equals(
 					classTypeField.getType(), "date_time")));
+
+		ClassTypeField classTypeField = ddmStructureClassType.getClassTypeField(
+			"Text38954058");
+
+		Assert.assertEquals(
+			classTypeField.getLabel(),
+			HtmlUtil.escape("<script>alert(document.cookie)</script>"));
 	}
 
 	@Inject

--- a/modules/apps/asset/asset-test/src/testIntegration/resources/com/liferay/asset/model/test/dependencies/data-definition.json
+++ b/modules/apps/asset/asset-test/src/testIntegration/resources/com/liferay/asset/model/test/dependencies/data-definition.json
@@ -754,6 +754,61 @@
 			"tip": {
 				"en_US": ""
 			}
+		},
+		{
+			"customProperties": {
+				"confirmationErrorMessage": {
+					"en_US": ""
+				},
+				"confirmationLabel": {
+					"en_US": ""
+				},
+				"dataType": "string",
+				"direction": [
+					"vertical"
+				],
+				"displayStyle": "singleline",
+				"fieldNamespace": "",
+				"fieldReference": "Text38954058",
+				"hideField": false,
+				"htmlAutocompleteAttribute": "",
+				"labelAtStructureLevel": true,
+				"nativeField": false,
+				"objectFieldName": "",
+				"options": {
+				},
+				"placeholder": {
+					"en_US": ""
+				},
+				"requireConfirmation": false,
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"tooltip": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "<script>alert(document.cookie)</script>"
+			},
+			"localizable": true,
+			"name": "Text38954058",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
 		}
 	],
 	"defaultDataLayout": {
@@ -948,6 +1003,16 @@
 								"columnSize": 12,
 								"fieldNames": [
 									"DateTime23546209"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Text38954058"
 								]
 							}
 						]

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalDefaultTemplateProviderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalDefaultTemplateProviderImpl.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
 import com.liferay.portal.kernel.template.TemplateVariableDefinition;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Collection;
@@ -73,7 +74,7 @@ public class JournalDefaultTemplateProviderImpl
 				templateVariableDefinition.generateCode(getLanguage())[0];
 
 			sb.append("<dt class=\"text-capitalize\">");
-			sb.append(templateVariableDefinition.getLabel());
+			sb.append(HtmlUtil.escape(templateVariableDefinition.getLabel()));
 			sb.append("</dt><dd>");
 			sb.append(code);
 			sb.append("</dd>");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-59048

This change prevents XSS in Asset publisher when using scripts in a structure label

# How am I fixing it?

Escaping the fields that caused the XSS

# How can you verify that it works?

Run the tests in DDMStructureClassTypeTest

Resending based on the request for some minor changes here https://github.com/brianchandotcom/liferay-portal/pull/163528#issuecomment-3055598934