### PR TITLE
LPD-62501 Modify object entry display page to use it for object entry version

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 18.1.1
+Bundle-Version: 18.2.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -257,7 +257,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 
 		return _getLayoutDisplayPageObjectProvider(
 			layoutDisplayPageProvider, groupId, friendlyURL,
-			_getVersion(params));
+			getVersion(params));
 	}
 
 	protected Layout getLayoutDisplayPageObjectProviderLayout(
@@ -294,6 +294,16 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		}
 
 		return locale;
+	}
+
+	protected String getVersion(Map<String, String[]> params) {
+		String[] versions = params.get("version");
+
+		if (ArrayUtil.isEmpty(versions)) {
+			return StringPool.BLANK;
+		}
+
+		return versions[0];
 	}
 
 	protected boolean isSameFriendlyURL(String url1, String url2) {
@@ -379,7 +389,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 			Map<String, String[]> params)
 		throws NoSuchInfoItemException {
 
-		String version = _getVersion(params);
+		String version = getVersion(params);
 
 		if (Validator.isNull(version)) {
 			return layoutDisplayPageObjectProvider.getDisplayObject();
@@ -541,16 +551,6 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		}
 
 		return StringPool.BLANK;
-	}
-
-	private String _getVersion(Map<String, String[]> params) {
-		String[] versions = params.get("version");
-
-		if (ArrayUtil.isEmpty(versions)) {
-			return StringPool.BLANK;
-		}
-
-		return versions[0];
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/portlet/CustomAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/portlet/CustomAssetDisplayPageFriendlyURLResolver.java
@@ -90,6 +90,12 @@ public class CustomAssetDisplayPageFriendlyURLResolver
 		if (Validator.isNumber(parts[2])) {
 			infoItemIdentifier = new ClassPKInfoItemIdentifier(
 				GetterUtil.getLong(parts[2]));
+
+			String version = getVersion(params);
+
+			if (version != null) {
+				infoItemIdentifier.setVersion(version);
+			}
 		}
 		else {
 			infoItemIdentifier = new ERCInfoItemIdentifier(parts[2]);

--- a/modules/apps/asset/asset-display-page-test/build.gradle
+++ b/modules/apps/asset/asset-display-page-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:info:info-test-util")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:object:object-api")

--- a/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/internal/portlet/test/CustomAssetDisplayPageFriendlyURLResolverTest.java
+++ b/modules/apps/asset/asset-display-page-test/src/testIntegration/java/com/liferay/asset/display/page/internal/portlet/test/CustomAssetDisplayPageFriendlyURLResolverTest.java
@@ -1,0 +1,162 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.display.page.internal.portlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageProviderRegistry;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.lang.reflect.Method;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class CustomAssetDisplayPageFriendlyURLResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			ListUtil.fromArray(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), "text")),
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		_objectDefinition.setEnableObjectEntryVersioning(true);
+
+		_objectDefinition =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition);
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProvider() throws Exception {
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"text", "textValue1"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"text", "textValue2"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(2, objectEntry.getVersion());
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			_getLayoutDisplayPageObjectProvider(
+				StringBundler.concat(
+					"/e/", _objectDefinition.getName(), StringPool.SLASH,
+					_portal.getClassNameId(_objectDefinition.getClassName()),
+					StringPool.SLASH, objectEntry.getObjectEntryId()),
+				HashMapBuilder.put(
+					"version", new String[] {"1"}
+				).build());
+
+		Assert.assertNotNull(layoutDisplayPageObjectProvider);
+
+		ObjectEntry actualObjectEntry =
+			(ObjectEntry)layoutDisplayPageObjectProvider.getDisplayObject();
+
+		Assert.assertEquals(1, actualObjectEntry.getVersion());
+	}
+
+	private LayoutDisplayPageObjectProvider<?>
+			_getLayoutDisplayPageObjectProvider(
+				String friendlyURL, Map<String, String[]> params)
+		throws Exception {
+
+		Method method = ReflectionUtil.getDeclaredMethod(
+			_friendlyURLResolver.getClass(),
+			"getLayoutDisplayPageObjectProvider",
+			LayoutDisplayPageProvider.class, long.class, String.class,
+			Map.class);
+
+		return (LayoutDisplayPageObjectProvider<?>)method.invoke(
+			_friendlyURLResolver,
+			_layoutDisplayPageProviderRegistry.
+				getLayoutDisplayPageProviderByClassName(
+					_objectDefinition.getClassName()),
+			RandomTestUtil.randomLong(), friendlyURL, params);
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.asset.display.page.internal.portlet.CustomAssetDisplayPageFriendlyURLResolver"
+	)
+	private FriendlyURLResolver _friendlyURLResolver;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutDisplayPageProviderRegistry
+		_layoutDisplayPageProviderRegistry;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -226,6 +226,10 @@ public interface ObjectEntryVersionLocalService
 	public ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectEntryVersion fetchObjectEntryVersion(
+		long objectEntryId, int version);
+
 	/**
 	 * Returns the object entry version with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -267,6 +267,12 @@ public class ObjectEntryVersionLocalServiceUtil {
 		return getService().fetchObjectEntryVersion(objectEntryVersionId);
 	}
 
+	public static ObjectEntryVersion fetchObjectEntryVersion(
+		long objectEntryId, int version) {
+
+		return getService().fetchObjectEntryVersion(objectEntryId, version);
+	}
+
 	/**
 	 * Returns the object entry version with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -304,6 +304,14 @@ public class ObjectEntryVersionLocalServiceWrapper
 			objectEntryVersionId);
 	}
 
+	@Override
+	public com.liferay.object.model.ObjectEntryVersion fetchObjectEntryVersion(
+		long objectEntryId, int version) {
+
+		return _objectEntryVersionLocalService.fetchObjectEntryVersion(
+			objectEntryId, version);
+	}
+
 	/**
 	 * Returns the object entry version with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -6,12 +6,14 @@
 package com.liferay.object.info.item.util;
 
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectEntryVersionLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -25,6 +27,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
 /**
@@ -57,12 +60,24 @@ public class ObjectEntryInfoItemUtil {
 			objectEntryManagerRegistry.getObjectEntryManager(
 				objectDefinition.getStorageType());
 
+		DTOConverterContext dtoConverterContext =
+			new DefaultDTOConverterContext(
+				false, null, null, null, null, themeDisplay.getLocale(), null,
+				themeDisplay.getUser());
+
+		ObjectEntryVersion objectEntryVersion =
+			ObjectEntryVersionLocalServiceUtil.fetchObjectEntryVersion(
+				serviceBuilderObjectEntry.getObjectEntryId(),
+				serviceBuilderObjectEntry.getVersion());
+
+		if (objectEntryVersion != null) {
+			dtoConverterContext.setAttribute(
+				"objectEntryVersion", objectEntryVersion);
+		}
+
 		try {
 			return objectEntryManager.getObjectEntry(
-				themeDisplay.getCompanyId(),
-				new DefaultDTOConverterContext(
-					false, null, null, null, null, themeDisplay.getLocale(),
-					null, themeDisplay.getUser()),
+				themeDisplay.getCompanyId(), dtoConverterContext,
 				serviceBuilderObjectEntry.getExternalReferenceCode(),
 				objectDefinition,
 				getScopeKey(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2939,6 +2939,15 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext.getUriInfo(),
 				dtoConverterContext.getUser());
 
+		ObjectEntryVersion objectEntryVersion =
+			(ObjectEntryVersion)dtoConverterContext.getAttribute(
+				"objectEntryVersion");
+
+		if (objectEntryVersion != null) {
+			defaultDTOConverterContext.setAttribute(
+				"objectEntryVersion", objectEntryVersion);
+		}
+
 		defaultDTOConverterContext.setAttribute(
 			"objectDefinition", objectDefinition);
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2939,6 +2939,9 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext.getUriInfo(),
 				dtoConverterContext.getUser());
 
+		defaultDTOConverterContext.setAttribute(
+			"objectDefinition", objectDefinition);
+
 		ObjectEntryVersion objectEntryVersion =
 			(ObjectEntryVersion)dtoConverterContext.getAttribute(
 				"objectEntryVersion");
@@ -2947,9 +2950,6 @@ public class DefaultObjectEntryManagerImpl
 			defaultDTOConverterContext.setAttribute(
 				"objectEntryVersion", objectEntryVersion);
 		}
-
-		defaultDTOConverterContext.setAttribute(
-			"objectDefinition", objectDefinition);
 
 		return _objectEntryDTOConverter.toDTO(
 			defaultDTOConverterContext, serviceBuilderObjectEntry);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -216,6 +216,14 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	@Override
+	public ObjectEntryVersion fetchObjectEntryVersion(
+		long objectEntryId, int version) {
+
+		return objectEntryVersionPersistence.fetchByOEI_V(
+			objectEntryId, version);
+	}
+
+	@Override
 	public ObjectEntryVersion getObjectEntryVersion(
 			long objectEntryId, int version)
 		throws PortalException {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
@@ -760,6 +760,40 @@ public class ObjectEntryVersionLocalServiceTest {
 	}
 
 	@Test
+	public void testFetchObjectEntryVersion() throws Exception {
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", "textObjectFieldValue1"
+			).build());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", "textObjectFieldValue2"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.fetchObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 1);
+
+		Assert.assertNotNull(objectEntryVersion);
+		Assert.assertEquals(1, objectEntryVersion.getVersion());
+
+		objectEntryVersion =
+			_objectEntryVersionLocalService.fetchObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 2);
+
+		Assert.assertNotNull(objectEntryVersion);
+		Assert.assertEquals(2, objectEntryVersion.getVersion());
+
+		Assert.assertNull(
+			_objectEntryVersionLocalService.fetchObjectEntryVersion(
+				objectEntry.getObjectEntryId(), 3));
+	}
+
+	@Test
 	public void testIsLatestObjectEntryVersion() throws Exception {
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			0, _objectDefinition.getObjectDefinitionId(),

--- a/modules/apps/object/object-web/build.gradle
+++ b/modules/apps/object/object-web/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.2"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.2"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -33,6 +33,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.model.ProxyObjectEntry;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCache;
@@ -107,6 +108,11 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				ObjectEntryInfoItemFieldValuesProvider.class.getName());
 
 		String key = String.valueOf(objectEntry.getObjectEntryId());
+
+		if (objectEntry.getVersion() > 0) {
+			key = StringBundler.concat(
+				key, StringPool.POUND, objectEntry.getVersion());
+		}
 
 		InfoItemFieldValues infoItemFieldValues = threadLocalCache.get(key);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -220,8 +220,6 @@ public class ObjectEntryLayoutDisplayPageProvider
 	}
 
 	private Map<String, Serializable> _getValues(JSONObject jsonObject) {
-		ObjectMapper objectMapper = new ObjectMapper();
-
 		try {
 			JSONObject propertiesJSONObject = jsonObject.getJSONObject(
 				"properties");
@@ -229,6 +227,8 @@ public class ObjectEntryLayoutDisplayPageProvider
 			if (JSONUtil.isEmpty(propertiesJSONObject)) {
 				return Collections.emptyMap();
 			}
+
+			ObjectMapper objectMapper = new ObjectMapper();
 
 			return objectMapper.readValue(
 				propertiesJSONObject.toString(),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -5,6 +5,10 @@
 
 package com.liferay.object.web.internal.layout.display.page;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.ERCInfoItemIdentifier;
@@ -14,12 +18,18 @@ import com.liferay.layout.display.page.BaseLayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryVersionLocalServiceUtil;
 import com.liferay.object.web.internal.util.ObjectEntryUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -29,6 +39,11 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Guilherme Camacho
@@ -86,6 +101,18 @@ public class ObjectEntryLayoutDisplayPageProvider
 
 			if (objectEntry == null) {
 				return null;
+			}
+
+			if (infoItemIdentifier.getVersion() != null) {
+				ObjectEntryVersion objectEntryVersion =
+					ObjectEntryVersionLocalServiceUtil.fetchObjectEntryVersion(
+						objectEntry.getObjectEntryId(),
+						GetterUtil.getInteger(infoItemIdentifier.getVersion()));
+
+				if (objectEntryVersion != null) {
+					_setObjectEntryVersionValues(
+						objectEntry, objectEntryVersion);
+				}
 			}
 
 			ObjectDefinition objectDefinition =
@@ -174,6 +201,61 @@ public class ObjectEntryLayoutDisplayPageProvider
 
 		return new ObjectEntryLayoutDisplayPageObjectProvider(
 			_infoItemFriendlyURLProvider, _objectDefinition, objectEntry);
+	}
+
+	private JSONObject _getContentJSONObject(
+		ObjectEntryVersion objectEntryVersion) {
+
+		try {
+			return JSONFactoryUtil.createJSONObject(
+				objectEntryVersion.getContent());
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+		}
+
+		return JSONFactoryUtil.createJSONObject();
+	}
+
+	private Map<String, Serializable> _getValues(JSONObject jsonObject) {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		try {
+			JSONObject propertiesJSONObject = jsonObject.getJSONObject(
+				"properties");
+
+			if (JSONUtil.isEmpty(propertiesJSONObject)) {
+				return Collections.emptyMap();
+			}
+
+			return objectMapper.readValue(
+				propertiesJSONObject.toString(),
+				new TypeReference<Map<String, Serializable>>() {
+				});
+		}
+		catch (JsonProcessingException jsonProcessingException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonProcessingException);
+			}
+		}
+
+		return Collections.emptyMap();
+	}
+
+	private void _setObjectEntryVersionValues(
+		ObjectEntry objectEntry, ObjectEntryVersion objectEntryVersion) {
+
+		JSONObject contentJSONObject = _getContentJSONObject(
+			objectEntryVersion);
+
+		objectEntry.setUserId(objectEntryVersion.getUserId());
+		objectEntry.setObjectEntryFolderId(
+			contentJSONObject.getLong("objectEntryFolderId"));
+		objectEntry.setVersion(objectEntryVersion.getVersion());
+		objectEntry.setStatus(objectEntryVersion.getStatus());
+		objectEntry.setValues(_getValues(contentJSONObject));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewVersionHistoryDisplayContext.java
@@ -65,7 +65,8 @@ public class ViewVersionHistoryDisplayContext {
 				StringBundler.concat(
 					_themeDisplay.getPortalURL(), _themeDisplay.getPathMain(),
 					GroupConstants.CMS_FRIENDLY_URL,
-					"/edit_content_item?objectEntryId={id}",
+					"/edit_content_item?objectEntryId={id}&version=",
+					"{systemProperties.version.number}",
 					"&p_l_mode=read&p_p_state=", LiferayWindowState.POP_UP,
 					"&redirect=", _themeDisplay.getURLCurrent()),
 				"view", "view-content",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/EditContentItemStrutsAction.java
@@ -75,6 +75,13 @@ public class EditContentItemStrutsAction implements StrutsAction {
 				editURL, "p_p_state", windowState);
 		}
 
+		int version = ParamUtil.getInteger(httpServletRequest, "version");
+
+		if (version > 0) {
+			editURL = HttpComponentsUtil.addParameter(
+				editURL, "version", version);
+		}
+
 		httpServletResponse.sendRedirect(editURL);
 
 		return null;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62501

We have the need to add a preview for each object entry versions. For that,  we have modified the object entry display page infrastructure in order to reuse it for object entry versions as well.  As we are already creating a DPT for the object definition classname, we have the need to reuse it to show the entry versions.

# How am I fixing it?

1. Supporting version param in CustomAssetDisplayPageFriendlyURLResolver in order to propagate the version we need to use.
2. Take into account above point, to fill with the correct version values and propage the version when needed.

# How can you verify that it works?

Run included integration tests.