### PR TITLE
LPD-63313 [BUG] - Publication dialog opens even when required fields are not filled

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -301,20 +301,12 @@ export default function SaveButtons({
 					</ClayDropDown.Item>
 
 					<ClayDropDown.Item
-						onClick={() => {
-							const titleInputComponent = Liferay.component(
-								`${portletNamespace}titleMapAsXML`
-							);
-							if (
-								titleInputComponent?.getValue(defaultLanguageId)
-							) {
+						onClick={async () => {
+							if (await validateRequiredFields(formId)) {
 								setPublishModalState({
 									publishModalAction: ACTION_SCHEDULE,
 									publishModalVisible: true,
 								});
-							}
-							else {
-								validateRequiredFields(formId);
 							}
 						}}
 						symbolLeft="date-time"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -85,24 +85,19 @@ export default function SaveButtons({
 		});
 	}, [portletNamespace]);
 
-	const onClick = (action) => {
-		const titleInputComponent = Liferay.component(
-			`${portletNamespace}titleMapAsXML`
-		);
+	const onClick = async (action) => {
+		if (!(await validateRequiredFields(formId))) {
+			return;
+		}
 
-		if (titleInputComponent?.getValue(defaultLanguageId)) {
-			if (articleId && !showPublishModal) {
-				handleButtonClick(action);
-			}
-			else {
-				setPublishModalState({
-					publishModalAction: action,
-					publishModalVisible: true,
-				});
-			}
+		if (articleId && !showPublishModal) {
+			handleButtonClick(action);
 		}
 		else {
-			validateRequiredFields(formId);
+			setPublishModalState({
+				publishModalAction: action,
+				publishModalVisible: true,
+			});
 		}
 	};
 
@@ -174,16 +169,28 @@ export default function SaveButtons({
 		);
 	};
 
-	const validateRequiredFields = (formId) => {
-		Liferay.Form.get(formId).formValidator.validate();
-		Liferay.componentReady(
-			`${portletNamespace}dataEngineLayoutRenderer`
-		).then((dataEngineLayoutRenderer) => {
-			const dataEngineLayoutRendererRef =
-				dataEngineLayoutRenderer?.reactComponentRef;
+	const validateRequiredFields = async (formId) => {
+		const formValidator = Liferay.Form?.get(formId)?.formValidator;
 
-			return dataEngineLayoutRendererRef.current.validate();
-		});
+		if (!formValidator) {
+			return true;
+		}
+
+		formValidator.validate();
+
+		if (formValidator.hasErrors()) {
+			return false;
+		}
+
+		const renderer = await Liferay.componentReady(
+			`${portletNamespace}dataEngineLayoutRenderer`
+		);
+
+		if (renderer?.reactComponentRef?.current?.validate) {
+			return renderer.reactComponentRef.current.validate();
+		}
+
+		return true;
 	};
 
 	useEffect(() => {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -86,14 +86,25 @@ export default function SaveButtons({
 	}, [portletNamespace]);
 
 	const onClick = async (action) => {
-		if (!(await validateRequiredFields(formId))) {
+		const titleInputComponent = Liferay.component(
+			`${portletNamespace}titleMapAsXML`
+		);
+
+		if (!titleInputComponent?.getValue(defaultLanguageId)) {
+			await validateRequiredFields(formId);
+
 			return;
 		}
 
 		if (articleId && !showPublishModal) {
 			handleButtonClick(action);
+
+			await validateRequiredFields(formId);
+
+			return;
 		}
-		else {
+
+		if (await validateRequiredFields(formId)) {
 			setPublishModalState({
 				publishModalAction: action,
 				publishModalVisible: true,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SaveButtons.js
@@ -183,10 +183,6 @@ export default function SaveButtons({
 	const validateRequiredFields = async (formId) => {
 		const formValidator = Liferay.Form?.get(formId)?.formValidator;
 
-		if (!formValidator) {
-			return true;
-		}
-
 		formValidator.validate();
 
 		if (formValidator.hasErrors()) {
@@ -197,11 +193,7 @@ export default function SaveButtons({
 			`${portletNamespace}dataEngineLayoutRenderer`
 		);
 
-		if (renderer?.reactComponentRef?.current?.validate) {
-			return renderer.reactComponentRef.current.validate();
-		}
-
-		return true;
+		return renderer.reactComponentRef.current.validate();
 	};
 
 	useEffect(() => {

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -232,4 +232,31 @@ describe('SaveButtons', () => {
 			screen.queryByText('please-enter-a-valid-date')
 		).not.toBeInTheDocument();
 	});
+
+	it('does not proceed if required fields validation fails', async () => {
+		global.Liferay.Form = {
+			get: () => ({
+				formValidator: {
+					hasErrors: jest.fn().mockReturnValue(true),
+					validate: jest.fn(),
+				},
+			}),
+		};
+
+		renderComponent({
+			...DEFAULT_PROPS,
+			articleId: null,
+			saveButtonLabel: 'save',
+		});
+
+		runAllTimersAndExecuteAction(() => {
+			userEvent.click(screen.getByText('save'));
+		});
+
+		expect(
+			screen.queryByText(
+				'confirm-the-web-content-visibility-before-saving-as-draft'
+			)
+		).not.toBeInTheDocument();
+	});
 });

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {act, render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -33,18 +33,6 @@ const renderComponent = (props = DEFAULT_PROPS) => {
 			<SaveButtons {...props} />
 		</>
 	);
-};
-
-const runAllTimersAndExecuteAction = (action) => {
-	jest.useFakeTimers();
-
-	action();
-
-	act(() => {
-		jest.runAllTimers();
-	});
-
-	jest.useRealTimers();
 };
 
 describe('SaveButtons', () => {
@@ -138,106 +126,98 @@ describe('SaveButtons', () => {
 		).not.toBeInTheDocument();
 	});
 
-	it('opens modal for all buttons when there is not an articleId', () => {
+	it('opens modal for all buttons when there is not an articleId', async () => {
 		renderComponent({
 			...DEFAULT_PROPS,
 			articleId: null,
 			saveButtonLabel: 'save',
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByText('save'));
-		});
+		userEvent.click(screen.getByText('save'));
 
 		expect(
-			screen.getByText(
+			await screen.findByText(
 				'confirm-the-web-content-visibility-before-saving-as-draft'
 			)
 		).toBeInTheDocument();
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByLabelText('close'));
-		});
+		userEvent.click(screen.getByLabelText('close'));
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(
-				screen.getByText('publish-with-permissions', {
-					selector: '.dropdown-item',
-				})
-			);
-		});
+		userEvent.click(
+			screen.getByText('publish-with-permissions', {
+				selector: '.dropdown-item',
+			})
+		);
 
 		expect(
-			screen.getByText(
+			await screen.findByText(
 				'confirm-the-web-content-visibility-before-publishing'
 			)
 		).toBeInTheDocument();
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByLabelText('close'));
+		userEvent.click(screen.getByLabelText('close'));
+
+		await waitFor(() => {
+			expect(
+				screen.queryByText(
+					'confirm-the-web-content-visibility-before-publishing'
+				)
+			).not.toBeInTheDocument();
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(
-				screen.getByText('schedule-publication', {
-					selector: '.dropdown-item',
-				})
-			);
-		});
+		userEvent.click(
+			screen.getByText('schedule-publication', {
+				selector: '.dropdown-item',
+			})
+		);
 
 		expect(
-			screen.getByText(
+			await screen.findByText(
 				'set-the-date-and-time-for-publishing-the-web-content-and-confirm-the-visibility-before-scheduling'
 			)
 		).toBeInTheDocument();
 	});
 
-	it('show alert and input feedback when trying to schedule without a date introduced', () => {
+	it('show alert and input feedback when trying to schedule without a date introduced', async () => {
 		renderComponent({
 			...DEFAULT_PROPS,
 			articleId: null,
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByText('schedule-publication'));
-		});
+		userEvent.click(screen.getByText('schedule-publication'));
 
-		userEvent.click(screen.getByText('schedule'));
+		userEvent.click(await screen.findByText('schedule'));
 
 		const alerts = screen.getAllByText('please-enter-a-valid-date');
 
 		expect(alerts.length).toBe(2);
 	});
 
-	it('shows error when introducing an invalid date', () => {
+	it('shows error when introducing an invalid date', async () => {
 		renderComponent({
 			...DEFAULT_PROPS,
 			articleId: null,
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByText('schedule-publication'));
-		});
+		userEvent.click(screen.getByText('schedule-publication'));
 
-		userEvent.type(screen.getByLabelText('date-and-time'), 'pepito');
+		userEvent.type(await screen.findByLabelText('date-and-time'), 'pepito');
 
 		expect(
 			screen.getByText('please-enter-a-valid-date')
 		).toBeInTheDocument();
 	});
 
-	it('show no error when introducing a past date', () => {
+	it('show no error when introducing a past date', async () => {
 		renderComponent({
 			...DEFAULT_PROPS,
 			articleId: null,
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByText('schedule-publication'));
-		});
+		userEvent.click(screen.getByText('schedule-publication'));
 
 		userEvent.type(
-			screen.getByLabelText('date-and-time'),
+			await screen.findByLabelText('date-and-time'),
 			'1970-01-01 12:00'
 		);
 
@@ -262,9 +242,7 @@ describe('SaveButtons', () => {
 			saveButtonLabel: 'save',
 		});
 
-		runAllTimersAndExecuteAction(() => {
-			userEvent.click(screen.getByText('save'));
-		});
+		userEvent.click(screen.getByText('save'));
 
 		expect(
 			screen.queryByText(

--- a/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
+++ b/modules/apps/journal/journal-web/test/js/SaveButtons.test.js
@@ -60,6 +60,19 @@ describe('SaveButtons', () => {
 			})
 		);
 
+		global.Liferay.componentReady = jest.fn().mockResolvedValue({
+			reactComponentRef: {current: {validate: () => true}},
+		});
+
+		global.Liferay.Form = {
+			get: () => ({
+				formValidator: {
+					hasErrors: jest.fn().mockReturnValue(false),
+					validate: jest.fn().mockReturnValue(true),
+				},
+			}),
+		};
+
 		global.Liferay.Workflow = {ACTION_PUBLISH: null};
 	});
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-63313

The publication dialog opens even when required fields are not filled.

# How am I fixing it?

Validation is added before opening the modal.

>[!NOTE]
> Validation is added in several points instead of at the beginning because, in this case `(articleId && !showPublishModal)` the validation changes before in `handleButtonClick(action);`.

# How can you verify that it works?

Run js unit test

```sh 
cd modules/apps/journal/journal-web
yarn run test test/js/SaveButtons.test.js --verbose
```

>[!NOTE]
> Because validation was moved to async, I had to make some tests async as well.

## test passing locally
<img width="893" height="323" alt="image" src="https://github.com/user-attachments/assets/7f4d8bb1-0bb4-4d74-808b-f54c021b349e" />

# Before Fix

https://github.com/user-attachments/assets/74d0208e-4906-4c6a-afd1-31be862ce1b8



# After Fix

https://github.com/user-attachments/assets/b05d8036-5118-4eb4-8092-b557546c073f


