### PR TITLE
LPD-64128 Set Selected Group ERC in preferences

### DIFF
--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/test/DLExportImportPortletPreferencesProcessorTest.java
@@ -517,6 +517,24 @@ public class DLExportImportPortletPreferencesProcessorTest {
 					DLFolder.class.getName(), folder.getFolderId())));
 	}
 
+	@Test
+	public void testImportDLFileEntryInDifferentGroup() throws Exception {
+		_setPortletPreferences(
+			DLAppTestUtil.addFileEntry(TestPropsValues.getGroupId()));
+
+		_portletDataContextImport.setSourceGroupId(
+			TestPropsValues.getGroupId());
+
+		Map<String, String> map = _getPortletPreferencesValues(
+			_exportImportPortletPreferencesProcessor.
+				processImportPortletPreferences(
+					_portletDataContextImport, _portletPreferences));
+
+		Assert.assertEquals(
+			_group.getExternalReferenceCode(),
+			map.get("selectedGroupExternalReferenceCode"));
+	}
+
 	private DepotEntry _addDepotEntry() throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/exportimport/portlet/preferences/processor/DLExportImportPortletPreferencesProcessor.java
@@ -62,6 +62,7 @@ import jakarta.portlet.ReadOnlyException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -406,6 +407,33 @@ public class DLExportImportPortletPreferencesProcessor
 						readOnlyException);
 				}
 			}
+		}
+
+		try {
+			long sourceGroupId = portletDataContext.getSourceGroupId();
+
+			if (sourceGroupId != 0) {
+				Group group = _groupLocalService.getGroup(sourceGroupId);
+
+				if (Objects.equals(
+						group.getExternalReferenceCode(),
+						portletPreferences.getValue(
+							_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
+							null))) {
+
+					Group selectedGroup = _groupLocalService.getGroup(
+						portletDataContext.getGroupId());
+
+					portletPreferences.setValue(
+						_PREFERENCE_KEY_SELECTED_GROUP_EXTERNAL_REFERENCE_CODE,
+						selectedGroup.getExternalReferenceCode());
+				}
+			}
+		}
+		catch (Exception exception) {
+			throw new PortletDataException(
+				"Unable to update portlet preferences during import",
+				exception);
 		}
 
 		// Root folder external reference code is not set, need to import


### PR DESCRIPTION
**What is this trying to solve?**

https://liferay.atlassian.net/browse/LPD-64128
Documents and Media Widget doesn't get the new site repository Id, it stays on the site template id.

**How am I fixing it?**

setValue was removed when we introduced ERC at https://github.com/liferay/liferay-portal/commit/fe960f69ff38c1ceb8bca17e3ed873afff261283#diff-b8b9a95db2810df642e7c07b3819689ec97f34f11f61902d28ccab5df79946e4L386

Reinstated and modified to use ERCs.

**How can you verify that it works?**
 gw testIntegration --tests=DLExportImportPortletPreferencesProcessorTest.testImportDLFileEntryInDifferentGroup