### PR TITLE
LPD-61068 Delete sharing entries after removing ObjectEntryFolder

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
+	testIntegrationImplementation project(":apps:sharing:sharing-api")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryFolderModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/ObjectEntryFolderModelListenerTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -26,15 +27,21 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sharing.security.permission.SharingEntryAction;
+import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,6 +54,7 @@ import org.junit.runner.RunWith;
 
 /**
  * @author Jürgen Kappler
+ * @author Roberto Díaz
  */
 @RunWith(Arquillian.class)
 public class ObjectEntryFolderModelListenerTest {
@@ -61,6 +69,19 @@ public class ObjectEntryFolderModelListenerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				_group.getGroupId(), _group.getCreatorUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				"",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
@@ -89,26 +110,13 @@ public class ObjectEntryFolderModelListenerTest {
 	@FeatureFlag("LPD-17564")
 	@Test
 	public void testAddObjectEntryFolder() throws Exception {
-		ObjectEntryFolder objectEntryFolder =
-			_objectEntryFolderLocalService.addObjectEntryFolder(
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-				_group.getGroupId(), _group.getCreatorUserId(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				"",
-				HashMapBuilder.put(
-					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
-				).build(),
-				RandomTestUtil.randomString(),
-				ServiceContextTestUtil.getServiceContext());
-
 		Map<Long, Set<String>> sourceRoleIdsToActionIds =
 			_resourcePermissionLocalService.
 				getAvailableResourcePermissionActionIds(
-					objectEntryFolder.getCompanyId(),
+					_objectEntryFolder.getCompanyId(),
 					ObjectEntryFolder.class.getName(),
 					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(objectEntryFolder.getObjectEntryFolderId()),
+					String.valueOf(_objectEntryFolder.getObjectEntryFolderId()),
 					TransformUtil.transform(
 						_resourceActionLocalService.getResourceActions(
 							ObjectEntryFolder.class.getName()),
@@ -127,14 +135,58 @@ public class ObjectEntryFolderModelListenerTest {
 		}
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testDeleteObjectEntryFolder() throws Exception {
+		int sharingEntriesInitialCount =
+			_sharingEntryLocalService.getSharingEntriesCount();
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				RandomTestUtil.randomString(), _group.getGroupId(),
+				_group.getCreatorUserId(),
+				_objectEntryFolder.getObjectEntryFolderId(), "",
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext());
+
+		User user = UserTestUtil.addGroupAdminUser(_group);
+
+		_sharingEntryLocalService.addSharingEntry(
+			null, TestPropsValues.getUserId(), 0, user.getUserId(),
+			_portal.getClassNameId(ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId(), _group.getGroupId(),
+			true, Arrays.asList(SharingEntryAction.VIEW), null,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			sharingEntriesInitialCount + 1,
+			_sharingEntryLocalService.getSharingEntriesCount());
+
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Assert.assertEquals(
+			sharingEntriesInitialCount,
+			_sharingEntryLocalService.getSharingEntriesCount());
+	}
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;
 
+	private ObjectEntryFolder _objectEntryFolder;
+
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject
 	private ResourceActionLocalService _resourceActionLocalService;
@@ -144,6 +196,9 @@ public class ObjectEntryFolderModelListenerTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private SharingEntryLocalService _sharingEntryLocalService;
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;

--- a/modules/apps/site/site-cms-site-initializer/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":apps:sharing:sharing-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:subscription:subscription-api")

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/ObjectEntryFolderModelListener.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.sharing.service.SharingEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,6 +62,21 @@ public class ObjectEntryFolderModelListener
 		}
 	}
 
+	@Override
+	public void onAfterRemove(ObjectEntryFolder objectEntryFolder)
+		throws ModelListenerException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectEntryFolder.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		_sharingEntryLocalService.deleteSharingEntries(
+			_portal.getClassNameId(ObjectEntryFolder.class.getName()),
+			objectEntryFolder.getObjectEntryFolderId());
+	}
+
 	private Role _getOrAddCMSAdministratorRoleAndPermissions(
 			long companyId, long userId)
 		throws Exception {
@@ -78,6 +95,9 @@ public class ObjectEntryFolderModelListener
 	}
 
 	@Reference
+	private Portal _portal;
+
+	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;
 
 	@Reference
@@ -85,5 +105,8 @@ public class ObjectEntryFolderModelListener
 
 	@Reference
 	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SharingEntryLocalService _sharingEntryLocalService;
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61068

# How am I fixing it?

Removing the sharing entries on folder removal

# How can you verify that it works?

Run the included automated tests: `com.liferay.site.cms.site.initializer.internal.model.listener.test.ObjectEntryFolderModelListenerTest#testDeleteObjectEntryFolder`