### PR TITLE
LPD-62422 Technical Task | Assign Site Member role following the new rules

### DIFF
--- a/modules/apps/roles/roles-admin-impl/build.gradle
+++ b/modules/apps/roles/roles-admin-impl/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")

--- a/modules/apps/roles/roles-admin-impl/build.gradle
+++ b/modules/apps/roles/roles-admin-impl/build.gradle
@@ -14,5 +14,7 @@ dependencies {
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
@@ -5,7 +5,12 @@
 
 package com.liferay.roles.admin.internal.security.permission.contributor;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.function.UnsafePredicate;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -48,7 +53,7 @@ public class SiteRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
-			if (group.isCMS() && _isDepotMember(group, roleCollection)) {
+			if (group.isCMS() && _isSpaceDepotEntryMember(group, roleCollection)) {
 				Role role = _roleLocalService.getRole(
 					roleCollection.getCompanyId(), RoleConstants.SITE_MEMBER);
 
@@ -60,7 +65,21 @@ public class SiteRoleContributor implements RoleContributor {
 		}
 	}
 
-	private boolean _isDepotMember(Group group, RoleCollection roleCollection)
+	private boolean _isGroupDepotEntrySpace(Group group)
+		throws PortalException {
+
+		if (!group.isDepot()) {
+			return false;
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
+			group.getGroupId());
+
+		return depotEntry.getType() == DepotConstants.TYPE_SPACE;
+	}
+
+	private boolean _isSpaceDepotEntryMember(
+			Group group, RoleCollection roleCollection)
 		throws PortalException {
 
 		User user = roleCollection.getUser();
@@ -69,7 +88,7 @@ public class SiteRoleContributor implements RoleContributor {
 			return false;
 		}
 
-		if (ListUtil.exists(user.getGroups(), Group::isDepot)) {
+		if (_exists(user.getGroups(), this::_isGroupDepotEntrySpace)) {
 			return true;
 		}
 
@@ -85,16 +104,33 @@ public class SiteRoleContributor implements RoleContributor {
 				group.getCompanyId(), roleName);
 
 			if (roles.contains(role) ||
-				ListUtil.exists(
+				_exists(
 					userGroupRoles,
 					userGroupRole ->
-						userGroupRole.getRoleId() == role.getRoleId())) {
+						(userGroupRole.getRoleId() == role.getRoleId()) &&
+							_isGroupDepotEntrySpace(
+								userGroupRole.getGroup()))) {
 
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	private <T, E extends Exception> boolean _exists(
+		List<T> list, UnsafePredicate<T, E> unsafePredicate) {
+
+		return ListUtil.exists(
+			list,
+			object -> {
+				try {
+					return unsafePredicate.test(object);
+				}
+				catch (Exception exception) {
+					return ReflectionUtil.throwException(exception);
+				}
+			});
 	}
 
 	private static final String[] _ASSET_LIBRARY_ROLES = {
@@ -113,5 +149,8 @@ public class SiteRoleContributor implements RoleContributor {
 
 	@Reference
 	private UserGroupRoleLocalService _userGroupRoleLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 }

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
@@ -5,17 +5,26 @@
 
 package com.liferay.roles.admin.internal.security.permission.contributor;
 
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.contributor.RoleCollection;
 import com.liferay.portal.kernel.security.permission.contributor.RoleContributor;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.Collection;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -39,7 +48,7 @@ public class SiteRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
-			if (group.isCMS()) {
+			if (group.isCMS() && _isDepotMember(group, roleCollection)) {
 				Role role = _roleLocalService.getRole(
 					roleCollection.getCompanyId(), RoleConstants.SITE_MEMBER);
 
@@ -51,6 +60,48 @@ public class SiteRoleContributor implements RoleContributor {
 		}
 	}
 
+	private boolean _isDepotMember(Group group, RoleCollection roleCollection)
+		throws PortalException {
+
+		User user = roleCollection.getUser();
+
+		if (group.getCompanyId() != user.getCompanyId()) {
+			return false;
+		}
+
+		if (ListUtil.exists(user.getGroups(), Group::isDepot)) {
+			return true;
+		}
+
+		UserBag userBag = roleCollection.getUserBag();
+
+		Collection<Role> roles = userBag.getRoles();
+
+		List<UserGroupRole> userGroupRoles =
+			_userGroupRoleLocalService.getUserGroupRoles(user.getUserId());
+
+		for (String roleName : _ASSET_LIBRARY_ROLES) {
+			Role role = _roleLocalService.fetchRole(
+				group.getCompanyId(), roleName);
+
+			if (roles.contains(role) ||
+				ListUtil.exists(
+					userGroupRoles,
+					userGroupRole ->
+						userGroupRole.getRoleId() == role.getRoleId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _ASSET_LIBRARY_ROLES = {
+		DepotRolesConstants.ASSET_LIBRARY_CONTENT_REVIEWER,
+		DepotRolesConstants.ASSET_LIBRARY_OWNER
+	};
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SiteRoleContributor.class);
 
@@ -59,5 +110,8 @@ public class SiteRoleContributor implements RoleContributor {
 
 	@Reference
 	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -94,7 +94,9 @@ public class SiteRoleContributor implements RoleContributor {
 
 		UserBag userBag = roleCollection.getUserBag();
 
-		Collection<Role> roles = userBag.getRoles();
+		long[] roleIds = userBag.getRoleIds();
+
+		Arrays.sort(roleIds);
 
 		List<UserGroupRole> userGroupRoles =
 			_userGroupRoleLocalService.getUserGroupRoles(user.getUserId());
@@ -103,7 +105,7 @@ public class SiteRoleContributor implements RoleContributor {
 			Role role = _roleLocalService.fetchRole(
 				group.getCompanyId(), roleName);
 
-			if (roles.contains(role) ||
+			if ((Arrays.binarySearch(roleIds, role.getRoleId()) >= 0) ||
 				_exists(
 					userGroupRoles,
 					userGroupRole ->

--- a/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
+++ b/modules/apps/roles/roles-admin-impl/src/main/java/com/liferay/roles/admin/internal/security/permission/contributor/SiteRoleContributor.java
@@ -53,7 +53,9 @@ public class SiteRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
-			if (group.isCMS() && _isSpaceDepotEntryMember(group, roleCollection)) {
+			if (group.isCMS() &&
+				_isSpaceDepotEntryMember(group, roleCollection)) {
+
 				Role role = _roleLocalService.getRole(
 					roleCollection.getCompanyId(), RoleConstants.SITE_MEMBER);
 
@@ -63,6 +65,21 @@ public class SiteRoleContributor implements RoleContributor {
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
+	}
+
+	private <T, E extends Exception> boolean _exists(
+		List<T> list, UnsafePredicate<T, E> unsafePredicate) {
+
+		return ListUtil.exists(
+			list,
+			object -> {
+				try {
+					return unsafePredicate.test(object);
+				}
+				catch (Exception exception) {
+					return ReflectionUtil.throwException(exception);
+				}
+			});
 	}
 
 	private boolean _isGroupDepotEntrySpace(Group group)
@@ -75,7 +92,11 @@ public class SiteRoleContributor implements RoleContributor {
 		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
 			group.getGroupId());
 
-		return depotEntry.getType() == DepotConstants.TYPE_SPACE;
+		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isSpaceDepotEntryMember(
@@ -110,29 +131,13 @@ public class SiteRoleContributor implements RoleContributor {
 					userGroupRoles,
 					userGroupRole ->
 						(userGroupRole.getRoleId() == role.getRoleId()) &&
-							_isGroupDepotEntrySpace(
-								userGroupRole.getGroup()))) {
+						_isGroupDepotEntrySpace(userGroupRole.getGroup()))) {
 
 				return true;
 			}
 		}
 
 		return false;
-	}
-
-	private <T, E extends Exception> boolean _exists(
-		List<T> list, UnsafePredicate<T, E> unsafePredicate) {
-
-		return ListUtil.exists(
-			list,
-			object -> {
-				try {
-					return unsafePredicate.test(object);
-				}
-				catch (Exception exception) {
-					return ReflectionUtil.throwException(exception);
-				}
-			});
 	}
 
 	private static final String[] _ASSET_LIBRARY_ROLES = {
@@ -144,6 +149,9 @@ public class SiteRoleContributor implements RoleContributor {
 		SiteRoleContributor.class);
 
 	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
@@ -151,8 +159,5 @@ public class SiteRoleContributor implements RoleContributor {
 
 	@Reference
 	private UserGroupRoleLocalService _userGroupRoleLocalService;
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
 
 }

--- a/modules/apps/roles/roles-admin-test/build.gradle
+++ b/modules/apps/roles/roles-admin-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")

--- a/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
+++ b/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
@@ -84,7 +84,7 @@ public class SiteRoleContributorTest {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			Collections.emptyMap(), DepotConstants.TYPE_SPACE,
 			ServiceContextTestUtil.getServiceContext());
 
 		_userLocalService.addGroupUsers(

--- a/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
+++ b/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/security/permission/contributor/test/SiteRoleContributorTest.java
@@ -6,6 +6,9 @@
 package com.liferay.roles.admin.internal.security.permission.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -14,15 +17,23 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,7 +51,9 @@ public class SiteRoleContributorTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -61,12 +74,34 @@ public class SiteRoleContributorTest {
 		Role role = _roleLocalService.fetchRole(
 			_group.getCompanyId(), RoleConstants.SITE_MEMBER);
 
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				permissionChecker.getRoleIds(
+					_user.getUserId(), _group.getGroupId()),
+				role.getRoleId()));
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		_userLocalService.addGroupUsers(
+			_depotEntry.getGroupId(), new long[] {_user.getUserId()});
+
 		Assert.assertTrue(
 			ArrayUtil.contains(
 				permissionChecker.getRoleIds(
 					_user.getUserId(), _group.getGroupId()),
 				role.getRoleId()));
 	}
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	private Group _group;
 
@@ -75,5 +110,8 @@ public class SiteRoleContributorTest {
 
 	@DeleteAfterTestRun
 	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
LPD-62422 Technical Task | Assign Site Member role following the new rules

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62258

When the Space Member role is assigned to a user, also the Site Member role is automatically assigned
This also applies to Space Content Reviewer and Space Members since these roles are additional to the Space Member role

# How am I fixing it?

Add site member role to the user role collection if the user is member/content reviewer/owner of at least 1 depot

# How can you verify that it works?

Run the included automated tests.

- Create an Asset library or a new space
- Create a new user and be sure that is member (no other role) of the created asset library
- log out and log in with the new user
- enter on the CMS site

**allowed pages are shown** 

# Commits


- **LPD-62422 add site member role to the user role collection if the user is member/content reviewer/owner of at least 1 depot**
- **LPD-62422 add logic to test that a depot member has the site member role for the cms too**

we have to take account that on the cms site the space is not shown because https://liferay.atlassian.net/browse/LPD-62960
