### PR TITLE
LPD-62427 Add sorts for the object entry version history

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -6,6 +6,10 @@
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItem;
+import com.liferay.frontend.data.set.model.FDSSortItemBuilder;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
+import com.liferay.frontend.data.set.model.FDSSortItemListBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.petra.string.StringBundler;
@@ -71,6 +75,16 @@ public class ViewVersionHistoryDisplayContext {
 				"delete", null));
 	}
 
+	public FDSSortItemList getFDSSortItemList() {
+		return FDSSortItemListBuilder.add(
+			_getFDSSortItem(false, "asc", "dateModified", "modified")
+		).add(
+			_getFDSSortItem(false, "asc", "title", "title")
+		).add(
+			_getFDSSortItem(true, "desc", "version", "version")
+		).build();
+	}
+
 	public Map<String, Object> getProps() throws PortalException {
 		return HashMapBuilder.<String, Object>put(
 			"backURL", ParamUtil.getString(_httpServletRequest, "backURL")
@@ -83,6 +97,20 @@ public class ViewVersionHistoryDisplayContext {
 				StringPool.QUOTE,
 				_objectEntry.getTitleValue(_themeDisplay.getLanguageId(), true),
 				"\" ", _language.get(_themeDisplay.getLocale(), "history"))
+		).build();
+	}
+
+	private FDSSortItem _getFDSSortItem(
+		boolean active, String direction, String key, String labelKey) {
+
+		return FDSSortItemBuilder.setActive(
+			active
+		).setDirection(
+			direction
+		).setKey(
+			key
+		).setLabel(
+			_language.get(_themeDisplay.getLocale(), labelKey)
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ViewVersionHistoryTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ViewVersionHistoryTableFDSView.java
@@ -39,9 +39,9 @@ public class ViewVersionHistoryTableFDSView extends BaseTableFDSView {
 				true
 			)
 		).add(
-			"systemProperties.version.number", "version",
+			"version", "version",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"version"
+				"versionTableCellRenderer"
 			).setSortable(
 				true
 			)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ViewVersionHistoryTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ViewVersionHistoryTableFDSView.java
@@ -34,11 +34,17 @@ public class ViewVersionHistoryTableFDSView extends BaseTableFDSView {
 		return fdsTableSchemaBuilder.add(
 			"title", "title",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"title")
+				"title"
+			).setSortable(
+				true
+			)
 		).add(
 			"systemProperties.version.number", "version",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"version")
+				"version"
+			).setSortable(
+				true
+			)
 		).add(
 			"status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
@@ -50,7 +56,10 @@ public class ViewVersionHistoryTableFDSView extends BaseTableFDSView {
 		).add(
 			"dateModified", "modified",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"dateTime")
+				"dateTime"
+			).setSortable(
+				true
+			)
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -9,6 +9,7 @@ import {navigate, sessionStorage, sub} from 'frontend-js-web';
 import deleteEntryAction from './actions/deleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
+import VersionRenderer from './cell_renderers/VersionRenderer';
 import {executeAsyncItemAction} from './utils/executeAsyncItemAction';
 
 export default function ViewVersionHistoryFDSPropsTransformer({
@@ -31,6 +32,11 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 				{
 					component: NameRenderer,
 					name: 'nameTableCellRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+				{
+					component: VersionRenderer,
+					name: 'versionTableCellRenderer',
 					type: 'internal',
 				} as IInternalRenderer,
 			],

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/VersionRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/VersionRenderer.tsx
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+const VersionRenderer = ({itemData}: {itemData: any}) => {
+	return <>{itemData.systemProperties.version.number}</>;
+};
+
+export default VersionRenderer;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_version_history.jsp
@@ -23,6 +23,7 @@ ViewVersionHistoryDisplayContext viewVersionHistoryDisplayContext = (ViewVersion
 		additionalProps="<%= viewVersionHistoryDisplayContext.getProps() %>"
 		apiURL="<%= viewVersionHistoryDisplayContext.getAPIURL() %>"
 		fdsActionDropdownItems="<%= viewVersionHistoryDisplayContext.getFDSActionDropdownItems() %>"
+		fdsSortItemList="<%= viewVersionHistoryDisplayContext.getFDSSortItemList() %>"
 		formName="fm"
 		id="<%= CMSSiteInitializerFDSNames.VIEW_HISTORY %>"
 		itemsPerPage="<%= 20 %>"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62427

# What is this trying to solve?

This PR add the sort improvements for the object entry version lists:

1. Add sorts to the management toolbar according to the designs
2. Fix version sort

# How am I fixing it?

1. Add sort to the management toolbar according to the designs. Add the sort to the DisplayContext and then to the FDS.
2. Fix sort for the cases that we have an embedded field like the version.  Add the version renderer to display the correct value of the field, but left the order as it is in order to sort by the indexed value that is the _version_ and not the _systemProperties.version.number_

# How can you verify that it works?

1. See the toolbar that now we can see the sorts and you can sort by any.
2. Try to order by version and see that is working fine.

# Additional information

Take into account that the order does not work for the moment until a [pr sent to bpm team](https://github.com/liferay-bpm/liferay-portal/pull/4841) is merged. So, please deploy the changes of the PR in order to test it.