### PR TITLE
LPD-62581 fix DeepLTranslator target language codes

### DIFF
--- a/modules/apps/translation/translation-translator-deepl/build.gradle
+++ b/modules/apps/translation/translation-translator-deepl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.2"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.13"

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.translation.translator.deepl.internal.translator;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.url.URLBuilder;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -74,7 +76,7 @@ public class DeepLTranslator extends BaseTranslator {
 			deepLTranslatorConfiguration);
 
 		String targetLanguageCode = StringUtil.toUpperCase(
-			getLanguageCode(translatorPacket.getTargetLanguageId()));
+			_getLanguageCode(true, translatorPacket.getTargetLanguageId()));
 
 		if (!supportedLanguageCodes.contains(targetLanguageCode)) {
 			throw new TranslatorException(
@@ -89,7 +91,8 @@ public class DeepLTranslator extends BaseTranslator {
 			deepLTranslatorConfiguration, translatorPacket.getFieldsMap(),
 			translatorPacket.getHTMLMap(),
 			StringUtil.toUpperCase(
-				getLanguageCode(translatorPacket.getSourceLanguageId())),
+				_getLanguageCode(
+					false, translatorPacket.getSourceLanguageId())),
 			targetLanguageCode);
 
 		return new TranslatorPacket() {
@@ -122,20 +125,66 @@ public class DeepLTranslator extends BaseTranslator {
 		};
 	}
 
+	private String _getLanguageCode(boolean targetLanguage, String languageId) {
+		List<String> parts = com.liferay.petra.string.StringUtil.split(
+			languageId, CharPool.UNDERLINE);
+
+		String firstPart = parts.get(0);
+
+		// AWS, Azure, DeepL, and GoogleCloud all expect ISO-639 language codes.
+		// ISO-639:1989 renamed "in" to "id." See LPD-23561.
+
+		if (firstPart.equals("in")) {
+			return "id";
+		}
+
+		String secondPart = parts.get(1);
+
+		if (secondPart.equals("ES")) {
+			return "es";
+		}
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(firstPart);
+
+		if (targetLanguage) {
+			if (firstPart.equals("en") || firstPart.equals("pt")) {
+				sb.append(CharPool.DASH);
+				sb.append(secondPart);
+			}
+			else if (firstPart.equals("zh")) {
+				sb.append(CharPool.DASH);
+
+				if (secondPart.equals("TW")) {
+					sb.append("HANT");
+				}
+				else {
+					sb.append("HANS");
+				}
+			}
+		}
+
+		return sb.toString();
+	}
+
 	private List<String> _getSupportedLanguageCodes(
 			DeepLTranslatorConfiguration deepLTranslatorConfiguration)
 		throws PortalException {
 
 		Http.Options options = new Http.Options();
 
-		options.addPart("type", "target");
 		options.setMethod(Http.Method.GET);
 
 		return JSONUtil.toList(
 			_jsonFactory.createJSONArray(
 				_invoke(
 					deepLTranslatorConfiguration.authKey(), options,
-					deepLTranslatorConfiguration.validateLanguageURL())),
+					URLBuilder.create(
+						deepLTranslatorConfiguration.validateLanguageURL()
+					).addParameter(
+						"type", "target"
+					).build())),
 			jsonObject -> jsonObject.getString("language"), _log);
 	}
 

--- a/modules/apps/translation/translation-translator-deepl/src/test/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslatorTest.java
+++ b/modules/apps/translation/translation-translator-deepl/src/test/java/com/liferay/translation/translator/deepl/internal/translator/DeepLTranslatorTest.java
@@ -1,0 +1,264 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.translation.translator.deepl.internal.translator;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.translation.translator.TranslatorPacket;
+import com.liferay.translation.translator.deepl.internal.configuration.DeepLTranslatorConfiguration;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Gergely Szalay
+ */
+public class DeepLTranslatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws ConfigurationException, IOException {
+		_companyId = RandomTestUtil.randomLong();
+
+		ReflectionTestUtil.setFieldValue(
+			_deepLTranslator, "_configurationProvider", _configurationProvider);
+
+		ReflectionTestUtil.setFieldValue(_deepLTranslator, "_http", _http);
+
+		ReflectionTestUtil.setFieldValue(
+			_deepLTranslator, "_jsonFactory", _jsonFactory);
+
+		_setUpPortalUtil();
+
+		_setUpDeepL();
+	}
+
+	@Test
+	public void testTranslationHandlesBaseLanguage() throws PortalException {
+		TranslatorPacket originTranslatorPacket = _getTranslatorPocket(
+			Map.of("infoField--JournalArticle_title--0", false), "en_US",
+			"ca_ES");
+
+		TranslatorPacket translatorPacket = _deepLTranslator.translate(
+			originTranslatorPacket);
+
+		Assert.assertEquals(
+			Map.of("infoField--JournalArticle_title--0", "¡Hola, mundo!"),
+			translatorPacket.getFieldsMap());
+	}
+
+	@Test
+	public void testTranslationHandlesLanguageVariant() throws PortalException {
+		TranslatorPacket originTranslatorPacket = _getTranslatorPocket(
+			Map.of("infoField--JournalArticle_title--0", false), "en_US",
+			"pt_BR");
+
+		TranslatorPacket translatorPacket = _deepLTranslator.translate(
+			originTranslatorPacket);
+
+		Assert.assertEquals(
+			Map.of("infoField--JournalArticle_title--0", "Olá, mundo!"),
+			translatorPacket.getFieldsMap());
+	}
+
+	@Test
+	public void testTranslationHandlesTraditionalChinese()
+		throws PortalException {
+
+		TranslatorPacket originTranslatorPacket = _getTranslatorPocket(
+			Map.of("infoField--JournalArticle_title--0", false), "en_US",
+			"zh_TW");
+
+		TranslatorPacket translatorPacket = _deepLTranslator.translate(
+			originTranslatorPacket);
+
+		Assert.assertEquals(
+			Map.of("infoField--JournalArticle_title--0", "哈囉，世界！"),
+			translatorPacket.getFieldsMap());
+	}
+
+	protected String read(String fileName) throws IOException {
+		Class<?> clazz = getClass();
+
+		InputStream inputStream = clazz.getResourceAsStream(
+			"dependencies/" + fileName);
+
+		return StringUtil.read(inputStream);
+	}
+
+	private String _getTranslationString(String text) {
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("{\"translations\":[{\"detected_source_language\":\"EN\",");
+		sb.append("\"text\":\"");
+		sb.append(text);
+		sb.append("\"}]}");
+
+		return sb.toString();
+	}
+
+	private TranslatorPacket _getTranslatorPocket(
+		Map<String, Boolean> htmlMap, String sourceLanguage,
+		String targetLanguage) {
+
+		return new TranslatorPacket() {
+
+			@Override
+			public long getCompanyId() {
+				return _companyId;
+			}
+
+			@Override
+			public Map<String, String> getFieldsMap() {
+				return Map.of(
+					"infoField--JournalArticle_title--0", "Hello, world!");
+			}
+
+			@Override
+			public Map<String, Boolean> getHTMLMap() {
+				return htmlMap;
+			}
+
+			@Override
+			public String getSourceLanguageId() {
+				return sourceLanguage;
+			}
+
+			@Override
+			public String getTargetLanguageId() {
+				return targetLanguage;
+			}
+
+		};
+	}
+
+	private void _setUpDeepL() throws ConfigurationException, IOException {
+		DeepLTranslatorConfiguration deepLTranslatorConfiguration =
+			Mockito.mock(DeepLTranslatorConfiguration.class);
+
+		Mockito.when(
+			_configurationProvider.getCompanyConfiguration(
+				DeepLTranslatorConfiguration.class, _companyId)
+		).thenReturn(
+			deepLTranslatorConfiguration
+		);
+
+		Mockito.when(
+			deepLTranslatorConfiguration.authKey()
+		).thenReturn(
+			"DEEPL_authkey"
+		);
+
+		Mockito.when(
+			deepLTranslatorConfiguration.enabled()
+		).thenReturn(
+			true
+		);
+
+		String languagesUrlString = "https://api-free.deepl.com/v2/languages";
+
+		Mockito.when(
+			deepLTranslatorConfiguration.validateLanguageURL()
+		).thenReturn(
+			languagesUrlString
+		);
+
+		Mockito.when(
+			deepLTranslatorConfiguration.url()
+		).thenReturn(
+			"https://api-free.deepl.com/v2/translate"
+		);
+
+		String[] urlArray = {languagesUrlString, ""};
+
+		Mockito.when(
+			PortalUtil.stripURLAnchor(Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			urlArray
+		);
+
+		Mockito.when(
+			_http.URLtoString(Mockito.any(Http.Options.class))
+		).thenAnswer(
+			invocation -> {
+				Http.Options options = invocation.getArgument(0);
+
+				Http.Response httpResponse = new Http.Response();
+
+				httpResponse.setResponseCode(200);
+
+				options.setResponse(httpResponse);
+
+				if (options.isPost()) {
+					Http.Body body = options.getBody();
+
+					JSONObject payloadJSONObject =
+						_jsonFactory.createJSONObject(body.getContent());
+
+					String targetLanguage = JSONUtil.getValue(
+						payloadJSONObject, "Object/target_lang"
+					).toString();
+
+					if (targetLanguage.equals("ZH-HANT")) {
+						return _getTranslationString("哈囉，世界！");
+					}
+
+					if (targetLanguage.equals("ES")) {
+						return _getTranslationString("¡Hola, mundo!");
+					}
+
+					if (targetLanguage.equals("PT-BR")) {
+						return _getTranslationString("Olá, mundo!");
+					}
+				}
+
+				return read("supported-language-codes.json");
+			}
+		);
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
+	}
+
+	private long _companyId;
+	private final ConfigurationProvider _configurationProvider = Mockito.mock(
+		ConfigurationProvider.class);
+	private final DeepLTranslator _deepLTranslator = new DeepLTranslator();
+	private final Http _http = Mockito.mock(Http.class);
+	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
+	private final Portal _portal = Mockito.mock(Portal.class);
+
+}

--- a/modules/apps/translation/translation-translator-deepl/src/test/resources/com/liferay/translation/translator/deepl/internal/translator/dependencies/supported-language-codes.json
+++ b/modules/apps/translation/translation-translator-deepl/src/test/resources/com/liferay/translation/translator/deepl/internal/translator/dependencies/supported-language-codes.json
@@ -1,0 +1,172 @@
+[
+	{
+		"language": "AR",
+		"name": "Arabic",
+		"supports_formality": false
+	},
+	{
+		"language": "BG",
+		"name": "Bulgarian",
+		"supports_formality": false
+	},
+	{
+		"language": "CS",
+		"name": "Czech",
+		"supports_formality": false
+	},
+	{
+		"language": "DA",
+		"name": "Danish",
+		"supports_formality": false
+	},
+	{
+		"language": "DE",
+		"name": "German",
+		"supports_formality": true
+	},
+	{
+		"language": "EL",
+		"name": "Greek",
+		"supports_formality": false
+	},
+	{
+		"language": "EN-GB",
+		"name": "English (British)",
+		"supports_formality": false
+	},
+	{
+		"language": "EN-US",
+		"name": "English (American)",
+		"supports_formality": false
+	},
+	{
+		"language": "ES",
+		"name": "Spanish",
+		"supports_formality": true
+	},
+	{
+		"language": "ET",
+		"name": "Estonian",
+		"supports_formality": false
+	},
+	{
+		"language": "FI",
+		"name": "Finnish",
+		"supports_formality": false
+	},
+	{
+		"language": "FR",
+		"name": "French",
+		"supports_formality": true
+	},
+	{
+		"language": "HU",
+		"name": "Hungarian",
+		"supports_formality": false
+	},
+	{
+		"language": "ID",
+		"name": "Indonesian",
+		"supports_formality": false
+	},
+	{
+		"language": "IT",
+		"name": "Italian",
+		"supports_formality": true
+	},
+	{
+		"language": "JA",
+		"name": "Japanese",
+		"supports_formality": true
+	},
+	{
+		"language": "KO",
+		"name": "Korean",
+		"supports_formality": false
+	},
+	{
+		"language": "LT",
+		"name": "Lithuanian",
+		"supports_formality": false
+	},
+	{
+		"language": "LV",
+		"name": "Latvian",
+		"supports_formality": false
+	},
+	{
+		"language": "NB",
+		"name": "Norwegian",
+		"supports_formality": false
+	},
+	{
+		"language": "NL",
+		"name": "Dutch",
+		"supports_formality": true
+	},
+	{
+		"language": "PL",
+		"name": "Polish",
+		"supports_formality": true
+	},
+	{
+		"language": "PT-BR",
+		"name": "Portuguese (Brazilian)",
+		"supports_formality": true
+	},
+	{
+		"language": "PT-PT",
+		"name": "Portuguese (European)",
+		"supports_formality": true
+	},
+	{
+		"language": "RO",
+		"name": "Romanian",
+		"supports_formality": false
+	},
+	{
+		"language": "RU",
+		"name": "Russian",
+		"supports_formality": true
+	},
+	{
+		"language": "SK",
+		"name": "Slovak",
+		"supports_formality": false
+	},
+	{
+		"language": "SL",
+		"name": "Slovenian",
+		"supports_formality": false
+	},
+	{
+		"language": "SV",
+		"name": "Swedish",
+		"supports_formality": false
+	},
+	{
+		"language": "TR",
+		"name": "Turkish",
+		"supports_formality": false
+	},
+	{
+		"language": "UK",
+		"name": "Ukrainian",
+		"supports_formality": false
+	},
+	{
+		"language": "ZH",
+		"name": "Chinese (simplified)",
+		"supports_formality": false
+	},
+	{
+		"language": "ZH-HANS",
+		"name": "Chinese (simplified)",
+		"supports_formality": false
+	},
+	{
+		"language": "ZH-HANT",
+		"name": "Chinese (traditional)",
+		"supports_formality": false
+	}
+]


### PR DESCRIPTION
What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-62581

When a trying to use auto translate zh_TW gives back the wrong translation, ca_ES not in the list.

How am I fixing it?
The first issue was options.addPart doesn't add type as a parameter, and it wont work with GET. Changed this to use URL builder to add as a parameter.

Second issue that the DeepL available language codes are different. ca_ES -> ES, zh_TW ->zh_HANT, PT and EN also has variants. So I added  unique _getLanguageCode() to retrieve DeepL codes.

How can you verify that it works?
Run the included tests.