### PR TITLE
LPD-61277 Accept CMS group ID as a valid site ID

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -81,7 +81,7 @@ public class GroupUtil {
 	private static boolean _checkGroup(Group group) {
 		if ((group != null) &&
 			(_isDepotOrSite(group) || _isDepotOrSite(group.getLiveGroup()) ||
-			 group.isUserGroup())) {
+			 group.isCMS() || group.isUserGroup())) {
 
 			return true;
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -25,6 +26,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.GroupUtil;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -110,6 +112,17 @@ public class GroupUtilTest {
 				_userGroupLocalService.deleteUserGroup(userGroup);
 			}
 		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testGetGroupIdWithFF() throws Exception {
+		Group group = _groupLocalService.fetchGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		Assume.assumeNotNull(group);
+
+		_testGetGroupId(group);
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61277

Accept the CMS group ID as a valid site ID so that the regular headless endpoints can be used with the CMS.

# How am I fixing it?

By explicitly allowing the CMS group when checking the parameter.

# How can you verify that it works?

Run the included integration test.