### PR TITLE
LPD-59382 Add expire action at object entry level

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -55,7 +55,7 @@ public class ViewContentsSectionDisplayContextTest
 			getFDSActionDropdownItems();
 
 		Assert.assertEquals(
-			fdsActionDropdownItems.toString(), 9,
+			fdsActionDropdownItems.toString(), 10,
 			fdsActionDropdownItems.size());
 
 		assertFDSActionDropdownItem(
@@ -71,19 +71,22 @@ public class ViewContentsSectionDisplayContextTest
 			fdsActionDropdownItems.get(3), "share", "share", "share", "get",
 			"item");
 		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(4), "pencil", "actionLink", "edit",
-			"get", "item");
-		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(5), "view", "viewContent", "view", "get",
+			fdsActionDropdownItems.get(4), "view", "viewContent", "view", "get",
 			"item");
 		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(6), "date-time", "version-history",
+			fdsActionDropdownItems.get(5), "pencil", "actionLink", "edit",
+			"get", "item");
+		assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(6), "time", "expire", "expire", "post",
+			"item");
+		assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(7), "date-time", "version-history",
 			"view-history", "get", "item");
 		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(7), "password-policies", "permissions",
+			fdsActionDropdownItems.get(8), "password-policies", "permissions",
 			"permissions", "get", "item");
 		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(8), "trash", "delete", "delete",
+			fdsActionDropdownItems.get(9), "trash", "delete", "delete",
 			"delete", "item");
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -268,6 +268,10 @@ public abstract class BaseSectionDisplayContext {
 				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
 				null),
 			new FDSActionDropdownItem(
+				"{actions.expire.href}", "time", "expire",
+				LanguageUtil.get(httpServletRequest, "expire"), "post",
+				"expire", "headless"),
+			new FDSActionDropdownItem(
 				StringBundler.concat(
 					themeDisplay.getPathFriendlyURLPublic(),
 					GroupConstants.CMS_FRIENDLY_URL,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-59382

# What is this trying to solve?

Add expire action to object entries

# How am I fixing it?

Adding the action to the getFDSActionDropdownItems

# How can you verify that it works?

1. Go to all, content or files section.
2. Add an object entry : Basic Web content or Basic Document.
3. Add some versions for the entry.
4. From the list of the section try yo expire the entry and you can get all versions expired.