### PR TITLE
LPD-60519 Add vertical ellipsis to Spaces section

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
@@ -159,7 +159,7 @@
 							{
 								"definition": {
 									"fragment": {
-										"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.SpaceStickerComponentSectionFragmentRenderer"
+										"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.BreadcrumbComponentSectionFragmentRenderer"
 									},
 									"fragmentConfig": {
 									},

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+/**
+ * @author Marco Galluzzi
+ */
+public class BreadcrumbDisplayContext {
+
+	public BreadcrumbDisplayContext(
+		long groupId, GroupLocalService groupLocalService,
+		HttpServletRequest httpServletRequest, String size) {
+
+		_groupId = groupId;
+		_groupLocalService = groupLocalService;
+		_size = GetterUtil.get(size, CMSSpaceConstants.SPACE_STICKER_LG);
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public Map<String, Object> getProps() throws Exception {
+		Group group = _groupLocalService.getGroup(_groupId);
+
+		return HashMapBuilder.<String, Object>put(
+			"breadcrumbItems",
+			JSONUtil.put(
+				JSONUtil.put(
+					"active", false
+				).put(
+					"href", StringPool.BLANK
+				).put(
+					"label", group.getDescriptiveName(_themeDisplay.getLocale())
+				))
+		).put(
+			"displayType",
+			() -> {
+				UnicodeProperties unicodeProperties =
+					group.getTypeSettingsProperties();
+
+				return GetterUtil.get(
+					unicodeProperties.get("logoColor"), "outline-0");
+			}
+		).put(
+			"size", _size
+		).build();
+	}
+
+	private final long _groupId;
+	private final GroupLocalService _groupLocalService;
+	private final String _size;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -45,7 +45,7 @@ public class BreadcrumbDisplayContext {
 
 		return HashMapBuilder.<String, Object>put(
 			"actionItems",
-			JSONUtil.put(
+			JSONUtil.putAll(
 				JSONUtil.put(
 					"href",
 					ActionUtil.getSpaceSettingsURL(
@@ -56,6 +56,17 @@ public class BreadcrumbDisplayContext {
 					LanguageUtil.get(_httpServletRequest, "space-settings")
 				).put(
 					"symbolLeft", "cog"
+				),
+				JSONUtil.put(
+					"label",
+					LanguageUtil.get(_httpServletRequest, "permissions")
+				).put(
+					"symbolLeft", "password-policies"
+				),
+				JSONUtil.put(
+					"label", LanguageUtil.get(_httpServletRequest, "delete")
+				).put(
+					"symbolLeft", "trash"
 				))
 		).put(
 			"breadcrumbItems",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -31,6 +33,7 @@ public class BreadcrumbDisplayContext {
 
 		_groupId = groupId;
 		_groupLocalService = groupLocalService;
+		_httpServletRequest = httpServletRequest;
 		_size = GetterUtil.get(size, CMSSpaceConstants.SPACE_STICKER_LG);
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -41,6 +44,20 @@ public class BreadcrumbDisplayContext {
 		Group group = _groupLocalService.getGroup(_groupId);
 
 		return HashMapBuilder.<String, Object>put(
+			"actionItems",
+			JSONUtil.put(
+				JSONUtil.put(
+					"href",
+					ActionUtil.getSpaceSettingsURL(
+						group.getClassPK(), _themeDisplay.getURLCurrent(),
+						_themeDisplay)
+				).put(
+					"label",
+					LanguageUtil.get(_httpServletRequest, "space-settings")
+				).put(
+					"symbolLeft", "cog"
+				))
+		).put(
 			"breadcrumbItems",
 			JSONUtil.put(
 				JSONUtil.put(
@@ -66,6 +83,7 @@ public class BreadcrumbDisplayContext {
 
 	private final long _groupId;
 	private final GroupLocalService _groupLocalService;
+	private final HttpServletRequest _httpServletRequest;
 	private final String _size;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.portlet.ActionRequest;
 
@@ -117,10 +118,8 @@ public class ViewAllSpacesDisplayContext {
 				"unpin", "unpin", "headless"),
 			new FDSActionDropdownItem(
 				StringBundler.concat(
-					_themeDisplay.getPathFriendlyURLPublic(),
-					GroupConstants.CMS_FRIENDLY_URL, "/e/space-settings/",
-					_portal.getClassNameId(DepotEntry.class), "/{id}?redirect=",
-					_themeDisplay.getURLCurrent()),
+					ActionUtil.getBaseSpaceSettingsURL(_themeDisplay),
+					"{id}?redirect=", _themeDisplay.getURLCurrent()),
 				"cog", "edit",
 				LanguageUtil.get(_httpServletRequest, "space-settings"), "get",
 				"update", null),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -100,6 +101,17 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 
 		return HashMapBuilder.<String, Object>put(
 			"breadcrumbItems", jsonArray
+		).put(
+			"displayType",
+			() -> {
+				UnicodeProperties unicodeProperties =
+					group.getTypeSettingsProperties();
+
+				return GetterUtil.get(
+					unicodeProperties.get("logoColor"), "outline-0");
+			}
+		).put(
+			"size", "sm"
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/BreadcrumbComponentSectionFragmentRenderer.java
@@ -9,7 +9,7 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
-import com.liferay.site.cms.site.initializer.internal.display.context.SpaceStickerDisplayContext;
+import com.liferay.site.cms.site.initializer.internal.display.context.BreadcrumbDisplayContext;
 import com.liferay.site.cms.site.initializer.internal.util.InfoItemUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Roberto Díaz
  */
 @Component(service = FragmentRenderer.class)
-public class SpaceStickerComponentSectionFragmentRenderer
+public class BreadcrumbComponentSectionFragmentRenderer
 	extends BaseComponentSectionFragmentRenderer {
 
 	@Override
@@ -33,12 +33,12 @@ public class SpaceStickerComponentSectionFragmentRenderer
 
 	@Override
 	protected String getLabelKey() {
-		return "space-sticker";
+		return "breadcrumb";
 	}
 
 	@Override
 	protected String getModuleName() {
-		return "SpaceSticker";
+		return "Breadcrumb";
 	}
 
 	@Override
@@ -47,12 +47,12 @@ public class SpaceStickerComponentSectionFragmentRenderer
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		SpaceStickerDisplayContext spaceStickerDisplayContext =
-			new SpaceStickerDisplayContext(
+		BreadcrumbDisplayContext breadcrumbDisplayContext =
+			new BreadcrumbDisplayContext(
 				InfoItemUtil.getGroupId(httpServletRequest), _groupLocalService,
 				httpServletRequest, CMSSpaceConstants.SPACE_STICKER_LG);
 
-		return spaceStickerDisplayContext.getProps();
+		return breadcrumbDisplayContext.getProps();
 	}
 
 	@Reference

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -184,6 +184,13 @@ public class ActionUtil {
 			GroupConstants.CMS_FRIENDLY_URL, "/add-space-members");
 	}
 
+	public static String getBaseSpaceSettingsURL(ThemeDisplay themeDisplay) {
+		return StringBundler.concat(
+			themeDisplay.getPathFriendlyURLPublic(),
+			GroupConstants.CMS_FRIENDLY_URL, "/e/space-settings/",
+			PortalUtil.getClassNameId(DepotEntry.class), StringPool.SLASH);
+	}
+
 	public static String getBaseSpaceURL(ThemeDisplay themeDisplay) {
 		return StringBundler.concat(
 			themeDisplay.getPathFriendlyURLPublic(),
@@ -295,6 +302,18 @@ public class ActionUtil {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	public static String getSpaceSettingsURL(
+		long classPK, String redirectURL, ThemeDisplay themeDisplay) {
+
+		String url = getBaseSpaceSettingsURL(themeDisplay) + classPK;
+
+		if (Validator.isNotNull(redirectURL)) {
+			return url + "?redirect=" + redirectURL;
+		}
+
+		return url;
 	}
 
 	public static String getSpaceURL(long classPK, ThemeDisplay themeDisplay) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
@@ -7,6 +7,7 @@ import ClayBreadcrumb from '@clayui/breadcrumb';
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import Nav from '@clayui/nav';
+import ClaySticker from '@clayui/sticker';
 import React, {ComponentProps} from 'react';
 
 import SpaceSticker from './SpaceSticker';
@@ -27,8 +28,11 @@ export interface BreadcrumbItem {
 export default function Breadcrumb({
 	actionItems,
 	breadcrumbItems,
+	displayType,
 	hideSpace,
-}: Props) {
+	size,
+}: Props &
+	Pick<React.ComponentProps<typeof ClaySticker>, 'displayType' | 'size'>) {
 	return (
 		<Nav
 			aria-label={Liferay.Language.get('breadcrumb')}
@@ -37,9 +41,10 @@ export default function Breadcrumb({
 			{!hideSpace && (
 				<div className="autofit-col mr-1">
 					<SpaceSticker
+						displayType={displayType}
 						hideName
 						name={breadcrumbItems[0]?.label}
-						size="sm"
+						size={size}
 					/>
 				</div>
 			)}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
@@ -12,7 +12,11 @@ import React, {ComponentProps} from 'react';
 
 import SpaceSticker from './SpaceSticker';
 
-interface Props {
+interface Props
+	extends Pick<
+		React.ComponentProps<typeof ClaySticker>,
+		'displayType' | 'size'
+	> {
 	actionItems?: ComponentProps<typeof ClayDropDownWithItems>['items'];
 	breadcrumbItems: BreadcrumbItem[];
 	hideSpace?: boolean;
@@ -31,8 +35,7 @@ export default function Breadcrumb({
 	displayType,
 	hideSpace,
 	size,
-}: Props &
-	Pick<React.ComponentProps<typeof ClaySticker>, 'displayType' | 'size'>) {
+}: Props) {
 	return (
 		<Nav
 			aria-label={Liferay.Language.get('breadcrumb')}

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/Breadcrumb.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/Breadcrumb.test.tsx
@@ -4,7 +4,8 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import Breadcrumb, {
@@ -128,5 +129,22 @@ describe('Breadcrumb', () => {
 		expect(container.getElementsByClassName('sticker')[0]).toHaveClass(
 			'sticker-lg'
 		);
+	});
+
+	it('renders the provided action item', async () => {
+		render(
+			<Breadcrumb
+				actionItems={[{label: 'Space Settings', symbolLeft: 'cog'}]}
+				breadcrumbItems={testBreadcrumbItemsSingle}
+			/>
+		);
+
+		userEvent.click(screen.getByLabelText('more-actions'));
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('menuitem', {name: 'Space Settings'})
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/components/Breadcrumb.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/components/Breadcrumb.test.tsx
@@ -11,24 +11,6 @@ import Breadcrumb, {
 	BreadcrumbItem,
 } from '../../../../src/main/resources/META-INF/resources/js/common/components/Breadcrumb';
 
-const testBreadcrumbItemsShort = [
-	{
-		active: false,
-		href: 'http://www.liferay.com/e/space/123/001',
-		label: 'My Space',
-	},
-	{
-		active: false,
-		href: 'http://localhost:8080/e/view-folder/123/001',
-		label: 'My Folder 1',
-	},
-	{
-		active: true,
-		href: 'http://localhost:8080/e/view-folder/123/002',
-		label: 'My Folder 2',
-	},
-];
-
 const testBreadcrumbItemsLong = [
 	{
 		active: false,
@@ -49,6 +31,32 @@ const testBreadcrumbItemsLong = [
 		active: true,
 		href: 'http://localhost:8080/e/view-folder/123/003',
 		label: 'My Folder 3',
+	},
+];
+
+const testBreadcrumbItemsShort = [
+	{
+		active: false,
+		href: 'http://www.liferay.com/e/space/123/001',
+		label: 'My Space',
+	},
+	{
+		active: false,
+		href: 'http://localhost:8080/e/view-folder/123/001',
+		label: 'My Folder 1',
+	},
+	{
+		active: true,
+		href: 'http://localhost:8080/e/view-folder/123/002',
+		label: 'My Folder 2',
+	},
+];
+
+const testBreadcrumbItemsSingle = [
+	{
+		active: false,
+		href: 'http://www.liferay.com/e/space/123/001',
+		label: 'My Space',
 	},
 ];
 
@@ -79,7 +87,7 @@ function expectBreadcrumbItemSticker(breadcrumbItem: BreadcrumbItem) {
 	).toHaveClass('sticker-overlay');
 }
 
-describe('FolderBreadcrumb', () => {
+describe('Breadcrumb', () => {
 	it('renders all elements of a short breadcrumb', () => {
 		render(<Breadcrumb breadcrumbItems={testBreadcrumbItemsShort} />);
 
@@ -100,5 +108,25 @@ describe('FolderBreadcrumb', () => {
 
 		expectBreadcrumbItem(testBreadcrumbItemsLong[2]);
 		expectBreadcrumbItem(testBreadcrumbItemsLong[3], true);
+	});
+
+	it('applies the provided props to the SpaceSticker', () => {
+		const {container} = render(
+			<Breadcrumb
+				breadcrumbItems={testBreadcrumbItemsSingle}
+				displayType="outline-7"
+				size="lg"
+			/>
+		);
+
+		expectBreadcrumbItemSticker(testBreadcrumbItemsSingle[0]);
+
+		expect(container.getElementsByClassName('sticker')[0]).toHaveClass(
+			'sticker-outline-7'
+		);
+
+		expect(container.getElementsByClassName('sticker')[0]).toHaveClass(
+			'sticker-lg'
+		);
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-60519

There should be a vertical ellipsis that appears next to the name of the Space when a user navigates to the Spaces section. Once clicked, it should display the following options:

* Space Settings -> IT WORKS
* Permissions -> Not working (it will be done in another issue [LPD-61208](https://liferay.atlassian.net/browse/LPD-61208))
* Delete -> Not working (it will be done in another issue  [LPD-61208](https://liferay.atlassian.net/browse/LPD-61208))

# How am I fixing it?

Using Breadcrumb component instead of SpaceSticker

# How can you verify that it works?

Manual navigation to a Space section or run unit tests:

* `cd modules/apps/site/site-cms-site-initializer`
* `npm run test Breadcrumb`