### PR TITLE
LPD-61290 Add view action for file and content versions

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -92,7 +92,7 @@ public class ViewContentsSectionDisplayContext
 					"&redirect=", themeDisplay.getURLCurrent()),
 				"view", "viewContent",
 				LanguageUtil.get(httpServletRequest, "view"), "get", null,
-				"modal"));
+				null));
 
 		return fdsActionDropdownItems;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -58,6 +58,12 @@ public class ViewVersionHistoryDisplayContext {
 				_language.get(_httpServletRequest, "download"), "get", null,
 				"link"),
 			new FDSActionDropdownItem(
+				StringPool.BLANK, "view", "view-file",
+				_language.get(_httpServletRequest, "view"), null, null, null,
+				HashMapBuilder.<String, Object>put(
+					"objectEntryFolderExternalReferenceCode", "L_FILES"
+				).build()),
+			new FDSActionDropdownItem(
 				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore"), "put", "restore",
 				null),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -68,16 +68,11 @@ public class ViewVersionHistoryDisplayContext {
 					"&p_l_mode=read&p_p_state=", LiferayWindowState.POP_UP,
 					"&redirect=", _themeDisplay.getURLCurrent()),
 				"view", "view-content",
-				LanguageUtil.get(_httpServletRequest, "view"), null, null, null,
-				HashMapBuilder.<String, Object>put(
-					"objectEntryFolderExternalReferenceCode", "L_CONTENTS"
-				).build()),
+				LanguageUtil.get(_httpServletRequest, "view"), null, null,
+				null),
 			new FDSActionDropdownItem(
 				StringPool.BLANK, "view", "view-file",
-				_language.get(_httpServletRequest, "view"), null, null, null,
-				HashMapBuilder.<String, Object>put(
-					"objectEntryFolderExternalReferenceCode", "L_FILES"
-				).build()),
+				_language.get(_httpServletRequest, "view"), null, null, null),
 			new FDSActionDropdownItem(
 				"{actions.restore.href}", "restore", "restore",
 				_language.get(_httpServletRequest, "restore"), "put", "restore",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -16,6 +16,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -57,6 +60,18 @@ public class ViewVersionHistoryDisplayContext {
 				"{file.link.href}", "download", "download",
 				_language.get(_httpServletRequest, "download"), "get", null,
 				"link"),
+			new FDSActionDropdownItem(
+				StringBundler.concat(
+					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
+					GroupConstants.CMS_FRIENDLY_URL,
+					"/edit_content_item?objectEntryId={id}",
+					"&p_l_mode=read&p_p_state=", LiferayWindowState.POP_UP,
+					"&redirect=", _themeDisplay.getURLCurrent()),
+				"view", "view-content",
+				LanguageUtil.get(_httpServletRequest, "view"), null, null, null,
+				HashMapBuilder.<String, Object>put(
+					"objectEntryFolderExternalReferenceCode", "L_CONTENTS"
+				).build()),
 			new FDSActionDropdownItem(
 				StringPool.BLANK, "view", "view-file",
 				_language.get(_httpServletRequest, "view"), null, null, null,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ContentsFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ContentsFDSPropsTransformer.ts
@@ -4,7 +4,9 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {openModal} from 'frontend-js-components-web';
 
+import formatActionURL from '../../common/utils/formatActionURL';
 import AssetTypeInfoPanel from '../info_panel/AssetTypeInfoPanelContent';
 import {EVENTS} from '../info_panel/util/constants';
 import createAssetAction from './actions/createAssetAction';
@@ -94,12 +96,6 @@ export default function ContentFDSPropsTransformer({
 			if (action?.data?.id === 'viewContent') {
 				return {
 					...action,
-					data: {
-						...action.data,
-						disableHeader: false,
-						size: 'full-screen',
-						title: 'View',
-					},
 					isVisible: (item: any) =>
 						Boolean(
 							item?.entryClassName !==
@@ -112,15 +108,14 @@ export default function ContentFDSPropsTransformer({
 		}),
 		onActionDropdownItemClick: ({
 			action,
+			event,
 			itemData,
 		}: {
 			action: any;
+			event: Event;
 			itemData: any;
 		}) => {
-			if (action?.data?.id === 'show-details') {
-				Liferay.fire(EVENTS.ASSET_DATA, {items: [{...itemData}]});
-			}
-			else if (action?.data?.id === 'share') {
+			if (action?.data?.id === 'share') {
 				const {autocompleteURL, collaboratorURLs} = additionalProps;
 
 				shareAction({
@@ -129,6 +124,18 @@ export default function ContentFDSPropsTransformer({
 					creator: itemData.embedded.creator,
 					itemId: itemData.embedded.id,
 					title: itemData.embedded?.title,
+				});
+			}
+			else if (action?.data?.id === 'show-details') {
+				Liferay.fire(EVENTS.ASSET_DATA, {items: [{...itemData}]});
+			}
+			else if (action?.data?.id === 'viewContent') {
+				event?.preventDefault();
+
+				openModal({
+					size: 'full-screen',
+					title: itemData.embedded.title,
+					url: formatActionURL(itemData, action.href),
 				});
 			}
 		},

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -7,6 +7,7 @@ import {IInternalRenderer} from '@liferay/frontend-data-set-web';
 import {openModal} from 'frontend-js-components-web';
 import {navigate, sessionStorage, sub} from 'frontend-js-web';
 
+import formatActionURL from '../../common/utils/formatActionURL';
 import FilePreviewerModalContent from '../modal/FilePreviewerModalContent';
 import deleteEntryAction from './actions/deleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
@@ -59,22 +60,9 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 			itemData,
 			loadData,
 		}: {
-			action: {data: {id: string; successMessage: string}; href?: string};
+			action: any;
 			event: Event;
-			itemData: {
-				actions: {
-					copy: {href: string; method: string};
-					delete: {href: string; method: string};
-					expire: {href: string; method: string};
-					restore: {href: string; method: string};
-				};
-				file: any;
-				systemProperties: {
-					version: {
-						number: number;
-					};
-				};
-			};
+			itemData: any;
 			loadData: () => {};
 		}) {
 			if (action.data.id === 'copy') {
@@ -148,12 +136,25 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 					url: itemData.actions.restore.href,
 				});
 			}
+			else if (action?.data?.id === 'view-content') {
+				event?.preventDefault();
+
+				openModal({
+					containerProps: {
+						className: '',
+					},
+					size: 'full-screen',
+					title: sub(
+						Liferay.Language.get('x-version-x'),
+						itemData.title,
+						`${sub(Liferay.Language.get('version-x'), itemData.systemProperties.version.number)}`
+					),
+					url: formatActionURL(itemData, action.href),
+				});
+			}
 			else if (action?.data?.id === 'view-file') {
 				if (itemData.file) {
 					openModal({
-						containerProps: {
-							className: '',
-						},
 						contentComponent: () =>
 							FilePreviewerModalContent(itemData.file),
 						size: 'full-screen',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -51,6 +51,18 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 					isVisible: (item: any) => Boolean(item?.file?.link?.href),
 				};
 			}
+			else if (action?.data?.id === 'view-content') {
+				return {
+					...action,
+					isVisible: (item: any) => Boolean(!item?.file?.link?.href),
+				};
+			}
+			else if (action?.data?.id === 'view-file') {
+				return {
+					...action,
+					isVisible: (item: any) => Boolean(item?.file?.link?.href),
+				};
+			}
 
 			return action;
 		}),
@@ -60,9 +72,23 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 			itemData,
 			loadData,
 		}: {
-			action: any;
+			action: {data: {id: string; successMessage: string}; href: string};
 			event: Event;
-			itemData: any;
+			itemData: {
+				actions: {
+					copy: {href: string; method: string};
+					delete: {href: string; method: string};
+					expire: {href: string; method: string};
+					restore: {href: string; method: string};
+				};
+				file: any;
+				systemProperties: {
+					version: {
+						number: number;
+					};
+				};
+				title: string;
+			};
 			loadData: () => {};
 		}) {
 			if (action.data.id === 'copy') {
@@ -137,34 +163,30 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 				});
 			}
 			else if (action?.data?.id === 'view-content') {
-				if (!itemData.file) {
-					event?.preventDefault();
+				event?.preventDefault();
 
-					openModal({
-						containerProps: {
-							className: '',
-						},
-						size: 'full-screen',
-						title: sub(
-							Liferay.Language.get('x-version-x'),
-							itemData.title,
-							`${sub(
-								Liferay.Language.get('version-x'),
-								itemData.systemProperties.version.number
-							)}`
-						),
-						url: formatActionURL(itemData, action.href),
-					});
-				}
+				openModal({
+					containerProps: {
+						className: '',
+					},
+					size: 'full-screen',
+					title: sub(
+						Liferay.Language.get('x-version-x'),
+						itemData.title,
+						`${sub(
+							Liferay.Language.get('version-x'),
+							itemData.systemProperties.version.number
+						)}`
+					),
+					url: formatActionURL(itemData, action.href),
+				});
 			}
 			else if (action?.data?.id === 'view-file') {
-				if (itemData.file) {
-					openModal({
-						contentComponent: () =>
-							FilePreviewerModalContent(itemData.file),
-						size: 'full-screen',
-					});
-				}
+				openModal({
+					contentComponent: () =>
+						FilePreviewerModalContent(itemData.file),
+					size: 'full-screen',
+				});
 			}
 		},
 	};

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -137,20 +137,25 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 				});
 			}
 			else if (action?.data?.id === 'view-content') {
-				event?.preventDefault();
+				if (!itemData.file) {
+					event?.preventDefault();
 
-				openModal({
-					containerProps: {
-						className: '',
-					},
-					size: 'full-screen',
-					title: sub(
-						Liferay.Language.get('x-version-x'),
-						itemData.title,
-						`${sub(Liferay.Language.get('version-x'), itemData.systemProperties.version.number)}`
-					),
-					url: formatActionURL(itemData, action.href),
-				});
+					openModal({
+						containerProps: {
+							className: '',
+						},
+						size: 'full-screen',
+						title: sub(
+							Liferay.Language.get('x-version-x'),
+							itemData.title,
+							`${sub(
+								Liferay.Language.get('version-x'),
+								itemData.systemProperties.version.number
+							)}`
+						),
+						url: formatActionURL(itemData, action.href),
+					});
+				}
 			}
 			else if (action?.data?.id === 'view-file') {
 				if (itemData.file) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -98,19 +98,6 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 					url: itemData.actions.copy.href,
 				});
 			}
-			else if (action.data.id === 'expire') {
-				event?.preventDefault();
-
-				executeAsyncItemAction({
-					method: itemData.actions.expire.method,
-					refreshData: loadData,
-					successMessage: sub(
-						Liferay.Language.get('expire-version-success-message'),
-						`<strong>${sub(Liferay.Language.get('version-x'), itemData.systemProperties.version.number)}</strong>`
-					),
-					url: itemData.actions.expire.href,
-				});
-			}
 			else if (action.data.id === 'delete') {
 				event?.preventDefault();
 
@@ -130,6 +117,19 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 						Liferay.Language.get('delete-version-x'),
 						itemData.systemProperties.version.number
 					),
+				});
+			}
+			else if (action.data.id === 'expire') {
+				event?.preventDefault();
+
+				executeAsyncItemAction({
+					method: itemData.actions.expire.method,
+					refreshData: loadData,
+					successMessage: sub(
+						Liferay.Language.get('expire-version-success-message'),
+						`<strong>${sub(Liferay.Language.get('version-x'), itemData.systemProperties.version.number)}</strong>`
+					),
+					url: itemData.actions.expire.href,
 				});
 			}
 			else if (action.data.id === 'restore') {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/ViewVersionHistoryFDSPropsTransformer.ts
@@ -4,8 +4,10 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {openModal} from 'frontend-js-components-web';
 import {navigate, sessionStorage, sub} from 'frontend-js-web';
 
+import FilePreviewerModalContent from '../modal/FilePreviewerModalContent';
 import deleteEntryAction from './actions/deleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
@@ -66,6 +68,7 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 					expire: {href: string; method: string};
 					restore: {href: string; method: string};
 				};
+				file: any;
 				systemProperties: {
 					version: {
 						number: number;
@@ -144,6 +147,18 @@ export default function ViewVersionHistoryFDSPropsTransformer({
 					),
 					url: itemData.actions.restore.href,
 				});
+			}
+			else if (action?.data?.id === 'view-file') {
+				if (itemData.file) {
+					openModal({
+						containerProps: {
+							className: '',
+						},
+						contentComponent: () =>
+							FilePreviewerModalContent(itemData.file),
+						size: 'full-screen',
+					});
+				}
 			}
 		},
 	};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61290

# What is this trying to solve?

Add view content for file and content versions. This PR add the code to add action to view version content and view version file. 

# How am I fixing it?

Modifying FDS propo transformer to add the modals.

# How can you verify that it works?

1. Go to content and file section and an add an entry
2. Add some versions of the entry
3. Go to the version list and click on view

# Important information

1. We don't have thumbnailURL for object entry versions and for that reason we can not see the file renderer.  I will send it in future PR's.
2. We don't have the edit_content_item struct action prepared to render a version of an object entry, so, for the moment we are showing the last version but we have to modify that struct action in order to support it. I will send it in future PR's.