### PR TITLE
LPD-62974 Technical Task | new space is created with space type

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Asset Library API
 Bundle-SymbolicName: com.liferay.headless.asset.library.api
-Bundle-Version: 5.0.1
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.headless.asset.library.dto.v1_0,\
 	com.liferay.headless.asset.library.resource.v1_0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
@@ -798,6 +798,47 @@ public class AssetLibrary implements Serializable {
 	private Supplier<Site[]> _sitesSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The asset library's type."
+	)
+	public Integer getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
+
+			_typeSupplier = null;
+		}
+
+		return type;
+	}
+
+	public void setType(Integer type) {
+		this.type = type;
+
+		_typeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setType(UnsafeSupplier<Integer, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
+			try {
+				return typeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The asset library's type.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Integer type;
+
+	@JsonIgnore
+	private Supplier<Integer> _typeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The asset library's associated users."
 	)
 	@Valid
@@ -1151,6 +1192,18 @@ public class AssetLibrary implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		Integer type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append(type);
 		}
 
 		UserAccount[] userAccounts = getUserAccounts();

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
@@ -383,6 +383,25 @@ public class AssetLibrary implements Cloneable, Serializable {
 
 	protected Site[] sites;
 
+	public Integer getType() {
+		return type;
+	}
+
+	public void setType(Integer type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<Integer, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Integer type;
+
 	public UserAccount[] getUserAccounts() {
 		return userAccounts;
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
@@ -261,6 +261,16 @@ public class AssetLibrarySerDes {
 			sb.append("]");
 		}
 
+		if (assetLibrary.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append(assetLibrary.getType());
+		}
+
 		if (assetLibrary.getUserAccounts() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -461,6 +471,13 @@ public class AssetLibrarySerDes {
 			map.put("sites", String.valueOf(assetLibrary.getSites()));
 		}
 
+		if (assetLibrary.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(assetLibrary.getType()));
+		}
+
 		if (assetLibrary.getUserAccounts() == null) {
 			map.put("userAccounts", null);
 		}
@@ -549,6 +566,9 @@ public class AssetLibrarySerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "sites")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "userAccounts")) {
@@ -679,6 +699,12 @@ public class AssetLibrarySerDes {
 					}
 
 					assetLibrary.setSites(sitesArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					assetLibrary.setType(
+						Integer.valueOf((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "userAccounts")) {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -98,6 +98,10 @@ components:
                         $ref: "#/components/schemas/Site"
                     readOnly: true
                     type: array
+                type:
+                    description:
+                        The asset library's type.
+                    type: integer
                 userAccounts:
                     description:
                         The asset library's associated users.

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -115,6 +115,7 @@ public class AssetLibraryDTOConverter
 								group.getGroupId())));
 				setSettings(() -> _toSettings(group));
 				setSiteId(group::getGroupId);
+				setType(depotEntry::getType);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -383,9 +383,14 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				unicodeProperties, serviceContext);
 		}
 
+		int type = DepotConstants.TYPE_ASSET_LIBRARY;
+
+		if (assetLibrary.getType() != null) {
+			type = assetLibrary.getType();
+		}
+
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
-			nameMap, descriptionMap, DepotConstants.TYPE_ASSET_LIBRARY,
-			serviceContext);
+			nameMap, descriptionMap, type, serviceContext);
 
 		group = depotEntry.getGroup();
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
@@ -436,7 +436,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the asset library using only the fields received in the request body. Any other fields are left untouched."
@@ -471,7 +471,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the asset library using only the fields received in the request body with the given external reference code. Any other fields are left untouched."
@@ -530,6 +530,10 @@ public abstract class BaseAssetLibraryResourceImpl
 
 		if (assetLibrary.getName_i18n() != null) {
 			existingAssetLibrary.setName_i18n(assetLibrary.getName_i18n());
+		}
+
+		if (assetLibrary.getType() != null) {
+			existingAssetLibrary.setType(assetLibrary.getType());
 		}
 
 		preparePatch(assetLibrary, existingAssetLibrary);
@@ -628,7 +632,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new asset library"
@@ -694,7 +698,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Replaces the asset library with information sent in the request body with the given external reference code. Any missing fields are deleted unless they are required."

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.asset.library.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -139,6 +140,18 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 				}
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setType(DepotConstants.TYPE_SPACE);
+
+		AssetLibrary postAssetLibrary = testPostAssetLibrary_addAssetLibrary(
+			randomAssetLibrary);
+
+		Assert.assertEquals(
+			Integer.valueOf(DepotConstants.TYPE_SPACE),
+			postAssetLibrary.getType());
+		assertValid(postAssetLibrary);
 	}
 
 	@Override
@@ -183,6 +196,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 	protected AssetLibrary randomAssetLibrary() throws Exception {
 		AssetLibrary assetLibrary = super.randomAssetLibrary();
 
+		assetLibrary.setType(DepotConstants.TYPE_ASSET_LIBRARY);
 		assetLibrary.setSettings(
 			new Settings() {
 				{

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
@@ -1671,6 +1671,14 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (assetLibrary.getType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("userAccounts", additionalAssertFieldName)) {
 				if (assetLibrary.getUserAccounts() == null) {
 					valid = false;
@@ -1969,6 +1977,16 @@ public abstract class BaseAssetLibraryResourceTestCase {
 			if (Objects.equals("sites", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						assetLibrary1.getSites(), assetLibrary2.getSites())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetLibrary1.getType(), assetLibrary2.getType())) {
 
 					return false;
 				}
@@ -2405,6 +2423,12 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("type")) {
+			sb.append(String.valueOf(assetLibrary.getType()));
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("userAccounts")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2475,6 +2499,7 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				numberOfUserAccounts = RandomTestUtil.randomInt();
 				numberOfUserGroups = RandomTestUtil.randomInt();
 				siteId = testGroup.getGroupId();
+				type = RandomTestUtil.randomInt();
 			}
 		};
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
@@ -7,6 +7,8 @@ import {Space} from '../../common/types/Space';
 import {UserAccount, UserGroup} from '../../common/types/UserAccount';
 import ApiHelper from './ApiHelper';
 
+const DEFAULT_SPACE_TYPE = 1;
+
 async function addSpace({
 	description,
 	name,
@@ -22,6 +24,7 @@ async function addSpace({
 			description,
 			name,
 			settings,
+			type: DEFAULT_SPACE_TYPE,
 		}
 	);
 }


### PR DESCRIPTION
LPD-62974 new space is created with space type

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62973

Everytime I create a Space from the CMS I want this space with the space type

# How am I fixing it?

On the creation (and only on the creation) of the depot, I will pass the type to the api data

# How can you verify that it works?

Run the included automated tests.



# Commits


- **LPD-62974 create the asset library with DepotConstants.TYPE_ASSET_LIBRARY by default if type is not present**
- **LPD-62974 add test to check the new type creation**
- **LPD-62974 add new field on the dto converter**
- **LPD-62974 on the creation of the space, set the type to type_space**


Note, for the test to pass fix on https://github.com/liferay-content-management/liferay-portal/pull/6963 is needed
