### PR TITLE
LPD-61967 Improve message when copying a version

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -21700,6 +21700,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name
 version-notes=Version Notes
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}.
 version-x-url=Version {0} URL
 versioning=Versioning
 versioning-strategy-overridable=Version Strategy Overridable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=عيّن هذا الخيار على "خ�
 version-name=اسم الإصدار
 version-notes=ملاحظات الإصدار
 version-x=الإصدار {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=عنوا {0} للإصدار URL
 versioning=تعيين الإصدار
 versioning-strategy-overridable=استراتيجية الإصدار القابل للتجاوز

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Задайте това на false, ак
 version-name=Име на версията
 version-notes=Бележки за версията (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Версии (Automatic Translation)
 versioning-strategy-overridable=Стратегия за версията може да се отменя (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Establiu això en fals si només s'hauri
 version-name=Nom de la versió
 version-notes=Notes de versió
 version-x=Versió {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la versió {0}
 versioning=Versions
 versioning-strategy-overridable=Estratègia de versions reemplaçable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Jméno/název verze
 version-notes=Version Notes (Automatic Copy)
 version-x=Verze {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Angiv dette til falsk, hvis kun den sene
 version-name=Versionsnavn
 version-notes=Bemærkninger til version (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versionering (Automatic Translation)
 versioning-strategy-overridable=Versionsstrategi kan tilsidesættes (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Auf false setzen, wenn standardmäßig n
 version-name=Versionsname
 version-notes=Versionshinweise
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL der Version {0}
 versioning=Versionierung
 versioning-strategy-overridable=Versionsstrategie überschreibbar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Auf false setzen, wenn standardmäßig n
 version-name=Versionsname
 version-notes=Versionshinweise
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL der Version {0}
 versioning=Versionierung
 versioning-strategy-overridable=Versionsstrategie überschreibbar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Auf false setzen, wenn standardmäßig n
 version-name=Versionsname
 version-notes=Versionshinweise
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL der Version {0}
 versioning=Versionierung
 versioning-strategy-overridable=Versionsstrategie überschreibbar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Ορίστε αυτό το θέμα σε
 version-name=Όνομα έκδοσης
 version-notes=Σημειώσεις έκδοσης (Automatic Translation)
 version-x=Έκδοση {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Έκδοση (Automatic Translation)
 versioning-strategy-overridable=Η στρατηγική έκδοσης είναι υπερισχύσιμη (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -21700,6 +21700,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name
 version-notes=Version Notes
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}.
 version-x-url=Version {0} URL
 versioning=Versioning
 versioning-strategy-overridable=Version Strategy Overridable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Establezca esta opción en falso si solo
 version-name=Nombre de la versión
 version-notes=Notas de la versión
 version-x=Versión {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la versión {0}
 versioning=Control de versiones
 versioning-strategy-overridable=Estrategia de versiones reemplazable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Establezca esta opción en falso si solo
 version-name=Nombre de la versión
 version-notes=Notas de la versión
 version-x=Versión {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la versión {0}
 versioning=Control de versiones
 versioning-strategy-overridable=Estrategia de versiones reemplazable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Establezca esta opción en falso si solo
 version-name=Nombre de la versión
 version-notes=Notas de la versión
 version-x=Versión {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la versión {0}
 versioning=Control de versiones
 versioning-strategy-overridable=Estrategia de versiones reemplazable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Establezca esta opción en falso si solo
 version-name=Nombre de la versión
 version-notes=Notas de la versión
 version-x=Versión {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la versión {0}
 versioning=Control de versiones
 versioning-strategy-overridable=Estrategia de versiones reemplazable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Seadke see väärtuseks false, kui vaiki
 version-name=Versiooni nimi
 version-notes=Versioonimärkmed (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioonimine (Automatic Translation)
 versioning-strategy-overridable=Versioonistrateegia alistatav (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Bertsio izena
 version-notes=Bertsioaren oharrak
 version-x={0} bertsioa
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Bertsioen kontrola
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=تنظیم این به نادرست اگ
 version-name=نام نسخه
 version-notes=یادداشت های نسخه
 version-x=نسخه‌ی{0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=آدرس اینترنتی نسخه {0}
 versioning=نسخه بندی
 versioning-strategy-overridable=نسخه استراتژی قابل اغماض

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -21692,6 +21692,7 @@ version-history-by-default-enabled-help=Aseta tämä epätodeksi vain, jos viime
 version-name=Version nimi
 version-notes=Versiohuomautukset
 version-x=Versio {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL
 versioning=Versiointi
 versioning-strategy-overridable=Versiostrategia Ohitettava

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Réglez ce paramètre sur faux si seulem
 version-name=Nom De la Version
 version-notes=Notes de version
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la version {0}
 versioning=Mise en version
 versioning-strategy-overridable=Stratégie de version remplaçable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Réglez ce paramètre sur faux si seulem
 version-name=Nom De la Version
 version-notes=Notes de version
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la version {0}
 versioning=Mise en version
 versioning-strategy-overridable=Stratégie de version remplaçable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Réglez ce paramètre sur faux si seulem
 version-name=Nom De la Version
 version-notes=Notes de version
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la version {0}
 versioning=Mise en version
 versioning-strategy-overridable=Stratégie de version remplaçable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Réglez ce paramètre sur faux si seulem
 version-name=Nom De la Version
 version-notes=Notes de version
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL de la version {0}
 versioning=Mise en version
 versioning-strategy-overridable=Stratégie de version remplaçable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Estableza isto en falso se só se deber�
 version-name=Nome da versión
 version-notes=Notas da versión
 version-x=Versión {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Versión {0} url
 versioning=Versións
 versioning-strategy-overridable=Estratexia de versións substituíbel

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=इसे झूठी सेट कर�
 version-name=Version नेम
 version-notes=वर्जन नोट्स (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=वर्जनिंग (Automatic Translation)
 versioning-strategy-overridable=वर्जन स्ट्रैटजी ओवरराइडेबल (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Naziv verzije
 version-notes=Version Notes (Automatic Copy)
 version-x=Verzija {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -21697,6 +21697,7 @@ version-history-by-default-enabled-help=Állítsa Hamis értékre, ha alapértel
 version-name=Verzió neve
 version-notes=Megjegyzések a verzióhoz
 version-x=Verzió {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=A {0}. verzió URL-címe
 versioning=Verziószámozás
 versioning-strategy-overridable=Felülírható verzióstratégia

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Atur ini ke false jika hanya versi terba
 version-name=Nama versi
 version-notes=Catatan Versi (Automatic Translation)
 version-x=Versi{0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Pembuatan versi (Automatic Translation)
 versioning-strategy-overridable=Strategi Versi Dapat Ditidakan (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -21695,6 +21695,7 @@ version-history-by-default-enabled-help=Impostare questa impostazione su false s
 version-name=Nome della Versione
 version-notes=Note della versione
 version-x=Versione {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL versione {0}
 versioning=Gestione versioni
 versioning-strategy-overridable=Strategia della versione di cui è possibile eseguire l'override (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Impostare questa impostazione su false s
 version-name=Nome della Versione
 version-notes=Note della versione
 version-x=Versione {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL versione {0}
 versioning=Gestione versioni
 versioning-strategy-overridable=Strategia della versione di cui è possibile eseguire l'override (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=הגדר אפשרות זו כ- false א�
 version-name=שם הגירסא
 version-notes=הערות גירסה
 version-x=גירסא {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=ה-URL של גירסה {0}
 versioning=ניהול גירסאות
 versioning-strategy-overridable=ניתן לעקוף אסטרטגיית גירסה (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Falseに設定すると、最新の承�
 version-name=バージョン名
 version-notes=バージョンメモ
 version-x=バージョン {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=バージョン {0} の URL
 versioning=バージョニング
 versioning-strategy-overridable=バージョン計画の上書き可否

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -21700,6 +21700,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name
 version-notes=Version Notes
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL
 versioning=Versioning
 versioning-strategy-overridable=Version Strategy Overridable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -21693,6 +21693,7 @@ version-history-by-default-enabled-help=웹 콘텐츠 기사의 최신 승인 �
 version-name=버전 이름
 version-notes=버전 노트
 version-x=버전 {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=버전 {0} URL
 versioning=버전 관리
 versioning-strategy-overridable=버전 전략 재정의 가능

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=ຊື່ລຸ້ນ
 version-notes=Version Notes (Automatic Copy)
 version-x=ລຸ້ນ {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Nustatykite, kad tai būtų klaidinga, j
 version-name=Versijos pavadinimas (Automatic Translation)
 version-notes=Versijos pastabos (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versijų kūrimas (Automatic Translation)
 versioning-strategy-overridable=Versijos strategijos nepaisoma (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Tetapkan ini kepada palsu jika hanya ver
 version-name=Nama Versi (Automatic Translation)
 version-notes=Nota Versi (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versi (Automatic Translation)
 versioning-strategy-overridable=Strategi Versi Boleh Digankriminasi (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Version Name (Automatic Copy)
 version-notes=Version Notes (Automatic Copy)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Settes til falsk om bare den siste godkj
 version-name=Versjonsnavn
 version-notes=Versjonsnotateter
 version-x=Versjon {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Versjon {0} URL
 versioning=Versjonering
 versioning-strategy-overridable=Versjoneringsstrategi overstyrbart

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -21697,6 +21697,7 @@ version-history-by-default-enabled-help=Stel dit in als 'onwaar' als alleen de l
 version-name=Versienaam
 version-notes=Versienota's
 version-x=Versie {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL-versie {0}
 versioning=Versiebeheer
 versioning-strategy-overridable=Versiestrategie overschrijfbaar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -21697,6 +21697,7 @@ version-history-by-default-enabled-help=Stel dit in als 'onwaar' als alleen de l
 version-name=Versie naam
 version-notes=Versienota's
 version-x=Versie {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL-versie {0}
 versioning=Versiebeheer
 versioning-strategy-overridable=Versiestrategie overschrijfbaar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Settes til falsk om bare den siste godkj
 version-name=Versjonsnavn
 version-notes=Versjonsnotateter
 version-x=Versjon {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Versjon {0} URL
 versioning=Versjonering
 versioning-strategy-overridable=Versjoneringsstrategi overstyrbart

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Ustaw to na false, jeśli tylko najnowsz
 version-name=Nazwa wersji
 version-notes=Uwagi Do Wersji
 version-x=Wersja {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Wersjonowanie
 versioning-strategy-overridable=Przesłonialne strategii wersji (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Definir como falso se apenas a última v
 version-name=Nome da versão
 version-notes=Notas da versão
 version-x=Versão {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL da Versão {0}
 versioning=Controle de versão
 versioning-strategy-overridable=Estratégia de versão substituível

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=Definir como falso se apenas a última v
 version-name=Nome da Versão
 version-notes=Notas da versão
 version-x=Versão {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL da Versão {0}
 versioning=Controle de versão
 versioning-strategy-overridable=Estratégia de versão substituível

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Setați acest lucru la fals în cazul î
 version-name=Nume Versiune
 version-notes=Note versiune (Automatic Translation)
 version-x=Versiune {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versiune (Automatic Translation)
 versioning-strategy-overridable=Strategia versiunii suprascrise (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Установите это на лож�
 version-name=Имя версии
 version-notes=Примечания версии (Automatic Translation)
 version-x=Версия {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Версия (Automatic Translation)
 versioning-strategy-overridable=Версия Стратегия Переодержимая (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Nastavte túto hodnotu na hodnotu false,
 version-name=Meno verzie
 version-notes=Poznámky k verzii (Automatic Translation)
 version-x=Verzia {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Znenie verzií (Automatic Translation)
 versioning-strategy-overridable=Prepísateľná stratégia verzií (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Nastavite to na napačno, če je privzet
 version-name=Ime različice.
 version-notes=Opombe različice (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Različica (Automatic Translation)
 versioning-strategy-overridable=Različica Strategija preglasljiva (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Име Верзије
 version-notes=Version Notes (Automatic Copy)
 version-x=Верзија {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=Ime Verzije
 version-notes=Version Notes (Automatic Copy)
 version-x=Verzija {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Versioning (Automatic Copy)
 versioning-strategy-overridable=Version Strategy Overridable (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Ange detta som falskt om den senast godk
 version-name=Versionsnamn
 version-notes=Versionsanteckningar
 version-x=Version {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL för version {0}
 versioning=Versionshantering
 versioning-strategy-overridable=Versionsstrategi kan åsidosättas

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=இதனை false என மாற்�
 version-name=பதிப்பின் பெயர்
 version-notes=பதிப்பின் குறிப்புகள்
 version-x=பதிப்பு {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=வெர்ஷன் {0} URL
 versioning=பதிப்புகள்
 versioning-strategy-overridable=வெர்ஷன் Strategy Overridable

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=ตั้งค่านี้เป็�
 version-name=ชื่อเวอร์ชัน
 version-notes=หมายเหตุเวอร์ชัน
 version-x=เวอร์ชัน {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=URL {0} เวอร์ชัน
 versioning=เวอร์ชัน
 versioning-strategy-overridable=วิธีการแทนที่เวอร์ชัน

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Web içeriği makalelerinin yalnızca en
 version-name=Sürüm Adı
 version-notes=Sürüm Notları (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Sürüm Oluşturma (Automatic Translation)
 versioning-strategy-overridable=Sürüm Stratejisi Geçersiz Kılınamaz (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Встановіть цей параме
 version-name=Ім'я версії
 version-notes=Примітки до версії (Automatic Translation)
 version-x=Version {0} (Automatic Copy)
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Керування версіями (Automatic Translation)
 versioning-strategy-overridable=Стратегія версії, яку можна перевизначити (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -21694,6 +21694,7 @@ version-history-by-default-enabled-help=Đặt điều này thành false nếu c
 version-name=Tên phiên bản
 version-notes=Ghi chú Phiên bản (Automatic Translation)
 version-x=Phiên bản {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=Version {0} URL (Automatic Copy)
 versioning=Phiên bản (Automatic Translation)
 versioning-strategy-overridable=Chiến lược phiên bản có thể ghi đè (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -21696,6 +21696,7 @@ version-history-by-default-enabled-help=如果在默认情况下只应发布 Web
 version-name=版本名称
 version-notes=版本注释
 version-x=版本{0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=版本 {0} URL
 versioning=版本
 versioning-strategy-overridable=版本策略可替换

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -21695,6 +21695,7 @@ version-history-by-default-enabled-help=Set this to false if only the latest app
 version-name=版本名稱
 version-notes=版本注釋
 version-x=版本 {0}
+version-x-successfully-copied-as-x=Version {0} successfully copied as {1}. (Automatic Copy)
 version-x-url=版本 {0} URL
 versioning=版本
 versioning-strategy-overridable=版本策略可替換

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -42,3 +42,23 @@ page import="com.liferay.site.cms.site.initializer.internal.display.context.View
 <liferay-util:html-top>
 	<aui:link href='<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>' rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
+
+<aui:script>
+	(function () {
+		const sessionKey = 'com.liferay.site.cms.site.initializer.successMessage';
+
+		const successMessage = Liferay.Util.SessionStorage.getItem(
+			sessionKey,
+			Liferay.Util.SessionStorage.TYPES.NECESSARY
+		);
+
+		if (successMessage) {
+			Liferay.Util.openToast({
+				message: successMessage,
+				type: 'success',
+			});
+
+			Liferay.Util.SessionStorage.removeItem(sessionKey);
+		}
+	})();
+</aui:script>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -4,7 +4,7 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
-import {navigate, sessionStorage} from 'frontend-js-web';
+import {navigate, sessionStorage, sub} from 'frontend-js-web';
 
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
@@ -55,6 +55,11 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 				actions: {
 					copy: {href: string; method: string};
 				};
+				systemProperties: {
+					version: {
+						number: number;
+					};
+				};
 			};
 		}) {
 			if (action.data.id === 'copy') {
@@ -62,11 +67,15 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 
 				executeAsyncItemAction({
 					method: itemData.actions.copy.method,
-					refreshData: () => {
+					refreshData: (responseData) => {
 						sessionStorage.setItem(
 							'com.liferay.site.cms.site.initializer.successMessage',
-							Liferay.Language.get(
-								'your-request-completed-successfully'
+							sub(
+								Liferay.Language.get(
+									'version-x-successfully-copied-as-x'
+								),
+								itemData.systemProperties.version.number,
+								`<strong>"${responseData.title}"</strong>`
 							),
 							sessionStorage.TYPES.NECESSARY
 						);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
@@ -21,13 +21,15 @@ export function executeAsyncItemAction({
 }: {
 	errorMessage?: string;
 	method?: string;
-	refreshData?: () => void;
+	refreshData?: (responseData: any) => void;
 	requestBody?: string;
 	setActionItemLoading?: (loading: boolean) => void;
 	showToast?: boolean;
 	successMessage?: string;
 	url: string;
 }): Promise<void> {
+	const DEFAULT_ERROR = Liferay.Language.get('an-unexpected-error-occurred');
+
 	const requestOptions: RequestInit = {
 		headers: {
 			'Accept': 'application/json',
@@ -43,30 +45,32 @@ export function executeAsyncItemAction({
 
 	return fetch(url, requestOptions)
 		.then((response) => {
-			if (response.ok) {
-				if (showToast) {
-					openToast({
-						message:
-							successMessage ||
-							Liferay.Language.get(
-								'your-request-completed-successfully'
-							),
-						type: 'success',
-					});
-				}
-
-				refreshData?.();
-			}
-			else {
+			if (!response.ok) {
 				openToast({
-					message:
-						errorMessage ||
-						Liferay.Language.get('an-unexpected-error-occurred'),
+					message: errorMessage || DEFAULT_ERROR,
 					type: 'danger',
 				});
 
 				setActionItemLoading?.(false);
+
+				throw DEFAULT_ERROR;
 			}
+
+			return response.json();
+		})
+		.then((responseData) => {
+			if (showToast) {
+				openToast({
+					message:
+						successMessage ||
+						Liferay.Language.get(
+							'your-request-completed-successfully'
+						),
+					type: 'success',
+				});
+			}
+
+			refreshData?.(responseData);
 		})
 		.catch(() => {
 			openToast({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
@@ -28,23 +28,3 @@ ViewContentsSectionDisplayContext viewContentsSectionDisplayContext = (ViewConte
 		style="fluid"
 	/>
 </div>
-
-<aui:script>
-	(function () {
-		const sessionKey = 'com.liferay.site.cms.site.initializer.successMessage';
-
-		const successMessage = Liferay.Util.SessionStorage.getItem(
-			sessionKey,
-			Liferay.Util.SessionStorage.TYPES.NECESSARY
-		);
-
-		if (successMessage) {
-			Liferay.Util.openToast({
-				message: successMessage,
-				type: 'success',
-			});
-
-			Liferay.Util.SessionStorage.removeItem(sessionKey);
-		}
-	})();
-</aui:script>


### PR DESCRIPTION
Improve message when copying a version

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-61967)

At the moment, after copying a version, the following message is shwon:

Success: Your request completed successfully.

It should be: 

Success: Version [X] successfully copied as "[Document name] (Copy)".

# How am I fixing it?

Modifying the code to show the correct message

# How can you verify that it works?

Follow the steps in the ticket
