### PR TITLE
LPD-61279 Technical Task | Show only Assets from Spaces

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/SharedAssetEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/SharedAssetEntityModel.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.user.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -21,6 +22,7 @@ public class SharedAssetEntityModel implements EntityModel {
 
 	public SharedAssetEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new BooleanEntityField("space", locale -> "space"),
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -6,12 +6,18 @@
 package com.liferay.headless.admin.user.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.headless.admin.user.client.dto.v1_0.SharedAsset;
+import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -21,6 +27,7 @@ import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -41,6 +48,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -55,11 +63,15 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -92,6 +104,100 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
 
 		_userLocalService.deleteUser(_user);
+	}
+
+	@Override
+	@Test
+	public void testGetMyUserAccountSharedAssetsSharedWithMePage()
+		throws Exception {
+
+		super.testGetMyUserAccountSharedAssetsSharedWithMePage();
+
+		DepotEntry assetLibraryDepotEntry =
+			_depotEntryLocalService.addDepotEntry(
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getGroupId(), _user.getUserId()));
+
+		DepotEntry spaceDepotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(), DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), _user.getUserId()));
+
+		ObjectDefinition depotScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		try {
+			Page<SharedAsset> page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null, Pagination.of(1, 10), null);
+
+			long totalCount = page.getTotalCount();
+
+			testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				randomSharedAsset());
+
+			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+				depotScopedObjectDefinition.getUserId(),
+				depotScopedObjectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
+				StringPool.TRUE);
+
+			_testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				assetLibraryDepotEntry.getGroupId(),
+				depotScopedObjectDefinition, randomSharedAsset());
+			_testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				spaceDepotEntry.getGroupId(), depotScopedObjectDefinition,
+				randomSharedAsset());
+			_testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				spaceDepotEntry.getGroupId(), depotScopedObjectDefinition,
+				randomSharedAsset());
+
+			page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, null, Pagination.of(1, 10), null);
+
+			Assert.assertEquals(totalCount + 4, page.getTotalCount());
+
+			page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, "(space eq false)", Pagination.of(1, 10),
+						null);
+
+			Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+			page =
+				sharedAssetResource.
+					getMyUserAccountSharedAssetsSharedWithMePage(
+						null, null, "(space eq true)", Pagination.of(1, 10),
+						null);
+
+			Assert.assertEquals(2, page.getTotalCount());
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				depotScopedObjectDefinition);
+
+			_depotEntryLocalService.deleteDepotEntry(assetLibraryDepotEntry);
+			_depotEntryLocalService.deleteDepotEntry(spaceDepotEntry);
+		}
 	}
 
 	@Override
@@ -141,32 +247,8 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 				SharedAsset sharedAsset)
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), _user.getUserId());
-
-		DLFileEntry dlFileEntry = _addDLFileEntry(
-			testGroup.getGroupId(), TestPropsValues.getUserId());
-
-		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-			testGroup.getGroupId(), _user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), 0, null,
-			HashMapBuilder.<String, Serializable>put(
-				"file", dlFileEntry.getFileEntryId()
-			).put(
-				"title", sharedAsset.getTitle()
-			).build(),
-			serviceContext);
-
-		return _toObjectEntrySharedAsset(
-			objectEntry, sharedAsset,
-			_sharingEntryLocalService.addSharingEntry(
-				sharedAsset.getExternalReferenceCode(), _user.getUserId(), 0,
-				TestPropsValues.getUserId(),
-				_classNameLocalService.getClassNameId(
-					_objectDefinition.getClassName()),
-				objectEntry.getObjectEntryId(), testGroup.getGroupId(), true,
-				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
+		return _testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+			testGroup.getGroupId(), _objectDefinition, sharedAsset);
 	}
 
 	private DLFileEntry _addDLFileEntry(long groupId, long userId)
@@ -244,6 +326,40 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 			objectDefinition);
 	}
 
+	private SharedAsset
+			_testGetMyUserAccountSharedAssetsSharedWithMePage_addSharedAsset(
+				long groupId, ObjectDefinition objectDefinition,
+				SharedAsset sharedAsset)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				groupId, _user.getUserId());
+
+		DLFileEntry dlFileEntry = _addDLFileEntry(
+			groupId, TestPropsValues.getUserId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			groupId, _user.getUserId(),
+			objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"file", dlFileEntry.getFileEntryId()
+			).put(
+				"title", sharedAsset.getTitle()
+			).build(),
+			serviceContext);
+
+		return _toObjectEntrySharedAsset(
+			objectEntry, sharedAsset,
+			_sharingEntryLocalService.addSharingEntry(
+				sharedAsset.getExternalReferenceCode(), _user.getUserId(), 0,
+				TestPropsValues.getUserId(),
+				_classNameLocalService.getClassNameId(
+					objectDefinition.getClassName()),
+				objectEntry.getObjectEntryId(), groupId, true,
+				Arrays.asList(SharingEntryAction.VIEW), null, serviceContext));
+	}
+
 	private SharedAsset _toObjectEntryFolderSharedAsset(
 			SharedAsset sharedAsset, SharingEntry sharingEntry)
 		throws Exception {
@@ -310,7 +426,14 @@ public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	@Inject
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;

--- a/modules/apps/sharing/sharing-service/build.gradle
+++ b/modules/apps/sharing/sharing-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")

--- a/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/search/spi/model/index/contributor/SharingEntryModelDocumentContributor.java
+++ b/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/search/spi/model/index/contributor/SharingEntryModelDocumentContributor.java
@@ -5,8 +5,15 @@
 
 package com.liferay.sharing.internal.search.spi.model.index.contributor;
 
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 import com.liferay.sharing.interpreter.SharingEntryInterpreter;
 import com.liferay.sharing.interpreter.SharingEntryInterpreterProvider;
@@ -14,6 +21,7 @@ import com.liferay.sharing.model.SharingEntry;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -33,6 +41,7 @@ public class SharingEntryModelDocumentContributor
 		document.addKeyword(Field.CLASS_NAME_ID, sharingEntry.getClassNameId());
 		document.addKeyword(
 			Field.CLASS_PK, String.valueOf(sharingEntry.getClassPK()));
+		document.addKeyword("space", _isSpace(sharingEntry.getGroupId()));
 		document.addDate(Field.CREATE_DATE, sharingEntry.getCreateDate());
 		document.addDate(Field.MODIFIED_DATE, sharingEntry.getModifiedDate());
 		document.addLocalizedText(Field.TITLE, _getTitleMap(sharingEntry));
@@ -58,6 +67,43 @@ public class SharingEntryModelDocumentContributor
 
 		return sharingEntryInterpreter.getTitleMap(sharingEntry);
 	}
+
+	private boolean _isSpace(long groupId) {
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if (group == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to get group " + groupId +
+						" while indexing document");
+			}
+
+			return false;
+		}
+
+		if (group.isDepot()) {
+			DepotEntry depotEntry =
+				_depotEntryLocalService.fetchGroupDepotEntry(groupId);
+
+			if ((depotEntry != null) &&
+				Objects.equals(
+					depotEntry.getType(), DepotConstants.TYPE_SPACE)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SharingEntryModelDocumentContributor.class);
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private SharingEntryInterpreterProvider _sharingEntryInterpreterProvider;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSharedWithMeSectionDisplayContext.java
@@ -29,7 +29,7 @@ public class ViewSharedWithMeSectionDisplayContext {
 
 	public String getAPIURL() {
 		return "/o/headless-admin-user/v1.0/my-user-account/shared-assets" +
-			"/shared-with-me";
+			"/shared-with-me?filter=space eq true";
 	}
 
 	public Map<String, Object> getEmptyState() {


### PR DESCRIPTION
LPD-61279 Technical Task | Show only Assets from Spaces (by now only Asset libraries)

Resent after : https://github.com/brianchandotcom/liferay-portal/pull/164176#issuecomment-3149875796
This PR is over Brian's master.
and by now, the spaces DO NOT HAVE space type so the list will be empty.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48676

As a content creator I want to be able to access a section to view assets that are shared with me so that I can take additional actions on these assets

Table View
- When at least one content is shared with the user, it will appear in the Shared with Me section in Table View
- Shared Content, Files and Folders exist in this view. Only Table View will be supported for now
- Content and Files shared individually will appear at the root level of the Shared with Me section


# How am I fixing it?

add the filter of groups ids to the API URl

# How can you verify that it works?

Run the included automated tests.


1. As admin
 1.1 Create a new User with CMS permission
 1.2 Go to CMS create some files and Share with the new User via the http://localhost:8080/o/api?endpoint=http://localhost:8080/o/cms/basic-documents/openapi.json postBasicDocumentCollaboratorsPage endpoint
2. Update the space to space type 
3. Log out and log in with new User
4. Go to CMS and see new Share with Me section




# Commits
- **LPD-61279 add the new parameter to the search results**
- **LPD-61279 add new filter to the api URL call on the cms**
- **LPD-61279 add test to check that GetMyUserAccountSharedAssetsSharedWithMePage with new filter works**
