### PR TITLE
LPD-60402 Add localisation for ClayDatePicker

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingConflictsView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingConflictsView.js
@@ -13,7 +13,7 @@ import ClayModal, {useModal} from '@clayui/modal';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import ClayPanel from '@clayui/panel';
 import {openConfirmModal} from 'frontend-js-components-web';
-import {navigate} from 'frontend-js-web';
+import {dateUtils, navigate} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import ChangeTrackingBaseScheduleView from './ChangeTrackingBaseScheduleView';
@@ -218,11 +218,27 @@ class ChangeTrackingConflictsView extends ChangeTrackingBaseScheduleView {
 										disabled={
 											!!this.unresolvedConflicts.length
 										}
+										firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+										months={[
+											`${Liferay.Language.get('january')}`,
+											`${Liferay.Language.get('february')}`,
+											`${Liferay.Language.get('march')}`,
+											`${Liferay.Language.get('april')}`,
+											`${Liferay.Language.get('may')}`,
+											`${Liferay.Language.get('june')}`,
+											`${Liferay.Language.get('july')}`,
+											`${Liferay.Language.get('august')}`,
+											`${Liferay.Language.get('september')}`,
+											`${Liferay.Language.get('october')}`,
+											`${Liferay.Language.get('november')}`,
+											`${Liferay.Language.get('december')}`,
+										]}
 										onValueChange={this.handleDateChange}
 										placeholder="YYYY-MM-DD"
 										spritemap={this.spritemap}
 										timezone={this.timeZone}
 										value={this.state.date}
+										weekdaysShort={dateUtils.getWeekdaysShort()}
 										years={{
 											end: new Date().getFullYear() + 1,
 											start: new Date().getFullYear() - 1,

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRescheduleView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRescheduleView.js
@@ -5,7 +5,7 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayDatePicker from '@clayui/date-picker';
-import {navigate} from 'frontend-js-web';
+import {dateUtils, navigate} from 'frontend-js-web';
 import React from 'react';
 
 import ChangeTrackingBaseScheduleView from './ChangeTrackingBaseScheduleView';
@@ -56,6 +56,21 @@ class ChangeTrackingRescheduleView extends ChangeTrackingBaseScheduleView {
 						<div className={this.getDateClassName()}>
 							<div>
 								<ClayDatePicker
+									firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+									months={[
+										`${Liferay.Language.get('january')}`,
+										`${Liferay.Language.get('february')}`,
+										`${Liferay.Language.get('march')}`,
+										`${Liferay.Language.get('april')}`,
+										`${Liferay.Language.get('may')}`,
+										`${Liferay.Language.get('june')}`,
+										`${Liferay.Language.get('july')}`,
+										`${Liferay.Language.get('august')}`,
+										`${Liferay.Language.get('september')}`,
+										`${Liferay.Language.get('october')}`,
+										`${Liferay.Language.get('november')}`,
+										`${Liferay.Language.get('december')}`,
+									]}
 									onValueChange={this.handleDateChange}
 									placeholder="YYYY-MM-DD"
 									spritemap={this.spritemap}
@@ -74,6 +89,7 @@ class ChangeTrackingRescheduleView extends ChangeTrackingBaseScheduleView {
 													this.state.date.getDate()
 												)
 									}
+									weekdaysShort={dateUtils.getWeekdaysShort()}
 									years={{
 										end: new Date().getFullYear() + 1,
 										start: new Date().getFullYear() - 1,

--- a/modules/apps/fragment/fragment-collection-filter-date/package.json
+++ b/modules/apps/fragment/fragment-collection-filter-date/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/date-picker": "3.140.0",
 		"@liferay/fragment-renderer-collection-filter-impl": "*",
+		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},
 	"main": "js/index.js",

--- a/modules/apps/fragment/fragment-collection-filter-date/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/fragment/fragment-collection-filter-date/src/main/resources/META-INF/resources/js/index.js
@@ -8,6 +8,7 @@ import {
 	getCollectionFilterValue,
 	setCollectionFilterValue,
 } from '@liferay/fragment-renderer-collection-filter-impl';
+import {dateUtils} from 'frontend-js-web';
 import React from 'react';
 
 export function FragmentCollectionFilterDate({
@@ -21,6 +22,21 @@ export function FragmentCollectionFilterDate({
 	return (
 		<ClayDatePicker
 			disabled={isDisabled}
+			firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+			months={[
+				`${Liferay.Language.get('january')}`,
+				`${Liferay.Language.get('february')}`,
+				`${Liferay.Language.get('march')}`,
+				`${Liferay.Language.get('april')}`,
+				`${Liferay.Language.get('may')}`,
+				`${Liferay.Language.get('june')}`,
+				`${Liferay.Language.get('july')}`,
+				`${Liferay.Language.get('august')}`,
+				`${Liferay.Language.get('september')}`,
+				`${Liferay.Language.get('october')}`,
+				`${Liferay.Language.get('november')}`,
+				`${Liferay.Language.get('december')}`,
+			]}
 			onValueChange={(value) =>
 				setCollectionFilterValue(
 					date,
@@ -31,6 +47,7 @@ export function FragmentCollectionFilterDate({
 			}
 			placeholder="YYYY-MM-DD"
 			value={value}
+			weekdaysShort={dateUtils.getWeekdaysShort()}
 		/>
 	);
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -52,13 +52,29 @@ export default function ScheduleOptions({
 				</label>
 
 				<ClayDatePicker
+					firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 					id={`${portletNamespace}displayDatePicker`}
+					months={[
+						`${Liferay.Language.get('january')}`,
+						`${Liferay.Language.get('february')}`,
+						`${Liferay.Language.get('march')}`,
+						`${Liferay.Language.get('april')}`,
+						`${Liferay.Language.get('may')}`,
+						`${Liferay.Language.get('june')}`,
+						`${Liferay.Language.get('july')}`,
+						`${Liferay.Language.get('august')}`,
+						`${Liferay.Language.get('september')}`,
+						`${Liferay.Language.get('october')}`,
+						`${Liferay.Language.get('november')}`,
+						`${Liferay.Language.get('december')}`,
+					]}
 					onChange={setDisplayDate}
 					placeholder="YYYY-MM-DD HH:mm"
 					required
 					time
 					timezone={timeZone.name}
 					value={displayDate || ''}
+					weekdaysShort={dateUtils.getWeekdaysShort()}
 					years={{
 						end: 9999,
 						start: new Date().getFullYear(),

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/ScheduleModal.js
@@ -8,6 +8,7 @@ import ClayButton from '@clayui/button';
 import ClayDatePicker from '@clayui/date-picker';
 import ClayModal from '@clayui/modal';
 import classnames from 'classnames';
+import {dateUtils} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -104,11 +105,27 @@ export default function ScheduleModal({
 
 					<ClayDatePicker
 						dateFormat="yyyy-MM-dd"
+						firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+						months={[
+							`${Liferay.Language.get('january')}`,
+							`${Liferay.Language.get('february')}`,
+							`${Liferay.Language.get('march')}`,
+							`${Liferay.Language.get('april')}`,
+							`${Liferay.Language.get('may')}`,
+							`${Liferay.Language.get('june')}`,
+							`${Liferay.Language.get('july')}`,
+							`${Liferay.Language.get('august')}`,
+							`${Liferay.Language.get('september')}`,
+							`${Liferay.Language.get('october')}`,
+							`${Liferay.Language.get('november')}`,
+							`${Liferay.Language.get('december')}`,
+						]}
 						onChange={setDisplayDate}
 						placeholder="yyyy-MM-dd HH:mm"
 						time
 						timezone={timeZone}
 						value={displayDate}
+						weekdaysShort={dateUtils.getWeekdaysShort()}
 						years={{
 							end: currentYear + DIFFERENCE_IN_YEARS,
 							start: currentYear,

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/panels/EditUserInfoPanel.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/panels/EditUserInfoPanel.js
@@ -645,8 +645,23 @@ function EditUserInfoPanel({
 						<ClayDatePicker
 							dateFormat="P"
 							disabled={isLoading}
+							firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 							id={`${namespace}birthDate`}
 							inputName={`${namespace}birthDate`}
+							months={[
+								`${Liferay.Language.get('january')}`,
+								`${Liferay.Language.get('february')}`,
+								`${Liferay.Language.get('march')}`,
+								`${Liferay.Language.get('april')}`,
+								`${Liferay.Language.get('may')}`,
+								`${Liferay.Language.get('june')}`,
+								`${Liferay.Language.get('july')}`,
+								`${Liferay.Language.get('august')}`,
+								`${Liferay.Language.get('september')}`,
+								`${Liferay.Language.get('october')}`,
+								`${Liferay.Language.get('november')}`,
+								`${Liferay.Language.get('december')}`,
+							]}
 							onChange={(value) => {
 								onChangeHandler({
 									target: {
@@ -660,6 +675,7 @@ function EditUserInfoPanel({
 								new Date(userData.birthDate),
 								'P'
 							)}
+							weekdaysShort={dateUtils.getWeekdaysShort()}
 							years={{
 								end: new Date().getFullYear(),
 								start: new Date().getFullYear() - 100,

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/DateInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/DateInput.js
@@ -22,6 +22,21 @@ function DateInput({disabled, name, setFieldTouched, setFieldValue, value}) {
 			<ClayDatePicker
 				dateFormat="MM/dd/yyyy"
 				disabled={disabled}
+				firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+				months={[
+					`${Liferay.Language.get('january')}`,
+					`${Liferay.Language.get('february')}`,
+					`${Liferay.Language.get('march')}`,
+					`${Liferay.Language.get('april')}`,
+					`${Liferay.Language.get('may')}`,
+					`${Liferay.Language.get('june')}`,
+					`${Liferay.Language.get('july')}`,
+					`${Liferay.Language.get('august')}`,
+					`${Liferay.Language.get('september')}`,
+					`${Liferay.Language.get('october')}`,
+					`${Liferay.Language.get('november')}`,
+					`${Liferay.Language.get('december')}`,
+				]}
 				onKeyDown={_handleKeyDown}
 				onValueChange={(value) => {
 					setFieldValue(
@@ -40,6 +55,7 @@ function DateInput({disabled, name, setFieldTouched, setFieldValue, value}) {
 						? dateUtils.format(new Date(value * 1000), 'MM/dd/yyyy')
 						: ''
 				}
+				weekdaysShort={dateUtils.getWeekdaysShort()}
 				years={{
 					end: 2024,
 					start: 1997,


### PR DESCRIPTION
LPD-60402 DatePicker is not localised

# What is this trying to solve?
[LPD-60402](https://liferay.atlassian.net/browse/LPD-60402)
ClayDatePicker elements are not localised.

# How am I fixing it?
By setting the correct localisation for `firstDayOfWeek`, `months` and `weekdaysShort`
NOTE: tooltips of the ClayDatePicker  component are not localisable.

# How can you verify that it works?
Follow the steps described in [LPD-60402](https://liferay.atlassian.net/browse/LPD-60402)

# Why doesn't this include any test?
UI issue that is tricky to test or pointless

Cheers,
Balázs