### PR TITLE
LPD-61967 Fix issue when calling endpoints with no body in response

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
@@ -49,7 +49,7 @@ export function executeAsyncItemAction({
 				throw new Error(DEFAULT_ERROR);
 			}
 
-			return response.json();
+			return response.status === 204 ? '' : response.json();
 		})
 		.then((responseData) => {
 			if (showToast) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/executeAsyncItemAction.ts
@@ -46,14 +46,7 @@ export function executeAsyncItemAction({
 	return fetch(url, requestOptions)
 		.then((response) => {
 			if (!response.ok) {
-				openToast({
-					message: errorMessage || DEFAULT_ERROR,
-					type: 'danger',
-				});
-
-				setActionItemLoading?.(false);
-
-				throw DEFAULT_ERROR;
+				throw new Error(DEFAULT_ERROR);
 			}
 
 			return response.json();
@@ -74,9 +67,7 @@ export function executeAsyncItemAction({
 		})
 		.catch(() => {
 			openToast({
-				message:
-					errorMessage ||
-					Liferay.Language.get('an-unexpected-error-occurred'),
+				message: errorMessage || DEFAULT_ERROR,
 				type: 'danger',
 			});
 


### PR DESCRIPTION
- **LPD-61967 Just throw the error and let the catch take care of it, otherwise it will be shown twice**
- **LPD-61967 If the status is 204 return an empty string, since it means there is no body involved**
