### PR TITLE
LPD-62409 Expose depot "type" in the headless api

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 8.0.1
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryService.java
@@ -57,6 +57,9 @@ public interface DepotEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public DepotEntry fetchGroupDepotEntry(long groupId) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
 			long groupId, int type, int start, int end)
 		throws PortalException;

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceUtil.java
@@ -47,6 +47,12 @@ public class DepotEntryServiceUtil {
 		return getService().deleteDepotEntry(depotEntryId);
 	}
 
+	public static DepotEntry fetchGroupDepotEntry(long groupId)
+		throws PortalException {
+
+		return getService().fetchGroupDepotEntry(groupId);
+	}
+
 	public static List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
 			long groupId, int type, int start, int end)
 		throws PortalException {

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryServiceWrapper.java
@@ -45,6 +45,13 @@ public class DepotEntryServiceWrapper
 	}
 
 	@Override
+	public DepotEntry fetchGroupDepotEntry(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _depotEntryService.fetchGroupDepotEntry(groupId);
+	}
+
+	@Override
 	public java.util.List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
 			long groupId, int type, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/search/spi/model/index/contributor/DepotEntryModelDocumentContributor.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/search/spi/model/index/contributor/DepotEntryModelDocumentContributor.java
@@ -38,6 +38,7 @@ public class DepotEntryModelDocumentContributor
 
 		document.addDate(Field.MODIFIED_DATE, depotEntry.getModifiedDate());
 		document.addText(Field.NAME, group.getName());
+		document.addKeyword(Field.TYPE, depotEntry.getType());
 
 		for (Locale locale :
 				_language.getAvailableLocales(depotEntry.getGroupId())) {

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/http/DepotEntryServiceHttp.java
@@ -124,6 +124,45 @@ public class DepotEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.depot.model.DepotEntry fetchGroupDepotEntry(
+			HttpPrincipal httpPrincipal, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DepotEntryServiceUtil.class, "fetchGroupDepotEntry",
+				_fetchGroupDepotEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.depot.model.DepotEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<com.liferay.depot.model.DepotEntry>
 			getCurrentAndGroupConnectedDepotEntries(
 				HttpPrincipal httpPrincipal, long groupId, int type, int start,
@@ -134,7 +173,7 @@ public class DepotEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class,
 				"getCurrentAndGroupConnectedDepotEntries",
-				_getCurrentAndGroupConnectedDepotEntriesParameterTypes2);
+				_getCurrentAndGroupConnectedDepotEntriesParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, start, end);
@@ -175,7 +214,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getDepotEntry",
-				_getDepotEntryParameterTypes3);
+				_getDepotEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId);
@@ -217,7 +256,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes4);
+				_getGroupConnectedDepotEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructuresAvailable, start, end);
@@ -260,7 +299,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupConnectedDepotEntries",
-				_getGroupConnectedDepotEntriesParameterTypes5);
+				_getGroupConnectedDepotEntriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type, start, end);
@@ -302,7 +341,7 @@ public class DepotEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class,
 				"getGroupConnectedDepotEntriesCount",
-				_getGroupConnectedDepotEntriesCountParameterTypes6);
+				_getGroupConnectedDepotEntriesCountParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, type);
@@ -342,7 +381,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "getGroupDepotEntry",
-				_getGroupDepotEntryParameterTypes7);
+				_getGroupDepotEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -387,7 +426,7 @@ public class DepotEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DepotEntryServiceUtil.class, "updateDepotEntry",
-				_updateDepotEntryParameterTypes8);
+				_updateDepotEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, depotEntryId, nameMap, descriptionMap,
@@ -432,27 +471,29 @@ public class DepotEntryServiceHttp {
 		};
 	private static final Class<?>[] _deleteDepotEntryParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[]
-		_getCurrentAndGroupConnectedDepotEntriesParameterTypes2 = new Class[] {
-			long.class, int.class, int.class, int.class
-		};
-	private static final Class<?>[] _getDepotEntryParameterTypes3 =
+	private static final Class<?>[] _fetchGroupDepotEntryParameterTypes2 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes4 = new Class[] {
+		_getCurrentAndGroupConnectedDepotEntriesParameterTypes3 = new Class[] {
+			long.class, int.class, int.class, int.class
+		};
+	private static final Class<?>[] _getDepotEntryParameterTypes4 =
+		new Class[] {long.class};
+	private static final Class<?>[]
+		_getGroupConnectedDepotEntriesParameterTypes5 = new Class[] {
 			long.class, boolean.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesParameterTypes5 = new Class[] {
+		_getGroupConnectedDepotEntriesParameterTypes6 = new Class[] {
 			long.class, int.class, int.class, int.class
 		};
 	private static final Class<?>[]
-		_getGroupConnectedDepotEntriesCountParameterTypes6 = new Class[] {
+		_getGroupConnectedDepotEntriesCountParameterTypes7 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupDepotEntryParameterTypes7 =
+	private static final Class<?>[] _getGroupDepotEntryParameterTypes8 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateDepotEntryParameterTypes8 =
+	private static final Class<?>[] _updateDepotEntryParameterTypes9 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class,

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryServiceImpl.java
@@ -68,6 +68,21 @@ public class DepotEntryServiceImpl extends DepotEntryServiceBaseImpl {
 	}
 
 	@Override
+	public DepotEntry fetchGroupDepotEntry(long groupId)
+		throws PortalException {
+
+		DepotEntry depotEntry = depotEntryLocalService.fetchGroupDepotEntry(
+			groupId);
+
+		if (depotEntry != null) {
+			_depotEntryModelResourcePermission.check(
+				getPermissionChecker(), depotEntry, ActionKeys.VIEW);
+		}
+
+		return depotEntry;
+	}
+
+	@Override
 	public List<DepotEntry> getCurrentAndGroupConnectedDepotEntries(
 			long groupId, int type, int start, int end)
 		throws PortalException {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Asset Library API
 Bundle-SymbolicName: com.liferay.headless.asset.library.api
-Bundle-Version: 5.1.1
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.headless.asset.library.dto.v1_0,\
 	com.liferay.headless.asset.library.resource.v1_0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/java/com/liferay/headless/asset/library/dto/v1_0/AssetLibrary.java
@@ -5,9 +5,12 @@
 
 package com.liferay.headless.asset.library.dto.v1_0;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
@@ -797,6 +800,58 @@ public class AssetLibrary implements Serializable {
 	@JsonIgnore
 	private Supplier<Site[]> _sitesSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@JsonGetter("type")
+	@Valid
+	public Type getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
+
+			_typeSupplier = null;
+		}
+
+		return type;
+	}
+
+	@JsonIgnore
+	public String getTypeAsString() {
+		Type type = getType();
+
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+
+		_typeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
+			try {
+				return typeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Type type;
+
+	@JsonIgnore
+	private Supplier<Type> _typeSupplier;
+
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The asset library's associated users."
 	)
@@ -1153,6 +1208,22 @@ public class AssetLibrary implements Serializable {
 			sb.append("]");
 		}
 
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
+		}
+
 		UserAccount[] userAccounts = getUserAccounts();
 
 		if (userAccounts != null) {
@@ -1208,6 +1279,44 @@ public class AssetLibrary implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
+
+	@GraphQLName("Type")
+	public static enum Type {
+
+		ASSET_LIBRARY("AssetLibrary"), SPACE("Space");
+
+		@JsonCreator
+		public static Type create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value)) {
+					return type;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 	private static String _escape(Object object) {
 		return StringUtil.replace(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-api/src/main/resources/com/liferay/headless/asset/library/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/dto/v1_0/AssetLibrary.java
@@ -383,6 +383,33 @@ public class AssetLibrary implements Cloneable, Serializable {
 
 	protected Site[] sites;
 
+	public Type getType() {
+		return type;
+	}
+
+	public String getTypeAsString() {
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Type type;
+
 	public UserAccount[] getUserAccounts() {
 		return userAccounts;
 	}
@@ -454,6 +481,39 @@ public class AssetLibrary implements Cloneable, Serializable {
 
 	public String toString() {
 		return AssetLibrarySerDes.toJSON(this);
+	}
+
+	public static enum Type {
+
+		ASSET_LIBRARY("AssetLibrary"), SPACE("Space");
+
+		public static Type create(String value) {
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value) ||
+					Objects.equals(type.name(), value)) {
+
+					return type;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
 	}
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-client/src/main/java/com/liferay/headless/asset/library/client/serdes/v1_0/AssetLibrarySerDes.java
@@ -261,6 +261,20 @@ public class AssetLibrarySerDes {
 			sb.append("]");
 		}
 
+		if (assetLibrary.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(assetLibrary.getType());
+
+			sb.append("\"");
+		}
+
 		if (assetLibrary.getUserAccounts() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -461,6 +475,13 @@ public class AssetLibrarySerDes {
 			map.put("sites", String.valueOf(assetLibrary.getSites()));
 		}
 
+		if (assetLibrary.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(assetLibrary.getType()));
+		}
+
 		if (assetLibrary.getUserAccounts() == null) {
 			map.put("userAccounts", null);
 		}
@@ -549,6 +570,9 @@ public class AssetLibrarySerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "sites")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "userAccounts")) {
@@ -679,6 +703,12 @@ public class AssetLibrarySerDes {
 					}
 
 					assetLibrary.setSites(sitesArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					assetLibrary.setType(
+						AssetLibrary.Type.create((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "userAccounts")) {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -98,6 +98,10 @@ components:
                         $ref: "#/components/schemas/Site"
                     readOnly: true
                     type: array
+                type:
+                    default: AssetLibrary
+                    enum: [AssetLibrary, Space]
+                    type: string
                 userAccounts:
                     description:
                         The asset library's associated users.

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -115,6 +115,7 @@ public class AssetLibraryDTOConverter
 								group.getGroupId())));
 				setSettings(() -> _toSettings(group));
 				setSiteId(group::getGroupId);
+				setType(() -> _assetLibraryTypes[depotEntry.getType()]);
 			}
 		};
 	}
@@ -163,6 +164,11 @@ public class AssetLibraryDTOConverter
 			}
 		};
 	}
+
+	private static final AssetLibrary.Type[] _assetLibraryTypes =
+		new AssetLibrary.Type[] {
+			AssetLibrary.Type.ASSET_LIBRARY, AssetLibrary.Type.SPACE
+		};
 
 	@Reference
 	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -13,6 +13,7 @@ import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.dto.v1_0.MimeTypeLimit;
 import com.liferay.headless.asset.library.dto.v1_0.Settings;
 import com.liferay.headless.asset.library.internal.resource.v1_0.BaseAssetLibraryResourceImpl;
+import com.liferay.headless.asset.library.internal.util.AssetLibraryUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -115,7 +116,9 @@ public class AssetLibraryDTOConverter
 								group.getGroupId())));
 				setSettings(() -> _toSettings(group));
 				setSiteId(group::getGroupId);
-				setType(() -> _assetLibraryTypes[depotEntry.getType()]);
+				setType(
+					() -> AssetLibraryUtil.getAssetLibraryType(
+						depotEntry.getType()));
 			}
 		};
 	}
@@ -164,11 +167,6 @@ public class AssetLibraryDTOConverter
 			}
 		};
 	}
-
-	private static final AssetLibrary.Type[] _assetLibraryTypes =
-		new AssetLibrary.Type[] {
-			AssetLibrary.Type.ASSET_LIBRARY, AssetLibrary.Type.SPACE
-		};
 
 	@Reference
 	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/odata/entity/v1_0/AssetLibraryEntityModel.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/odata/entity/v1_0/AssetLibraryEntityModel.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.asset.library.internal.odata.entity.v1_0;
+
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.headless.asset.library.internal.util.AssetLibraryUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+
+import java.util.Map;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AssetLibraryEntityModel implements EntityModel {
+
+	public AssetLibraryEntityModel() {
+		_entityFieldsMap = EntityModel.toEntityFieldsMap(
+			new EntityField(
+				"type", EntityField.Type.STRING, locale -> "type",
+				locale -> "type",
+				value -> String.valueOf(
+					AssetLibraryUtil.getDepotEntryType(
+						AssetLibrary.Type.create((String)value)))));
+	}
+
+	@Override
+	public Map<String, EntityField> getEntityFieldsMap() {
+		return _entityFieldsMap;
+	}
+
+	private final Map<String, EntityField> _entityFieldsMap;
+
+}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/odata/entity/v1_0/AssetLibraryEntityModel.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/odata/entity/v1_0/AssetLibraryEntityModel.java
@@ -5,7 +5,6 @@
 
 package com.liferay.headless.asset.library.internal.odata.entity.v1_0;
 
-import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.internal.util.AssetLibraryUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -23,8 +22,7 @@ public class AssetLibraryEntityModel implements EntityModel {
 				"type", EntityField.Type.STRING, locale -> "type",
 				locale -> "type",
 				value -> String.valueOf(
-					AssetLibraryUtil.getDepotEntryType(
-						AssetLibrary.Type.create((String)value)))));
+					AssetLibraryUtil.getDepotEntryType((String)value))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -6,7 +6,6 @@
 package com.liferay.headless.asset.library.internal.resource.v1_0;
 
 import com.liferay.depot.constants.DepotActionKeys;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotAppCustomization;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.model.DepotEntryPin;
@@ -383,8 +382,10 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				unicodeProperties, serviceContext);
 		}
 
+		AssetLibrary.Type assetLibraryType = assetLibrary.getType();
+
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
-			nameMap, descriptionMap, DepotConstants.TYPE_ASSET_LIBRARY,
+			nameMap, descriptionMap, assetLibraryType.ordinal(),
 			serviceContext);
 
 		group = depotEntry.getGroup();

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -17,6 +17,8 @@ import com.liferay.document.library.configuration.DLSizeLimitConfigurationProvid
 import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.dto.v1_0.MimeTypeLimit;
 import com.liferay.headless.asset.library.dto.v1_0.Settings;
+import com.liferay.headless.asset.library.internal.odata.entity.v1_0.AssetLibraryEntityModel;
+import com.liferay.headless.asset.library.internal.util.AssetLibraryUtil;
 import com.liferay.headless.asset.library.resource.v1_0.AssetLibraryResource;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringPool;
@@ -38,6 +40,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -45,6 +48,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
+
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -201,6 +206,11 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		return _toAssetLibrary(
 			_depotEntryService.getGroupDepotEntry(
 				_getGroupIdByExternalReferenceCode(externalReferenceCode)));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
+		return _assetLibraryEntityModel;
 	}
 
 	@Override
@@ -382,10 +392,12 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 				unicodeProperties, serviceContext);
 		}
 
-		AssetLibrary.Type assetLibraryType = assetLibrary.getType();
-
 		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
-			nameMap, descriptionMap, assetLibraryType.ordinal(),
+			nameMap, descriptionMap,
+			AssetLibraryUtil.getDepotEntryType(
+				GetterUtil.getObject(
+					assetLibrary.getType(),
+					() -> AssetLibrary.Type.ASSET_LIBRARY)),
 			serviceContext);
 
 		group = depotEntry.getGroup();
@@ -691,6 +703,9 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		_dlSizeLimitConfigurationProvider.updateGroupSizeLimit(
 			groupId, 0L, 0L, mimeTypeSizeLimits);
 	}
+
+	private static final AssetLibraryEntityModel _assetLibraryEntityModel =
+		new AssetLibraryEntityModel();
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.AssetLibraryDTOConverter)"

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/AssetLibraryResourceImpl.java
@@ -79,8 +79,7 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
-			assetLibraryId);
+		DepotEntry depotEntry = _getGroupDepotEntry(assetLibraryId);
 
 		_depotEntryService.deleteDepotEntry(depotEntry.getDepotEntryId());
 	}
@@ -117,8 +116,7 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
-			assetLibraryId);
+		DepotEntry depotEntry = _getGroupDepotEntry(assetLibraryId);
 
 		_depotEntryPinService.deleteDepotEntryPin(
 			contextUser.getUserId(), depotEntry.getDepotEntryId());
@@ -190,8 +188,7 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return _toAssetLibrary(
-			_depotEntryService.getGroupDepotEntry(assetLibraryId));
+		return _toAssetLibrary(_getGroupDepotEntry(assetLibraryId));
 	}
 
 	@Override
@@ -222,8 +219,7 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
-			assetLibraryId);
+		DepotEntry depotEntry = _getGroupDepotEntry(assetLibraryId);
 
 		Group group = depotEntry.getGroup();
 
@@ -344,8 +340,7 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		DepotEntry depotEntry = _depotEntryService.getGroupDepotEntry(
-			assetLibraryId);
+		DepotEntry depotEntry = _getGroupDepotEntry(assetLibraryId);
 
 		_depotEntryPinService.addDepotEntryPin(
 			contextUser.getUserId(), depotEntry.getDepotEntryId());
@@ -456,6 +451,19 @@ public class AssetLibraryResourceImpl extends BaseAssetLibraryResourceImpl {
 		}
 
 		return depotAppCustomizationMap;
+	}
+
+	private DepotEntry _getGroupDepotEntry(Long assetLibraryId)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryService.fetchGroupDepotEntry(
+			assetLibraryId);
+
+		if (depotEntry != null) {
+			return depotEntry;
+		}
+
+		return _depotEntryService.getDepotEntry(assetLibraryId);
 	}
 
 	private long _getGroupIdByExternalReferenceCode(

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/BaseAssetLibraryResourceImpl.java
@@ -436,7 +436,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/{assetLibraryId}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the asset library using only the fields received in the request body. Any other fields are left untouched."
@@ -471,7 +471,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the asset library using only the fields received in the request body with the given external reference code. Any other fields are left untouched."
@@ -530,6 +530,10 @@ public abstract class BaseAssetLibraryResourceImpl
 
 		if (assetLibrary.getName_i18n() != null) {
 			existingAssetLibrary.setName_i18n(assetLibrary.getName_i18n());
+		}
+
+		if (assetLibrary.getType() != null) {
+			existingAssetLibrary.setType(assetLibrary.getType());
 		}
 
 		preparePatch(assetLibrary, existingAssetLibrary);
@@ -628,7 +632,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new asset library"
@@ -694,7 +698,7 @@ public abstract class BaseAssetLibraryResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/{externalReferenceCode}' -d $'{"assetLibraryKey": ___, "description": ___, "description_i18n": ___, "externalReferenceCode": ___, "name": ___, "name_i18n": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Replaces the asset library with information sent in the request body with the given external reference code. Any missing fields are deleted unless they are required."

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/util/AssetLibraryUtil.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/util/AssetLibraryUtil.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.asset.library.internal.util;
+
+import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AssetLibraryUtil {
+
+	public static AssetLibrary.Type getAssetLibraryType(int depotEntryType) {
+		return _assetLibraryTypes[depotEntryType];
+	}
+
+	public static int getDepotEntryType(AssetLibrary.Type assetLibraryType) {
+		return assetLibraryType.ordinal();
+	}
+
+	private static final AssetLibrary.Type[] _assetLibraryTypes =
+		new AssetLibrary.Type[] {
+			AssetLibrary.Type.ASSET_LIBRARY, AssetLibrary.Type.SPACE
+		};
+
+}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/util/AssetLibraryUtil.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/util/AssetLibraryUtil.java
@@ -6,6 +6,10 @@
 package com.liferay.headless.asset.library.internal.util;
 
 import com.liferay.headless.asset.library.dto.v1_0.AssetLibrary;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Map;
 
 /**
  * @author Adolfo Pérez
@@ -20,9 +24,22 @@ public class AssetLibraryUtil {
 		return assetLibraryType.ordinal();
 	}
 
+	public static int getDepotEntryType(String assetLibraryTypeString) {
+		return _depotEntryTypes.get(
+			StringUtil.toLowerCase(assetLibraryTypeString));
+	}
+
 	private static final AssetLibrary.Type[] _assetLibraryTypes =
 		new AssetLibrary.Type[] {
 			AssetLibrary.Type.ASSET_LIBRARY, AssetLibrary.Type.SPACE
 		};
+	private static final Map<String, Integer> _depotEntryTypes =
+		HashMapBuilder.put(
+			StringUtil.toLowerCase(AssetLibrary.Type.ASSET_LIBRARY.getValue()),
+			getDepotEntryType(AssetLibrary.Type.ASSET_LIBRARY)
+		).put(
+			StringUtil.toLowerCase(AssetLibrary.Type.SPACE.getValue()),
+			getDepotEntryType(AssetLibrary.Type.SPACE)
+		).build();
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/bnd.bnd
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/bnd.bnd
@@ -1,4 +1,6 @@
 Bundle-Name: Liferay Headless Asset Library Test
 Bundle-SymbolicName: com.liferay.headless.asset.library.test
 Bundle-Version: 1.0.0
--includeresource: com.liferay.headless.asset.library.client.jar=com.liferay.headless.asset.library.client-*.jar;lib:=true
+-includeresource:\
+	com.liferay.headless.asset.library.client.jar=com.liferay.headless.asset.library.client-*.jar;lib:=true,\
+	com.liferay.headless.batch.engine.client.jar=com.liferay.headless.batch.engine.client-*.jar;lib:=true

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -13,6 +13,8 @@ import com.liferay.depot.service.DepotEntryPinLocalService;
 import com.liferay.headless.asset.library.client.dto.v1_0.AssetLibrary;
 import com.liferay.headless.asset.library.client.dto.v1_0.MimeTypeLimit;
 import com.liferay.headless.asset.library.client.dto.v1_0.Settings;
+import com.liferay.headless.asset.library.client.pagination.Page;
+import com.liferay.headless.asset.library.client.pagination.Pagination;
 import com.liferay.headless.asset.library.client.problem.Problem;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -67,6 +69,31 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
 			Assert.assertNull(problem.getTitle());
 		}
+	}
+
+	@Override
+	@Test
+	public void testGetAssetLibrariesPage() throws Exception {
+		super.testGetAssetLibrariesPage();
+
+		Page<AssetLibrary> page = assetLibraryResource.getAssetLibrariesPage(
+			null, null, "type eq 'Space'", Pagination.of(1, 10), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary assetLibrary = testGetAssetLibrariesPage_addAssetLibrary(
+			randomAssetLibrary);
+
+		page = assetLibraryResource.getAssetLibrariesPage(
+			null, null, "type eq 'Space'", Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assetLibraryResource.deleteAssetLibrary(assetLibrary.getId());
 	}
 
 	@Override
@@ -139,6 +166,16 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 				}
 			});
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary = assetLibraryResource.postAssetLibrary(
+			randomAssetLibrary);
+
+		Assert.assertEquals(
+			AssetLibrary.Type.SPACE, postedAssetLibrary.getType());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/BaseAssetLibraryResourceTestCase.java
@@ -1671,6 +1671,14 @@ public abstract class BaseAssetLibraryResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (assetLibrary.getType() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("userAccounts", additionalAssertFieldName)) {
 				if (assetLibrary.getUserAccounts() == null) {
 					valid = false;
@@ -1969,6 +1977,16 @@ public abstract class BaseAssetLibraryResourceTestCase {
 			if (Objects.equals("sites", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						assetLibrary1.getSites(), assetLibrary2.getSites())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("type", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						assetLibrary1.getType(), assetLibrary2.getType())) {
 
 					return false;
 				}
@@ -2401,6 +2419,11 @@ public abstract class BaseAssetLibraryResourceTestCase {
 		}
 
 		if (entityFieldName.equals("sites")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("type")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/SiteResourceTest.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -32,6 +34,12 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.setUp();
 
 		_testSite = _addSite();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testBatchEngineDeleteImportTask() {
 	}
 
 	@Override

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -17,6 +17,8 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -32,6 +34,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		super.setUp();
 
 		_testUser = UserTestUtil.addUser();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testBatchEngineDeleteImportTask() {
 	}
 
 	@Override

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserGroupResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserGroupResourceTest.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -38,6 +40,12 @@ public class UserGroupResourceTest extends BaseUserGroupResourceTestCase {
 		super.setUp();
 
 		_testUserGroup = _addUserGroup();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testBatchEngineDeleteImportTask() {
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62409

It should be possible to create depots of both kinds through the headless api, and filter by type when retrieving them.

# How can you verify that it works?

Run the included integration tests.