### PR TITLE
LPD-62168 Unable to add image field to web content via headless API if the field is required

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMValueUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.delivery.dto.v1_0.util;
 
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
@@ -161,6 +162,16 @@ public class DDMValueUtil {
 
 		return new UnlocalizedValue(
 			GetterUtil.getString(contentFieldValue.getData()));
+	}
+
+	private static String _getFileEntryUrl(FileEntry fileEntry) {
+		try {
+			return DLURLHelperUtil.getPreviewURL(
+				fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK);
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	private static Layout _getLayout(
@@ -439,6 +450,8 @@ public class DDMValueUtil {
 		).put(
 			"classPK", fileEntry.getFileEntryId()
 		).put(
+			"description", description
+		).put(
 			"fileEntryId", fileEntry.getFileEntryId()
 		).put(
 			"groupId", fileEntry.getGroupId()
@@ -450,6 +463,8 @@ public class DDMValueUtil {
 			"title", fileEntry.getFileName()
 		).put(
 			"type", "document"
+		).put(
+			"url", _getFileEntryUrl(fileEntry)
 		).put(
 			"uuid", fileEntry.getUuid()
 		).toString();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -651,28 +651,8 @@ public class StructuredContentResourceTest
 
 		super.testPostStructuredContentFolderStructuredContent();
 
-		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
-			testGroup.getGroupId(),
-			_portal.getClassNameId(JournalArticle.class.getName()),
-			_localizedDDMStructure.getStructureId(), true,
-			WorkflowConstants.STATUS_APPROVED);
-
-		Locale locale = LocaleUtil.getDefault();
-
-		StructuredContent randomStructuredContent = _randomStructuredContent(
-			locale);
-
-		StructuredContentResource structuredContentResource =
-			_buildStructureContentResource(locale);
-
-		StructuredContent postStructuredContent =
-			structuredContentResource.
-				postStructuredContentFolderStructuredContent(
-					_journalFolder.getFolderId(), randomStructuredContent);
-
-		Assert.assertTrue(
-			postStructuredContent.getRenderedContents()[0].
-				getMarkedAsDefault());
+		_testPostStructuredContentFolderStructuredContentWithDisplayPage();
+		_testPostStructuredContentFolderStructuredContentWithMandatoryImageField();
 	}
 
 	@Override
@@ -2650,6 +2630,87 @@ public class StructuredContentResourceTest
 
 		Assert.assertEquals(1, jsonObject.getLong("processedItemsCount"));
 		Assert.assertEquals(1, jsonObject.getLong("totalItemsCount"));
+	}
+
+	private void _testPostStructuredContentFolderStructuredContentWithDisplayPage()
+		throws Exception {
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			testGroup.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			_localizedDDMStructure.getStructureId(), true,
+			WorkflowConstants.STATUS_APPROVED);
+
+		Locale locale = LocaleUtil.getDefault();
+
+		StructuredContent randomStructuredContent = _randomStructuredContent(
+			locale);
+
+		StructuredContentResource structuredContentResource =
+			_buildStructureContentResource(locale);
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.
+				postStructuredContentFolderStructuredContent(
+					_journalFolder.getFolderId(), randomStructuredContent);
+
+		Assert.assertTrue(
+			postStructuredContent.getRenderedContents()[0].
+				getMarkedAsDefault());
+	}
+
+	private void _testPostStructuredContentFolderStructuredContentWithMandatoryImageField()
+		throws Exception {
+
+		DDMStructure imageStructure = _addDDMStructure(
+			testGroup, "test-ddm-structure-image.json");
+
+		StructuredContent structuredContent = randomStructuredContent();
+
+		structuredContent.setContentStructureId(
+			imageStructure.getStructureId());
+
+		structuredContent.setContentFields(
+			new ContentField[] {
+				new ContentField() {
+					{
+						contentFieldValue = new ContentFieldValue() {
+							{
+								image = new ContentDocument() {
+									{
+										description =
+											RandomTestUtil.randomString();
+										id = _dlFileEntry.getFileEntryId();
+									}
+								};
+							}
+						};
+						name = "image";
+					}
+				}
+			});
+
+		StructuredContent postStructuredContent =
+			structuredContentResource.
+				postStructuredContentFolderStructuredContent(
+					_journalFolder.getFolderId(), structuredContent);
+
+		assertValid(postStructuredContent);
+
+		StructuredContent getStructuredContent =
+			structuredContentResource.getStructuredContent(
+				postStructuredContent.getId());
+
+		ContentField contentField = getStructuredContent.getContentFields()[0];
+
+		Assert.assertEquals("image", contentField.getName());
+
+		ContentDocument contentDocument = contentField.getContentFieldValue(
+		).getImage();
+
+		Assert.assertNotNull(contentDocument);
+		Assert.assertEquals(
+			_dlFileEntry.getFileEntryId(), (long)contentDocument.getId());
 	}
 
 	private void _testPutSiteStructuredContentByExternalReferenceCodeWithCustomField()

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-image.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-ddm-structure-image.json
@@ -1,0 +1,29 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fields": [
+		{
+			"dataType": "image",
+			"fieldNamespace": "ddm",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Image"
+			},
+			"localizable": true,
+			"name": "image",
+			"predefinedValue": {
+				"en_US": ""
+			},
+			"readOnly": false,
+			"repeatable": false,
+			"required": true,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			},
+			"type": "ddm-image"
+		}
+	]
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62168

When a structure contains a mandatory image field, it is currently not possible to create a web content article that includes an image.

# How am I fixing it?

This fix adds the url and description properties to the contentDocument JSON, ensuring the mandatory image field is correctly populated during content creation.

# How can you verify that it works?

"Run the included automated tests."