### PR TITLE
LPD-64243 DLFileVersionLocalServiceImpl#fetchLatestFileVersion returns wrong result

### DIFF
--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -93,6 +94,45 @@ public class DLFileVersionLocalServiceTest {
 			DLStoreUtil.hasFile(
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(), dlFileVersion.getStoreFileName()));
+	}
+
+	@Test
+	public void testFetchLatestFileVersion() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null, null,
+			serviceContext);
+
+		for (int i = 0; i < 11; i++) {
+			DLAppServiceUtil.updateFileEntry(
+				fileEntry.getFileEntryId(), null, ContentTypes.TEXT_PLAIN,
+				RandomTestUtil.randomString(), StringPool.BLANK,
+				StringPool.BLANK, StringPool.BLANK,
+				DLVersionNumberIncrease.MINOR, (byte[])null,
+				fileEntry.getDisplayDate(), fileEntry.getExpirationDate(),
+				fileEntry.getReviewDate(), serviceContext);
+		}
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntry.getFileEntryId());
+
+		DLFileVersion dlFileVersion =
+			_dlFileVersionLocalService.fetchLatestFileVersion(
+				dlFileEntry.getFileEntryId(), true);
+
+		Assert.assertEquals("1.11", dlFileVersion.getVersion());
+
+		dlFileVersion = _dlFileVersionLocalService.fetchLatestFileVersion(
+			dlFileEntry.getFileEntryId(), true,
+			WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertEquals("1.11", dlFileVersion.getVersion());
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -36,8 +36,24 @@ public class DLFileVersionLocalServiceImpl
 	public DLFileVersion fetchLatestFileVersion(
 		long fileEntryId, boolean excludeWorkingCopy) {
 
-		List<DLFileVersion> dlFileVersions =
-			dlFileVersionPersistence.findByFileEntryId(fileEntryId);
+		return fetchLatestFileVersion(
+			fileEntryId, excludeWorkingCopy, WorkflowConstants.STATUS_ANY);
+	}
+
+	@Override
+	public DLFileVersion fetchLatestFileVersion(
+		long fileEntryId, boolean excludeWorkingCopy, int status) {
+
+		List<DLFileVersion> dlFileVersions = null;
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			dlFileVersions = dlFileVersionPersistence.findByFileEntryId(
+				fileEntryId);
+		}
+		else {
+			dlFileVersions = dlFileVersionPersistence.findByF_S(
+				fileEntryId, status);
+		}
 
 		if (dlFileVersions.isEmpty()) {
 			return null;
@@ -59,19 +75,6 @@ public class DLFileVersionLocalServiceImpl
 		}
 
 		return dlFileVersion;
-	}
-
-	@Override
-	public DLFileVersion fetchLatestFileVersion(
-		long fileEntryId, boolean excludeWorkingCopy, int status) {
-
-		if (status == WorkflowConstants.STATUS_ANY) {
-			return fetchLatestFileVersion(fileEntryId, excludeWorkingCopy);
-		}
-
-		return dlFileVersionPersistence.fetchByF_S_Last(
-			fileEntryId, status,
-			DLFileVersionVersionComparator.getInstance(false));
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

[LPD-64243 DLFileVersionLocalServiceImpl#fetchLatestFileVersion returns wrong result](https://liferay.atlassian.net/browse/LPD-64243)

```
public DLFileVersion fetchLatestFileVersion(
	long fileEntryId, boolean excludeWorkingCopy, int status) {
```
returns the lowest version instead of the highest.

# How am I fixing it?
Reuse logic from
```
public DLFileVersion fetchLatestFileVersion(
	long fileEntryId, boolean excludeWorkingCopy) {
```
to fix ordering in 2 ways:
1. sorting order is now correct, highest version is returned
2. sorting now happens in the service layer, as version is a String with special ordering rules that sql can't handle

# How can you verify that it works?
```
cd modules/apps/document-library/document-library-test
gw testIntegration --tests DLFileVersionLocalServiceTest.testFetchLatestFileVersion
```

Cheers,
Balázs