### PR TITLE
LPD-64042 Document headless PATCH API does not update friendlyURLPath and can remove description

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -395,7 +395,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		}
 
 		if (description == null) {
-			existingFileEntry.getDescription();
+			description = existingFileEntry.getDescription();
 		}
 
 		if (displayDate == null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -375,6 +375,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		String description = null;
 		Date displayDate = null;
 		Date expirationDate = null;
+		String urlTitle = null;
 
 		if (document != null) {
 			fileName = document.getFileName();
@@ -382,6 +383,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
+			urlTitle = document.getFriendlyUrlPath();
 		}
 
 		if (fileName == null) {
@@ -406,8 +408,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				documentId, fileName, binaryFile.getContentType(), title, null,
-				description, null, DLVersionNumberIncrease.AUTOMATIC,
+				documentId, fileName, binaryFile.getContentType(), title,
+				urlTitle, description, null, DLVersionNumberIncrease.AUTOMATIC,
 				binaryFile.getInputStream(), binaryFile.getSize(), displayDate,
 				expirationDate, existingFileEntry.getReviewDate(),
 				_createServiceContext(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -208,6 +208,15 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	@Test
+	public void testPatchDocument() throws Exception {
+		super.testPatchDocument();
+
+		_testPatchDocumentWithFriendlyUrlPath();
+		_testPatchDocumentWithoutFriendlyUrlPath();
+	}
+
+	@Override
+	@Test
 	public void testPostDocumentFolderDocument() throws Exception {
 		super.testPostDocumentFolderDocument();
 
@@ -288,7 +297,9 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "fileName", "friendlyUrlPath", "title"};
+		return new String[] {
+			"description", "fileName", "friendlyUrlPath", "title"
+		};
 	}
 
 	@Override
@@ -497,6 +508,53 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
 
 		return httpResponse.getContent();
+	}
+
+	private void _testPatchDocumentWithFriendlyUrlPath() throws Exception {
+		Document postDocument = testPatchDocument_addDocument();
+
+		Document document = new Document();
+
+		String friendlyUrlPath = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		document.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document patchDocument = documentResource.patchDocument(
+			postDocument.getId(), document, new HashMap<>());
+
+		Document expectedPatchDocument = postDocument.clone();
+
+		expectedPatchDocument.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document getDocument = documentResource.getDocument(
+			patchDocument.getId());
+
+		assertEquals(expectedPatchDocument, getDocument);
+		assertValid(getDocument);
+	}
+
+	private void _testPatchDocumentWithoutFriendlyUrlPath() throws Exception {
+		Document postDocument = testPatchDocument_addDocument();
+
+		Document document = new Document();
+
+		String description = StringUtil.toLowerCase(StringUtil.randomString());
+
+		document.setDescription(description);
+
+		Document patchDocument = documentResource.patchDocument(
+			postDocument.getId(), document, new HashMap<>());
+
+		Document expectedPatchDocument = postDocument.clone();
+
+		expectedPatchDocument.setDescription(description);
+
+		Document getDocument = documentResource.getDocument(
+			patchDocument.getId());
+
+		assertEquals(expectedPatchDocument, getDocument);
+		assertValid(getDocument);
 	}
 
 	private void _testPostDocumentFolderDocumentWithDLFileEntryType()

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -288,7 +288,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "fileName", "title"};
+		return new String[] {"description", "fileName", "friendlyUrlPath", "title"};
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

[LPD-64042 Document headless PATCH API does not update friendlyURLPath and can remove description](https://liferay.atlassian.net/browse/LPD-64042)
Sending a PATCH request to a Document
- with friendlyURLPath does not persist this value,
- without a description delete the persisted description

# How am I fixing it?
- Introducing friendlyURLPath processing to PATCH method
- Fixing description handling in PATCH method

# How can you verify that it works?
```
cd modules/apps/headless/headless-delivery/headless-delivery-test
gw testIntegration --tests DocumentResourceTest.testPatchDocument
```

Cheers,
Balázs
