### PR TITLE
LPD-64250 Selecting a Web Content from a different Site will lead to StackOverflowError

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -167,8 +167,12 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 				layoutDisplayPageObjectProvider.getClassPK(),
 				layoutDisplayPageObjectProvider.getClassTypeId())) {
 
-			return _getURLViewInContext(
-				layoutDisplayPageObjectProvider, themeDisplay);
+			if (groupId == themeDisplay.getScopeGroupId()) {
+				return _getURLViewInContext(
+					layoutDisplayPageObjectProvider, themeDisplay);
+			}
+
+			return null;
 		}
 
 		return StringBundler.concat(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/asset/display/internal/portlet/test/AssetDisplayPageFriendlyURLProviderImplTest.java
@@ -110,6 +110,33 @@ public class AssetDisplayPageFriendlyURLProviderImplTest {
 	}
 
 	@Test
+	public void testGetFriendlyURLPreventsCrossSiteCircularCall()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+			_group.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			journalArticle.getDDMStructureId(), true,
+			WorkflowConstants.STATUS_APPROVED);
+
+		_setUpThemeDisplay(
+			_layoutLocalService.getLayout(_assetDisplayPageEntry.getPlid()));
+
+		Assert.assertNull(
+			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+				new InfoItemReference(
+					JournalArticle.class.getName(),
+					journalArticle.getResourcePrimKey()),
+				LocaleUtil.getSiteDefault(), _themeDisplay));
+	}
+
+	@Test
 	public void testGetFriendlyURLWithLayoutUUIDBasedAssetDisplayPage()
 		throws Exception {
 


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-64250

### How am I fixing it?
Preventing `StackOverflowError` in cross-site Asset Publisher scenarios by only calling `_getURLViewInContext()` for same-site scenarios, returning null for cross-site cases to break the circular call chain.

### How can you verify that it works?
To test run:
`gw testIntegration --tests AssetDisplayPageFriendlyURLProviderImplTest`

Or manually test based on the LPD steps