### PR TITLE
LPD-61338 Fix the case when the newly created web content item is vertically misaligned due to a missing checkbox in the UI

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
@@ -119,15 +119,15 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 			}
 		}
 
-		if (!showInput) {
-			return StringPool.BLANK;
-		}
+		String checkBoxRowIds = StringPool.BLANK;
 
-		String checkBoxRowIds = StringBundler.concat(
-			"['", _liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
-			JournalFolder.class.getSimpleName(), "', '",
-			_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
-			JournalArticle.class.getSimpleName(), "']");
+		if (showInput) {
+			checkBoxRowIds = StringBundler.concat(
+				"['", _liferayPortletResponse.getNamespace(),
+				RowChecker.ROW_IDS, JournalFolder.class.getSimpleName(), "', '",
+				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
+				JournalArticle.class.getSimpleName(), "']");
+		}
 
 		return getRowCheckBox(
 			httpServletRequest, checked, disabled,

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
@@ -42,7 +42,7 @@ public class EntriesCheckerTest {
 
 	@AfterClass
 	public static void tearDownClass() {
-		_articleLocalServiceUtilMockedStatic.close();
+		_journalArticleLocalServiceUtilMockedStatic.close();
 		_languageUtilMockedStatic.close();
 		_journalArticlePermissionMockedStatic.close();
 	}
@@ -60,7 +60,7 @@ public class EntriesCheckerTest {
 			_ARTICLE_ID
 		);
 
-		_articleLocalServiceUtilMockedStatic.when(
+		_journalArticleLocalServiceUtilMockedStatic.when(
 			() -> JournalArticleLocalServiceUtil.fetchArticle(
 				_SCOPE_GROUP_ID, _ARTICLE_ID)
 		).thenReturn(
@@ -86,7 +86,8 @@ public class EntriesCheckerTest {
 		String rowCheckBox = entriesChecker.getRowCheckBox(
 			_getHttpServletRequest(), false, false, _ARTICLE_ID);
 
-		Assert.assertTrue((rowCheckBox != null) && !rowCheckBox.isEmpty());
+		Assert.assertNotNull(rowCheckBox);
+		Assert.assertFalse(rowCheckBox.isEmpty());
 	}
 
 	private HttpServletRequest _getHttpServletRequest() {
@@ -139,7 +140,7 @@ public class EntriesCheckerTest {
 	private static final long _SCOPE_GROUP_ID = 0;
 
 	private static final MockedStatic<JournalArticleLocalServiceUtil>
-		_articleLocalServiceUtilMockedStatic = Mockito.mockStatic(
+		_journalArticleLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			JournalArticleLocalServiceUtil.class);
 	private static final MockedStatic<JournalArticlePermission>
 		_journalArticlePermissionMockedStatic = Mockito.mockStatic(

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.search;
+
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jan Brychta
+ */
+public class EntriesCheckerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetRowCheckBoxForNoJournalArticlePermissions() {
+		EntriesChecker entriesChecker = new EntriesChecker(
+			_getLiferayPortletRequest(), _getLiferayPortletResponse());
+
+		try (MockedStatic<JournalArticleLocalServiceUtil>
+				articleLocalServiceUtilMockedStatic = Mockito.mockStatic(
+					JournalArticleLocalServiceUtil.class);
+			MockedStatic<LanguageUtil> languageUtilMockedStatic =
+				Mockito.mockStatic(LanguageUtil.class);
+			MockedStatic<JournalArticlePermission>
+				journalArticlePermissionMockedStatic = Mockito.mockStatic(
+					JournalArticlePermission.class)) {
+
+			JournalArticle mockArticle = Mockito.mock(JournalArticle.class);
+
+			Mockito.when(
+				mockArticle.getArticleId()
+			).thenReturn(
+				_ARTICLE_ID
+			);
+
+			articleLocalServiceUtilMockedStatic.when(
+				() -> JournalArticleLocalServiceUtil.fetchArticle(
+					_SCOPE_GROUP_ID, _ARTICLE_ID)
+			).thenReturn(
+				mockArticle
+			);
+
+			languageUtilMockedStatic.when(
+				() -> LanguageUtil.get(
+					Mockito.any(Locale.class), Mockito.eq("select"))
+			).thenReturn(
+				"Select (mocked)"
+			);
+
+			journalArticlePermissionMockedStatic.when(
+				() -> JournalArticlePermission.contains(
+					ArgumentMatchers.any(PermissionChecker.class),
+					ArgumentMatchers.any(JournalArticle.class),
+					ArgumentMatchers.anyString())
+			).thenReturn(
+				false
+			);
+
+			String rowCheckBox = entriesChecker.getRowCheckBox(
+				_getHttpServletRequest(), false, false, _ARTICLE_ID);
+
+			Assert.assertTrue((rowCheckBox != null) && !rowCheckBox.isEmpty());
+		}
+	}
+
+	private HttpServletRequest _getHttpServletRequest() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			_getThemeDisplay()
+		);
+
+		return httpServletRequest;
+	}
+
+	private LiferayPortletRequest _getLiferayPortletRequest() {
+		LiferayPortletRequest liferayPortletRequest = Mockito.mock(
+			LiferayPortletRequest.class);
+
+		ThemeDisplay themeDisplay = _getThemeDisplay();
+
+		Mockito.when(
+			liferayPortletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		return liferayPortletRequest;
+	}
+
+	private LiferayPortletResponse _getLiferayPortletResponse() {
+		return Mockito.mock(LiferayPortletResponse.class);
+	}
+
+	private PermissionChecker _getPermissionChecker() {
+		return Mockito.mock(PermissionChecker.class);
+	}
+
+	private ThemeDisplay _getThemeDisplay() {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setPermissionChecker(_getPermissionChecker());
+		themeDisplay.setScopeGroupId(_SCOPE_GROUP_ID);
+
+		return themeDisplay;
+	}
+
+	private static final String _ARTICLE_ID = "1234";
+
+	private static final long _SCOPE_GROUP_ID = 0;
+
+}

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/search/EntriesCheckerTest.java
@@ -20,6 +20,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Locale;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -39,56 +40,53 @@ public class EntriesCheckerTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
+	@AfterClass
+	public static void tearDownClass() {
+		_articleLocalServiceUtilMockedStatic.close();
+		_languageUtilMockedStatic.close();
+		_journalArticlePermissionMockedStatic.close();
+	}
+
 	@Test
 	public void testGetRowCheckBoxForNoJournalArticlePermissions() {
 		EntriesChecker entriesChecker = new EntriesChecker(
 			_getLiferayPortletRequest(), _getLiferayPortletResponse());
 
-		try (MockedStatic<JournalArticleLocalServiceUtil>
-				articleLocalServiceUtilMockedStatic = Mockito.mockStatic(
-					JournalArticleLocalServiceUtil.class);
-			MockedStatic<LanguageUtil> languageUtilMockedStatic =
-				Mockito.mockStatic(LanguageUtil.class);
-			MockedStatic<JournalArticlePermission>
-				journalArticlePermissionMockedStatic = Mockito.mockStatic(
-					JournalArticlePermission.class)) {
+		JournalArticle mockArticle = Mockito.mock(JournalArticle.class);
 
-			JournalArticle mockArticle = Mockito.mock(JournalArticle.class);
+		Mockito.when(
+			mockArticle.getArticleId()
+		).thenReturn(
+			_ARTICLE_ID
+		);
 
-			Mockito.when(
-				mockArticle.getArticleId()
-			).thenReturn(
-				_ARTICLE_ID
-			);
+		_articleLocalServiceUtilMockedStatic.when(
+			() -> JournalArticleLocalServiceUtil.fetchArticle(
+				_SCOPE_GROUP_ID, _ARTICLE_ID)
+		).thenReturn(
+			mockArticle
+		);
 
-			articleLocalServiceUtilMockedStatic.when(
-				() -> JournalArticleLocalServiceUtil.fetchArticle(
-					_SCOPE_GROUP_ID, _ARTICLE_ID)
-			).thenReturn(
-				mockArticle
-			);
+		_languageUtilMockedStatic.when(
+			() -> LanguageUtil.get(
+				Mockito.any(Locale.class), Mockito.eq("select"))
+		).thenReturn(
+			"Select (mocked)"
+		);
 
-			languageUtilMockedStatic.when(
-				() -> LanguageUtil.get(
-					Mockito.any(Locale.class), Mockito.eq("select"))
-			).thenReturn(
-				"Select (mocked)"
-			);
+		_journalArticlePermissionMockedStatic.when(
+			() -> JournalArticlePermission.contains(
+				ArgumentMatchers.any(PermissionChecker.class),
+				ArgumentMatchers.any(JournalArticle.class),
+				ArgumentMatchers.anyString())
+		).thenReturn(
+			false
+		);
 
-			journalArticlePermissionMockedStatic.when(
-				() -> JournalArticlePermission.contains(
-					ArgumentMatchers.any(PermissionChecker.class),
-					ArgumentMatchers.any(JournalArticle.class),
-					ArgumentMatchers.anyString())
-			).thenReturn(
-				false
-			);
+		String rowCheckBox = entriesChecker.getRowCheckBox(
+			_getHttpServletRequest(), false, false, _ARTICLE_ID);
 
-			String rowCheckBox = entriesChecker.getRowCheckBox(
-				_getHttpServletRequest(), false, false, _ARTICLE_ID);
-
-			Assert.assertTrue((rowCheckBox != null) && !rowCheckBox.isEmpty());
-		}
+		Assert.assertTrue((rowCheckBox != null) && !rowCheckBox.isEmpty());
 	}
 
 	private HttpServletRequest _getHttpServletRequest() {
@@ -139,5 +137,14 @@ public class EntriesCheckerTest {
 	private static final String _ARTICLE_ID = "1234";
 
 	private static final long _SCOPE_GROUP_ID = 0;
+
+	private static final MockedStatic<JournalArticleLocalServiceUtil>
+		_articleLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			JournalArticleLocalServiceUtil.class);
+	private static final MockedStatic<JournalArticlePermission>
+		_journalArticlePermissionMockedStatic = Mockito.mockStatic(
+			JournalArticlePermission.class);
+	private static final MockedStatic<LanguageUtil> _languageUtilMockedStatic =
+		Mockito.mockStatic(LanguageUtil.class);
 
 }


### PR DESCRIPTION
What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61338

The newly created web content item is vertically misaligned due to a missing checkbox in the UI.

How am I fixing it?

Change the logic to show a checkbox even user does not have permission to make any actions. In this, when you check this checkbox, then corresponding actions are disabled ( this follows the same pattern we have in place for Blogs, D&Ms)