### PR TITLE
pull request 163555 LPD 58488

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -323,6 +323,10 @@ public interface ObjectEntryVersionLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean isLatestObjectEntryVersion(long objectEntryId, int version)
+		throws PortalException;
+
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
 			ObjectEntry objectEntry)
 		throws PortalException;

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -399,6 +399,13 @@ public class ObjectEntryVersionLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static boolean isLatestObjectEntryVersion(
+			long objectEntryId, int version)
+		throws PortalException {
+
+		return getService().isLatestObjectEntryVersion(objectEntryId, version);
+	}
+
 	public static ObjectEntryVersion updateLatestObjectEntryVersion(
 			com.liferay.object.model.ObjectEntry objectEntry)
 		throws PortalException {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -459,6 +459,14 @@ public class ObjectEntryVersionLocalServiceWrapper
 	}
 
 	@Override
+	public boolean isLatestObjectEntryVersion(long objectEntryId, int version)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryVersionLocalService.isLatestObjectEntryVersion(
+			objectEntryId, version);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntryVersion
 			updateLatestObjectEntryVersion(
 				com.liferay.object.model.ObjectEntry objectEntry)

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -988,7 +988,17 @@ public class ObjectEntryDTOConverter
 		if (objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
-			long fileEntryId = GetterUtil.getLong(serializable);
+			long fileEntryId = 0;
+
+			if (serializable instanceof Long) {
+				fileEntryId = GetterUtil.getLong(serializable);
+			}
+			else if (serializable instanceof Map) {
+				Map<String, Serializable> map =
+					(Map<String, Serializable>)serializable;
+
+				fileEntryId = GetterUtil.getLong(map.get("id"));
+			}
 
 			if (fileEntryId == 0) {
 				return null;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -27,6 +27,7 @@ import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
@@ -54,6 +55,7 @@ import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
 import com.liferay.object.service.ObjectEntryVersionService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -928,13 +930,11 @@ public class DefaultObjectEntryManagerImpl
 				_objectEntryVersionService.getObjectEntryVersions(
 					objectEntryId, _getStartPosition(pagination),
 					_getEndPosition(pagination)),
-				objectEntryVersion -> {
-					dtoConverterContext.setAttribute(
-						"objectEntryVersion", objectEntryVersion);
-
-					return _objectEntryDTOConverter.toDTO(
-						dtoConverterContext, serviceBuilderObjectEntry);
-				}),
+				objectEntryVersion -> _objectEntryDTOConverter.toDTO(
+					_getObjectEntryVersionDTOConverterContext(
+						dtoConverterContext, objectEntryVersion,
+						serviceBuilderObjectEntry),
+					serviceBuilderObjectEntry)),
 			pagination,
 			_objectEntryVersionService.getObjectEntryVersionsCount(
 				objectEntryId));
@@ -1607,6 +1607,103 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT;
+	}
+
+	private DTOConverterContext _getObjectEntryVersionDTOConverterContext(
+			DTOConverterContext dtoConverterContext,
+			ObjectEntryVersion objectEntryVersion,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
+		throws Exception {
+
+		Map<String, Map<String, String>> actions =
+			dtoConverterContext.getActions();
+
+		if (GetterUtil.getBoolean(
+				dtoConverterContext.getAttribute("addActions"), true)) {
+
+			if (actions == null) {
+				actions = Collections.emptyMap();
+			}
+
+			HashMap<String, String> templateParameterMap = HashMapBuilder.put(
+				"version", String.valueOf(objectEntryVersion.getVersion())
+			).build();
+
+			boolean latestObjectEntryVersion =
+				_objectEntryVersionLocalService.isLatestObjectEntryVersion(
+					serviceBuilderObjectEntry.getObjectEntryId(),
+					objectEntryVersion.getVersion());
+
+			actions = HashMapBuilder.create(
+				actions
+			).<String, Map<String, String>>put(
+				"delete",
+				() -> {
+					if (latestObjectEntryVersion) {
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.DELETE, "deleteObjectEntryByVersion",
+						serviceBuilderObjectEntry, templateParameterMap,
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
+				"expire",
+				() -> {
+					if (!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-17564") ||
+						latestObjectEntryVersion ||
+						objectEntryVersion.isExpired() ||
+						objectEntryVersion.isDraft() ||
+						objectEntryVersion.isPending()) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.UPDATE, "postObjectEntryByVersionExpire",
+						serviceBuilderObjectEntry, templateParameterMap,
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
+				"get",
+				_addAction(
+					ActionKeys.VIEW, "getObjectEntryByVersion",
+					serviceBuilderObjectEntry, templateParameterMap,
+					dtoConverterContext.getUriInfo())
+			).put(
+				"restore",
+				() -> {
+					if (latestObjectEntryVersion ||
+						objectEntryVersion.isExpired()) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.UPDATE, "putObjectEntryByVersionRestore",
+						serviceBuilderObjectEntry, templateParameterMap,
+						dtoConverterContext.getUriInfo());
+				}
+			).build();
+		}
+
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				dtoConverterContext.isAcceptAllLanguages(), actions,
+				dtoConverterContext.getDTOConverterRegistry(),
+				dtoConverterContext.getHttpServletRequest(),
+				serviceBuilderObjectEntry.getObjectEntryId(),
+				dtoConverterContext.getLocale(),
+				dtoConverterContext.getUriInfo(),
+				dtoConverterContext.getUser());
+
+		defaultDTOConverterContext.setAttribute(
+			"objectEntryVersion", objectEntryVersion);
+
+		return defaultDTOConverterContext;
 	}
 
 	private Map<String, ObjectRelationship> _getObjectRelationships(
@@ -2452,6 +2549,9 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 	@Reference
 	private ObjectEntryVersionService _objectEntryVersionService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1082,7 +1082,7 @@ public class DefaultObjectEntryManagerImpl
 	private Map<String, String> _addAction(
 			String actionName, String methodName,
 			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
-			HashMap<String, String> templateParameterMap, UriInfo uriInfo)
+			Map<String, String> templateParameterMap, UriInfo uriInfo)
 		throws Exception {
 
 		return ActionUtil.addAction(
@@ -1621,7 +1621,7 @@ public class DefaultObjectEntryManagerImpl
 		if (GetterUtil.getBoolean(
 				dtoConverterContext.getAttribute("addActions"), true)) {
 
-			HashMap<String, String> templateParameterMap = HashMapBuilder.put(
+			Map<String, String> templateParameterMap = HashMapBuilder.put(
 				"version", String.valueOf(objectEntryVersion.getVersion())
 			).build();
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1615,15 +1615,11 @@ public class DefaultObjectEntryManagerImpl
 			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
 		throws Exception {
 
-		Map<String, Map<String, String>> actions =
-			dtoConverterContext.getActions();
+		Map<String, Map<String, String>> actions = GetterUtil.getObject(
+			dtoConverterContext.getActions(), Collections::emptyMap);
 
 		if (GetterUtil.getBoolean(
 				dtoConverterContext.getAttribute("addActions"), true)) {
-
-			if (actions == null) {
-				actions = Collections.emptyMap();
-			}
 
 			HashMap<String, String> templateParameterMap = HashMapBuilder.put(
 				"version", String.valueOf(objectEntryVersion.getVersion())
@@ -2209,15 +2205,11 @@ public class DefaultObjectEntryManagerImpl
 			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
 		throws Exception {
 
-		Map<String, Map<String, String>> actions =
-			dtoConverterContext.getActions();
+		Map<String, Map<String, String>> actions = GetterUtil.getObject(
+			dtoConverterContext.getActions(), Collections::emptyMap);
 
 		if (GetterUtil.getBoolean(
 				dtoConverterContext.getAttribute("addActions"), true)) {
-
-			if (actions == null) {
-				actions = Collections.emptyMap();
-			}
 
 			actions = HashMapBuilder.create(
 				actions

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -5724,9 +5724,11 @@ public class ObjectEntryLocalServiceImpl
 		_updateResourcePermissions(
 			objectDefinition, objectEntry, serviceContext);
 
-		_deleteFileEntries(
-			objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
-			transientValues);
+		if (!objectDefinition.isEnableObjectEntryVersioning()) {
+			_deleteFileEntries(
+				objectEntry.getValues(), objectEntry.getObjectDefinitionId(),
+				transientValues);
+		}
 
 		_executeObjectActions(
 			objectEntry.getCompanyId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -7,7 +7,6 @@ package com.liferay.object.service.impl;
 
 import com.liferay.object.configuration.ObjectEntryVersionConfiguration;
 import com.liferay.object.entry.util.ObjectEntryDTOConverterUtil;
-import com.liferay.object.exception.NoSuchObjectEntryVersionException;
 import com.liferay.object.exception.RequiredObjectEntryVersionException;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryVersion;
@@ -335,7 +334,7 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	private ObjectEntryVersion _getLatestObjectEntryVersion(long objectEntryId)
-		throws NoSuchObjectEntryVersionException {
+		throws PortalException {
 
 		return objectEntryVersionPersistence.findByObjectEntryId_First(
 			objectEntryId,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.object.service.impl;
 
 import com.liferay.object.configuration.ObjectEntryVersionConfiguration;
 import com.liferay.object.entry.util.ObjectEntryDTOConverterUtil;
+import com.liferay.object.exception.NoSuchObjectEntryVersionException;
 import com.liferay.object.exception.RequiredObjectEntryVersionException;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryVersion;
@@ -244,6 +245,20 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	@Override
+	public boolean isLatestObjectEntryVersion(long objectEntryId, int version)
+		throws PortalException {
+
+		ObjectEntryVersion objectEntryVersion = _getLatestObjectEntryVersion(
+			objectEntryId);
+
+		if (version == objectEntryVersion.getVersion()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
 			ObjectEntry objectEntry)
 		throws PortalException {
@@ -317,6 +332,14 @@ public class ObjectEntryVersionLocalServiceImpl
 		objectEntryVersion.setStatusDate(date);
 
 		return objectEntryVersionPersistence.update(objectEntryVersion);
+	}
+
+	private ObjectEntryVersion _getLatestObjectEntryVersion(long objectEntryId)
+		throws NoSuchObjectEntryVersionException {
+
+		return objectEntryVersionPersistence.findByObjectEntryId_First(
+			objectEntryId,
+			ObjectEntryVersionVersionComparator.getInstance(false));
 	}
 
 	private ObjectEntryVersion _updateObjectEntryVersion(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5863,7 +5863,7 @@ public class ObjectEntryLocalServiceTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
-	public void testUpdateObjectEntryWithAttachmentAndVersioning()
+	public void testUpdateObjectEntryWithAttachmentAndEnableObjectEntryVersioning()
 		throws Exception {
 
 		Map<String, Serializable> values =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5924,8 +5924,6 @@ public class ObjectEntryLocalServiceTest {
 
 		_objectDefinition.setEnableObjectEntryVersioning(true);
 
-		_objectDefinition.isEnableObjectEntryVersioning();
-
 		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
 
 		values = HashMapBuilder.<String, Serializable>put(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5924,7 +5924,7 @@ public class ObjectEntryLocalServiceTest {
 
 		_objectDefinition.setEnableObjectEntryVersioning(true);
 
-		_objectDefinition.isEnableObjectEntryVersioning()
+		_objectDefinition.isEnableObjectEntryVersioning();
 
 		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -23,6 +23,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.expando.kernel.model.ExpandoColumn;
@@ -133,6 +134,8 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Address;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -154,6 +157,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -210,6 +214,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.Serializable;
 
@@ -249,8 +254,10 @@ import javax.crypto.spec.SecretKeySpec;
 import org.hamcrest.CoreMatchers;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -281,6 +288,22 @@ public class ObjectEntryLocalServiceTest {
 			PermissionCheckerMethodTestRule.INSTANCE,
 			ScriptManagementConfigurationTestRule.INSTANCE,
 			SynchronousDestinationTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectEntryLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ModelListener.class, _testDLFileEntryModelListener, null);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_serviceRegistration.unregister();
+	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -319,6 +342,31 @@ public class ObjectEntryLocalServiceTest {
 					ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER,
 					ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
 					"Age of Death", "ageOfDeath", false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+					"Attachment", "attachment",
+					Arrays.asList(
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.
+								NAME_ACCEPTED_FILE_EXTENSIONS
+						).value(
+							"txt"
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_FILE_SOURCE
+						).value(
+							ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+						).value(
+							String.valueOf(100)
+						).build()),
+					false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 					ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
@@ -5813,6 +5861,98 @@ public class ObjectEntryLocalServiceTest {
 		_testUpdateObjectEntryWithObjectRelationship();
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testUpdateObjectEntryWithAttachmentAndVersioning()
+		throws Exception {
+
+		Map<String, Serializable> values =
+			HashMapBuilder.<String, Serializable>put(
+				"attachment",
+				() -> {
+					DLFileEntry dlFileEntry = _addDLFileEntry();
+
+					return String.valueOf(dlFileEntry.getFileEntryId());
+				}
+			).put(
+				"emailAddressDomain", "@liferay.com"
+			).put(
+				"emailAddressRequired", "test@liferay.com"
+			).put(
+				"firstName", "Juan"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build();
+
+		ObjectEntry objectEntry = _addOrUpdateObjectEntry("juan", 0, values);
+
+		long fileEntryId1 = _testDLFileEntryModelListener.getLastFileEntryId();
+
+		_assertObjectEntryValues(
+			24, values,
+			_objectEntryLocalService.getValues(objectEntry.getObjectEntryId()));
+
+		values = HashMapBuilder.<String, Serializable>put(
+			"attachment",
+			() -> {
+				DLFileEntry dlFileEntry = _addDLFileEntry();
+
+				return String.valueOf(dlFileEntry.getFileEntryId());
+			}
+		).put(
+			"emailAddressDomain", "@liferay.com"
+		).put(
+			"emailAddressRequired", "test@liferay.com"
+		).put(
+			"firstName", "Juan"
+		).put(
+			"listTypeEntryKeyRequired", "listTypeEntryKey1"
+		).build();
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(), values,
+			ServiceContextTestUtil.getServiceContext());
+
+		long fileEntryId2 = _testDLFileEntryModelListener.getLastFileEntryId();
+
+		_assertObjectEntryValues(
+			24, values,
+			_objectEntryLocalService.getValues(objectEntry.getObjectEntryId()));
+
+		Assert.assertNull(
+			_dlFileEntryLocalService.fetchDLFileEntry(fileEntryId1));
+
+		_objectDefinition.setEnableObjectEntryVersioning(true);
+
+		_objectDefinition.isEnableObjectEntryVersioning()
+
+		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
+
+		values = HashMapBuilder.<String, Serializable>put(
+			"attachment",
+			() -> {
+				DLFileEntry dlFileEntry = _addDLFileEntry();
+
+				return String.valueOf(dlFileEntry.getFileEntryId());
+			}
+		).put(
+			"emailAddressDomain", "@liferay.com"
+		).put(
+			"emailAddressRequired", "test@liferay.com"
+		).put(
+			"firstName", "Juan"
+		).put(
+			"listTypeEntryKeyRequired", "listTypeEntryKey1"
+		).build();
+
+		_objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(), values,
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertNotNull(
+			_dlFileEntryLocalService.fetchDLFileEntry(fileEntryId2));
+	}
+
 	@Test
 	public void testUpdateObjectEntryWithJavaDelegateObjectValidationRule()
 		throws Exception {
@@ -6402,6 +6542,26 @@ public class ObjectEntryLocalServiceTest {
 			objectField.getObjectFieldSettings());
 	}
 
+	private DLFileEntry _addDLFileEntry() throws Exception {
+		Company company = _companyLocalService.getCompanyById(
+			TestPropsValues.getCompanyId());
+
+		String content = RandomTestUtil.randomString();
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), company.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TempFileEntryUtil.getTempFileName(
+				RandomTestUtil.randomString() + ".txt"),
+			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			new ByteArrayInputStream(content.getBytes()), 0, null, null, null,
+			ServiceContextTestUtil.getServiceContext());
+
+		return _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
 	private ObjectAction _addObjectAction(
 			ObjectDefinition objectDefinition, String objectActionTriggerKey)
 		throws Exception {
@@ -6502,15 +6662,25 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	private ObjectEntry _addOrUpdateObjectEntry(
-			String externalReferenceCode, long groupId,
+			String externalReferenceCode, long groupId, long objectDefinitionId,
 			Map<String, Serializable> values)
 		throws Exception {
 
 		return _objectEntryLocalService.addOrUpdateObjectEntry(
 			externalReferenceCode, groupId, TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(),
+			objectDefinitionId,
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			values, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addOrUpdateObjectEntry(
+			String externalReferenceCode, long groupId,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		return _addOrUpdateObjectEntry(
+			externalReferenceCode, groupId,
+			_objectDefinition.getObjectDefinitionId(), values);
 	}
 
 	private void _addSystemObjectField(ObjectField objectField)
@@ -8098,6 +8268,10 @@ public class ObjectEntryLocalServiceTest {
 		ObjectValidationRuleConstants.ENGINE_TYPE_JAVA_DELEGATE_PREFIX +
 			RandomTestUtil.randomString();
 
+	private static ServiceRegistration<?> _serviceRegistration;
+	private static final TestDLFileEntryModelListener
+		_testDLFileEntryModelListener = new TestDLFileEntryModelListener();
+
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
 
@@ -8109,6 +8283,9 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private CounterLocalService _counterLocalService;
@@ -8220,6 +8397,24 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private WorkflowTaskManager _workflowTaskManager;
+
+	private static class TestDLFileEntryModelListener
+		extends BaseModelListener<DLFileEntry> {
+
+		public Long getLastFileEntryId() {
+			return _fileEntryIds.get(_fileEntryIds.size() - 1);
+		}
+
+		@Override
+		public void onAfterCreate(DLFileEntry dlFileEntry)
+			throws ModelListenerException {
+
+			_fileEntryIds.add(dlFileEntry.getFileEntryId());
+		}
+
+		private List<Long> _fileEntryIds = new ArrayList<>();
+
+	}
 
 	private static class TestObjectValidationRuleEngine
 		implements CompanyScoped, ObjectDefinitionScoped,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
@@ -716,6 +716,35 @@ public class ObjectEntryVersionLocalServiceTest {
 				objectEntry.getObjectEntryId()));
 	}
 
+	@Test
+	public void testIsLatestObjectEntryVersion() throws Exception {
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", "textObjectFieldValue1"
+			).build());
+
+		Assert.assertEquals(1, objectEntry.getVersion());
+		Assert.assertTrue(
+			_objectEntryVersionLocalService.isLatestObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 1));
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", "textObjectFieldValue2"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(2, objectEntry.getVersion());
+		Assert.assertFalse(
+			_objectEntryVersionLocalService.isLatestObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 1));
+		Assert.assertTrue(
+			_objectEntryVersionLocalService.isLatestObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 2));
+	}
+
 	private void _assertEquals(
 			List<ObjectEntryVersion> expectedObjectEntryVersions,
 			List<ObjectEntryVersion> actualObjectEntryVersions)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -215,7 +215,7 @@ public abstract class BaseSectionDisplayContext {
 					GroupConstants.CMS_FRIENDLY_URL,
 					"/version-history?objectEntryId={embedded.id}&backURL=",
 					themeDisplay.getURLCurrent()),
-				null, "version-history",
+				"date-time", "version-history",
 				LanguageUtil.get(httpServletRequest, "view-history"), "get",
 				"versions", null),
 			new FDSActionDropdownItem(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -63,7 +63,7 @@ public class ViewVersionHistoryDisplayContext {
 				_language.get(_httpServletRequest, "delete"), "delete",
 				"delete", "headless"),
 			new FDSActionDropdownItem(
-				"{actions.expire.href}", "expire", "expire",
+				"{actions.expire.href}", "time", "expire",
 				_language.get(_httpServletRequest, "expire"), "post", "expire",
 				"headless"),
 			new FDSActionDropdownItem(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -42,8 +42,12 @@ public class ViewVersionHistoryDisplayContext {
 	}
 
 	public String getAPIURL() throws PortalException {
-		StringBundler sb = new StringBundler(_getObjectDefinitionBaseURL());
+		StringBundler sb = new StringBundler(5);
 
+		sb.append("/o");
+		sb.append(_objectDefinition.getRESTContextPath());
+		sb.append(StringPool.SLASH);
+		sb.append(_objectEntry.getObjectEntryId());
 		sb.append("/versions");
 
 		return sb.toString();
@@ -55,15 +59,15 @@ public class ViewVersionHistoryDisplayContext {
 				_language.get(
 					_httpServletRequest,
 					"are-you-sure-you-want-to-delete-this-entry"),
-				null, "trash", "delete",
+				"{actions.delete.href}", "trash", "delete",
 				_language.get(_httpServletRequest, "delete"), "delete",
 				"delete", "headless"),
 			new FDSActionDropdownItem(
-				_getFDSActionDropdownItemHref("expire"), "expire", "expire",
+				"{actions.expire.href}", "expire", "expire",
 				_language.get(_httpServletRequest, "expire"), "post", "expire",
 				"headless"),
 			new FDSActionDropdownItem(
-				_getFDSActionDropdownItemHref("restore"), "restore", "restore",
+				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore"), "put", "restore",
 				"headless"),
 			new FDSActionDropdownItem(
@@ -78,22 +82,6 @@ public class ViewVersionHistoryDisplayContext {
 		).put(
 			"title", _objectEntry.getTitleValue(_themeDisplay.getLanguageId())
 		).build();
-	}
-
-	private String _getFDSActionDropdownItemHref(String action) {
-		return _getObjectDefinitionBaseURL() +
-			"/by-version/{systemProperties.version.number}" + action;
-	}
-
-	private String _getObjectDefinitionBaseURL() {
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("/o");
-		sb.append(_objectDefinition.getRESTContextPath());
-		sb.append(StringPool.SLASH);
-		sb.append(_objectEntry.getObjectEntryId());
-
-		return sb.toString();
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -11,14 +11,15 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,10 +29,11 @@ import java.util.Map;
 public class ViewVersionHistoryDisplayContext {
 
 	public ViewVersionHistoryDisplayContext(
-		HttpServletRequest httpServletRequest,
+		HttpServletRequest httpServletRequest, Language language,
 		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
 
 		_httpServletRequest = httpServletRequest;
+		_language = language;
 		_objectDefinition = objectDefinition;
 		_objectEntry = objectEntry;
 
@@ -40,19 +42,30 @@ public class ViewVersionHistoryDisplayContext {
 	}
 
 	public String getAPIURL() throws PortalException {
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(_getObjectDefinitionBaseURL());
 
-		sb.append("/o");
-		sb.append(_objectDefinition.getRESTContextPath());
-		sb.append(StringPool.SLASH);
-		sb.append(_objectEntry.getObjectEntryId());
 		sb.append("/versions");
 
 		return sb.toString();
 	}
 
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
-		return Collections.emptyList();
+		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				_language.get(
+					_httpServletRequest,
+					"are-you-sure-you-want-to-delete-this-entry"),
+				null, "trash", "delete",
+				_language.get(_httpServletRequest, "delete"), "delete",
+				"delete", "headless"),
+			new FDSActionDropdownItem(
+				_getFDSActionDropdownItemHref("expire"), "expire", "expire",
+				_language.get(_httpServletRequest, "expire"), "post", "expire",
+				"headless"),
+			new FDSActionDropdownItem(
+				_getFDSActionDropdownItemHref("restore"), "restore", "restore",
+				_language.get(_httpServletRequest, "restore"), "put", "restore",
+				"headless"));
 	}
 
 	public Map<String, Object> getToolbarReactData() throws PortalException {
@@ -63,7 +76,24 @@ public class ViewVersionHistoryDisplayContext {
 		).build();
 	}
 
+	private String _getFDSActionDropdownItemHref(String action) {
+		return _getObjectDefinitionBaseURL() +
+			"/by-version/{systemProperties.version.number}" + action;
+	}
+
+	private String _getObjectDefinitionBaseURL() {
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("/o");
+		sb.append(_objectDefinition.getRESTContextPath());
+		sb.append(StringPool.SLASH);
+		sb.append(_objectEntry.getObjectEntryId());
+
+		return sb.toString();
+	}
+
 	private final HttpServletRequest _httpServletRequest;
+	private final Language _language;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectEntry _objectEntry;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -65,7 +65,11 @@ public class ViewVersionHistoryDisplayContext {
 			new FDSActionDropdownItem(
 				_getFDSActionDropdownItemHref("restore"), "restore", "restore",
 				_language.get(_httpServletRequest, "restore"), "put", "restore",
-				"headless"));
+				"headless"),
+			new FDSActionDropdownItem(
+				"{file.link.href}", "download", "download",
+				_language.get(_httpServletRequest, "download"), "get", null,
+				"link"));
 	}
 
 	public Map<String, Object> getToolbarReactData() throws PortalException {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewVersionHistoryJSPFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewVersionHistoryJSPFragmentRenderer.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.site.cms.site.initializer.internal.display.context.ViewVersionHistoryDisplayContext;
 
@@ -44,13 +45,16 @@ public class ViewVersionHistoryJSPFragmentRenderer
 				objectEntry.getObjectDefinitionId());
 
 		return new ViewVersionHistoryDisplayContext(
-			httpServletRequest, objectDefinition, objectEntry);
+			httpServletRequest, _language, objectDefinition, objectEntry);
 	}
 
 	@Override
 	protected String getLabelKey() {
 		return "view-version-history";
 	}
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -34,6 +34,7 @@ export {default as FolderFDSPropsTransformer} from './main_view/props_transforme
 export {default as StructureUsagesFDSPropsTransformer} from './main_view/props_transformer/StructureUsagesFDSPropsTransformer';
 export {default as StructuresFDSPropsTransformer} from './main_view/props_transformer/StructuresFDSPropsTransformer';
 export {default as TagUsagesFDSPropsTransformer} from './main_view/props_transformer/TagUsagesFDSPropsTransformer';
+export {default as ViewVersionHistoryFDSPropsTransformer} from './main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer';
 export {default as VocabularyFDSPropsTransformer} from './main_view/props_transformer/VocabularyFDSPropsTransformer';
 export {default as AddSpaceMembers} from './main_view/spaces/AddSpaceMembers';
 export {default as NewSpace} from './main_view/spaces/NewSpace';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+
+import AuthorRenderer from './cell_renderers/AuthorRenderer';
+import NameRenderer from './cell_renderers/NameRenderer';
+
+export default function ViewVersionHistoryFDSPropsTransformer({
+	itemsActions = [],
+	...otherProps
+}: {
+	itemsActions?: any[];
+	otherProps: any;
+}) {
+	return {
+		...otherProps,
+		customRenderers: {
+			tableCell: [
+				{
+					component: AuthorRenderer,
+					name: 'authorTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: NameRenderer,
+					name: 'nameTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+			],
+		},
+		itemsActions: itemsActions.map((action) => {
+			if (action?.data?.id === 'download') {
+				return {
+					...action,
+					isVisible: (item: any) => Boolean(item?.file?.link?.href),
+				};
+			}
+
+			return action;
+		}),
+	};
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
@@ -25,6 +25,7 @@ ViewVersionHistoryDisplayContext viewVersionHistoryDisplayContext = (ViewVersion
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.VIEW_HISTORY %>"
 		itemsPerPage="<%= 20 %>"
+		propsTransformer="{ViewVersionHistoryFDSPropsTransformer} from site-cms-site-initializer"
 		style="fluid"
 	/>
 </div>


### PR DESCRIPTION
- **LPD-59463 Merge license-cluster tests into license**
- **LPD-59463 Remove license-cluster test routine**
- **LPD-58864 Remove redundent permission checks**
- **LPD-58864 Remove redundent permission checking from productfrom product thumbnails**
- **LPD-58864 Remove redundent permission checking for compare cart**
- **LPD-58864 Baseline**
- **LPD-60240 Remove this crazy json detour for a plain entity attribute getting**
- **LPD-60240 SF**
- **LPD-47038 use the correct FF on the set of the categories ids**
- **LPD-60222 I found an issue that is there since forever and causes a visual bug where the current configuration tab is not highlighted when it's a factory instance or the user reset the configuration value**
- **LPD-60222 add test**
- **LPD-60222 Simplify**
- **LPD-60222 Order in service.xml / tables.sql**
- **LPD-60222 Sort (seems to contradict my previous commit but it doesn't, since this is not based on service.xml)**
- **LPD-59149 Upgrade tomcat to 10.1.42 in app.server.properties and build-test.xml**
- **LPD-59149 Upgrade tomcat to 10.1.42 on dependencies properties**
- **LPD-59149 Upgrade tomcat to 10.1.42 in modules**
- **LPD-59149 Upgrade tomcat to 10.1.42 on portal-web**
- **LPD-59149 Auto generate, by running ant build-lib-versions**
- **LPD-60241 Avoid the useless JSONObject wrapping/unwrapping, just get what is needed.**
- **LPD-60241 Semantic versioning**
- **LPD-60065 Add waitFor pattern**
- **LPD-60065 Mock loadClientExtensions**
- **LPD-60065 Click first action with name**
- **LPD-60065 Use expect to pass utils to make tests robust**
- **LPD-60065 Fix locators**
- **LPD-60065 Best practice: use random strings**
- **LPD-60065 Put goto on top**
- **LPD-60065 Close modal**
- **LPD-60065 Delete tags at the end of tests**
- **LPD-57008 removed unused keywords from LDAP config file**
- **LPD-57008 ant update-portal-osgi-configuration-properties**
- **LPD-57008 add test**
- **LPD-57008 Since these locators now reference deleted configuration values, we shouldn't put them in the LdapConfigurationPage, but rather just use them directly in our specific test.  Also, since they are only used once (and probably never again), inlining them would be the correct approach anyways.**
- **LPD-57008 This should provide more coverage with less code**
- **LPD-57008 Baseline**
- **LPD-57008 prep next**
- **LPD-57008 settings.gradle**
- **LPD-59048 Escape label text**
- **LPD-59048 Add Test**
- **LRCI-6086 Add ability to enable build caching with an env var**
- **LRCI-6024 Add method to add downstream build reports to a top level build report**
- **LRCI-6024 Override references to get batch names**
- **LRCI-6024 Add method for new constructor for testray case result**
- **LRCI-6024 Only generate build reports if configured**
- **LRCI-6024 Add method to get the module paths from a test class report**
- **LRCI-6024 Add method to get cached downstream build reports**
- **LRCI-6024 Add ability to cache playwright tests**
- **LRCI-6024 Add ability to cache modules semantic versioning tests**
- **LRCI-6024 Add ability to cache js unit tests**
- **LRCI-6024 Simplify isBuildCachingEnabled logic**
- **LRCI-6024 Avoid checksums on checksum files**
- **LRCI-6024 Add downstream build json to top level build upon completion**
- **LRCI-6024 Fix JS Unit batch reporting & caching**
- **LRCI-6024 Rename**
- **LRCI-6024 Sort**
- **LRCI-6024 prep next**
- **LPD-60184 File name is different in master and 7.x**
- **LPD-59844 Print the default company's information into the company.csv file in order to generate the missing dl folders for all the companies**
- **LPD-58516 add body on disconnect**
- **Revert "LPD-32730 Updated the method so it doesn't change the order in the Object View"**
- **LPD-57550 Change logic for selected array creation to fix order**
- **LPD-57550 Adjust jest unitary test to address creation of new object fields in object view**
- **LPD-57550 Add unitary jest test for removing fields in add object view**
- **LPD-57550 Create playwright test for objectview field add behavior**
- **LPD-60184 prep next**
- **LPD-60184 prep next**
- **LRSD-9468 add list types**
- **LRSD-9468 add object definitions**
- **LRSD-9468 add object relationships**
- **LRSD-9468 add object entries**
- **LPD-58488 Add delete, expire and restore actions**
- **LPD-58488 Take into account that for object entry versions we are not getting directly the fileEntryId and instead of it we are getting a map with some values of the file among them the fileEntryId**
- **LPD-59288 Do not delete old object entry version files since we have to keep them if the versioning is enabled**
- **LPD-58488 Add download action and table cell renderers**
- **LPD-58488 Add isLatestVersion method**
- **LPD-58488 buildService**
- **LPD-58488 Add object entry version actions**
- **LPD-58488 Use URL actions from the object entry version items**
- **LPD-57488 Add expire icon**
- **LPD-58488 Add icon**
- **LPD-58488 Add test to test IsLatestObjectEntryVersion new method**
- **LPD-58488 Add test to test that we are not deleting file entries for the versions if the object definition is configured to have versions**
- **LPD-58488 Improve**
- **LPD-58488 Fix compile issue**
- **LPD-58488 Change method to use interface, and change call accordingly**
- **LPD-58488 Shouldn't be here**
- **LPD-58488 Simplify**
- **LPD-58488 Better naming**
