### PR TITLE
LPD-60435 Technical Task | Show title and type of share asset on list on all the cases on shared with me page

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -114,12 +114,16 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return assetRenderer;
 		}
 
+		if (!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564")) {
+
+			return null;
+		}
+
 		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
 			groupId);
 
-		if (FeatureFlagManagerUtil.isEnabled("LPD-17564") &&
-			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
-
+		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
 			return assetRenderer;
 		}
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -10,12 +10,15 @@ import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.util.AssetRendererFactoryWrapper;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.depot.web.internal.application.controller.DepotApplicationController;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -107,6 +110,15 @@ public class DepotAssetRendererFactoryWrapper<T>
 					getCurrentAndAncestorSiteAndDepotGroupIds(
 						_getGroupId(group.getGroupId())),
 				groupId)) {
+
+			return assetRenderer;
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
+			groupId);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-17564") &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
 
 			return assetRenderer;
 		}

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -7,12 +7,16 @@ package com.liferay.depot.web.internal.asset.model;
 
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.function.Consumer;
@@ -96,15 +100,14 @@ public class DepotAssetRendererFactoryWrapperTest {
 			depotGroupId
 		);
 
-		long groupId = _setUpGroup();
-
 		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
 			new DepotAssetRendererFactoryWrapper(
-				_assetRendererFactory, null, null, _groupLocalService, null,
-				null, _siteConnectedGroupGroupProvider);
+				_assetRendererFactory, null, _depotEntryLocalService,
+				_groupLocalService, null, null,
+				_siteConnectedGroupGroupProvider);
 
 		try (SafeCloseable safeCloseable =
-				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
+				GroupThreadLocal.setGroupIdWithSafeCloseable(_setUpGroup())) {
 
 			Assert.assertNull(
 				depotAssetRendererFactoryWrapper.getAssetRenderer(
@@ -192,6 +195,76 @@ public class DepotAssetRendererFactoryWrapperTest {
 		}
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testGetAssetRendererByDepotEntryType() throws Exception {
+		AssetRenderer<Object> assetRenderer = Mockito.mock(AssetRenderer.class);
+
+		Mockito.when(
+			_assetRendererFactory.getAssetRenderer(Mockito.anyLong())
+		).thenReturn(
+			assetRenderer
+		);
+
+		long depotGroupId = _setUpDepotGroup();
+
+		Mockito.when(
+			assetRenderer.getGroupId()
+		).thenReturn(
+			depotGroupId
+		);
+
+		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
+
+		Mockito.when(
+			_depotEntryLocalService.getGroupDepotEntry(Mockito.anyLong())
+		).thenReturn(
+			depotEntry
+		);
+
+		Mockito.when(
+			depotEntry.getType()
+		).thenReturn(
+			DepotConstants.TYPE_SPACE
+		);
+
+		DepotAssetRendererFactoryWrapper depotAssetRendererFactoryWrapper =
+			new DepotAssetRendererFactoryWrapper(
+				_assetRendererFactory, null, _depotEntryLocalService,
+				_groupLocalService, null, null,
+				_siteConnectedGroupGroupProvider);
+
+		long groupId = _setUpGroup();
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
+
+			Assert.assertSame(
+				assetRenderer,
+				depotAssetRendererFactoryWrapper.getAssetRenderer(
+					RandomTestUtil.randomLong()));
+		}
+
+		Mockito.when(
+			depotEntry.getType()
+		).thenReturn(
+			DepotConstants.TYPE_ASSET_LIBRARY
+		);
+
+		depotAssetRendererFactoryWrapper = new DepotAssetRendererFactoryWrapper(
+			_assetRendererFactory, null, _depotEntryLocalService,
+			_groupLocalService, null, null, _siteConnectedGroupGroupProvider);
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
+
+			Assert.assertSame(
+				null,
+				depotAssetRendererFactoryWrapper.getAssetRenderer(
+					RandomTestUtil.randomLong()));
+		}
+	}
+
 	private long _setUpControlPanelGroup() throws Exception {
 		return _setUpGroup(
 			group -> Mockito.when(
@@ -252,6 +325,8 @@ public class DepotAssetRendererFactoryWrapperTest {
 
 	private final AssetRendererFactory<Object> _assetRendererFactory =
 		Mockito.mock(AssetRendererFactory.class);
+	private final DepotEntryLocalService _depotEntryLocalService = Mockito.mock(
+		DepotEntryLocalService.class);
 	private final GroupLocalService _groupLocalService = Mockito.mock(
 		GroupLocalService.class);
 	private final SiteConnectedGroupGroupProvider


### PR DESCRIPTION
LPD-60435 Technical Task | Show title and type of share asset on list on all the cases on shared with me page

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-48676

We want to show the title and the type on the shared with me page.

# How am I fixing it?

Adding a case when we obtain the asset renderer that if is a space, return the data

# How can you verify that it works?

Run the included automated tests.

# Commits

- **LPD-60435 on the case that the asset library is an space type, show the rendered because it's not connected**
- **LPD-60435 add test to check that on some cases this is returning the asset libraries when is depot and a space**
