### PR TITLE
LPD-62472 Journal Article Shows Wrong Display Date When Published After Draft

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/AutoSaveArticleMVCResourceCommandTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
@@ -299,7 +300,11 @@ public class AutoSaveArticleMVCResourceCommandTest {
 		themeDisplay.setLocale(LocaleUtil.US);
 		themeDisplay.setRequest(mockMultipartHttpServletRequest);
 		themeDisplay.setSiteGroupId(_group.getGroupId());
-		themeDisplay.setUser(TestPropsValues.getUser());
+
+		User user = TestPropsValues.getUser();
+
+		themeDisplay.setTimeZone(user.getTimeZone());
+		themeDisplay.setUser(user);
 
 		return themeDisplay;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalArticleUtil.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -333,6 +334,17 @@ public class JournalArticleUtil {
 					WorkflowConstants.STATUS_DRAFT, article.getStatus())) {
 
 				serviceContext.setModelPermissions(null);
+			}
+
+			if (article.isDraft() && (version == 1.0)) {
+				Calendar calendar = CalendarFactoryUtil.getCalendar(
+					serviceContext.getTimeZone());
+
+				displayDateMinute = calendar.get(Calendar.MINUTE);
+				displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
+				displayDateDay = calendar.get(Calendar.DAY_OF_MONTH);
+				displayDateMonth = calendar.get(Calendar.MONTH);
+				displayDateYear = calendar.get(Calendar.YEAR);
 			}
 
 			if (actionName.equals("/journal/update_article")) {

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -1946,3 +1946,41 @@ baseTest(
 		}
 	}
 );
+
+baseTest(
+	'Journal Article Shows Wrong Display Date When Published After Draft',
+	{
+		tag: '@LPD-62472',
+	},
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		baseTest.setTimeout(120000);
+
+		await journalEditArticlePage.saveAsDraftWithPermissions(
+			getRandomString()
+		);
+
+		await page.waitForTimeout(50000);
+
+		await page.getByRole('button', {name: 'Publish'}).click();
+
+		await page.waitForTimeout(50000);
+
+		await page.getByRole('menuitem', {name: 'Publish'}).click();
+
+		await journalPage.changeView('table');
+
+		const firstDisplayDateTd = page
+			.locator('td.lfr-display-date-column')
+			.first();
+
+		const spanInsideTd = firstDisplayDateTd.locator('span');
+
+		await spanInsideTd.waitFor({state: 'visible'});
+
+		const displayDateText = await spanInsideTd.textContent();
+
+		expect(displayDateText).not.toBe('1 Minute ago');
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62472

When a web content is kept in draft for a long time and then published, the display date incorrectly shows the draft creation time instead of the actual publish time

# How am I fixing it?

On publish, set the display date to the current time when the version is 1.0 and the status is Draft.

# How can you verify that it works?
 
Run the included automated tests.
