### PR TITLE
LPD-62897 The values of the fields associated with the updated 7.2 structures are lost if I import and override them

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/DataDefinitionUtil.java
@@ -100,11 +100,7 @@ public class DataDefinitionUtil {
 				dataDefinitionField, ddmStructure);
 
 			if (existingFieldName != null) {
-				if (isValidFieldName(existingFieldName)) {
-					return existingFieldName;
-				}
-
-				fieldName = existingFieldName;
+				return existingFieldName;
 			}
 		}
 

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/util/DataDefinitionUtilTest.java
@@ -50,7 +50,7 @@ public class DataDefinitionUtilTest {
 		_testUpdateDataDefinitionFields();
 		_testUpdateDataDefinitionFieldsWithExistingFieldName();
 		_testUpdateDataDefinitionFieldsWithExistingFieldNameAndExistingReference();
-		_testUpdateDataDefinitionFieldsWithExistingInvalidFieldName();
+		_testUpdateDataDefinitionFieldsWithExistingLegacyFieldNameAndExistingReference();
 	}
 
 	private DataDefinition _getDataDefinition() {
@@ -184,7 +184,7 @@ public class DataDefinitionUtilTest {
 		_fieldName = originalFieldName;
 	}
 
-	private void _testUpdateDataDefinitionFieldsWithExistingInvalidFieldName() {
+	private void _testUpdateDataDefinitionFieldsWithExistingLegacyFieldNameAndExistingReference() {
 		DataDefinition dataDefinition = _getDataDefinition();
 
 		DataDefinitionUtil.updateDataDefinitionFields(
@@ -192,7 +192,7 @@ public class DataDefinitionUtilTest {
 
 		String newFieldName = _getDataDefinitionFieldName(dataDefinition);
 
-		Assert.assertTrue(DataDefinitionUtil.isValidFieldName(newFieldName));
+		Assert.assertEquals(_fieldName, newFieldName);
 	}
 
 	private String _fieldName;


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-62897
### How am I fixing it?
By not updating already existing field names based on https://liferay.slack.com/archives/C031U3B3EUW/p1754396254738639
### How can you verify that it works?
With the steps on the LPD,
`gw test --tests=DataDefinitionUtilTest`