### PR TITLE
LPD-61325 Exception when enabling staging for Asset Libraries

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -9,22 +9,15 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-
-import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -42,37 +35,6 @@ public class GroupModelListenerTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@FeatureFlag("LPD-17564")
-	@Test
-	public void testAddDepotEntry() throws Exception {
-		_depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), StringUtil.randomString()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			2,
-			_objectEntryFolderLocalService.getObjectEntryFoldersCount(
-				_depotEntry.getGroupId(), _depotEntry.getCompanyId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
-
-		AssertUtils.assertEquals(
-			Arrays.asList("Contents", "Files"),
-			ListUtil.sort(
-				ListUtil.toList(
-					_objectEntryFolderLocalService.getObjectEntryFolders(
-						_depotEntry.getGroupId(), _depotEntry.getCompanyId(),
-						ObjectEntryFolderConstants.
-							PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-					ObjectEntryFolder::getName)));
-	}
 
 	@FeatureFlag("LPD-17564")
 	@Test
@@ -95,9 +57,6 @@ public class GroupModelListenerTest {
 				ObjectEntryFolderConstants.
 					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
 	}
-
-	@DeleteAfterTestRun
-	private DepotEntry _depotEntry;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/DepotEntryLocalServiceTest.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class DepotEntryLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testAddDepotEntry() throws Exception {
+		_testAddDepotEntry();
+		_testAddDepotEntryEnablingStaging();
+	}
+
+	private void _assertObjectEntryFolders(DepotEntry depotEntry) {
+		Assert.assertEquals(
+			2,
+			_objectEntryFolderLocalService.getObjectEntryFoldersCount(
+				depotEntry.getGroupId(), depotEntry.getCompanyId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT));
+
+		AssertUtils.assertEquals(
+			Arrays.asList("Contents", "Files"),
+			ListUtil.sort(
+				ListUtil.toList(
+					_objectEntryFolderLocalService.getObjectEntryFolders(
+						depotEntry.getGroupId(), depotEntry.getCompanyId(),
+						ObjectEntryFolderConstants.
+							PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					ObjectEntryFolder::getName)));
+	}
+
+	private Group _getGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		group.setType(GroupConstants.TYPE_DEPOT);
+
+		return _groupLocalService.updateGroup(group);
+	}
+
+	private void _testAddDepotEntry() throws Exception {
+		_assertObjectEntryFolders(
+			_depotEntryLocalService.addDepotEntry(
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), StringUtil.randomString()
+				).build(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), StringUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext()));
+	}
+
+	private void _testAddDepotEntryEnablingStaging() throws Exception {
+		_group = _getGroup();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute("staging", Boolean.TRUE);
+
+		_assertObjectEntryFolders(
+			_depotEntryLocalService.addDepotEntry(_group, serviceContext));
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
@@ -15,9 +15,6 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -29,18 +26,6 @@ import org.osgi.service.component.annotations.Reference;
 public class DepotEntryModelListener extends BaseModelListener<DepotEntry> {
 
 	@Override
-	public void onAfterCreate(DepotEntry depotEntry)
-		throws ModelListenerException {
-
-		try {
-			_onAfterCreate(depotEntry);
-		}
-		catch (Exception exception) {
-			throw new ModelListenerException(exception);
-		}
-	}
-
-	@Override
 	public void onBeforeRemove(DepotEntry depotEntry)
 		throws ModelListenerException {
 
@@ -50,35 +35,6 @@ public class DepotEntryModelListener extends BaseModelListener<DepotEntry> {
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);
 		}
-	}
-
-	private void _onAfterCreate(DepotEntry depotEntry) throws Exception {
-		if (!FeatureFlagManagerUtil.isEnabled(
-				depotEntry.getCompanyId(), "LPD-17564")) {
-
-			return;
-		}
-
-		Group group = depotEntry.getGroup();
-
-		_objectEntryFolderLocalService.addObjectEntryFolder(
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-			group.getGroupId(), group.getCreatorUserId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			"",
-			HashMapBuilder.put(
-				LocaleUtil.ENGLISH, "Contents"
-			).build(),
-			"Contents", ServiceContextThreadLocal.getServiceContext());
-		_objectEntryFolderLocalService.addObjectEntryFolder(
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
-			group.getGroupId(), group.getCreatorUserId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			"",
-			HashMapBuilder.put(
-				LocaleUtil.ENGLISH, "Files"
-			).build(),
-			"Files", ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private void _onBeforeRemove(DepotEntry depotEntry) throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceWrapper;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ServiceWrapper.class)
+public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
+	extends DepotEntryLocalServiceWrapper {
+
+	@Override
+	public DepotEntry addDepotEntry(Group group, ServiceContext serviceContext)
+		throws PortalException {
+
+		DepotEntry depotEntry = super.addDepotEntry(group, serviceContext);
+
+		_addObjectEntryFolders(depotEntry);
+
+		return depotEntry;
+	}
+
+	@Override
+	public DepotEntry addDepotEntry(
+			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		DepotEntry depotEntry = super.addDepotEntry(
+			nameMap, descriptionMap, serviceContext);
+
+		_addObjectEntryFolders(depotEntry);
+
+		return depotEntry;
+	}
+
+	private void _addObjectEntryFolders(DepotEntry depotEntry) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				depotEntry.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		try {
+			Group group = depotEntry.getGroup();
+
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				group.getGroupId(), group.getCreatorUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				"",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, "Contents"
+				).build(),
+				"Contents", ServiceContextThreadLocal.getServiceContext());
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
+				group.getGroupId(), group.getCreatorUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				"",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, "Files"
+				).build(),
+				"Files", ServiceContextThreadLocal.getServiceContext());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CMSObjectEntryFolderDepotEntryLocalServiceWrapper.class);
+
+	@Reference
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}


### PR DESCRIPTION
Exception when enabling staging for Asset Libraries

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-61325)

A user cannot enable staging for asset libraries. There's an error thrown when trying to do so

# How am I fixing it?

There are 2 methods to create asset libraries. One that receives a group, and the other that creates the group. So using a model listener won't cover both cases. The idea is to create a service wrapper that creates the object folders for it instead of the model listener. That way both cases are covered

# How can you verify that it works?

Execute the provided integration tests