### PR TITLE
LPD-55654 Add copy label when copying an object entry version

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -64,6 +64,8 @@ import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -1339,30 +1341,7 @@ public class DefaultObjectEntryManagerImpl
 			_objectFieldLocalService.fetchObjectField(
 				objectDefinition.getTitleObjectFieldId());
 
-		if ((titleObjectField != null) &&
-			Objects.equals(
-				titleObjectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
-
-			if (titleObjectField.isLocalized()) {
-				Map<String, Object> i18nValues =
-					(Map<String, Object>)values.get(
-						titleObjectField.getI18nObjectFieldName());
-
-				String language = LocaleUtil.toLanguageId(
-					LocaleUtil.getSiteDefault());
-
-				i18nValues.put(
-					language,
-					_getNewValue(String.valueOf(i18nValues.get(language))));
-			}
-			else {
-				String value = GetterUtil.getString(
-					values.get(titleObjectField.getName()));
-
-				values.put(titleObjectField.getName(), _getNewValue(value));
-			}
-		}
+		_replaceValues(objectDefinition, scopeKey, titleObjectField, values);
 
 		return _addObjectEntry(
 			dtoConverterContext, objectDefinition, objectEntry,
@@ -1620,11 +1599,40 @@ public class DefaultObjectEntryManagerImpl
 			objectRelationship.getObjectRelationshipId(), primaryKey);
 	}
 
-	private String _getNewValue(String value) {
-		return StringBundler.concat(
-			value, StringPool.SPACE, StringPool.OPEN_PARENTHESIS,
-			_language.get(LocaleUtil.getSiteDefault(), "copy"),
+	private String _getNewValue(
+			long groupId, ObjectDefinition objectDefinition,
+			ObjectField objectField, String value)
+		throws Exception {
+
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
+
+		String newValue = StringBundler.concat(
+			value, StringPool.SPACE, StringPool.OPEN_PARENTHESIS, copy,
 			StringPool.CLOSE_PARENTHESIS);
+
+		String prefix = value;
+
+		Table<?> table = _objectFieldLocalService.getTable(
+			objectDefinition.getObjectDefinitionId(), objectField.getName());
+
+		Column<?, String> objectFieldColumn =
+			(Column<?, String>)table.getColumn(objectField.getDBColumnName());
+
+		for (int i = 1;; i++) {
+			long count = objectEntryLocalService.getValuesListCount(
+				new Long[] {groupId}, objectDefinition.getCompanyId(),
+				objectDefinition.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				objectFieldColumn.eq(newValue), null);
+
+			if (count == 0) {
+				return newValue;
+			}
+
+			newValue = StringBundler.concat(
+				prefix, StringPool.SPACE, StringPool.OPEN_PARENTHESIS, copy,
+				StringPool.SPACE, i, StringPool.CLOSE_PARENTHESIS);
+		}
 	}
 
 	private ObjectEntry _getObjectEntry(
@@ -2214,6 +2222,44 @@ public class DefaultObjectEntryManagerImpl
 
 				properties.remove(objectField.getName());
 			}
+		}
+	}
+
+	private void _replaceValues(
+			ObjectDefinition objectDefinition, String scopeKey,
+			ObjectField objectField, Map<String, Serializable> values)
+		throws Exception {
+
+		if ((objectField == null) ||
+			!Objects.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
+
+			return;
+		}
+
+		long groupId = getGroupId(objectDefinition, scopeKey);
+
+		if (objectField.isLocalized()) {
+			Map<String, Object> i18nValues = (Map<String, Object>)values.get(
+				objectField.getI18nObjectFieldName());
+
+			String languageId = LocaleUtil.toLanguageId(
+				LocaleUtil.getSiteDefault());
+
+			String value = GetterUtil.getString(i18nValues.get(languageId));
+
+			i18nValues.put(
+				languageId,
+				_getNewValue(groupId, objectDefinition, objectField, value));
+		}
+		else {
+			String value = GetterUtil.getString(
+				values.get(objectField.getName()));
+
+			values.put(
+				objectField.getName(),
+				_getNewValue(groupId, objectDefinition, objectField, value));
 		}
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1701,7 +1701,8 @@ public class DefaultObjectEntryManagerImpl
 					if (!FeatureFlagManagerUtil.isEnabled(
 							serviceBuilderObjectEntry.getCompanyId(),
 							"LPD-17564") ||
-						!objectEntryVersion.isApproved()) {
+						(!objectEntryVersion.isApproved() &&
+						 !objectEntryVersion.isDraft())) {
 
 						return null;
 					}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -177,29 +177,16 @@ public class DefaultObjectEntryManagerImpl
 
 		validateReadOnlyObjectFields(null, objectDefinition, objectEntry);
 
-		long groupId = getGroupId(objectDefinition, scopeKey);
-
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
 
-		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryService.addObjectEntry(
-				groupId, objectDefinition.getObjectDefinitionId(),
-				_getObjectEntryFolderId(
-					objectDefinition.getCompanyId(), groupId, objectEntry,
-					serviceContext),
-				objectEntry.getDefaultLanguageId(),
-				_toObjectValues(
-					dtoConverterContext.getLocale(), objectDefinition,
-					objectEntry, scopeKey, serviceContext),
-				serviceContext);
+		Map<String, Serializable> values = _toObjectValues(
+			dtoConverterContext.getLocale(), objectDefinition, objectEntry,
+			scopeKey, serviceContext);
 
-		return _toObjectEntry(
-			dtoConverterContext, objectDefinition,
-			_addOrUpdateNestedObjectEntries(
-				dtoConverterContext, objectDefinition, objectEntry,
-				_getObjectRelationships(objectDefinition, objectEntry),
-				serviceBuilderObjectEntry, scopeKey));
+		return _addObjectEntry(
+			dtoConverterContext, objectDefinition, objectEntry, scopeKey,
+			serviceContext, values);
 	}
 
 	@Override
@@ -1101,6 +1088,33 @@ public class DefaultObjectEntryManagerImpl
 
 		return _addAction(
 			actionName, methodName, serviceBuilderObjectEntry, null, uriInfo);
+	}
+
+	private ObjectEntry _addObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			String scopeKey, ServiceContext serviceContext,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		validateReadOnlyObjectFields(null, objectDefinition, objectEntry);
+
+		long groupId = getGroupId(objectDefinition, scopeKey);
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryService.addObjectEntry(
+				groupId, objectDefinition.getObjectDefinitionId(),
+				_getObjectEntryFolderId(
+					objectDefinition.getCompanyId(), groupId, objectEntry,
+					serviceContext),
+				objectEntry.getDefaultLanguageId(), values, serviceContext);
+
+		return _toObjectEntry(
+			dtoConverterContext, objectDefinition,
+			_addOrUpdateNestedObjectEntries(
+				dtoConverterContext, objectDefinition, objectEntry,
+				_getObjectRelationships(objectDefinition, objectEntry),
+				serviceBuilderObjectEntry, scopeKey));
 	}
 
 	private com.liferay.object.model.ObjectEntry

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1321,9 +1321,47 @@ public class DefaultObjectEntryManagerImpl
 
 		_removeReadOnlyProperties(objectDefinition, objectEntry);
 
-		return addObjectEntry(
+		String scopeKey = objectEntry.getScopeKey();
+
+		ServiceContext serviceContext = _createServiceContext(
+			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
+
+		Map<String, Serializable> values = _toObjectValues(
+			dtoConverterContext.getLocale(), objectDefinition, objectEntry,
+			scopeKey, serviceContext);
+
+		ObjectField titleObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectDefinition.getTitleObjectFieldId());
+
+		if ((titleObjectField != null) &&
+			Objects.equals(
+				titleObjectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_TEXT)) {
+
+			if (titleObjectField.isLocalized()) {
+				Map<String, Object> i18nValues =
+					(Map<String, Object>)values.get(
+						titleObjectField.getI18nObjectFieldName());
+
+				String language = LocaleUtil.toLanguageId(
+					LocaleUtil.getSiteDefault());
+
+				i18nValues.put(
+					language,
+					_getNewValue(String.valueOf(i18nValues.get(language))));
+			}
+			else {
+				String value = GetterUtil.getString(
+					values.get(titleObjectField.getName()));
+
+				values.put(titleObjectField.getName(), _getNewValue(value));
+			}
+		}
+
+		return _addObjectEntry(
 			dtoConverterContext, objectDefinition, objectEntry,
-			objectEntry.getScopeKey());
+			objectEntry.getScopeKey(), serviceContext, values);
 	}
 
 	private ServiceContext _createServiceContext(
@@ -1575,6 +1613,13 @@ public class DefaultObjectEntryManagerImpl
 		return objectRelatedModelsProvider.fetchRelatedModel(
 			GroupThreadLocal.getGroupId(),
 			objectRelationship.getObjectRelationshipId(), primaryKey);
+	}
+
+	private String _getNewValue(String value) {
+		return StringBundler.concat(
+			value, StringPool.SPACE, StringPool.OPEN_PARENTHESIS,
+			_language.get(LocaleUtil.getSiteDefault(), "copy"),
+			StringPool.CLOSE_PARENTHESIS);
 	}
 
 	private ObjectEntry _getObjectEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1326,6 +1326,11 @@ public class DefaultObjectEntryManagerImpl
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
 
+		if (objectDefinition.isEnableObjectEntryDraft()) {
+			serviceContext.setWorkflowAction(
+				WorkflowConstants.ACTION_SAVE_DRAFT);
+		}
+
 		Map<String, Serializable> values = _toObjectValues(
 			dtoConverterContext.getLocale(), objectDefinition, objectEntry,
 			scopeKey, serviceContext);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1695,7 +1695,7 @@ public class DefaultObjectEntryManagerImpl
 
 			actions = HashMapBuilder.create(
 				actions
-			).<String, Map<String, String>>put(
+			).put(
 				"copy",
 				() -> {
 					if (!FeatureFlagManagerUtil.isEnabled(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2982,7 +2982,9 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
-	public void testCopyObjectEntryByVersionWithTextField() throws Exception {
+	public void testCopyObjectEntryByVersionWithTextObjectField()
+		throws Exception {
+
 		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
 			dtoConverterContext, _objectDefinition5,
 			new ObjectEntry() {
@@ -3012,8 +3014,52 @@ public class DefaultObjectEntryManagerImplTest
 			},
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		_testCopyObjectEntryByVersionWithLocalizedTextField(objectEntry);
-		_testCopyObjectEntryByVersionWithNonlocalizedTextField(objectEntry);
+		ObjectField objectField = objectFieldLocalService.fetchObjectField(
+			_objectDefinition5.getObjectDefinitionId(),
+			"localizedTextObjectFieldName");
+
+		_objectDefinition5.setTitleObjectFieldId(
+			objectField.getObjectFieldId());
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
+		_assertLocalizedTextObjectFieldValueCopy(
+			"en_US localizedTextObjectFieldValue1 (Copy)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1),
+			objectField);
+
+		_assertLocalizedTextObjectFieldValueCopy(
+			"en_US localizedTextObjectFieldValue1 (Copy 1)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1),
+			objectField);
+
+		objectField = objectFieldLocalService.fetchObjectField(
+			_objectDefinition5.getObjectDefinitionId(), "textObjectFieldName");
+
+		_objectDefinition5.setTitleObjectFieldId(
+			objectField.getObjectFieldId());
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
+		_assertTextObjectFieldValueCopy(
+			"textObjectFieldValue (Copy)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1));
+
+		_assertTextObjectFieldValueCopy(
+			"textObjectFieldValue (Copy 1)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1));
 	}
 
 	@Test
@@ -8317,63 +8363,6 @@ public class DefaultObjectEntryManagerImplTest
 
 		_assertObjectEntryStatus(
 			WorkflowConstants.STATUS_APPROVED, objectEntry);
-	}
-
-	private void _testCopyObjectEntryByVersionWithLocalizedTextField(
-			ObjectEntry objectEntry)
-		throws Exception {
-
-		ObjectField objectField = objectFieldLocalService.fetchObjectField(
-			_objectDefinition5.getObjectDefinitionId(),
-			"localizedTextObjectFieldName");
-
-		_objectDefinition5.setTitleObjectFieldId(
-			objectField.getObjectFieldId());
-
-		_objectDefinition5 =
-			objectDefinitionLocalService.updateObjectDefinition(
-				_objectDefinition5);
-
-		_assertLocalizedTextObjectFieldValueCopy(
-			"en_US localizedTextObjectFieldValue1 (Copy)",
-			_defaultObjectEntryManager.copyObjectEntryByVersion(
-				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1),
-			objectField);
-
-		_assertLocalizedTextObjectFieldValueCopy(
-			"en_US localizedTextObjectFieldValue1 (Copy 1)",
-			_defaultObjectEntryManager.copyObjectEntryByVersion(
-				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1),
-			objectField);
-	}
-
-	private void _testCopyObjectEntryByVersionWithNonlocalizedTextField(
-			ObjectEntry objectEntry)
-		throws Exception {
-
-		ObjectField objectField = objectFieldLocalService.fetchObjectField(
-			_objectDefinition5.getObjectDefinitionId(), "textObjectFieldName");
-
-		_objectDefinition5.setTitleObjectFieldId(
-			objectField.getObjectFieldId());
-
-		_objectDefinition5 =
-			objectDefinitionLocalService.updateObjectDefinition(
-				_objectDefinition5);
-
-		_assertTextObjectFieldValueCopy(
-			"textObjectFieldValue (Copy)",
-			_defaultObjectEntryManager.copyObjectEntryByVersion(
-				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1));
-
-		_assertTextObjectFieldValueCopy(
-			"textObjectFieldValue (Copy 1)",
-			_defaultObjectEntryManager.copyObjectEntryByVersion(
-				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1));
 	}
 
 	private void _testDeleteObjectEntryWithAccountEntryRestricted2(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2961,48 +2961,18 @@ public class DefaultObjectEntryManagerImplTest
 			_defaultObjectEntryManager.copyObjectEntryByVersion(
 				dtoConverterContext, objectEntry.getExternalReferenceCode(),
 				_objectDefinition4, _group.getGroupKey(), 2));
-	}
 
-	@Test
-	public void testCopyObjectEntryByVersionAsDraft() throws Exception {
-		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
-			dtoConverterContext, _objectDefinition5,
-			new ObjectEntry() {
-				{
-					externalReferenceCode = RandomTestUtil.randomString();
-					keywords = new String[] {RandomTestUtil.randomString()};
-					properties = HashMapBuilder.<String, Object>put(
-						"localizedTextObjectFieldName_i18n",
-						HashMapBuilder.put(
-							"en_US", "en_US localizedTextObjectFieldValue1"
-						).put(
-							"pt_BR", "pt_BR localizedTextObjectFieldValue1"
-						).build()
-					).put(
-						"textObjectFieldName", "textObjectFieldValue"
-					).build();
-					systemProperties = new SystemProperties() {
-						{
-							version = new Version() {
-								{
-									number = 1;
-								}
-							};
-						}
-					};
-				}
-			},
-			ObjectDefinitionConstants.SCOPE_COMPANY);
+		// Status
 
-		_objectDefinition5.setEnableObjectEntryDraft(true);
+		_objectDefinition4.setEnableObjectEntryDraft(true);
 
-		_objectDefinition5 =
+		_objectDefinition4 =
 			objectDefinitionLocalService.updateObjectDefinition(
-				_objectDefinition5);
+				_objectDefinition4);
 
 		ObjectEntry copyObjectEntry =
 			_defaultObjectEntryManager.copyObjectEntryByVersion(
-				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				dtoConverterContext, _objectDefinition4, objectEntry.getId(),
 				1);
 
 		Status status = copyObjectEntry.getStatus();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2959,6 +2959,54 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testCopyObjectEntryByVersionAsDraft() throws Exception {
+		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
+			dtoConverterContext, _objectDefinition5,
+			new ObjectEntry() {
+				{
+					externalReferenceCode = RandomTestUtil.randomString();
+					keywords = new String[] {RandomTestUtil.randomString()};
+					properties = HashMapBuilder.<String, Object>put(
+						"localizedTextObjectFieldName_i18n",
+						HashMapBuilder.put(
+							"en_US", "en_US localizedTextObjectFieldValue1"
+						).put(
+							"pt_BR", "pt_BR localizedTextObjectFieldValue1"
+						).build()
+					).put(
+						"textObjectFieldName", "textObjectFieldValue"
+					).build();
+					systemProperties = new SystemProperties() {
+						{
+							version = new Version() {
+								{
+									number = 1;
+								}
+							};
+						}
+					};
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_objectDefinition5.setEnableObjectEntryDraft(true);
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
+		ObjectEntry copyObjectEntry =
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1);
+
+		Status status = copyObjectEntry.getStatus();
+
+		AssertUtils.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, status.getCode());
+	}
+
+	@Test
 	public void testCopyObjectEntryByVersionWithTextField() throws Exception {
 		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
 			dtoConverterContext, _objectDefinition5,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -807,6 +807,35 @@ public class DefaultObjectEntryManagerImplTest
 			objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition4);
 
+		_objectDefinition5 = _createObjectDefinition(
+			Arrays.asList(
+				new TextObjectFieldBuilder(
+				).indexed(
+					true
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"textObjectFieldName"
+				).build(),
+				new TextObjectFieldBuilder(
+				).indexed(
+					true
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).localized(
+					true
+				).name(
+					"localizedTextObjectFieldName"
+				).build()));
+
+		_objectDefinition5.setEnableObjectEntryVersioning(true);
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
 		_accountAdministratorRole = _roleLocalService.getRole(
 			companyId,
 			AccountRoleConstants.REQUIRED_ROLE_NAME_ACCOUNT_ADMINISTRATOR);
@@ -2927,6 +2956,41 @@ public class DefaultObjectEntryManagerImplTest
 			_defaultObjectEntryManager.copyObjectEntryByVersion(
 				dtoConverterContext, objectEntry.getExternalReferenceCode(),
 				_objectDefinition4, _group.getGroupKey(), 2));
+	}
+
+	@Test
+	public void testCopyObjectEntryByVersionWithTextField() throws Exception {
+		ObjectEntry objectEntry = _defaultObjectEntryManager.addObjectEntry(
+			dtoConverterContext, _objectDefinition5,
+			new ObjectEntry() {
+				{
+					externalReferenceCode = RandomTestUtil.randomString();
+					keywords = new String[] {RandomTestUtil.randomString()};
+					properties = HashMapBuilder.<String, Object>put(
+						"localizedTextObjectFieldName_i18n",
+						HashMapBuilder.put(
+							"en_US", "en_US localizedTextObjectFieldValue1"
+						).put(
+							"pt_BR", "pt_BR localizedTextObjectFieldValue1"
+						).build()
+					).put(
+						"textObjectFieldName", "textObjectFieldValue"
+					).build();
+					systemProperties = new SystemProperties() {
+						{
+							version = new Version() {
+								{
+									number = 1;
+								}
+							};
+						}
+					};
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_testCopyObjectEntryByVersionWithLocalizedTextField(objectEntry);
+		_testCopyObjectEntryByVersionWithNonlocalizedTextField(objectEntry);
 	}
 
 	@Test
@@ -8208,6 +8272,68 @@ public class DefaultObjectEntryManagerImplTest
 			WorkflowConstants.STATUS_APPROVED, objectEntry);
 	}
 
+	private void _testCopyObjectEntryByVersionWithLocalizedTextField(
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		ObjectField objectField = objectFieldLocalService.fetchObjectField(
+			_objectDefinition5.getObjectDefinitionId(),
+			"localizedTextObjectFieldName");
+
+		_objectDefinition5.setTitleObjectFieldId(
+			objectField.getObjectFieldId());
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
+		ObjectEntry copyObjectEntry =
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1);
+
+		Assert.assertNotNull(copyObjectEntry);
+
+		Map<String, Object> properties = copyObjectEntry.getProperties();
+
+		Map<String, Object> i18nValues = (Map<String, Object>)properties.get(
+			objectField.getI18nObjectFieldName());
+
+		String language = LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
+
+		Assert.assertEquals(
+			"en_US localizedTextObjectFieldValue1 (Copy)",
+			String.valueOf(i18nValues.get(language)));
+	}
+
+	private void _testCopyObjectEntryByVersionWithNonlocalizedTextField(
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		ObjectField objectField = objectFieldLocalService.fetchObjectField(
+			_objectDefinition5.getObjectDefinitionId(), "textObjectFieldName");
+
+		_objectDefinition5.setTitleObjectFieldId(
+			objectField.getObjectFieldId());
+
+		_objectDefinition5 =
+			objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition5);
+
+		ObjectEntry copyObjectEntry =
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1);
+
+		Assert.assertNotNull(copyObjectEntry);
+
+		Map<String, Object> properties = copyObjectEntry.getProperties();
+
+		Assert.assertEquals(
+			"textObjectFieldValue (Copy)",
+			properties.get("textObjectFieldName"));
+	}
+
 	private void _testDeleteObjectEntryWithAccountEntryRestricted2(
 			String actionId, Tree tree)
 		throws Exception {
@@ -8420,6 +8546,9 @@ public class DefaultObjectEntryManagerImplTest
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition4;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition5;
 
 	@Inject
 	private ObjectDefinitionSettingLocalService

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -115,6 +115,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -812,6 +813,8 @@ public class DefaultObjectEntryManagerImplTest
 				new TextObjectFieldBuilder(
 				).indexed(
 					true
+				).indexedLanguageId(
+					LanguageUtil.getLanguageId(LocaleUtil.getDefault())
 				).labelMap(
 					LocalizedMapUtil.getLocalizedMap(
 						RandomTestUtil.randomString())
@@ -821,6 +824,8 @@ public class DefaultObjectEntryManagerImplTest
 				new TextObjectFieldBuilder(
 				).indexed(
 					true
+				).indexedLanguageId(
+					LanguageUtil.getLanguageId(LocaleUtil.getDefault())
 				).labelMap(
 					LocalizedMapUtil.getLocalizedMap(
 						RandomTestUtil.randomString())
@@ -7567,6 +7572,21 @@ public class DefaultObjectEntryManagerImplTest
 		}
 	}
 
+	private void _assertLocalizedTextObjectFieldValueCopy(
+		String expectedValue, ObjectEntry objectEntry,
+		ObjectField objectField) {
+
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		Map<String, Object> i18nValues = (Map<String, Object>)properties.get(
+			objectField.getI18nObjectFieldName());
+
+		String language = LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
+
+		Assert.assertEquals(
+			expectedValue, String.valueOf(i18nValues.get(language)));
+	}
+
 	private void _assertLocalizedValues(
 			Map<String, Object> expectedLocalizedValues, String languageId,
 			long objectEntryId)
@@ -7702,6 +7722,15 @@ public class DefaultObjectEntryManagerImplTest
 					).build();
 				}
 			});
+	}
+
+	private void _assertTextObjectFieldValueCopy(
+		String expectedValue, ObjectEntry objectEntry) {
+
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		Assert.assertEquals(
+			expectedValue, properties.get("textObjectFieldName"));
 	}
 
 	private void _assignAccountEntryRole(
@@ -8335,23 +8364,19 @@ public class DefaultObjectEntryManagerImplTest
 			objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition5);
 
-		ObjectEntry copyObjectEntry =
+		_assertLocalizedTextObjectFieldValueCopy(
+			"en_US localizedTextObjectFieldValue1 (Copy)",
 			_defaultObjectEntryManager.copyObjectEntryByVersion(
 				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1);
+				1),
+			objectField);
 
-		Assert.assertNotNull(copyObjectEntry);
-
-		Map<String, Object> properties = copyObjectEntry.getProperties();
-
-		Map<String, Object> i18nValues = (Map<String, Object>)properties.get(
-			objectField.getI18nObjectFieldName());
-
-		String language = LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
-
-		Assert.assertEquals(
-			"en_US localizedTextObjectFieldValue1 (Copy)",
-			String.valueOf(i18nValues.get(language)));
+		_assertLocalizedTextObjectFieldValueCopy(
+			"en_US localizedTextObjectFieldValue1 (Copy 1)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1),
+			objectField);
 	}
 
 	private void _testCopyObjectEntryByVersionWithNonlocalizedTextField(
@@ -8368,18 +8393,17 @@ public class DefaultObjectEntryManagerImplTest
 			objectDefinitionLocalService.updateObjectDefinition(
 				_objectDefinition5);
 
-		ObjectEntry copyObjectEntry =
+		_assertTextObjectFieldValueCopy(
+			"textObjectFieldValue (Copy)",
 			_defaultObjectEntryManager.copyObjectEntryByVersion(
 				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
-				1);
+				1));
 
-		Assert.assertNotNull(copyObjectEntry);
-
-		Map<String, Object> properties = copyObjectEntry.getProperties();
-
-		Assert.assertEquals(
-			"textObjectFieldValue (Copy)",
-			properties.get("textObjectFieldName"));
+		_assertTextObjectFieldValueCopy(
+			"textObjectFieldValue (Copy 1)",
+			_defaultObjectEntryManager.copyObjectEntryByVersion(
+				dtoConverterContext, _objectDefinition5, objectEntry.getId(),
+				1));
 	}
 
 	private void _testDeleteObjectEntryWithAccountEntryRestricted2(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -335,16 +335,17 @@ public abstract class BaseSectionDisplayContext {
 		}
 	}
 
+	protected String appendStatus(String filterString) {
+		return StringBundler.concat(
+			filterString, " and status in (", StringUtil.merge(_statuses, ","),
+			")");
+	}
+
 	protected abstract String getCMSSectionFilterString();
 
 	protected abstract String[] getObjectFolderExternalReferenceCodes();
 
 	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
-
-	protected String getStatusFilterString() {
-		return StringBundler.concat(
-			"status in (", StringUtil.merge(_statuses, ","), ")");
-	}
 
 	protected final DepotEntryLocalService depotEntryLocalService;
 	protected final GroupLocalService groupLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.portlet.ActionRequest;
@@ -54,6 +55,7 @@ import jakarta.portlet.ActionRequest;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -339,6 +341,11 @@ public abstract class BaseSectionDisplayContext {
 
 	protected abstract String getRootObjectEntryFolderExternalReferenceCode();
 
+	protected String getStatusFilterString() {
+		return StringBundler.concat(
+			"status in (", StringUtil.merge(_statuses, ","), ")");
+	}
+
 	protected final DepotEntryLocalService depotEntryLocalService;
 	protected final GroupLocalService groupLocalService;
 	protected final HttpServletRequest httpServletRequest;
@@ -538,6 +545,10 @@ public abstract class BaseSectionDisplayContext {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseSectionDisplayContext.class);
+
+	private static final List<Integer> _statuses = Arrays.asList(
+		WorkflowConstants.STATUS_APPROVED, WorkflowConstants.STATUS_DRAFT,
+		WorkflowConstants.STATUS_EXPIRED);
 
 	private final ObjectDefinitionService _objectDefinitionService;
 	private final ObjectDefinitionSettingLocalService

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -11,7 +11,6 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -19,7 +18,6 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -84,18 +82,9 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		String filterString =
+		return appendStatus(
 			"(cmsSection eq 'contents' or cmsSection eq 'files') and cmsKind " +
-				"eq 'object'";
-
-		String statusFilterString = getStatusFilterString();
-
-		if (Validator.isNotNull(statusFilterString)) {
-			filterString = StringBundler.concat(
-				filterString, " and ", statusFilterString);
-		}
-
-		return filterString;
+				"eq 'object'");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -11,6 +11,7 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -18,6 +19,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -82,8 +84,18 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "(cmsSection eq 'contents' or cmsSection eq 'files') and " +
-			"cmsKind eq 'object'";
+		String filterString =
+			"(cmsSection eq 'contents' or cmsSection eq 'files') and cmsKind " +
+				"eq 'object'";
+
+		String statusFilterString = getStatusFilterString();
+
+		if (Validator.isNotNull(statusFilterString)) {
+			filterString = StringBundler.concat(
+				filterString, " and ", statusFilterString);
+		}
+
+		return filterString;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -78,7 +80,16 @@ public class ViewContentsSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'contents'";
+		String filterString = "cmsRoot eq true and cmsSection eq 'contents'";
+
+		String statusFilterString = getStatusFilterString();
+
+		if (Validator.isNotNull(statusFilterString)) {
+			filterString = StringBundler.concat(
+				filterString, " and ", statusFilterString);
+		}
+
+		return filterString;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -10,7 +10,6 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectDefinitionSettingLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -18,7 +17,6 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -80,16 +78,7 @@ public class ViewContentsSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		String filterString = "cmsRoot eq true and cmsSection eq 'contents'";
-
-		String statusFilterString = getStatusFilterString();
-
-		if (Validator.isNotNull(statusFilterString)) {
-			filterString = StringBundler.concat(
-				filterString, " and ", statusFilterString);
-		}
-
-		return filterString;
+		return appendStatus("cmsRoot eq true and cmsSection eq 'contents'");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -99,16 +98,7 @@ public class ViewFilesSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		String filterString = "cmsRoot eq true and cmsSection eq 'files'";
-
-		String statusFilterString = getStatusFilterString();
-
-		if (Validator.isNotNull(statusFilterString)) {
-			filterString = StringBundler.concat(
-				filterString, " and ", statusFilterString);
-		}
-
-		return filterString;
+		return appendStatus("cmsRoot eq true and cmsSection eq 'files'");
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -98,7 +99,16 @@ public class ViewFilesSectionDisplayContext
 
 	@Override
 	protected String getCMSSectionFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'files'";
+		String filterString = "cmsRoot eq true and cmsSection eq 'files'";
+
+		String statusFilterString = getStatusFilterString();
+
+		if (Validator.isNotNull(statusFilterString)) {
+			filterString = StringBundler.concat(
+				filterString, " and ", statusFilterString);
+		}
+
+		return filterString;
 	}
 
 	@Override


### PR DESCRIPTION
Story: https://liferay.atlassian.net/browse/LPD-49836

For the new CMS, we cant to enable copying assets, and one of the requirements is that the asset has a new title with (Copy) appended to it. Because of the nature of objects, it only makes sense to add this label to those fields of type TEXT.

Also, we want to leave the copy with a draft status if the object definition allows it

# How am I fixing it?

We are changing DefaultObjectEntryManagerImpl to achieve this. We calculate the fields, retrive the one that is used as title, and if it's of type text we change it befor adding the object.

# How can you verify that it works?

Integration tests are included in the PR

From the interface, it can be tested in the view version history in the CMS

https://github.com/user-attachments/assets/b48d2a3f-1179-46fb-8e2b-c691ed6281d0

Follow up: https://github.com/brianchandotcom/liferay-portal/pull/163857