### PR TITLE
LPD-64538 Fix tests in journal-web/main/journalArticlePermissionsAndSchedule.spec.ts

### DIFF
--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -466,6 +466,12 @@ export class JournalEditArticlePage {
 				: `Success:${title} will be published on`
 		);
 
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'list'}),
+			trigger: this.page.getByLabel('Select View, Currently Selected: '),
+		});
+
 		const row = await this.page
 			.locator('.list-group-item')
 			.filter({hasText: title});


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64538

The test is waiting for WC correctly created. The problem is on the type of view.
Error:
```
waiting for locator('.list-group-item').filter({ hasText: '358808cd-6e2d-4a4d-9fd1-3fe7cd5cd96f' }).locator('span.label').filter({ hasText: 'Pending' }) to be visible
```

Failing tests:

* journal-web/main/journalArticlePermissionsAndSchedule.spec.ts > Create a web content scheduled
* journal-web/main/journalArticlePermissionsAndSchedule.spec.ts > Create a web content scheduled with workflow activated

# How am I fixing it?

Make sure the view is of type "List"

# How can you verify that it works?

`npm run playwright -- test -g 'Create a web content scheduled'`