### PR TITLE
LPD-64105 Investigate failure in com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest#testGetObjectEntryActionsWithSystemSharingDisabled

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5959,6 +5959,8 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectEntryActionsWithSystemSharingDisabled()
 		throws Exception {
 
+		_addCMSGroup();
+
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
 					"com.liferay.sharing.internal.configuration." +


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64105

Fix test, which is only failing in CI.

# How am I fixing it?

Add CMS initialization in test

# How can you verify that it works?

Run test `gw tI --tests 'ObjectEntryResourceTest.testGetObjectEntryActionsWithCompanySharingDisabled'`
