### PR TITLE
LPD-61987 Technical Task | Change from CMS_CONSUMER to CMS_MEMBER

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 7.4.1
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/constants/DepotRolesConstants.java
@@ -23,6 +23,4 @@ public class DepotRolesConstants {
 
 	public static final String ASSET_LIBRARY_OWNER = "Asset Library Owner";
 
-	public static final String CMS_CONSUMER = "CMS Consumer";
-
 }

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
@@ -9,7 +9,6 @@ import com.liferay.depot.internal.util.DepotRoleUtil;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Role;
@@ -35,13 +34,6 @@ public class DepotRolesPortalInstanceLifecycleListener
 		throws PortalException {
 
 		for (String name : DepotRoleUtil.DEPOT_ROLE_NAMES) {
-			if (name.equals(RoleConstants.CMS_MEMBER) &&
-				!FeatureFlagManagerUtil.isEnabled(
-					company.getCompanyId(), "LPD-17564")) {
-
-				continue;
-			}
-
 			Role role = _getOrCreateRole(company.getCompanyId(), name);
 
 			_resourceLocalService.addResources(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/instance/lifecycle/DepotRolesPortalInstanceLifecycleListener.java
@@ -5,7 +5,6 @@
 
 package com.liferay.depot.internal.instance.lifecycle;
 
-import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.internal.util.DepotRoleUtil;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
@@ -36,7 +35,7 @@ public class DepotRolesPortalInstanceLifecycleListener
 		throws PortalException {
 
 		for (String name : DepotRoleUtil.DEPOT_ROLE_NAMES) {
-			if (name.equals(DepotRolesConstants.CMS_CONSUMER) &&
+			if (name.equals(RoleConstants.CMS_MEMBER) &&
 				!FeatureFlagManagerUtil.isEnabled(
 					company.getCompanyId(), "LPD-17564")) {
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
@@ -92,7 +92,7 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
 			Objects.equals(
 				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER) ||
-			Objects.equals(role.getName(), DepotRolesConstants.CMS_CONSUMER)) {
+			Objects.equals(role.getName(), RoleConstants.CMS_MEMBER)) {
 
 			return false;
 		}
@@ -107,7 +107,7 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 			Objects.equals(
 				role.getName(),
 				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
-			Objects.equals(role.getName(), DepotRolesConstants.CMS_CONSUMER)) {
+			Objects.equals(role.getName(), RoleConstants.CMS_MEMBER)) {
 
 			return true;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/roles/admin/role/type/contributor/DepotRoleTypeContributor.java
@@ -91,8 +91,7 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 				role.getName(),
 				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
 			Objects.equals(
-				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER) ||
-			Objects.equals(role.getName(), RoleConstants.CMS_MEMBER)) {
+				role.getName(), DepotRolesConstants.ASSET_LIBRARY_OWNER)) {
 
 			return false;
 		}
@@ -106,8 +105,7 @@ public class DepotRoleTypeContributor implements RoleTypeContributor {
 				role.getName(), DepotRolesConstants.ASSET_LIBRARY_MEMBER) ||
 			Objects.equals(
 				role.getName(),
-				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER) ||
-			Objects.equals(role.getName(), RoleConstants.CMS_MEMBER)) {
+				DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER)) {
 
 			return true;
 		}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
@@ -10,14 +10,12 @@ import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.contributor.RoleCollection;
 import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
@@ -79,13 +77,6 @@ public class DepotRoleContributor implements RoleContributor {
 						break;
 					}
 				}
-			}
-
-			if (FeatureFlagManagerUtil.isEnabled(
-					group.getCompanyId(), "LPD-17564") &&
-				group.isCMS()) {
-
-				_addRoleId(roleCollection, RoleConstants.CMS_MEMBER);
 			}
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/contributor/DepotRoleContributor.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.contributor.RoleCollection;
 import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
@@ -84,7 +85,7 @@ public class DepotRoleContributor implements RoleContributor {
 					group.getCompanyId(), "LPD-17564") &&
 				group.isCMS()) {
 
-				_addRoleId(roleCollection, DepotRolesConstants.CMS_CONSUMER);
+				_addRoleId(roleCollection, RoleConstants.CMS_MEMBER);
 			}
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
@@ -9,7 +9,6 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.internal.instance.lifecycle.DepotRolesPortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -31,7 +30,7 @@ public class DepotRoleUtil {
 		DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER,
 		DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
 		DepotRolesConstants.ASSET_LIBRARY_MEMBER,
-		DepotRolesConstants.ASSET_LIBRARY_OWNER, RoleConstants.CMS_MEMBER
+		DepotRolesConstants.ASSET_LIBRARY_OWNER
 	};
 
 	public static Map<Locale, String> getDescriptionMap(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/util/DepotRoleUtil.java
@@ -9,6 +9,7 @@ import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.internal.instance.lifecycle.DepotRolesPortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -30,8 +31,7 @@ public class DepotRoleUtil {
 		DepotRolesConstants.ASSET_LIBRARY_CONNECTED_SITE_MEMBER,
 		DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
 		DepotRolesConstants.ASSET_LIBRARY_MEMBER,
-		DepotRolesConstants.ASSET_LIBRARY_OWNER,
-		DepotRolesConstants.CMS_CONSUMER
+		DepotRolesConstants.ASSET_LIBRARY_OWNER, RoleConstants.CMS_MEMBER
 	};
 
 	public static Map<Locale, String> getDescriptionMap(

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -12,9 +12,7 @@ import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.test.util.DepotTestUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -23,18 +21,15 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -57,32 +52,6 @@ public class DepotRoleContributorTest {
 		_depotEntry = _addDepotEntry();
 
 		_group = GroupTestUtil.addGroup();
-	}
-
-	@FeatureFlag("LPD-17564")
-	@Test
-	public void testCMSMemberRoleAssignment() throws Exception {
-		Role role = _roleLocalService.fetchRole(
-			_group.getCompanyId(), RoleConstants.CMS_MEMBER);
-
-		Assume.assumeNotNull(role);
-
-		Group group = GroupTestUtil.addGroup(
-			_group.getCompanyId(), TestPropsValues.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
-
-		DepotTestUtil.withSiteMember(
-			group,
-			user -> {
-				PermissionChecker permissionChecker =
-					_permissionCheckerFactory.create(user);
-
-				Assert.assertTrue(
-					ArrayUtil.contains(
-						permissionChecker.getRoleIds(
-							user.getUserId(), group.getGroupId()),
-						role.getRoleId()));
-			});
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -14,6 +14,7 @@ import com.liferay.depot.test.util.DepotTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -60,9 +61,9 @@ public class DepotRoleContributorTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
-	public void testCMSConsumerRoleAssignment() throws Exception {
+	public void testCMSMemberRoleAssignment() throws Exception {
 		Role role = _roleLocalService.fetchRole(
-			_group.getCompanyId(), DepotRolesConstants.CMS_CONSUMER);
+			_group.getCompanyId(), RoleConstants.CMS_MEMBER);
 
 		Assume.assumeNotNull(role);
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleDisplayContext.java
@@ -380,7 +380,7 @@ public class DepotAdminSelectRoleDisplayContext {
 							DepotRolesConstants.ASSET_LIBRARY_MEMBER,
 							role.getName()) &&
 						!Objects.equals(
-							DepotRolesConstants.CMS_CONSUMER, role.getName()));
+							RoleConstants.CMS_MEMBER, role.getName()));
 			}
 
 			if (!GroupPermissionUtil.contains(
@@ -404,8 +404,7 @@ public class DepotAdminSelectRoleDisplayContext {
 					!Objects.equals(
 						DepotRolesConstants.ASSET_LIBRARY_OWNER,
 						role.getName()) &&
-					!Objects.equals(
-						DepotRolesConstants.CMS_CONSUMER, role.getName()) &&
+					!Objects.equals(RoleConstants.CMS_MEMBER, role.getName()) &&
 					RolePermissionUtil.contains(
 						permissionChecker, _group.getGroupId(),
 						role.getRoleId(), ActionKeys.ASSIGN_MEMBERS));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -11,7 +11,6 @@ import com.liferay.asset.kernel.model.AssetTagGroupRel;
 import com.liferay.asset.kernel.service.AssetTagGroupRelLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
-import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetLibrary;
@@ -689,14 +688,13 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		// group creation.
 
 		Role role = _roleLocalService.fetchRole(
-			testDepotEntryGroup.getCompanyId(),
-			DepotRolesConstants.CMS_CONSUMER);
+			testDepotEntryGroup.getCompanyId(), RoleConstants.CMS_MEMBER);
 
 		if (role == null) {
 			_roleLocalService.addRole(
 				null, TestPropsValues.getUserId(), null, 0,
-				DepotRolesConstants.CMS_CONSUMER, null, null,
-				RoleConstants.TYPE_DEPOT, null, null);
+				RoleConstants.CMS_MEMBER, null, null, RoleConstants.TYPE_DEPOT,
+				null, null);
 		}
 
 		GroupTestUtil.addGroup(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -8,7 +8,6 @@ package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalService;
-import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetLibrary;
@@ -652,14 +651,13 @@ public class TaxonomyVocabularyResourceTest
 		// group creation.
 
 		Role role = _roleLocalService.fetchRole(
-			testDepotEntryGroup.getCompanyId(),
-			DepotRolesConstants.CMS_CONSUMER);
+			testDepotEntryGroup.getCompanyId(), RoleConstants.CMS_MEMBER);
 
 		if (role == null) {
 			_roleLocalService.addRole(
 				null, TestPropsValues.getUserId(), null, 0,
-				DepotRolesConstants.CMS_CONSUMER, null, null,
-				RoleConstants.TYPE_DEPOT, null, null);
+				RoleConstants.CMS_MEMBER, null, null, RoleConstants.TYPE_DEPOT,
+				null, null);
 		}
 
 		GroupTestUtil.addGroup(

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/role/type/contributor/RegularRoleTypeContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/role/type/contributor/RegularRoleTypeContributor.java
@@ -13,6 +13,7 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.roles.admin.role.type.contributor.RoleTypeContributor;
 
 import java.util.Locale;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -78,7 +79,9 @@ public class RegularRoleTypeContributor implements RoleTypeContributor {
 
 	@Override
 	public boolean isAllowDelete(Role role) {
-		if (role == null) {
+		if ((role == null) ||
+			Objects.equals(role.getName(), RoleConstants.CMS_MEMBER)) {
+
 			return false;
 		}
 
@@ -92,7 +95,8 @@ public class RegularRoleTypeContributor implements RoleTypeContributor {
 	}
 
 	private static final String[] _AUTOMATICALLY_ASSIGNED_ROLE_NAMES = {
-		RoleConstants.GUEST, RoleConstants.OWNER, RoleConstants.USER
+		RoleConstants.CMS_MEMBER, RoleConstants.GUEST, RoleConstants.OWNER,
+		RoleConstants.USER
 	};
 
 	@Reference

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/RegularRoleContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/RegularRoleContributor.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.roles.admin.internal.security.permission.contributor;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.contributor.RoleCollection;
+import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alicia García
+ */
+@Component(service = RoleContributor.class)
+public class RegularRoleContributor implements RoleContributor {
+
+	@Override
+	public void contribute(RoleCollection roleCollection) {
+		try {
+			if (!FeatureFlagManagerUtil.isEnabled(
+					roleCollection.getCompanyId(), "LPD-17564") ||
+				(roleCollection.getGroupId() <= 0)) {
+
+				return;
+			}
+
+			Group group = _groupLocalService.getGroup(
+				roleCollection.getGroupId());
+
+			if (group.isCMS()) {
+				Role role = _roleLocalService.getRole(
+					roleCollection.getCompanyId(), RoleConstants.CMS_MEMBER);
+
+				roleCollection.addRoleId(role.getRoleId());
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RegularRoleContributor.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/RegularRoleContributorTest.java
+++ b/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/RegularRoleContributorTest.java
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.roles.admin.internal.security.permission.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class RegularRoleContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+
+		_user = UserTestUtil.addUser();
+
+		UserTestUtil.setUser(_user);
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testCMSMemberRoleAssignment() throws Exception {
+		Role role = _roleLocalService.fetchRole(
+			_group.getCompanyId(), RoleConstants.CMS_MEMBER);
+
+		Assume.assumeNotNull(role);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				permissionChecker.getRoleIds(
+					_user.getUserId(), _group.getGroupId()),
+				role.getRoleId()));
+	}
+
+	private Group _group;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/instance/lifecycle/AddDefaultServiceAccountUserPortalInstanceLifecycleListener.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/instance/lifecycle/AddDefaultServiceAccountUserPortalInstanceLifecycleListener.java
@@ -7,7 +7,14 @@ package com.liferay.users.admin.internal.instance.lifecycle;
 
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ResourceLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -22,8 +29,44 @@ public class AddDefaultServiceAccountUserPortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {
+		if (FeatureFlagManagerUtil.isEnabled(
+				company.getCompanyId(), "LPD-17564")) {
+
+			Role role = _roleLocalService.fetchRole(
+				company.getCompanyId(), RoleConstants.CMS_MEMBER);
+
+			if (role == null) {
+				boolean addResource = PermissionThreadLocal.isAddResource();
+
+				try {
+					PermissionThreadLocal.setAddResource(false);
+
+					User user = _userLocalService.getGuestUser(
+						company.getCompanyId());
+
+					role = _roleLocalService.addRole(
+						null, user.getUserId(), null, 0,
+						RoleConstants.CMS_MEMBER, null, null,
+						RoleConstants.TYPE_REGULAR, null, null);
+				}
+				finally {
+					PermissionThreadLocal.setAddResource(addResource);
+				}
+			}
+
+			_resourceLocalService.addResources(
+				company.getCompanyId(), 0, 0, Role.class.getName(),
+				role.getRoleId(), false, false, false);
+		}
+
 		_userLocalService.addDefaultServiceAccountUser(company.getCompanyId());
 	}
+
+	@Reference
+	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/RoleConstants.java
@@ -26,6 +26,8 @@ public class RoleConstants {
 
 	public static final String CMS_ADMINISTRATOR = "CMS Administrator";
 
+	public static final String CMS_MEMBER = "CMS Member";
+
 	public static final String GUEST = "Guest";
 
 	public static final String NAME_INVALID_CHARACTERS =

--- a/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/role/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0


### PR DESCRIPTION

https://liferay.atlassian.net/browse/LPD-61987 Technical Task | Change from CMS_CONSUMER to CMS_MEMBER

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-40060

CMS Member role

As a Role Administrator I want to be able to have an out-of-the-box CMS Member role so that the users have access to the different sections of the CMS


This role should be a Regular role
	CMS Member - It is automatically assigned when a user is assigned with a Space Role (AL Roles).
	This role has no permissions by default

# How am I fixing it?

I renamed the CMS_CONSUMER to CMS_MEMBER
I moved the role to regular one.
I'm moving all the logic to the role-admin module.

# How can you verify that it works?

Run the included automated tests.



# Commits



- **LPD-61987 Rename the role CMS_CONSUMER to CMS_MEMBER and change its place to RoleConstants**
- **LPD-61987 role is now regular one**
- **LPD-61987 move test**
- **LPD-61987 baseline**
