### PR TITLE
LPD-59994 Adds copy version action to the UI

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1632,6 +1632,22 @@ public class DefaultObjectEntryManagerImpl
 			actions = HashMapBuilder.create(
 				actions
 			).<String, Map<String, String>>put(
+				"copy",
+				() -> {
+					if (!FeatureFlagManagerUtil.isEnabled(
+							serviceBuilderObjectEntry.getCompanyId(),
+							"LPD-17564") ||
+						!objectEntryVersion.isApproved()) {
+
+						return null;
+					}
+
+					return _addAction(
+						ActionKeys.ADD_ENTRY, "postObjectEntryByVersionCopy",
+						serviceBuilderObjectEntry, templateParameterMap,
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
 				"delete",
 				() -> {
 					if (latestObjectEntryVersion) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -68,6 +68,10 @@ public class ViewVersionHistoryDisplayContext {
 				_language.get(_httpServletRequest, "expire"), "post", "expire",
 				"headless"),
 			new FDSActionDropdownItem(
+				"{actions.copy.href}", "copy", "copy",
+				_language.get(_httpServletRequest, "make-a-copy"), "post",
+				"copy", "headless"),
+			new FDSActionDropdownItem(
 				_language.get(
 					_httpServletRequest,
 					"are-you-sure-you-want-to-delete-this-entry"),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -56,24 +56,24 @@ public class ViewVersionHistoryDisplayContext {
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems() {
 		return ListUtil.fromArray(
 			new FDSActionDropdownItem(
-				_language.get(
-					_httpServletRequest,
-					"are-you-sure-you-want-to-delete-this-entry"),
-				"{actions.delete.href}", "trash", "delete",
-				_language.get(_httpServletRequest, "delete"), "delete",
-				"delete", "headless"),
-			new FDSActionDropdownItem(
-				"{actions.expire.href}", "time", "expire",
-				_language.get(_httpServletRequest, "expire"), "post", "expire",
-				"headless"),
+				"{file.link.href}", "download", "download",
+				_language.get(_httpServletRequest, "download"), "get", null,
+				"link"),
 			new FDSActionDropdownItem(
 				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore"), "put", "restore",
 				"headless"),
 			new FDSActionDropdownItem(
-				"{file.link.href}", "download", "download",
-				_language.get(_httpServletRequest, "download"), "get", null,
-				"link"));
+				"{actions.expire.href}", "time", "expire",
+				_language.get(_httpServletRequest, "expire"), "post", "expire",
+				"headless"),
+			new FDSActionDropdownItem(
+				_language.get(
+					_httpServletRequest,
+					"are-you-sure-you-want-to-delete-this-entry"),
+				"{actions.delete.href}", "trash", "delete",
+				_language.get(_httpServletRequest, "delete"), "delete",
+				"delete", "headless"));
 	}
 
 	public Map<String, Object> getToolbarReactData() throws PortalException {


### PR DESCRIPTION
Allow to copy object entry versions from the UI

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-59994)

One of the actions we want to be available is the copy action from the versions screen

# How am I fixing it?

Retrieve the actions and also show it in the interface

# How can you verify that it works?

* Go to the CMS and edit several times a content (or file)
* Click on the kebab and go to the versions view
* Click on the kebab of any version and click copy
* Go back to the main view, and a copy (with the same name) will be shown

# What's not included

* The label for (Copy) is in review by the BPM Team here: https://github.com/liferay-bpm/liferay-portal/pull/4806
* Navigation to the main view is still missing
