### PR TITLE
LPD-62918 Use nested field for selectedItemsKey attribute

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_all.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_all.jsp
@@ -23,7 +23,7 @@ ViewAllSectionDisplayContext viewAllSectionDisplayContext = (ViewAllSectionDispl
 		id="<%= CMSSiteInitializerFDSNames.ALL_SECTION %>"
 		itemsPerPage="<%= 20 %>"
 		propsTransformer="{AllFDSPropsTransformer} from site-cms-site-initializer"
-		selectedItemsKey="id"
+		selectedItemsKey="embedded.id"
 		selectionType="multiple"
 		style="fluid"
 	/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_contents.jsp
@@ -23,7 +23,7 @@ ViewContentsSectionDisplayContext viewContentsSectionDisplayContext = (ViewConte
 		id="<%= CMSSiteInitializerFDSNames.CONTENTS_SECTION %>"
 		itemsPerPage="<%= 20 %>"
 		propsTransformer="{ContentsFDSPropsTransformer} from site-cms-site-initializer"
-		selectedItemsKey="id"
+		selectedItemsKey="embedded.id"
 		selectionType="multiple"
 		style="fluid"
 	/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_files.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_files.jsp
@@ -23,7 +23,7 @@ ViewFilesSectionDisplayContext viewFilesSectionDisplayContext = (ViewFilesSectio
 		id="<%= CMSSiteInitializerFDSNames.FILES_SECTION %>"
 		itemsPerPage="<%= 20 %>"
 		propsTransformer="{FilesFDSPropsTransformer} from site-cms-site-initializer"
-		selectedItemsKey="id"
+		selectedItemsKey="embedded.id"
 		selectionType="multiple"
 		style="fluid"
 	/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_folder.jsp
@@ -30,7 +30,7 @@ ViewFolderSectionDisplayContext viewFolderSectionDisplayContext = (ViewFolderSec
 		id="<%= CMSSiteInitializerFDSNames.VIEW_FOLDER %>"
 		itemsPerPage="<%= 20 %>"
 		propsTransformer="{FolderFDSPropsTransformer} from site-cms-site-initializer"
-		selectedItemsKey="id"
+		selectedItemsKey="embedded.id"
 		selectionType="multiple"
 		style="fluid"
 	/>


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-62918)

### How did I solve it

Search api return the item ids in a nested field `{embedded.id}`, so I use this as `selectedItemKeys`, as this is possible now from https://liferay.atlassian.net/browse/LPD-55419

### How to test it

Check from the management toolbar, or several one by one (for this, you have to click in the checkbox. Clicking outside unchecks the others)
<img width="1722" height="814" alt="Screenshot 2025-08-13 at 18 11 08" src="https://github.com/user-attachments/assets/06f660d8-439d-4d16-92be-c9f06e5a8ea4" />

