### PR TITLE
LPD-61166 Language key missing from success message after removing a user group from Spaces creation page

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersWithList.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersWithList.tsx
@@ -301,9 +301,7 @@ export function SpaceMembersWithList({
 		if (error) {
 			openToast({
 				message: sub(
-					Liferay.Language.get(
-						'unable-to-remove-group-x-from-space-x'
-					),
+					Liferay.Language.get('unable-to-remove-group-x-from-space'),
 					[`<strong>${item.name}</strong>`]
 				),
 				type: 'danger',
@@ -313,7 +311,7 @@ export function SpaceMembersWithList({
 			openToast({
 				message: sub(
 					Liferay.Language.get(
-						'group-x-successfully-removed-from-space-x'
+						'group-x-successfully-removed-from-space'
 					),
 					[`<strong>${item.name}</strong>`]
 				),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61166

Use correct language key

How to test: follow the steps in the ticket