### PR TITLE
LPD-62769 Include 'type' in API call

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesDepotApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesDepotApiHelper.ts
@@ -28,6 +28,7 @@ export class JSONWebServicesDepotApiHelper {
 			'descriptionMap',
 			JSON.stringify({en_US: getRandomString()})
 		);
+		urlSearchParams.append('type', '0');
 
 		return this.apiHelpers.post(
 			`${liferayConfig.environment.baseUrl}${this.basePath}/add-depot-entry`,


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62769

# How am I fixing it?

The API for adding a Depot Entry was updated to require a `type` in https://liferay.atlassian.net/browse/LPD-61564. This broke the current API helper method in Playwright causing tests to start failing.

I'm not sure what the various types are so I opted for `0`. If there's a better value to be using please let me know.

# How can you verify that it works?

In `modules/test/playwright` run `npm run playwright -- test -g 'Add Global or Asset Library Vocabulary Navigation Menu item'`