### PR TITLE
LPD-62554 Sharing action is missing in All Section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -86,6 +86,12 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 				StringPool.BLANK, "info-circle-open", "show-details",
 				LanguageUtil.get(httpServletRequest, "show-details"), null,
 				null, "infoPanel"));
+		fdsActionDropdownItems.add(
+			3,
+			new FDSActionDropdownItem(
+				null, "share", "share",
+				LanguageUtil.get(httpServletRequest, "share"), "get", null,
+				"link"));
 
 		return fdsActionDropdownItems;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/ShareModalContent.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/ShareModalContent.scss
@@ -6,6 +6,16 @@ html#{$cadmin-selector} {
 			max-height: 368px;
 		}
 
+		.list-group-item {
+			.autofit-col.dropdown-options {
+				padding: 0;
+			}
+
+			.autofit-col:first-of-type {
+				padding-left: 0;
+			}
+		}
+
 		.permissions-picker {
 			height: 24px;
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/ShareModalContent.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/ShareModalContent.scss
@@ -6,16 +6,6 @@ html#{$cadmin-selector} {
 			max-height: 368px;
 		}
 
-		.list-group-item {
-			.autofit-col.dropdown-options {
-				padding: 0;
-			}
-
-			.autofit-col:first-of-type {
-				padding-left: 0;
-			}
-		}
-
 		.permissions-picker {
 			height: 24px;
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
@@ -90,18 +90,27 @@ function CollaboratorListItem({
 			</div>
 
 			<div className="autofit-col autofit-col-expand">
-				<div className="align-items-center d-flex">
-					<span className="text-3 text-truncate text-weight-semi-bold">
-						{user.name}
-					</span>
-
-					{toBeShared && (
-						<span className="inline-item inline-item-after label label-inverse-light">
-							<span className="label-item label-item-expand">
-								{Liferay.Language.get('to-be-shared')}
-							</span>
+				<div className="align-items-center d-flex justify-content-between">
+					<div className="d-flex text-truncate">
+						<span className="text-3 text-truncate text-weight-semi-bold">
+							{user.name}
 						</span>
-					)}
+
+						{toBeShared && (
+							<span className="inline-item inline-item-after label label-inverse-light">
+								<span className="label-item label-item-expand text-nowrap">
+									{Liferay.Language.get('to-be-shared')}
+								</span>
+							</span>
+						)}
+					</div>
+
+					<div>
+						<PermissionSelector
+							actionIds={actionIds}
+							onChange={handleChangeUserProperties}
+						/>
+					</div>
 				</div>
 
 				{error ? (
@@ -136,14 +145,7 @@ function CollaboratorListItem({
 				)}
 			</div>
 
-			<div className="autofit-col">
-				<PermissionSelector
-					actionIds={actionIds}
-					onChange={handleChangeUserProperties}
-				/>
-			</div>
-
-			<div className="autofit-col">
+			<div className="autofit-col dropdown-options">
 				<div className="d-flex">
 					<ExpirationDateSelector
 						dateExpired={dateExpired}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/share_modal_content/ShareModalContent.tsx
@@ -71,7 +71,7 @@ function CollaboratorListItem({
 			className="border-0 c-px-0 c-py-1 list-group-item list-group-item-flex"
 			key={`collaborator-${user.id}`}
 		>
-			<div className="autofit-col">
+			<div className="autofit-col pl-0">
 				<ClaySticker displayType="secondary" shape="circle" size="sm">
 					{type === COLLABORATOR_TYPE.USER ? (
 						'image' in user && user.image ? (
@@ -145,7 +145,7 @@ function CollaboratorListItem({
 				)}
 			</div>
 
-			<div className="autofit-col dropdown-options">
+			<div className="autofit-col p-0">
 				<div className="d-flex">
 					<ExpirationDateSelector
 						dateExpired={dateExpired}
@@ -498,7 +498,7 @@ export default function ShareModalContent({
 										className="border-0 c-px-0 c-py-1 list-group-item list-group-item-flex"
 										key={`listItem-creator-${creator.id}`}
 									>
-										<div className="autofit-col">
+										<div className="autofit-col pl-0">
 											<ClaySticker
 												displayType="secondary"
 												shape="circle"

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AllFDSPropsTransformer.ts
@@ -11,6 +11,7 @@ import {EVENTS} from '../info_panel/util/constants';
 import FilePreviewerModalContent from '../modal/FilePreviewerModalContent';
 import createAssetAction from './actions/createAssetAction';
 import multipleFilesUploadAction from './actions/multipleFilesUploadAction';
+import shareAction from './actions/shareAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
 import SpaceRenderer from './cell_renderers/SpaceRenderer';
@@ -23,10 +24,16 @@ const ACTIONS = {
 };
 
 export default function AllFDSPropsTransformer({
+	additionalProps,
 	creationMenu,
 	itemsActions = [],
 	...otherProps
 }: {
+	additionalProps: {
+		autocompleteURL: string;
+		cmsGroupId?: number;
+		collaboratorURLs: Record<string, string>;
+	};
 	creationMenu: any;
 	itemsActions?: any[];
 	otherProps: any;
@@ -64,7 +71,7 @@ export default function AllFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
-		infoPanelComponent: () => AssetTypeInfoPanel(otherProps),
+		infoPanelComponent: () => AssetTypeInfoPanel({additionalProps}),
 		itemsActions: itemsActions.map((action) => {
 			if (action?.data?.id === 'download') {
 				return {
@@ -112,6 +119,17 @@ export default function AllFDSPropsTransformer({
 					contentComponent: () =>
 						FilePreviewerModalContent(itemData.embedded.file),
 					size: 'full-screen',
+				});
+			}
+			else if (action?.data?.id === 'share') {
+				const {autocompleteURL, collaboratorURLs} = additionalProps;
+
+				shareAction({
+					autocompleteURL,
+					collaboratorURL: collaboratorURLs[itemData.entryClassName],
+					creator: itemData.embedded.creator,
+					itemId: itemData.embedded.id,
+					title: itemData.embedded?.title,
 				});
 			}
 		},

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {PORTLET_URLS} from '../../../utils/portletUrls';
+import {cmsPagesTest} from './fixtures/cmsPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPS-179669': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'Can view Share modal for added content',
+	{tag: '@LPD-62554'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const applicationName = 'cms/knowledge-bases';
+		const spaceName = 'Default';
+
+		const file1Title = `title ${getRandomString()}`;
+
+		const objectEntry1 = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: file1Title,
+			},
+			applicationName,
+			spaceName
+		);
+
+		await page.goto(PORTLET_URLS.cmsAll);
+
+		await contentsPage.execItemAction({
+			action: 'Share',
+			filter: file1Title,
+		});
+
+		await expect(page.locator('.modal-title')).toContainText(file1Title);
+
+		await apiHelpers.objectEntry.deleteObjectEntry(
+			applicationName,
+			String(objectEntry1.id)
+		);
+	}
+);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
@@ -9,6 +9,7 @@ import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidd
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
+import {DataSetPage} from './DataSetPage';
 
 type SidePanelName = 'General' | 'Comments' | 'Schedule';
 
@@ -33,12 +34,14 @@ type Field =
 
 export class ContentsPage {
 	readonly page: Page;
+	readonly dataSetFragmentPage: DataSetPage;
 
 	readonly newButton: Locator;
 	readonly publishButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+		this.dataSetFragmentPage = new DataSetPage(page);
 
 		this.newButton = page.getByLabel('New');
 		this.publishButton = page.getByText('Publish', {exact: true});
@@ -105,6 +108,13 @@ export class ContentsPage {
 		await this.openSidePanel('General');
 
 		await this.closeSidePanel();
+	}
+
+	async execItemAction({action, filter}: {action: string; filter: string}) {
+		await this.dataSetFragmentPage.execItemAction({
+			action,
+			filter,
+		});
 	}
 
 	async fillData(fields: Field[]) {

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -15,6 +15,7 @@ export const PORTLET_URLS = {
 		'/~/control_panel/manage?p_p_id=com_liferay_bookmarks_web_portlet_BookmarksAdminPortlet',
 	categoriesAdmin: '/~/control_panel/manage/-/categories_admin/vocabularies',
 	cms: 'web/cms/home',
+	cmsAll: 'web/cms/all',
 	cmsCategories: 'web/cms/categorization/view-categories',
 	cmsContents: 'web/cms/contents',
 	cmsEditCategory: 'web/cms/categorization/edit-category',


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-62554

This adds the sharing modal to the actions dropdown in the "All" Section.

### How am I fixing it?
Basically by applying similar changes in the displayContext and propsTransformer as in the previous ticket related to sharing modal. 
Here's how it looks:
<img width="1504" height="703" alt="Screenshot 2025-08-13 at 6 09 24 PM" src="https://github.com/user-attachments/assets/1214ebf1-05eb-4f15-a78a-3bf60a795019" />

Also some styling was updated in order to remove some padding and keep some text on the same line, so there's better use of space (requested by Austin). Here's how it looks:
<img width="600" alt="Screenshot 2025-08-13 at 6 01 46 PM" src="https://github.com/user-attachments/assets/c4b2499b-078a-4425-a910-24a2922a2e69" />

Hopefully the changes look straightforward, thanks for taking a look!
