### PR TITLE
LPD-63133 Trigger language change event only if the language was changed

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -5,7 +5,7 @@
 
 import classNames from 'classnames';
 import {TranslationAdminSelector} from 'frontend-js-components-web';
-import React from 'react';
+import React, {useRef} from 'react';
 
 import {TranslationManagerProps} from './Types';
 import useTranslationProgress from './useTranslationProgress';
@@ -29,31 +29,36 @@ export default function TranslationManager({
 		namespace,
 		selectedLanguageId: initialSelectedLanguageId,
 	});
+	const lastSelectedLanguageIdRef = useRef(selectedLanguageId);
 
 	const handleSelectedLanguageIdChange = (
 		languageId: Liferay.Language.Locale
 	) => {
-		Liferay.fire('inputLocalized:localeChanged', {
-			item: document.querySelector(
-				`[data-languageid="${languageId}"][data-value="${languageId}"]`
-			),
-		});
+		if (languageId !== lastSelectedLanguageIdRef.current) {
+			lastSelectedLanguageIdRef.current = languageId;
 
-		const descriptionMessage = document.getElementById(
-			`${namespace}descriptionNotTranslatableMessage`
-		);
-		const friendlyURLMessage = document.getElementById(
-			`${namespace}friendlyURLNotTranslatableMessage`
-		);
+			Liferay.fire('inputLocalized:localeChanged', {
+				item: document.querySelector(
+					`[data-languageid="${languageId}"][data-value="${languageId}"]`
+				),
+			});
 
-		if (descriptionMessage && friendlyURLMessage) {
-			if (selectedLanguageId !== defaultLanguageId) {
-				descriptionMessage.hidden = false;
-				friendlyURLMessage.hidden = false;
-			}
-			else {
-				descriptionMessage.hidden = true;
-				friendlyURLMessage.hidden = true;
+			const descriptionMessage = document.getElementById(
+				`${namespace}descriptionNotTranslatableMessage`
+			);
+			const friendlyURLMessage = document.getElementById(
+				`${namespace}friendlyURLNotTranslatableMessage`
+			);
+
+			if (descriptionMessage && friendlyURLMessage) {
+				if (selectedLanguageId !== defaultLanguageId) {
+					descriptionMessage.hidden = false;
+					friendlyURLMessage.hidden = false;
+				}
+				else {
+					descriptionMessage.hidden = true;
+					friendlyURLMessage.hidden = true;
+				}
 			}
 		}
 	};

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
@@ -8,7 +8,7 @@ import useTranslationProgress, {
 } from '../../../src/main/resources/META-INF/resources/js/translation_manager/useTranslationProgress';
 
 import '@testing-library/jest-dom/extend-expect';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, within} from '@testing-library/react';
 import {act, renderHook} from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -100,11 +100,11 @@ describe('TranslationManager', () => {
 		);
 	});
 
-	it('attaches inputLocalized:localeChanged fire event on mount', () => {
+	it('fires `inputLocalized:localeChanged` event when language is changed', async () => {
 		const renderComponent = () =>
 			render(
 				<>
-					<div data-languageid="en_US" data-value="en_US" />
+					<div data-languageid="ca_ES" data-value="ca_ES" />
 
 					<TranslationManager {...DEFAULT_PROPS} />
 				</>
@@ -112,15 +112,36 @@ describe('TranslationManager', () => {
 
 		renderComponent();
 
-		const item = document.createElement('div');
-		item.dataset.value = 'en_US';
-		item.dataset.languageid = 'en_US';
+		userEvent.click(screen.getByRole('combobox'));
+
+		const listbox = await screen.findByRole('listbox');
+		fireEvent.click(within(listbox).getByText('ca-ES'));
+
+		const item = document.querySelector(
+			'[data-languageid="ca_ES"][data-value="ca_ES"]'
+		);
 
 		expect(global.Liferay.fire).toHaveBeenCalledWith(
 			'inputLocalized:localeChanged',
 			{
 				item,
 			}
+		);
+	});
+
+	it('does not fire `inputLocalized:localeChanged` event when language is not changed', async () => {
+		renderComponent();
+
+		(global.Liferay.fire as jest.Mock).mockClear();
+
+		userEvent.click(screen.getByRole('combobox'));
+
+		const listbox = await screen.findByRole('listbox');
+		fireEvent.click(within(listbox).getByText('en-US'));
+
+		expect(global.Liferay.fire).not.toHaveBeenCalledWith(
+			'inputLocalized:localeChanged',
+			expect.anything()
 		);
 	});
 


### PR DESCRIPTION
# What is this trying to solve?

[LPD-63133](https://liferay.atlassian.net/browse/LPD-63133)

Non Translated Fields are shown when the language selector is clicked.

# How am I fixing it?

Triggering the language change event only if the current language it is different from selected language

# How can you verify that it works?

Follow the steps in ticket