### PR TITLE
LPD-60148 NullPointerException in ObjectEntryModelResourcePermission because "objectEntryModelResourcePermissionLogic" is null (5th try)

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -171,6 +171,7 @@ public class ObjectEntryModelResourcePermission
 				_objectEntryModelResourcePermissionLogicSupplier.get();
 
 		if ((!actionId.equals(ActionKeys.VIEW) || objectEntry.isApproved()) &&
+			(objectEntryModelResourcePermissionLogic != null) &&
 			Objects.equals(
 				objectEntryModelResourcePermissionLogic.contains(
 					permissionChecker, objectDefinition.getClassName(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
@@ -1,0 +1,197 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.sharing.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.context.ContextUserReplace;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.security.permission.SharingPermissionChecker;
+import com.liferay.sharing.service.SharingEntryLocalService;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Marco Galluzzi
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_configurationTemporarySwapper = new ConfigurationTemporarySwapper(
+			"com.liferay.sharing.internal.configuration." +
+				"SharingSystemConfiguration",
+			HashMapDictionaryBuilder.<String, Object>put(
+				"enabled", false
+			).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_configurationTemporarySwapper.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_groupUser = UserTestUtil.addGroupUser(
+			_group, RoleConstants.POWER_USER);
+
+		_objectDefinition = _addObjectDefinition();
+
+		_modelResourcePermission =
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				_objectDefinition.getClassName());
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		_sharingPermissionCheckerServiceTracker = ServiceTrackerFactory.open(
+			bundle.getBundleContext(),
+			StringBundler.concat(
+				"(&(model.class.name=", _objectDefinition.getClassName(),
+				")(objectClass=", SharingPermissionChecker.class.getName(),
+				"))"));
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_sharingPermissionCheckerServiceTracker.close();
+	}
+
+	@Test
+	public void testUserWithViewSharingEntryActionCannotViewPrivateModel()
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry();
+
+		_addSharingEntry(objectEntry, _groupUser.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(_groupUser);
+
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, permissionChecker)) {
+
+			Assert.assertFalse(
+				_modelResourcePermission.contains(
+					permissionChecker, objectEntry, ActionKeys.VIEW));
+		}
+	}
+
+	private ObjectDefinition _addObjectDefinition() throws Exception {
+		return ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), "fieldName")),
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	private ObjectEntry _addObjectEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		return ObjectEntryLocalServiceUtil.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, Collections.emptyMap(), serviceContext);
+	}
+
+	private void _addSharingEntry(ObjectEntry objectEntry, long toUserId)
+		throws Exception {
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, toUserId,
+			_classNameLocalService.getClassNameId(
+				objectEntry.getModelClassName()),
+			objectEntry.getObjectEntryId(), _group.getGroupId(), true,
+			Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+	}
+
+	private static ConfigurationTemporarySwapper _configurationTemporarySwapper;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private User _groupUser;
+	private ModelResourcePermission<ObjectEntry> _modelResourcePermission;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
+
+	private ServiceTracker<SharingPermissionChecker, SharingPermissionChecker>
+		_sharingPermissionCheckerServiceTracker;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
@@ -76,7 +76,7 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 	}
 
 	@Test
-	public void testUserWithViewSharingEntryActionCannotViewPrivateModel()
+	public void testUserWithViewSharingEntryActionCannotViewObjectEntry()
 		throws Exception {
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/sharing/test/ObjectEntrySharingWhenSystemSharingIsDisabledTest.java
@@ -46,11 +46,8 @@ import com.liferay.sharing.service.SharingEntryLocalService;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,66 +70,57 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_configurationTemporarySwapper = new ConfigurationTemporarySwapper(
-			"com.liferay.sharing.internal.configuration." +
-				"SharingSystemConfiguration",
-			HashMapDictionaryBuilder.<String, Object>put(
-				"enabled", false
-			).build());
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		_configurationTemporarySwapper.close();
-	}
-
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
-
-		_groupUser = UserTestUtil.addGroupUser(
-			_group, RoleConstants.POWER_USER);
-
-		_objectDefinition = _addObjectDefinition();
-
-		_modelResourcePermission =
-			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
-				_objectDefinition.getClassName());
-
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
-
-		_sharingPermissionCheckerServiceTracker = ServiceTrackerFactory.open(
-			bundle.getBundleContext(),
-			StringBundler.concat(
-				"(&(model.class.name=", _objectDefinition.getClassName(),
-				")(objectClass=", SharingPermissionChecker.class.getName(),
-				"))"));
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		_sharingPermissionCheckerServiceTracker.close();
 	}
 
 	@Test
 	public void testUserWithViewSharingEntryActionCannotViewPrivateModel()
 		throws Exception {
 
-		ObjectEntry objectEntry = _addObjectEntry();
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.sharing.internal.configuration." +
+						"SharingSystemConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", false
+					).build())) {
 
-		_addSharingEntry(objectEntry, _groupUser.getUserId());
+			ObjectDefinition objectDefinition = _addObjectDefinition();
 
-		PermissionChecker permissionChecker =
-			PermissionCheckerFactoryUtil.create(_groupUser);
+			ModelResourcePermission<ObjectEntry> modelResourcePermission =
+				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+					objectDefinition.getClassName());
 
-		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
-				_groupUser, permissionChecker)) {
+			ServiceTracker<SharingPermissionChecker, SharingPermissionChecker>
+				sharingPermissionCheckerServiceTracker =
+					_getSharingPermissionCheckerServiceTracker(
+						objectDefinition.getClassName());
 
-			Assert.assertFalse(
-				_modelResourcePermission.contains(
-					permissionChecker, objectEntry, ActionKeys.VIEW));
+			try {
+				ObjectEntry objectEntry = _addObjectEntry(
+					objectDefinition.getObjectDefinitionId());
+
+				User user = UserTestUtil.addGroupUser(
+					_group, RoleConstants.POWER_USER);
+
+				_addSharingEntry(objectEntry, user.getUserId());
+
+				PermissionChecker permissionChecker =
+					PermissionCheckerFactoryUtil.create(user);
+
+				try (ContextUserReplace contextUserReplace =
+						new ContextUserReplace(user, permissionChecker)) {
+
+					Assert.assertFalse(
+						modelResourcePermission.contains(
+							permissionChecker, objectEntry, ActionKeys.VIEW));
+				}
+			}
+			finally {
+				sharingPermissionCheckerServiceTracker.close();
+			}
 		}
 	}
 
@@ -146,7 +134,9 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 			ObjectDefinitionConstants.SCOPE_SITE);
 	}
 
-	private ObjectEntry _addObjectEntry() throws Exception {
+	private ObjectEntry _addObjectEntry(long objectDefinitionId)
+		throws Exception {
+
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
@@ -156,7 +146,7 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 
 		return ObjectEntryLocalServiceUtil.addObjectEntry(
 			_group.getGroupId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(),
+			objectDefinitionId,
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null, Collections.emptyMap(), serviceContext);
 	}
@@ -174,7 +164,19 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 				_group, TestPropsValues.getUserId()));
 	}
 
-	private static ConfigurationTemporarySwapper _configurationTemporarySwapper;
+	private ServiceTracker<SharingPermissionChecker, SharingPermissionChecker>
+		_getSharingPermissionCheckerServiceTracker(
+			String objectDefinitionClassName) {
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		return ServiceTrackerFactory.open(
+			bundle.getBundleContext(),
+			StringBundler.concat(
+				"(&(model.class.name=", objectDefinitionClassName,
+				")(objectClass=", SharingPermissionChecker.class.getName(),
+				"))"));
+	}
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
@@ -182,16 +184,7 @@ public class ObjectEntrySharingWhenSystemSharingIsDisabledTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
-	private User _groupUser;
-	private ModelResourcePermission<ObjectEntry> _modelResourcePermission;
-
-	@DeleteAfterTestRun
-	private ObjectDefinition _objectDefinition;
-
 	@Inject
 	private SharingEntryLocalService _sharingEntryLocalService;
-
-	private ServiceTracker<SharingPermissionChecker, SharingPermissionChecker>
-		_sharingPermissionCheckerServiceTracker;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

:exclamation:  This is a FOLLOW UP of https://github.com/liferay-content-management/liferay-portal/pull/6837 and https://github.com/liferay-content-management/liferay-portal/pull/6844 and https://github.com/liferay-content-management/liferay-portal/pull/6850 and https://github.com/liferay-content-management/liferay-portal/pull/6859

https://liferay.atlassian.net/browse/LPD-60148

Avoiding a potential null pointer exception in `ObjectEntryModelResourcePermission`

:warning:  NOTE: the test has been created in a new class `ObjectEntrySharingWhenSystemSharingIsDisabledTest` because when disabling System Sharing in only one test in existing class `ObjectEntrySharingTest` we have errors like this: `java.lang.IllegalStateException: The service has been unregistered`.

# How am I fixing it?

Checking for null

# How can you verify that it works?

Run integration test:

* `cd modules/apps/object/object-test`
* `gw tI --tests ObjectEntrySharingWhenSystemSharingIsDisabledTest`

