### PR TITLE
LPD-63298 Make CMS work only with "Space" depot entries

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/depot-entries.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/depot-entries.json
@@ -7,6 +7,7 @@
 		},
 		"name_i18n": {
 			"en_US": "Default"
-		}
+		},
+		"type": "Space"
 	}
 ]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -1948,7 +1948,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 						jsonObject.getString("name_i18n")),
 					SiteInitializerUtil.toMap(
 						jsonObject.getString("description_i18n")),
-					DepotConstants.TYPE_ASSET_LIBRARY, serviceContext);
+					_getDepotEntryType(jsonObject.getString("type")),
+					serviceContext);
 			}
 
 			UnicodeProperties unicodeProperties = new UnicodeProperties(true);
@@ -5462,6 +5463,22 @@ public class BundleSiteInitializer implements SiteInitializer {
 		}
 
 		return map;
+	}
+
+	private int _getDepotEntryType(String assetLibraryTypeString) {
+		if (Validator.isNull(assetLibraryTypeString) ||
+			StringUtil.equalsIgnoreCase(
+				assetLibraryTypeString, "AssetLibrary")) {
+
+			return DepotConstants.TYPE_ASSET_LIBRARY;
+		}
+		else if (StringUtil.equalsIgnoreCase(assetLibraryTypeString, "Space")) {
+			return DepotConstants.TYPE_SPACE;
+		}
+
+		throw new IllegalArgumentException(
+			"Asset library type " + assetLibraryTypeString +
+				" must be one of: AssetLibrary, Space.");
 	}
 
 	private Serializable _getExpandoAttributeValue(JSONObject jsonObject)

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpacesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewSpacesSectionDisplayContextTest.java
@@ -209,7 +209,7 @@ public class ViewSpacesSectionDisplayContextTest
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			null, DepotConstants.TYPE_SPACE,
 			new ServiceContext() {
 				{
 					setCompanyId(group.getCompanyId());
@@ -236,7 +236,7 @@ public class ViewSpacesSectionDisplayContextTest
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			null, DepotConstants.TYPE_ASSET_LIBRARY,
+			null, DepotConstants.TYPE_SPACE,
 			new ServiceContext() {
 				{
 					setCompanyId(group.getCompanyId());

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
@@ -67,8 +67,9 @@ public class ViewAllSpacesDisplayContext {
 	}
 
 	public String getAPIURL() {
-		return "/o/headless-asset-library/v1.0/asset-libraries?nestedFields=" +
-			"numberOfSites,numberOfUserAccounts,numberOfUserGroups";
+		return "/o/headless-asset-library/v1.0/asset-libraries?filter=type " +
+			"eq 'Space'&nestedFields=numberOfSites,numberOfUserAccounts," +
+				"numberOfUserGroups";
 	}
 
 	public List<DropdownItem> getBulkActionDropdownItems() {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpacesDisplayContext.java
@@ -134,7 +134,8 @@ public class ViewSpacesDisplayContext {
 
 		Page<AssetLibrary> assetLibrariesPage =
 			assetLibraryResource.getAssetLibrariesPage(
-				null, null, null, Pagination.of(1, 5), null);
+				null, null, assetLibraryResource.toFilter("type eq 'Space'"),
+				Pagination.of(1, 5), null);
 
 		return Page.of(
 			assetLibrariesPage.getActions(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
@@ -22,6 +22,7 @@ async function addSpace({
 			description,
 			name,
 			settings,
+			type: 'Space',
 		}
 	);
 }
@@ -133,7 +134,7 @@ async function getSpaceUsers({
 
 async function getSpaces(): Promise<Space[]> {
 	const {data, error} = await ApiHelper.get<{items: Space[]}>(
-		'/o/headless-asset-library/v1.0/asset-libraries'
+		"/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'"
 	);
 
 	if (data) {

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/NewSpace.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/NewSpace.test.tsx
@@ -119,6 +119,7 @@ describe('NewSpace', () => {
 					settings: {
 						logoColor: 'outline-0',
 					},
+					type: 'Space',
 				}
 			);
 		});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-63298

The CMS should only display depot entries of type "space".

# How am I fixing it?

By adding an OData filter where appropriate, and passing the correct type when creating a space.

Additionally, add support for depot entry type to the bundle site initializer extender.