### PR TITLE
LPD-64520 Fix POSHI tests KB Article with Attachment

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBAdmin.testcase
@@ -84,7 +84,7 @@ definition {
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
 		KBArticle.viewKBArticleWithAttachmentCP(
-			kbArticleAttachment = "Document_1.txt (259 B) Delete",
+			kbArticleAttachment = "Document_1.txt (259 B)",
 			kbArticleContent = "Knowledge Base Article Content Edit",
 			kbArticleTitle = "Knowledge Base Article Title Edit");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/knowledgebase/KBArticle.testcase
@@ -79,7 +79,7 @@ definition {
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
 		KBArticle.viewKBArticleWithAttachmentCP(
-			kbArticleAttachment = "Document_1.txt (259 B) Delete",
+			kbArticleAttachment = "Document_1.txt (259 B)",
 			kbArticleContent = "Knowledge Base Article Content",
 			kbArticleTitle = "Knowledge Base Article Title");
 	}
@@ -773,7 +773,7 @@ definition {
 		KBAdmin.openKBAdmin(siteURLKey = "guest");
 
 		KBArticle.viewKBArticleWithAttachmentCP(
-			kbArticleAttachment = "Document_1.txt (259 B) Delete",
+			kbArticleAttachment = "Document_1.txt (259 B)",
 			kbArticleContent = "Knowledge Base Article Content",
 			kbArticleTitle = "Knowledge Base Article Title");
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64520

Error in tests:
```
java.lang.Exception: Actual text "Document_1.txt (259 B)" does not match pattern "(?iu)Document_1\.txt \(259 B\) Delete" at "//div[contains(@id,'AttachmentsContainer')]"
```

# How am I fixing it?

Remove word "delete" from attachment link

# How can you verify that it works?

Run failing tests