### PR TITLE
LPD-57711 Add mimeType support to file entries

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -301,6 +301,47 @@ public class FileEntry implements Serializable {
 	private Supplier<Link> _linkSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public String getMimeType() {
+		if (_mimeTypeSupplier != null) {
+			mimeType = _mimeTypeSupplier.get();
+
+			_mimeTypeSupplier = null;
+		}
+
+		return mimeType;
+	}
+
+	public void setMimeType(String mimeType) {
+		this.mimeType = mimeType;
+
+		_mimeTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setMimeType(
+		UnsafeSupplier<String, Exception> mimeTypeUnsafeSupplier) {
+
+		_mimeTypeSupplier = () -> {
+			try {
+				return mimeTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String mimeType;
+
+	@JsonIgnore
+	private Supplier<String> _mimeTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getName() {
 		if (_nameSupplier != null) {
 			name = _nameSupplier.get();
@@ -578,6 +619,22 @@ public class FileEntry implements Serializable {
 			sb.append("\"link\": ");
 
 			sb.append(String.valueOf(link));
+		}
+
+		String mimeType = getMimeType();
+
+		if (mimeType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"mimeType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(mimeType));
+
+			sb.append("\"");
 		}
 
 		String name = getName();

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -49,6 +49,9 @@ components:
                 link:
                     $ref: "#/components/schemas/Link"
                     readOnly: true
+                mimeType:
+                    readOnly: true
+                    type: string
                 name:
                     type: string
                 previewURL:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -718,6 +718,7 @@ public class ObjectEntryDTOConverter
 				_dlAppService, dlFileEntry, _dlURLHelper,
 				objectDefinition.getExternalReferenceCode(),
 				objectEntry.getExternalReferenceCode(), _portal));
+		fileEntry.setMimeType(dlFileEntry::getMimeType);
 		fileEntry.setName(dlFileEntry::getFileName);
 		fileEntry.setPreviewURL(
 			() -> NestedFieldsSupplier.supply(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -13613,16 +13613,6 @@ public class ObjectEntryResourceTest {
 			// Sort by several fields
 
 			_testSortByFieldName(
-				endpoint1, jsonObject1, jsonObject2,
-				String.format("%s/dateCreated", _objectRelationship1.getName()),
-				String.format("%s/id", _objectRelationship1.getName()),
-				String.format(
-					"%s/%s/dateCreated", _objectRelationship1.getName(),
-					_objectRelationship2.getName()),
-				String.format(
-					"%s/%s/id", _objectRelationship1.getName(),
-					_objectRelationship2.getName()));
-			_testSortByFieldName(
 				endpoint1, jsonObject2, jsonObject1,
 				String.format("%s/creator", _objectRelationship1.getName()),
 				String.format("%s/creatorId", _objectRelationship1.getName()),
@@ -13646,6 +13636,16 @@ public class ObjectEntryResourceTest {
 					_objectRelationship2.getName()),
 				String.format(
 					"%s/%s/userId", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2,
+				String.format("%s/dateCreated", _objectRelationship1.getName()),
+				String.format("%s/id", _objectRelationship1.getName()),
+				String.format(
+					"%s/%s/dateCreated", _objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/id", _objectRelationship1.getName(),
 					_objectRelationship2.getName()));
 		}
 		finally {
@@ -14066,6 +14066,8 @@ public class ObjectEntryResourceTest {
 				jsonObject.getString("externalReferenceCode"));
 			Assert.assertEquals(
 				dlFileEntry.getFileEntryId(), jsonObject.getLong("id"));
+			Assert.assertEquals(
+				dlFileEntry.getMimeType(), jsonObject.getString("mimeType"));
 			Assert.assertEquals(
 				dlFileEntry.getFileName(), jsonObject.getString("name"));
 		}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -14056,9 +14056,8 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _assertAttachmentJSONObject(
-			DLFileEntry dlFileEntry, String fileBase64, JSONObject jsonObject,
-			JSONObject scopeJSONObject)
-		throws Exception {
+		DLFileEntry dlFileEntry, String fileBase64, JSONObject jsonObject,
+		JSONObject scopeJSONObject) {
 
 		if (dlFileEntry != null) {
 			Assert.assertEquals(
@@ -14088,8 +14087,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _assertCustomObjectEntryWithPermissions(
-			JSONArray expectedPermissionsJSONArray, JSONObject jsonObject)
-		throws Exception {
+		JSONArray expectedPermissionsJSONArray, JSONObject jsonObject) {
 
 		JSONArray actualPermissionsJSONArray = jsonObject.getJSONArray(
 			"permissions");
@@ -14104,9 +14102,7 @@ public class ObjectEntryResourceTest {
 			JSONCompareMode.LENIENT);
 	}
 
-	private void _assertEquals(JSONArray nestedObjectEntriesJSONArray)
-		throws Exception {
-
+	private void _assertEquals(JSONArray nestedObjectEntriesJSONArray) {
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
 				JSONUtil.put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57711



# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-57711

Add a new field to use it in the CMS

# How am I fixing it?

Adding the needed field to the schema

# How can you verify that it works?

Run the included automated tests, for example:

`ObjectEntryResourceTest.testGetObjectEntryWithAttachmentObjectField
`


