### PR TITLE
LPD-64757 [Support] - Wiki is displayed without permissions in product menu

### DIFF
--- a/modules/apps/wiki/wiki-web-test/build.gradle
+++ b/modules/apps/wiki/wiki-web-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation project(":apps:application-list:application-list-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-api")

--- a/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/application/list/test/WikiPanelAppTest.java
+++ b/modules/apps/wiki/wiki-web-test/src/testIntegration/java/com/liferay/wiki/web/internal/application/list/test/WikiPanelAppTest.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.wiki.web.internal.application.list.test;
+
+import com.liferay.application.list.PanelApp;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@RunWith(Arquillian.class)
+public class WikiPanelAppTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@FeatureFlag("LPD-35013")
+	@Test
+	public void testIsShow() throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
+
+		Assert.assertTrue(
+			_wikiPanelApp.isShow(
+				permissionChecker,
+				_groupLocalService.getGroup(TestPropsValues.getGroupId())));
+	}
+
+	@FeatureFlag("LPD-35013")
+	@Test
+	public void testIsShowWithNoAdminUser() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		try {
+			PermissionChecker permissionChecker =
+				PermissionCheckerFactoryUtil.create(user);
+
+			Assert.assertFalse(
+				_wikiPanelApp.isShow(
+					permissionChecker,
+					_groupLocalService.getGroup(TestPropsValues.getGroupId())));
+		}
+		finally {
+			_userLocalService.deleteUser(user);
+		}
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.wiki.web.internal.application.list.WikiPanelApp"
+	)
+	private PanelApp _wikiPanelApp;
+
+}

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/application/list/WikiPanelApp.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/application/list/WikiPanelApp.java
@@ -44,8 +44,13 @@ public class WikiPanelApp extends BasePanelApp {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		return FeatureFlagManagerUtil.isEnabled(
-			group.getCompanyId(), "LPD-35013");
+		if (FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-35013")) {
+
+			return super.isShow(permissionChecker, group);
+		}
+
+		return false;
 	}
 
 	@Reference(


### PR DESCRIPTION
Motivation
-----
Fix Wiki app is displayed in product menu without user permission.

<img width="1667" height="1039" alt="ECU-12686" src="https://github.com/user-attachments/assets/acf7ba1b-b345-4332-8135-aaa7bcab13bc" />

[Link to the issue](https://liferay.atlassian.net/browse/LPD-64757)

Proposed Solution
-----
Call super method isShow method in WikiPanelApp to check permissions, like we are doing in other PanelApps.

<img width="1665" height="1037" alt="Captura de pantalla 2025-09-05 a las 17 13 26" src="https://github.com/user-attachments/assets/6ade27e0-60d8-4262-843d-9a951f8c8a95" />

