### PR TITLE
LPD-62170 CMS: cannot access to a folder.  Include additionalProps in the folders view

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
@@ -20,6 +20,7 @@ ViewFolderSectionDisplayContext viewFolderSectionDisplayContext = (ViewFolderSec
 	</div>
 
 	<frontend-data-set:headless-display
+		additionalProps="<%= viewFolderSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= viewFolderSectionDisplayContext.getAPIURL() %>"
 		bulkActionDropdownItems="<%= viewFolderSectionDisplayContext.getBulkActionDropdownItems() %>"
 		creationMenu="<%= viewFolderSectionDisplayContext.getCreationMenu() %>"


### PR DESCRIPTION
Link to issue https://liferay.atlassian.net/browse/LPD-62170

There is an error thrown in the console because a parameter is missing in a component. That is included in additionalProps attribute, so I added it to the folders view. 