### PR TITLE
LPD-62431 Also concat mbMessageId to reply urlSubject in order to avoid massive iterations on non A-Z or 0-9 comments

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -2347,7 +2347,9 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		String uniqueUrlSubject = urlSubject;
 
-		if (Objects.equals(StringPool.DASH, urlSubject)) {
+		if (Objects.equals(StringPool.DASH, urlSubject) ||
+			Objects.equals(urlSubject, "re-")) {
+
 			uniqueUrlSubject = urlSubject + mbMessageId;
 		}
 

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageLocalServiceTest.java
@@ -164,6 +164,37 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
+	public void testAddMessageUrlSubject() throws PortalException {
+		String subject = StringPool.DASH;
+		String body = StringPool.BLANK;
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+
+		MBMessage message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, "bbcode", inputStreamOVPs, false, 0.0, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			subject + message.getMessageId(), message.getUrlSubject());
+
+		subject =
+			MBMessageConstants.MESSAGE_SUBJECT_PREFIX_RE + StringPool.DASH;
+
+		message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, "bbcode", inputStreamOVPs, false, 0.0, false,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			"re-" + message.getMessageId(), message.getUrlSubject());
+	}
+
+	@Test
 	public void testAddMessageWithEmptyBody() throws Exception {
 		User user = TestPropsValues.getUser();
 		String subject = StringUtil.randomString();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62431

# What is this trying to solve?
[LPD-62431 Also concat mbMessageId to reply urlSubject in order to avoid massive iterations on non A-Z or 0-9 comments](https://liferay.atlassian.net/browse/LPD-62431)
Replies to MBMessages where urlSubject ends up as `re-` will face performance degradation in calculating unique suffix.

# How am I fixing it?
Reusing the idea of [LPS-190841](https://liferay.atlassian.net/browse/LPS-190841), not only `-`, but `re-` should be using the mbMessageId already unique suffix

# How can you verify that it works?
1. Create a Thread titled `-`
2. Reply to it
3. Check the DB for the urlSubject of the latest MBMessage
4. Which should not be `re-`, `re-1` or any similar `re-${smallNumber}, but `re-${mbMessageId }`

# Why doesn't this include any test?
It is a performance improvement in a Deprecated feature

Cheers,
Balázs