### PR TITLE
LPD-61789 Highlight active spaces in navigation

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpacesDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
+import com.liferay.site.cms.site.initializer.internal.util.InfoItemUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -40,6 +41,7 @@ public class ViewSpacesDisplayContext {
 		PortletResourcePermission portletResourcePermission) {
 
 		_assetLibraryResourceFactory = assetLibraryResourceFactory;
+		_httpServletRequest = httpServletRequest;
 		_jsonFactory = jsonFactory;
 		_portletResourcePermission = portletResourcePermission;
 
@@ -51,6 +53,8 @@ public class ViewSpacesDisplayContext {
 		Page<AssetLibrary> page = _getPage();
 
 		return HashMapBuilder.<String, Object>put(
+			"allSpacesActive", _isAllSpacesActive(_themeDisplay)
+		).put(
 			"allSpacesURL",
 			StringBundler.concat(
 				_themeDisplay.getPathFriendlyURLPublic(),
@@ -60,6 +64,8 @@ public class ViewSpacesDisplayContext {
 			JSONUtil.toJSONArray(
 				page.getItems(),
 				assetLibrary -> JSONUtil.put(
+					"active", _isAssetLibraryActive(assetLibrary)
+				).put(
 					"id", assetLibrary.getId()
 				).put(
 					"name", assetLibrary.getName()
@@ -139,7 +145,26 @@ public class ViewSpacesDisplayContext {
 			Pagination.of(1, 5), assetLibrariesPage.getTotalCount());
 	}
 
+	private boolean _isAllSpacesActive(ThemeDisplay themeDisplay) {
+		String urlCurrent = themeDisplay.getURLCurrent();
+
+		return urlCurrent.contains("/all-spaces");
+	}
+
+	private boolean _isAssetLibraryActive(AssetLibrary assetLibrary) {
+		if ((InfoItemUtil.getDepotEntryId(_httpServletRequest) ==
+				assetLibrary.getId()) ||
+			(InfoItemUtil.getGroupId(_httpServletRequest) ==
+				assetLibrary.getId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private final AssetLibraryResource.Factory _assetLibraryResourceFactory;
+	private final HttpServletRequest _httpServletRequest;
 	private final JSONFactory _jsonFactory;
 	private final PortletResourcePermission _portletResourcePermission;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces_navigation/SpacesNavigation.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces_navigation/SpacesNavigation.tsx
@@ -13,6 +13,7 @@ import SpaceSticker from '../../common/components/SpaceSticker';
 import {LogoColor} from '../../common/types/Space';
 
 export interface AssetLibrary {
+	active?: boolean;
 	id: number;
 	name: string;
 	settings?: {
@@ -22,6 +23,7 @@ export interface AssetLibrary {
 }
 
 interface SpacesNavigationProps {
+	allSpacesActive: boolean;
 	allSpacesURL: string;
 	assetLibraries: AssetLibrary[];
 	assetLibrariesCount: number;
@@ -46,6 +48,7 @@ interface VerticalNavItem {
 }
 
 const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
+	allSpacesActive,
 	allSpacesURL,
 	assetLibraries,
 	assetLibrariesCount,
@@ -62,12 +65,14 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 
 	const spacesNavigationItem = {
 		items: [
-			...assetLibraries.map(({name, settings, url}) => ({
+			...assetLibraries.map(({active, name, settings, url}) => ({
+				active,
 				href: url,
 				label: name,
 				stickerDisplayType: settings?.logoColor as LogoColor,
 			})),
 			{
+				active: allSpacesActive,
 				href: allSpacesURL,
 				icon: 'box-container',
 				label: sub(
@@ -101,6 +106,7 @@ const SpacesNavigation: React.FC<SpacesNavigationProps> = ({
 			{(item: VerticalNavItem) => {
 				return (
 					<VerticalNav.Item
+						active={item.active}
 						href={item.href}
 						items={item.items}
 						key={item.label}


### PR DESCRIPTION
# What is this trying to solve?

[{url}
](https://liferay.atlassian.net/browse/LPD-61789)

# How am I fixing it?

Passing the information to apply the styles

# How can you verify that it works?

Go to the CMS and select "all spaces" or a space and the tab should be active.

From this:

<img width="276" height="179" alt="Captura de pantalla 2025-07-28 a las 14 54 15" src="https://github.com/user-attachments/assets/65812c9c-2c3a-4461-8890-1f5359fe5fd5" />


To this:

<img width="424" height="149" alt="Captura de pantalla 2025-07-28 a las 14 53 16" src="https://github.com/user-attachments/assets/2b0eea6e-95d8-4c9f-a0df-3a0708bf5d73" />



