### PR TITLE
LPD-60429 Technical Task | Allow folders to be shared with individual users

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -171,6 +171,11 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 				"{embedded.file.link.href}", "download", "download",
 				LanguageUtil.get(httpServletRequest, "download"), "get", null,
 				"link"));
+		fdsActionDropdownItems.add(
+			new FDSActionDropdownItem(
+				null, "share", "share",
+				LanguageUtil.get(httpServletRequest, "share"), "get", null,
+				"link"));
 
 		if (!Objects.equals(
 				getRootObjectEntryFolderExternalReferenceCode(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CollaboratorService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CollaboratorService.ts
@@ -25,7 +25,11 @@ async function getCollaborators(collaboratorURL: string, itemId: number) {
 			share: boolean;
 			type: string;
 		}>;
-	}>(collaboratorURL.replace('{objectEntryId}', itemId.toString()).replace('{objectEntryFolderId}',  itemId.toString()));
+	}>(
+		collaboratorURL
+			.replace('{objectEntryId}', itemId.toString())
+			.replace('{objectEntryFolderId}', itemId.toString())
+	);
 
 	if (data) {
 		return data.items;
@@ -46,7 +50,9 @@ async function updateCollaborators(
 	}[]
 ) {
 	return await ApiHelper.post(
-        collaboratorURL.replace('{objectEntryId}', itemId.toString()).replace('{objectEntryFolderId}',  itemId.toString()),
+		collaboratorURL
+			.replace('{objectEntryId}', itemId.toString())
+			.replace('{objectEntryFolderId}', itemId.toString()),
 		collaborators
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CollaboratorService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/CollaboratorService.ts
@@ -25,7 +25,7 @@ async function getCollaborators(collaboratorURL: string, itemId: number) {
 			share: boolean;
 			type: string;
 		}>;
-	}>(collaboratorURL.replace('{objectEntryId}', itemId.toString()));
+	}>(collaboratorURL.replace('{objectEntryId}', itemId.toString()).replace('{objectEntryFolderId}',  itemId.toString()));
 
 	if (data) {
 		return data.items;
@@ -46,7 +46,7 @@ async function updateCollaborators(
 	}[]
 ) {
 	return await ApiHelper.post(
-		collaboratorURL.replace('{objectEntryId}', itemId.toString()),
+        collaboratorURL.replace('{objectEntryId}', itemId.toString()).replace('{objectEntryFolderId}',  itemId.toString()),
 		collaborators
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/FolderFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/FolderFDSPropsTransformer.ts
@@ -10,6 +10,7 @@ import {EVENTS} from '../info_panel/util/constants';
 import createAssetAction from './actions/createAssetAction';
 import createFolderAction from './actions/createFolderAction';
 import multipleFilesUploadAction from './actions/multipleFilesUploadAction';
+import shareAction from './actions/shareAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import NameRenderer from './cell_renderers/NameRenderer';
 import SimpleActionLinkRenderer from './cell_renderers/SimpleActionLinkRenderer';
@@ -26,10 +27,16 @@ const OBJECT_ENTRY_FOLDER_CLASSNAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
 export default function FolderFDSPropsTransformer({
+	additionalProps,
 	creationMenu,
 	itemsActions = [],
 	...otherProps
 }: {
+	additionalProps: {
+		autocompleteURL: string;
+		cmsGroupId?: number;
+		collaboratorURLs: Record<string, string>;
+	};
 	creationMenu: any;
 	itemsActions?: any[];
 	otherProps: any;
@@ -67,7 +74,7 @@ export default function FolderFDSPropsTransformer({
 				} as IInternalRenderer,
 			],
 		},
-		infoPanelComponent: () => AssetTypeInfoPanel(otherProps),
+		infoPanelComponent: () => AssetTypeInfoPanel({additionalProps}),
 		itemsActions: itemsActions.map((action) => {
 			if (action?.data?.id === 'download') {
 				return {
@@ -94,10 +101,21 @@ export default function FolderFDSPropsTransformer({
 			itemData,
 		}: {
 			action: any;
-			itemData: [];
+			itemData: any;
 		}) => {
 			if (action?.data?.id === 'show-details') {
 				Liferay.fire(EVENTS.ASSET_DATA, {items: [{...itemData}]});
+			}
+			else if (action?.data?.id === 'share') {
+				const {autocompleteURL, collaboratorURLs} = additionalProps;
+
+				shareAction({
+					autocompleteURL,
+					collaboratorURL: collaboratorURLs[itemData.entryClassName],
+					creator: itemData.embedded.creator,
+					itemId: itemData.embedded.id,
+					title: itemData.embedded?.title,
+				});
 			}
 		},
 		onSelectedItemsChange: (selectedItems: any[]) => {


### PR DESCRIPTION
LPD-60429 Technical Task | Allow folders to be shared with individual users

re-sent after https://github.com/brianchandotcom/liferay-portal/pull/164472#issuecomment-3194230207

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47902

Allow folders to be shared with individual users/groups

# How am I fixing it?

Adding the function of sharing for object entry folders

# How can you verify that it works?


- Create a new User
- On CMS create a folder
- Share with new user


# Commits
- **LPD-60429 add share dropdown on folders page**
- **LPD-60429 take into account that now we can share objects entry folders or objects entries**
