### PR TITLE
LPD-61338 Fix the case when the newly created web content item is vertically misaligned due to a missing checkbox in the UI

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
@@ -119,15 +119,15 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 			}
 		}
 
-		if (!showInput) {
-			return StringPool.BLANK;
-		}
+		String checkBoxRowIds = StringPool.BLANK;
 
-		String checkBoxRowIds = StringBundler.concat(
-			"['", _liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
-			JournalFolder.class.getSimpleName(), "', '",
-			_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
-			JournalArticle.class.getSimpleName(), "']");
+		if (showInput) {
+			checkBoxRowIds = StringBundler.concat(
+				"['", _liferayPortletResponse.getNamespace(),
+				RowChecker.ROW_IDS, JournalFolder.class.getSimpleName(), "', '",
+				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
+				JournalArticle.class.getSimpleName(), "']");
+		}
 
 		return getRowCheckBox(
 			httpServletRequest, checked, disabled,


### PR DESCRIPTION
**What is this trying to solve?**

https://liferay.atlassian.net/browse/LPD-61338

The newly created web content item is vertically misaligned due to a missing checkbox in the UI.

**How am I fixing it?**

Change the logic to show a checkbox even user does not have permission to make any actions. In this, when you check this checkbox, then corresponding actions are disabled ( this follows the same pattern we have in place for Blogs, D&Ms)