### PR TITLE
LPD-63313 Publication dialog opens even when required fields are not filled

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -85,24 +85,19 @@ export default function SaveButtons({
 		});
 	}, [portletNamespace]);
 
-	const onClick = (action) => {
-		const titleInputComponent = Liferay.component(
-			`${portletNamespace}titleMapAsXML`
-		);
+	const onClick = async (action) => {
+		if (!(await validateRequiredFields(formId))) {
+			return;
+		}
 
-		if (titleInputComponent?.getValue(defaultLanguageId)) {
-			if (articleId && !showPublishModal) {
-				handleButtonClick(action);
-			}
-			else {
-				setPublishModalState({
-					publishModalAction: action,
-					publishModalVisible: true,
-				});
-			}
+		if (articleId && !showPublishModal) {
+			handleButtonClick(action);
 		}
 		else {
-			validateRequiredFields(formId);
+			setPublishModalState({
+				publishModalAction: action,
+				publishModalVisible: true,
+			});
 		}
 	};
 
@@ -174,16 +169,28 @@ export default function SaveButtons({
 		);
 	};
 
-	const validateRequiredFields = (formId) => {
-		Liferay.Form.get(formId).formValidator.validate();
-		Liferay.componentReady(
-			`${portletNamespace}dataEngineLayoutRenderer`
-		).then((dataEngineLayoutRenderer) => {
-			const dataEngineLayoutRendererRef =
-				dataEngineLayoutRenderer?.reactComponentRef;
+	const validateRequiredFields = async (formId) => {
+		const formValidator = Liferay.Form?.get(formId)?.formValidator;
 
-			return dataEngineLayoutRendererRef.current.validate();
-		});
+		if (!formValidator) {
+			return true;
+		}
+
+		formValidator.validate();
+
+		if (formValidator.hasErrors()) {
+			return false;
+		}
+
+		const renderer = await Liferay.componentReady(
+			`${portletNamespace}dataEngineLayoutRenderer`
+		);
+
+		if (renderer?.reactComponentRef?.current?.validate) {
+			return renderer.reactComponentRef.current.validate();
+		}
+
+		return true;
 	};
 
 	useEffect(() => {

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -232,4 +232,31 @@ describe('SaveButtons', () => {
 			screen.queryByText('please-enter-a-valid-date')
 		).not.toBeInTheDocument();
 	});
+
+	it('does not proceed if required fields validation fails', async () => {
+		global.Liferay.Form = {
+			get: () => ({
+				formValidator: {
+					hasErrors: jest.fn().mockReturnValue(true),
+					validate: jest.fn(),
+				},
+			}),
+		};
+
+		renderComponent({
+			...DEFAULT_PROPS,
+			articleId: null,
+			saveButtonLabel: 'save',
+		});
+
+		runAllTimersAndExecuteAction(() => {
+			userEvent.click(screen.getByText('save'));
+		});
+
+		expect(
+			screen.queryByText(
+				'confirm-the-web-content-visibility-before-saving-as-draft'
+			)
+		).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-63313

Prevent saving or publishing web content when required fields are missing

# How am I fixing it?

Adding a validation step that blocks the action until all required fields are satisfied, ensuring the draft/publish flow only continues when the content is valid.

# How can you verify that it works?

Run the included automated tests.