### PR TITLE
LPD-61753 Navigate to main view after copying a version of an entry

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -74,7 +74,7 @@ public class ViewVersionHistoryDisplayContext {
 				"delete", "headless"));
 	}
 
-	public Map<String, Object> getToolbarReactData() throws PortalException {
+	public Map<String, Object> getProps() throws PortalException {
 		return HashMapBuilder.<String, Object>put(
 			"backURL", ParamUtil.getString(_httpServletRequest, "backURL")
 		).put(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -64,7 +64,7 @@ public class ViewVersionHistoryDisplayContext {
 			new FDSActionDropdownItem(
 				"{actions.copy.href}", "copy", "copy",
 				_language.get(_httpServletRequest, "make-a-copy"), "post",
-				"copy", "headless"),
+				"copy", null),
 			new FDSActionDropdownItem(
 				_language.get(
 					_httpServletRequest,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -4,16 +4,19 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {navigate, sessionStorage} from 'frontend-js-web';
 
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
+import {executeAsyncItemAction} from './utils/executeAsyncItemAction';
 
 export default function ViewVersionHistoryFDSPropsTransformer({
+	additionalProps,
 	itemsActions = [],
 	...otherProps
 }: {
+	additionalProps: any;
 	itemsActions?: any[];
-	otherProps: any;
 }) {
 	return {
 		...otherProps,
@@ -41,5 +44,38 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 
 			return action;
 		}),
+		onActionDropdownItemClick({
+			action,
+			event,
+			itemData,
+		}: {
+			action: {data: {id: string}};
+			event: Event;
+			itemData: {
+				actions: {
+					copy: {href: string; method: string};
+				};
+			};
+		}) {
+			if (action.data.id === 'copy') {
+				event?.preventDefault();
+
+				executeAsyncItemAction({
+					method: itemData.actions.copy.method,
+					refreshData: () => {
+						sessionStorage.setItem(
+							'com.liferay.site.cms.site.initializer.successMessage',
+							Liferay.Language.get(
+								'your-request-completed-successfully'
+							),
+							sessionStorage.TYPES.NECESSARY
+						);
+
+						navigate(additionalProps.backURL);
+					},
+					url: itemData.actions.copy.href,
+				});
+			}
+		},
 	};
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -73,6 +73,7 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 
 						navigate(additionalProps.backURL);
 					},
+					showToast: false,
 					url: itemData.actions.copy.href,
 				});
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
@@ -20,7 +20,7 @@ export function executeAsyncItemAction({
 }: {
 	errorMessage?: string;
 	method?: string;
-	refreshData?: () => {};
+	refreshData?: () => void;
 	requestBody?: string;
 	setActionItemLoading?: (loading: boolean) => void;
 	successMessage?: string;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
@@ -15,6 +15,7 @@ export function executeAsyncItemAction({
 	refreshData,
 	requestBody,
 	setActionItemLoading,
+	showToast = true,
 	successMessage,
 	url,
 }: {
@@ -23,6 +24,7 @@ export function executeAsyncItemAction({
 	refreshData?: () => void;
 	requestBody?: string;
 	setActionItemLoading?: (loading: boolean) => void;
+	showToast?: boolean;
 	successMessage?: string;
 	url: string;
 }): Promise<void> {
@@ -42,14 +44,16 @@ export function executeAsyncItemAction({
 	return fetch(url, requestOptions)
 		.then((response) => {
 			if (response.ok) {
-				openToast({
-					message:
-						successMessage ||
-						Liferay.Language.get(
-							'your-request-completed-successfully'
-						),
-					type: 'success',
-				});
+				if (showToast) {
+					openToast({
+						message:
+							successMessage ||
+							Liferay.Language.get(
+								'your-request-completed-successfully'
+							),
+						type: 'success',
+					});
+				}
 
 				refreshData?.();
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
@@ -28,3 +28,23 @@ ViewContentsSectionDisplayContext viewContentsSectionDisplayContext = (ViewConte
 		style="fluid"
 	/>
 </div>
+
+<aui:script>
+	(function () {
+		const sessionKey = 'com.liferay.site.cms.site.initializer.successMessage';
+
+		const successMessage = Liferay.Util.SessionStorage.getItem(
+			sessionKey,
+			Liferay.Util.SessionStorage.TYPES.NECESSARY
+		);
+
+		if (successMessage) {
+			Liferay.Util.openToast({
+				message: successMessage,
+				type: 'success',
+			});
+
+			Liferay.Util.SessionStorage.removeItem(sessionKey);
+		}
+	})();
+</aui:script>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
@@ -15,7 +15,7 @@ ViewVersionHistoryDisplayContext viewVersionHistoryDisplayContext = (ViewVersion
 	<div>
 		<react:component
 			module="{Toolbar} from site-cms-site-initializer"
-			props="<%= viewVersionHistoryDisplayContext.getToolbarReactData() %>"
+			props="<%= viewVersionHistoryDisplayContext.getProps() %>"
 		/>
 	</div>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
@@ -20,6 +20,7 @@ ViewVersionHistoryDisplayContext viewVersionHistoryDisplayContext = (ViewVersion
 	</div>
 
 	<frontend-data-set:headless-display
+		additionalProps="<%= viewVersionHistoryDisplayContext.getProps() %>"
 		apiURL="<%= viewVersionHistoryDisplayContext.getAPIURL() %>"
 		fdsActionDropdownItems="<%= viewVersionHistoryDisplayContext.getFDSActionDropdownItems() %>"
 		formName="fm"


### PR DESCRIPTION
LPD-61753 Navigate to main view after copying a version of an entry

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-61753)

When copying a versioned entry we want the user to be redirected to the main view

# How am I fixing it?

Since FDS takes control of the redirect and leaves it on the same page, we override the onActionClick. We set the session storage to show the message and then redirect the user to the main view

# How can you verify that it works?

* Go to the CMS
* Create a new Web Content
* Click on the kebab -> view history
* Click on the copy action

The user will be redirected to the web content view and a success message will be shown

https://github.com/user-attachments/assets/589f5a33-919a-4bbf-9caa-44779fe7efe4


