### PR TITLE
LPD-64010 Enable VIEW permission for Guest and User roles in the OOTB CMS Structures by default

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -113,7 +113,7 @@ public class ViewFilesSectionDisplayContextTest
 			primaryItems = (List<DropdownItem>)creationMenu.get("primaryItems");
 
 			Assert.assertEquals(
-				primaryItems.toString(), 2, primaryItems.size());
+				primaryItems.toString(), 4, primaryItems.size());
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/service/test/ObjectEntryLocalServiceTest.java
@@ -1,0 +1,252 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.cms.site.initializer.internal.display.context.test.BaseDisplayContextTestCase;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.File;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Alicia García
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ObjectEntryLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		if (_isCMSSiteInitialized()) {
+			return;
+		}
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		try {
+
+			// These tests require the instance to be created with the feature
+			// flag LPD-17564 enabled. On CI, feature flags are enabled on
+			// demand for each test, but not during instance initialization.
+			// Until the feature flag LPD-17564 is removed, run the instance
+			// lifecycle initializer manually so that the role is created.
+
+			SiteInitializer siteInitializer =
+				_siteInitializerRegistry.getSiteInitializer(
+					"com.liferay.site.initializer.cms");
+
+			siteInitializer.initialize(_group.getGroupId());
+
+			Bundle testBundle = FrameworkUtil.getBundle(
+				BaseDisplayContextTestCase.class);
+
+			BundleContext bundleContext = testBundle.getBundleContext();
+
+			for (Bundle bundle : bundleContext.getBundles()) {
+				if (Objects.equals(
+						bundle.getSymbolicName(),
+						"com.liferay.site.initializer.cms")) {
+
+					_setUpProcessedFile(bundle, "01.object.folder");
+					_setUpProcessedFile(bundle, "02.object.definition");
+
+					CompletableFuture<Void> completableFuture =
+						_batchEngineUnitProcessor.processBatchEngineUnits(
+							_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+					completableFuture.join();
+				}
+			}
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@Test
+	public void testPublishSystemObjectDefinition() throws Exception {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				_getObjectFolderExternalReferenceCode(), _group.getCompanyId());
+
+		ObjectDefinition systemObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.addSystemObjectDefinition(
+				null, TestPropsValues.getUserId(),
+				objectFolder.getObjectFolderId(), null, null, false, false,
+				true, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, "Test", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				false, ObjectDefinitionConstants.SCOPE_SITE, null, 1,
+				WorkflowConstants.STATUS_DRAFT, Collections.emptyList(),
+				List.of(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), StringUtil.randomId())));
+
+		systemObjectDefinition =
+			_objectDefinitionLocalService.publishSystemObjectDefinition(
+				TestPropsValues.getUserId(),
+				systemObjectDefinition.getObjectDefinitionId());
+
+		Role role = _roleLocalService.getRole(
+			systemObjectDefinition.getCompanyId(),
+			RoleConstants.CMS_ADMINISTRATOR);
+
+		String[] actionIds = {
+			ActionKeys.DELETE, ActionKeys.PERMISSIONS, ActionKeys.UPDATE,
+			ActionKeys.VIEW
+		};
+
+		for (String actionId : actionIds) {
+			Assert.assertTrue(
+				_resourcePermissionLocalService.hasResourcePermission(
+					systemObjectDefinition.getCompanyId(),
+					systemObjectDefinition.getClassName(),
+					ResourceConstants.SCOPE_COMPANY,
+					String.valueOf(systemObjectDefinition.getCompanyId()),
+					role.getRoleId(), actionId));
+		}
+
+		String[] viewPermissionRoleNames = {
+			RoleConstants.GUEST, RoleConstants.USER
+		};
+
+		for (String roleName : viewPermissionRoleNames) {
+			role = _roleLocalService.getRole(
+				systemObjectDefinition.getCompanyId(), roleName);
+
+			Assert.assertTrue(
+				_resourcePermissionLocalService.hasResourcePermission(
+					systemObjectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(
+						systemObjectDefinition.getObjectDefinitionId()),
+					role.getRoleId(), ActionKeys.VIEW));
+		}
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			systemObjectDefinition.getObjectDefinitionId());
+	}
+
+	private String _getObjectFolderExternalReferenceCode() {
+		if (RandomTestUtil.randomBoolean()) {
+			return ObjectFolderConstants.
+				EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES;
+		}
+
+		return ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES;
+	}
+
+	private boolean _isCMSSiteInitialized() {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.fetchObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+				_group.getCompanyId());
+
+		if (objectFolder != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _setUpProcessedFile(Bundle bundle, String fileName) {
+		File file = bundle.getDataFile(
+			".com.liferay.site.initializer.cms.internal.batch." + fileName +
+				".batch.engine.data.json.0.processed");
+
+		if ((file != null) && file.exists()) {
+			file.delete();
+		}
+	}
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
@@ -75,6 +75,18 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 					ActionKeys.DELETE, ActionKeys.PERMISSIONS,
 					ActionKeys.UPDATE, ActionKeys.VIEW
 				});
+
+			for (String roleName : _VIEW_PERMISSION_ROLE_NAMES) {
+				role = _roleLocalService.getRole(
+					objectDefinition.getCompanyId(), roleName);
+
+				_resourcePermissionLocalService.setResourcePermissions(
+					objectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(objectDefinition.getObjectDefinitionId()),
+					role.getRoleId(), new String[] {ActionKeys.VIEW});
+			}
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -99,6 +111,10 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 			null, userId, null, 0, name, null, null, RoleConstants.TYPE_REGULAR,
 			null, null);
 	}
+
+	private static final String[] _VIEW_PERMISSION_ROLE_NAMES = {
+		RoleConstants.GUEST, RoleConstants.USER
+	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CMSPermissionsObjectDefinitionLocalServiceWrapper.class);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSPermissionsObjectDefinitionLocalServiceWrapper.java
@@ -76,17 +76,8 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 					ActionKeys.UPDATE, ActionKeys.VIEW
 				});
 
-			for (String roleName : _VIEW_PERMISSION_ROLE_NAMES) {
-				role = _roleLocalService.getRole(
-					objectDefinition.getCompanyId(), roleName);
-
-				_resourcePermissionLocalService.setResourcePermissions(
-					objectDefinition.getCompanyId(),
-					ObjectDefinition.class.getName(),
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(objectDefinition.getObjectDefinitionId()),
-					role.getRoleId(), new String[] {ActionKeys.VIEW});
-			}
+			_setResourcePermissions(objectDefinition, RoleConstants.GUEST);
+			_setResourcePermissions(objectDefinition, RoleConstants.USER);
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -112,9 +103,19 @@ public class CMSPermissionsObjectDefinitionLocalServiceWrapper
 			null, null);
 	}
 
-	private static final String[] _VIEW_PERMISSION_ROLE_NAMES = {
-		RoleConstants.GUEST, RoleConstants.USER
-	};
+	private void _setResourcePermissions(
+			ObjectDefinition objectDefinition, String roleName)
+		throws PortalException {
+
+		Role role = _roleLocalService.getRole(
+			objectDefinition.getCompanyId(), roleName);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			objectDefinition.getCompanyId(), ObjectDefinition.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectDefinition.getObjectDefinitionId()),
+			role.getRoleId(), new String[] {ActionKeys.VIEW});
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CMSPermissionsObjectDefinitionLocalServiceWrapper.class);


### PR DESCRIPTION
LPD-64010 Enable VIEW permission for Guest and User roles in the OOTB CMS Structures by default

THis PR it's the same as https://github.com/liferay-content-management/liferay-portal/pull/7036 with additional commit with changes asked on : https://github.com/brianchandotcom/liferay-portal/pull/165078#issuecomment-3245214526

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64010

I want an user to be able to see the documents/wc/blogs shared. For this, we need to allow the guest /user see the structures (basic object definitions)

# How am I fixing it?

On the creation of the system object definitions, when we are assigning the cms_admin permissions, add the view action to guest and user for that object definition

# How can you verify that it works?

Run the included automated tests.

# Commits
- **LPD-64010 when the object definition defines the permission for the CMS_ADMIN, add the permission for the GUEST and USER roles.**
- **LPD-64010 add test to check that the permissions are set when a system object definition is published**
- **LPD-64010 now the definitions has permissions so you can see 4 options**
- **LPD-64010 do not iterate on the array**
