### PR TITLE
LPD-61200 "Select From List" field (multiple selections) sorting not working in API when Order Options Alphabetically is active

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -58,7 +58,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.SortedMap;
 import java.util.TimeZone;
+import java.util.TreeMap;
 
 /**
  * @author Javier Gamarra
@@ -415,6 +417,11 @@ public class ContentFieldUtil {
 
 				List<String> values = new ArrayList<>();
 
+				boolean alphabeticalOrder = GetterUtil.getBoolean(
+					ddmFormField.getProperty("alphabeticalOrder"));
+
+				SortedMap<String, String> sortedMap = new TreeMap<>();
+
 				List<String> list = TransformUtil.transform(
 					JSONUtil.toStringList(
 						JSONFactoryUtil.createJSONArray(valueString)),
@@ -422,10 +429,18 @@ public class ContentFieldUtil {
 						LocalizedValue localizedValue =
 							ddmFormFieldOptions.getOptionLabels(value);
 
-						values.add(
-							ddmFormFieldOptions.getOptionReference(value));
+						String optionReference =
+							ddmFormFieldOptions.getOptionReference(value);
 
-						return localizedValue.getString(locale);
+						values.add(optionReference);
+
+						String displayName = localizedValue.getString(locale);
+
+						if (alphabeticalOrder) {
+							sortedMap.put(displayName, optionReference);
+						}
+
+						return displayName;
 					});
 
 				return new ContentFieldValue() {
@@ -438,6 +453,12 @@ public class ContentFieldUtil {
 									return list.get(0);
 								}
 
+								if (alphabeticalOrder) {
+									return String.valueOf(
+										JSONFactoryUtil.createJSONArray(
+											sortedMap.keySet()));
+								}
+
 								return String.valueOf(
 									JSONFactoryUtil.createJSONArray(list));
 							});
@@ -447,6 +468,12 @@ public class ContentFieldUtil {
 									(values.size() == 1)) {
 
 									return values.get(0);
+								}
+
+								if (alphabeticalOrder) {
+									return String.valueOf(
+										JSONFactoryUtil.createJSONArray(
+											sortedMap.values()));
 								}
 
 								return String.valueOf(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -36,7 +36,9 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -412,72 +414,42 @@ public class ContentFieldUtil {
 						 ddmFormField.getType(),
 						 DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE)) {
 
-				DDMFormFieldOptions ddmFormFieldOptions =
-					ddmFormField.getDDMFormFieldOptions();
+				ObjectValuePair<List<String>, List<String>> objectValuePair =
+					_getDisplayNamesOptionReferencesObjectValuePair(
+						GetterUtil.getBoolean(
+							ddmFormField.getProperty("alphabeticalOrder")),
+						ddmFormField.getDDMFormFieldOptions(), locale,
+						JSONUtil.toStringList(
+							JSONFactoryUtil.createJSONArray(valueString)));
 
-				List<String> values = new ArrayList<>();
-
-				boolean alphabeticalOrder = GetterUtil.getBoolean(
-					ddmFormField.getProperty("alphabeticalOrder"));
-
-				SortedMap<String, String> sortedMap = new TreeMap<>();
-
-				List<String> list = TransformUtil.transform(
-					JSONUtil.toStringList(
-						JSONFactoryUtil.createJSONArray(valueString)),
-					value -> {
-						LocalizedValue localizedValue =
-							ddmFormFieldOptions.getOptionLabels(value);
-
-						String optionReference =
-							ddmFormFieldOptions.getOptionReference(value);
-
-						values.add(optionReference);
-
-						String displayName = localizedValue.getString(locale);
-
-						if (alphabeticalOrder) {
-							sortedMap.put(displayName, optionReference);
-						}
-
-						return displayName;
-					});
+				List<String> displayNames = objectValuePair.getKey();
+				List<String> optionReferences = objectValuePair.getValue();
 
 				return new ContentFieldValue() {
 					{
 						setData(
 							() -> {
 								if (!ddmFormField.isMultiple() &&
-									(list.size() == 1)) {
+									(displayNames.size() == 1)) {
 
-									return list.get(0);
-								}
-
-								if (alphabeticalOrder) {
-									return String.valueOf(
-										JSONFactoryUtil.createJSONArray(
-											sortedMap.keySet()));
+									return displayNames.get(0);
 								}
 
 								return String.valueOf(
-									JSONFactoryUtil.createJSONArray(list));
+									JSONFactoryUtil.createJSONArray(
+										displayNames));
 							});
 						setValue(
 							() -> {
 								if (!ddmFormField.isMultiple() &&
-									(values.size() == 1)) {
+									(optionReferences.size() == 1)) {
 
-									return values.get(0);
-								}
-
-								if (alphabeticalOrder) {
-									return String.valueOf(
-										JSONFactoryUtil.createJSONArray(
-											sortedMap.values()));
+									return optionReferences.get(0);
 								}
 
 								return String.valueOf(
-									JSONFactoryUtil.createJSONArray(values));
+									JSONFactoryUtil.createJSONArray(
+										optionReferences));
 							});
 					}
 				};
@@ -521,6 +493,45 @@ public class ContentFieldUtil {
 
 			return new ContentFieldValue();
 		}
+	}
+
+	private static ObjectValuePair<List<String>, List<String>>
+		_getDisplayNamesOptionReferencesObjectValuePair(
+			boolean alphabeticalOrder, DDMFormFieldOptions ddmFormFieldOptions,
+			Locale locale, List<String> values) {
+
+		if (alphabeticalOrder) {
+			SortedMap<String, String> sortedMap = new TreeMap<>();
+
+			for (String value : values) {
+				LocalizedValue localizedValue =
+					ddmFormFieldOptions.getOptionLabels(value);
+
+				sortedMap.put(
+					localizedValue.getString(locale),
+					ddmFormFieldOptions.getOptionReference(value));
+			}
+
+			return new ObjectValuePair(
+				ListUtil.fromCollection(sortedMap.keySet()),
+				ListUtil.fromCollection(sortedMap.values()));
+		}
+
+		List<String> optionReferences = new ArrayList<>();
+
+		List<String> displayNames = TransformUtil.transform(
+			values,
+			value -> {
+				optionReferences.add(
+					ddmFormFieldOptions.getOptionReference(value));
+
+				LocalizedValue localizedValue =
+					ddmFormFieldOptions.getOptionLabels(value);
+
+				return localizedValue.getString(locale);
+			});
+
+		return new ObjectValuePair<>(displayNames, optionReferences);
 	}
 
 	private static FileEntry _getFileEntry(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/StructuredContentDTOConverterTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/StructuredContentDTOConverterTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.delivery.internal.dto.v1_0.converter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.data.engine.rest.test.util.DataDefinitionTestUtil;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
+import com.liferay.headless.delivery.dto.v1_0.ContentField;
+import com.liferay.headless.delivery.dto.v1_0.ContentFieldValue;
+import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+import java.io.InputStream;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class StructuredContentDTOConverterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testToDTO() throws Exception {
+		String xml = _read("test-data-definition-select-from-list.json");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(xml);
+
+		DataDefinition dataDefinition =
+			DataDefinitionTestUtil.addDataDefinition(
+				"journal", _dataDefinitionResourceFactory, _group.getGroupId(),
+				jsonObject.toString(), TestPropsValues.getUser());
+
+		DDMStructure ddmStructure =
+			DDMStructureLocalServiceUtil.getDDMStructure(
+				dataDefinition.getId());
+
+		JournalArticle journalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0,
+				_read("test-journal-article-select-from-list.xml"),
+				ddmStructure.getStructureKey(), null, LocaleUtil.US, null,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getCompanyId(), _group.getGroupId(),
+					TestPropsValues.getUserId()));
+
+		StructuredContent structuredContent = _toDTO(journalArticle);
+
+		ContentField[] contentFields = structuredContent.getContentFields();
+
+		Assert.assertEquals(
+			Arrays.toString(contentFields), 1, contentFields.length);
+
+		ContentField contentField = contentFields[0];
+
+		ContentFieldValue contentFieldValue =
+			contentField.getContentFieldValue();
+
+		Assert.assertEquals(
+			"[\"one\",\"three\",\"two\"]", contentFieldValue.getData());
+	}
+
+	private String _read(String fileName) throws Exception {
+		Class<?> clazz = getClass();
+
+		InputStream inputStream = clazz.getResourceAsStream(
+			"dependencies/" + fileName);
+
+		return StringUtil.read(inputStream);
+	}
+
+	private StructuredContent _toDTO(JournalArticle journalArticle)
+		throws Exception {
+
+		DTOConverter<JournalArticle, StructuredContent> dtoConverter =
+			(DTOConverter<JournalArticle, StructuredContent>)
+				_dtoConverterRegistry.getDTOConverter(
+					JournalArticle.class.getName());
+
+		DefaultDTOConverterContext dtoConverterContext =
+			new DefaultDTOConverterContext(
+				_dtoConverterRegistry, journalArticle.getResourcePrimKey(),
+				LocaleUtil.getDefault(), null, null);
+
+		return dtoConverter.toDTO(dtoConverterContext, journalArticle);
+	}
+
+	@Inject
+	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	@Inject
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	private Group _group;
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/StructuredContentDTOConverterTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/StructuredContentDTOConverterTest.java
@@ -21,6 +21,7 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -65,7 +66,33 @@ public class StructuredContentDTOConverterTest {
 
 	@Test
 	public void testToDTO() throws Exception {
-		String xml = _read("test-data-definition-select-from-list.json");
+		_testSelectedFromList(
+			Boolean.FALSE.toString(), "[\"one\",\"two\",\"three\"]");
+
+		_testSelectedFromList(
+			Boolean.TRUE.toString(), "[\"one\",\"three\",\"two\"]");
+	}
+
+	private String _read(String fileName) throws Exception {
+		Class<?> clazz = getClass();
+
+		InputStream inputStream = clazz.getResourceAsStream(
+			"dependencies/" + fileName);
+
+		return StringUtil.read(inputStream);
+	}
+
+	private void _testSelectedFromList(
+			String alphabeticalOrder, String expectedData)
+		throws Exception {
+
+		int nextInt = RandomUtil.nextInt(5);
+
+		String xml = StringUtil.replace(
+			StringUtil.replace(
+				_read("test-data-definition-select-from-list.json"),
+				"[$ALPHABETICAL_ORDER$]", alphabeticalOrder),
+			"[$RANDOM_INT$]", String.valueOf(nextInt));
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(xml);
 
@@ -82,7 +109,9 @@ public class StructuredContentDTOConverterTest {
 			JournalTestUtil.addArticleWithXMLContent(
 				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0,
-				_read("test-journal-article-select-from-list.xml"),
+				StringUtil.replace(
+					_read("test-journal-article-select-from-list.xml"),
+					"[$RANDOM_INT$]", String.valueOf(nextInt)),
 				ddmStructure.getStructureKey(), null, LocaleUtil.US, null,
 				ServiceContextTestUtil.getServiceContext(
 					_group.getCompanyId(), _group.getGroupId(),
@@ -100,17 +129,7 @@ public class StructuredContentDTOConverterTest {
 		ContentFieldValue contentFieldValue =
 			contentField.getContentFieldValue();
 
-		Assert.assertEquals(
-			"[\"one\",\"three\",\"two\"]", contentFieldValue.getData());
-	}
-
-	private String _read(String fileName) throws Exception {
-		Class<?> clazz = getClass();
-
-		InputStream inputStream = clazz.getResourceAsStream(
-			"dependencies/" + fileName);
-
-		return StringUtil.read(inputStream);
+		Assert.assertEquals(expectedData, contentFieldValue.getData());
 	}
 
 	private StructuredContent _toDTO(JournalArticle journalArticle)

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-data-definition-select-from-list.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-data-definition-select-from-list.json
@@ -1,0 +1,113 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"alphabeticalOrder": true,
+				"dataSourceType": [
+					"manual"
+				],
+				"dataType": "string",
+				"ddmDataProviderInstanceId": [
+				],
+				"ddmDataProviderInstanceOutput": [
+				],
+				"fieldNamespace": "",
+				"fieldReference": "Select49882440",
+				"labelAtStructureLevel": true,
+				"multiple": true,
+				"nativeField": false,
+				"objectFieldName": "",
+				"options": {
+					"en_US": [
+						{
+							"label": "one",
+							"reference": "Option26076936",
+							"value": "Option26076936"
+						},
+						{
+							"label": "two",
+							"reference": "Option91018188",
+							"value": "Option91018188"
+						},
+						{
+							"label": "three",
+							"reference": "Option53387445",
+							"value": "Option53387445"
+						}
+					]
+				},
+				"requiredErrorMessage": {
+					"en_US": ""
+				},
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": [
+				]
+			},
+			"fieldType": "select",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Select from List"
+			},
+			"localizable": true,
+			"name": "Select49882440",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"dataDefinitionKey": "35731",
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Select49882440"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "test"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "test"
+	},
+	"storageType": "default"
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-data-definition-select-from-list.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-data-definition-select-from-list.json
@@ -6,7 +6,7 @@
 	"dataDefinitionFields": [
 		{
 			"customProperties": {
-				"alphabeticalOrder": true,
+				"alphabeticalOrder": "[$ALPHABETICAL_ORDER$]",
 				"dataSourceType": [
 					"manual"
 				],
@@ -16,7 +16,7 @@
 				"ddmDataProviderInstanceOutput": [
 				],
 				"fieldNamespace": "",
-				"fieldReference": "Select49882440",
+				"fieldReference": "Select[$RANDOM_INT$]0",
 				"labelAtStructureLevel": true,
 				"multiple": true,
 				"nativeField": false,
@@ -25,18 +25,18 @@
 					"en_US": [
 						{
 							"label": "one",
-							"reference": "Option26076936",
-							"value": "Option26076936"
+							"reference": "Option[$RANDOM_INT$]1",
+							"value": "Option[$RANDOM_INT$]1"
 						},
 						{
 							"label": "two",
-							"reference": "Option91018188",
-							"value": "Option91018188"
+							"reference": "Option[$RANDOM_INT$]2",
+							"value": "Option[$RANDOM_INT$]2"
 						},
 						{
 							"label": "three",
-							"reference": "Option53387445",
-							"value": "Option53387445"
+							"reference": "Option[$RANDOM_INT$]3",
+							"value": "Option[$RANDOM_INT$]3"
 						}
 					]
 				},
@@ -56,7 +56,7 @@
 				"en_US": "Select from List"
 			},
 			"localizable": true,
-			"name": "Select49882440",
+			"name": "Select[$RANDOM_INT$]0",
 			"nestedDataDefinitionFields": [
 			],
 			"readOnly": false,
@@ -68,7 +68,7 @@
 			}
 		}
 	],
-	"dataDefinitionKey": "35731",
+	"dataDefinitionKey": "[$RANDOM_INT$]",
 	"defaultDataLayout": {
 		"dataLayoutFields": {
 		},
@@ -80,7 +80,7 @@
 							{
 								"columnSize": 12,
 								"fieldNames": [
-									"Select49882440"
+									"Select[$RANDOM_INT$]0"
 								]
 							}
 						]

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-journal-article-select-from-list.xml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-journal-article-select-from-list.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="Select49882440" index-type="keyword" instance-id="jq6xk2iy" name="Select49882440" type="select">
+		<dynamic-content language-id="en_US">
+			<option><![CDATA[Option26076936]]></option>
+			<option><![CDATA[Option91018188]]></option>
+			<option><![CDATA[Option53387445]]></option>
+		</dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-journal-article-select-from-list.xml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/internal/dto/v1_0/converter/test/dependencies/test-journal-article-select-from-list.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 
 <root available-locales="en_US" default-locale="en_US" version="1.0">
-	<dynamic-element field-reference="Select49882440" index-type="keyword" instance-id="jq6xk2iy" name="Select49882440" type="select">
+	<dynamic-element field-reference="Select[$RANDOM_INT$]0" index-type="keyword" instance-id="jq6xk[$RANDOM_INT$]iy" name="Select[$RANDOM_INT$]0" type="select">
 		<dynamic-content language-id="en_US">
-			<option><![CDATA[Option26076936]]></option>
-			<option><![CDATA[Option91018188]]></option>
-			<option><![CDATA[Option53387445]]></option>
+			<option><![CDATA[Option[$RANDOM_INT$]1]]></option>
+			<option><![CDATA[Option[$RANDOM_INT$]2]]></option>
+			<option><![CDATA[Option[$RANDOM_INT$]3]]></option>
 		</dynamic-content>
 	</dynamic-element>
 </root>


### PR DESCRIPTION
LPD-61200 "Select From List" field (multiple selections) sorting not working in API when Order Options Alphabetically is active

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61200

Is the option on the multiple selector list "alphabeticalOrder" is active, then order th elements on the return of the API

# How am I fixing it?

Ordering the elements when processed if the option is active


# How can you verify that it works?

Run the included automated tests.



# Commits

- **LPD-61200 return sorted values in case that alphabeticalOrder is active**
- **LPD-61200 add test to check that if on alphabetical order, the returned data comes sorted**
- **LPD-61200 check ordered and not. if we want to test both behaviours we should generate different elements**
