### PR TITLE
LPD-63752 Sharing action is missing in Spaces sections

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -68,11 +68,11 @@ public class ViewContentsSectionDisplayContextTest
 			fdsActionDropdownItems.get(2), "pencil", "editFolder", "edit",
 			"get", "item");
 		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(3), "share", "share", "share", "get",
-			"item");
-		assertFDSActionDropdownItem(
-			fdsActionDropdownItems.get(4), "pencil", "actionLink", "edit",
+			fdsActionDropdownItems.get(3), "pencil", "actionLink", "edit",
 			"get", "item");
+		assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(4), "share", "share", "share", "get",
+			"item");
 		assertFDSActionDropdownItem(
 			fdsActionDropdownItems.get(5), "time", "expire", "expire", "post",
 			"item");

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -269,6 +269,10 @@ public abstract class BaseSectionDisplayContext {
 				LanguageUtil.get(httpServletRequest, "edit"), "get", "update",
 				null),
 			new FDSActionDropdownItem(
+				null, "share", "share",
+				LanguageUtil.get(httpServletRequest, "share"), "get", "share",
+				"link"),
+			new FDSActionDropdownItem(
 				"{actions.expire.href}", "time", "expire",
 				LanguageUtil.get(httpServletRequest, "expire"), "post",
 				"expire", "headless"),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -75,12 +75,6 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 				StringPool.BLANK, "info-circle-open", "show-details",
 				LanguageUtil.get(httpServletRequest, "show-details"), null,
 				null, "infoPanel"));
-		fdsActionDropdownItems.add(
-			3,
-			new FDSActionDropdownItem(
-				null, "share", "share",
-				LanguageUtil.get(httpServletRequest, "share"), "get", null,
-				"link"));
 
 		return fdsActionDropdownItems;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -72,12 +72,6 @@ public class ViewContentsSectionDisplayContext
 				StringPool.BLANK, "info-circle-open", "show-details",
 				LanguageUtil.get(httpServletRequest, "show-details"), null,
 				null, "infoPanel"));
-		fdsActionDropdownItems.add(
-			3,
-			new FDSActionDropdownItem(
-				null, "share", "share",
-				LanguageUtil.get(httpServletRequest, "share"), "get", "share",
-				"link"));
 
 		return fdsActionDropdownItems;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -86,12 +86,6 @@ public class ViewFilesSectionDisplayContext
 			super.getFDSActionDropdownItems();
 
 		fdsActionDropdownItems.add(
-			3,
-			new FDSActionDropdownItem(
-				null, "share", "share",
-				LanguageUtil.get(httpServletRequest, "share"), "get", "share",
-				"link"));
-		fdsActionDropdownItems.add(
 			5,
 			new FDSActionDropdownItem(
 				StringPool.BLANK, "info-circle-open", "show-details",

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -175,11 +175,6 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 				"{embedded.file.link.href}", "download", "download",
 				LanguageUtil.get(httpServletRequest, "download"), "get", null,
 				"link"));
-		fdsActionDropdownItems.add(
-			new FDSActionDropdownItem(
-				null, "share", "share",
-				LanguageUtil.get(httpServletRequest, "share"), "get", null,
-				"link"));
 
 		if (!Objects.equals(
 				getRootObjectEntryFolderExternalReferenceCode(),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/HomeRecentAssetsFDSPropsTransformer.ts
@@ -8,12 +8,19 @@ import {openModal} from 'frontend-js-components-web';
 
 import formatActionURL from '../../common/utils/formatActionURL';
 import FilePreviewerModalContent from '../modal/FilePreviewerModalContent';
+import shareAction from './actions/shareAction';
 import AssetRenderer from './cell_renderers/AssetRenderer';
 
 export default function HomeRecentAssetsFDSPropsTransformer({
+	additionalProps,
 	itemsActions = [],
 	...otherProps
 }: {
+	additionalProps: {
+		autocompleteURL: string;
+		cmsGroupId?: number;
+		collaboratorURLs: Record<string, string>;
+	};
 	itemsActions?: any[];
 	otherProps: any;
 }) {
@@ -80,6 +87,17 @@ export default function HomeRecentAssetsFDSPropsTransformer({
 							headerName: itemData.embedded.title,
 						}),
 					size: 'full-screen',
+				});
+			}
+			else if (action?.data?.id === 'share') {
+				const {autocompleteURL, collaboratorURLs} = additionalProps;
+
+				shareAction({
+					autocompleteURL,
+					collaboratorURL: collaboratorURLs[itemData.entryClassName],
+					creator: itemData.embedded.creator,
+					itemId: itemData.embedded.id,
+					title: itemData.embedded?.title,
 				});
 			}
 		},

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -467,6 +467,11 @@ export class DataApiHelpers extends ApiHelpers {
 			else if (item.type === 'apiApplication') {
 				await this.apiBuilder.deleteApiApplication(item.id);
 			}
+			else if (item.type === 'assetLibrary') {
+				await this.headlessAssetLibrary.deleteAssetLibrariesPage(
+					item.id
+				);
+			}
 			else if (item.type === 'catalog') {
 				await this.headlessCommerceAdminCatalog.deleteCatalog(item.id);
 			}

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -18,15 +18,18 @@ export class HeadlessAssetLibraryApiHelper {
 		description,
 		name,
 		settings = {},
+		type = 'Space',
 	}: {
 		description?: string;
 		name: string;
 		settings: any;
+		type: string;
 	}) {
 		const data = JSON.stringify({
 			description,
 			name,
 			settings,
+			type,
 		});
 
 		const assetLibrary = await this.apiHelpers.post(

--- a/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAssetLibraryApiHelper.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ApiHelpers} from './ApiHelpers';
+import {ApiHelpers, DataApiHelpers} from './ApiHelpers';
 
 export class HeadlessAssetLibraryApiHelper {
 	apiHelpers: ApiHelpers;
@@ -14,11 +14,47 @@ export class HeadlessAssetLibraryApiHelper {
 		this.basePath = 'headless-asset-library/v1.0';
 	}
 
+	async createAssetLibrariesPage({
+		description,
+		name,
+		settings = {},
+	}: {
+		description?: string;
+		name: string;
+		settings: any;
+	}) {
+		const data = JSON.stringify({
+			description,
+			name,
+			settings,
+		});
+
+		const assetLibrary = await this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries`,
+			{data}
+		);
+
+		if (this.apiHelpers instanceof DataApiHelpers) {
+			this.apiHelpers.data.push({
+				id: assetLibrary.id,
+				type: 'assetLibrary',
+			});
+		}
+
+		return assetLibrary;
+	}
+
 	async getAssetLibrariesPage() {
 		const response = await this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries`
 		);
 
 		return response?.items;
+	}
+
+	async deleteAssetLibrariesPage(assetLibraryId: number) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/asset-libraries/${assetLibraryId}`
+		);
 	}
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -26,32 +26,45 @@ test(
 	{tag: '@LPD-62554'},
 	async ({apiHelpers, assetsPage, page}) => {
 		const applicationName = 'cms/knowledge-bases';
-		const spaceName = 'Default';
+		const file1Title = `Title ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		let objectEntry1;
 
-		const file1Title = `title ${getRandomString()}`;
-
-		const objectEntry1 = await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title: file1Title,
+		await apiHelpers.headlessAssetLibrary.createAssetLibrariesPage({
+			name: spaceName,
+			settings: {
+				logoColor: 'outline-3',
+				sharingEnabled: true,
 			},
-			applicationName,
-			spaceName
-		);
-
-		await assetsPage.gotoAll();
-
-		await assetsPage.execItemAction({
-			action: 'Share',
-			filter: file1Title,
 		});
 
-		await expect(page.locator('.modal-title')).toContainText(file1Title);
+		try {
+			objectEntry1 = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: file1Title,
+				},
+				applicationName,
+				spaceName
+			);
 
-		await apiHelpers.objectEntry.deleteObjectEntry(
-			applicationName,
-			String(objectEntry1.id)
-		);
+			await assetsPage.gotoAll();
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: file1Title,
+			});
+
+			await expect(page.locator('.modal-title')).toContainText(
+				file1Title
+			);
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				applicationName,
+				String(objectEntry1.id)
+			);
+		}
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -36,6 +36,7 @@ test(
 				logoColor: 'outline-3',
 				sharingEnabled: true,
 			},
+			type: 'Space',
 		});
 
 		try {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
@@ -173,6 +173,7 @@ test(
 				logoColor: 'outline-3',
 				sharingEnabled: true,
 			},
+			type: 'Space',
 		});
 
 		try {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
@@ -157,3 +157,50 @@ test(
 		expect(globalSiteLocator).not.toBeVisible();
 	}
 );
+
+test(
+	'Can view Share modal for added content',
+	{tag: '@LPD-62554'},
+	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
+		const applicationName = 'cms/knowledge-bases';
+		const file1Title = `Title ${getRandomString()}`;
+		const spaceName = `Space ${getRandomString()}`;
+		let objectEntry1;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrariesPage({
+			name: spaceName,
+			settings: {
+				logoColor: 'outline-3',
+				sharingEnabled: true,
+			},
+		});
+
+		try {
+			objectEntry1 = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: file1Title,
+				},
+				applicationName,
+				spaceName
+			);
+
+			await spaceSummaryPage.goto(spaceName);
+
+			await assetsPage.execItemAction({
+				action: 'Share',
+				filter: file1Title,
+			});
+
+			await expect(page.locator('.modal-title')).toContainText(
+				file1Title
+			);
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				applicationName,
+				String(objectEntry1.id)
+			);
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63752 - Sharing action is missing in Spaces sections

### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-63752

### How am I fixing it?
This adds the share dropdown item to the `BaseSectionDisplayContext.java` file instead now, so then the individual option can be removed from the All, Contents, Files display contexts. It also adds the share option to `ViewSpaceFiles` / `View SpaceContent` pages, as intended by the ticket.

This adds the share option to `HomeRecentAsset` page as well automatically, so the transformer was updated to support it.

### How can you verify that it works?
It should be viewable once you 'enable sharing' on the space and then try to view a file/content on the space summary page!

Also added a playwright test, which required updating `apiHelpers` to support making new spaces. If there's any issues doing this, let me know!

Screenshot:
<img width="800" alt="Screenshot 2025-08-27 at 4 30 35 PM" src="https://github.com/user-attachments/assets/ea34e769-879d-4afd-829b-410abaaf75f9" />
