### PR TITLE
LPD-64042 & LPD-64529 Document headless PATCH API does not update friendlyURLPath, description, expireDate and publishDate

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -395,7 +395,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		}
 
 		if (description == null) {
-			existingFileEntry.getDescription();
+			description = existingFileEntry.getDescription();
 		}
 
 		if (displayDate == null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -372,6 +372,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		String fileName = null;
 		String title = null;
+		String urlTitle = null;
 		String description = null;
 		Date displayDate = null;
 		Date expirationDate = null;
@@ -379,6 +380,7 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		if (document != null) {
 			fileName = document.getFileName();
 			title = document.getTitle();
+			urlTitle = document.getFriendlyUrlPath();
 			description = document.getDescription();
 			displayDate = document.getDatePublished();
 			expirationDate = document.getDateExpired();
@@ -406,8 +408,8 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 
 		return _toDocument(
 			_dlAppService.updateFileEntry(
-				documentId, fileName, binaryFile.getContentType(), title, null,
-				description, null, DLVersionNumberIncrease.AUTOMATIC,
+				documentId, fileName, binaryFile.getContentType(), title,
+				urlTitle, description, null, DLVersionNumberIncrease.AUTOMATIC,
 				binaryFile.getInputStream(), binaryFile.getSize(), displayDate,
 				expirationDate, existingFileEntry.getReviewDate(),
 				_createServiceContext(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -399,11 +399,11 @@ public class DocumentResourceImpl extends BaseDocumentResourceImpl {
 		}
 
 		if (displayDate == null) {
-			existingFileEntry.getDisplayDate();
+			displayDate = existingFileEntry.getDisplayDate();
 		}
 
 		if (expirationDate == null) {
-			existingFileEntry.getExpirationDate();
+			expirationDate = existingFileEntry.getExpirationDate();
 		}
 
 		return _toDocument(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -288,7 +288,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "fileName", "title"};
+		return new String[] {"description", "fileName", "friendlyUrlPath", "title"};
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -208,6 +208,16 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	@Test
+	public void testPatchDocument() throws Exception {
+		super.testPatchDocument();
+
+		_testPatchDocumentWithDates();
+		_testPatchDocumentWithFriendlyUrlPath();
+		_testPatchDocumentWithoutFriendlyUrlPath();
+	}
+
+	@Override
+	@Test
 	public void testPostDocumentFolderDocument() throws Exception {
 		super.testPostDocumentFolderDocument();
 
@@ -288,7 +298,9 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"description", "fileName", "friendlyUrlPath", "title"};
+		return new String[] {
+			"description", "fileName", "friendlyUrlPath", "title"
+		};
 	}
 
 	@Override
@@ -497,6 +509,73 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
 
 		return httpResponse.getContent();
+	}
+
+	private void _testPatchDocumentWithDates() throws Exception {
+		Document postDocument = testPatchDocument_addDocument();
+
+		Date dateExpired = postDocument.getDateExpired();
+		Date datePublished = postDocument.getDatePublished();
+
+		Document document = new Document();
+
+		document.setDescription(RandomTestUtil.randomString(10));
+
+		Document patchDocument = documentResource.patchDocument(
+			postDocument.getId(), document, new HashMap<>());
+
+		Document getDocument = documentResource.getDocument(
+			patchDocument.getId());
+
+		Assert.assertEquals(dateExpired, getDocument.getDateExpired());
+		Assert.assertEquals(datePublished, getDocument.getDatePublished());
+	}
+
+	private void _testPatchDocumentWithFriendlyUrlPath() throws Exception {
+		Document postDocument = testPatchDocument_addDocument();
+
+		Document document = new Document();
+
+		String friendlyUrlPath = StringUtil.toLowerCase(
+			StringUtil.randomString());
+
+		document.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document patchDocument = documentResource.patchDocument(
+			postDocument.getId(), document, new HashMap<>());
+
+		Document expectedPatchDocument = postDocument.clone();
+
+		expectedPatchDocument.setFriendlyUrlPath(friendlyUrlPath);
+
+		Document getDocument = documentResource.getDocument(
+			patchDocument.getId());
+
+		assertEquals(expectedPatchDocument, getDocument);
+		assertValid(getDocument);
+	}
+
+	private void _testPatchDocumentWithoutFriendlyUrlPath() throws Exception {
+		Document postDocument = testPatchDocument_addDocument();
+
+		Document document = new Document();
+
+		String description = StringUtil.toLowerCase(StringUtil.randomString());
+
+		document.setDescription(description);
+
+		Document patchDocument = documentResource.patchDocument(
+			postDocument.getId(), document, new HashMap<>());
+
+		Document expectedPatchDocument = postDocument.clone();
+
+		expectedPatchDocument.setDescription(description);
+
+		Document getDocument = documentResource.getDocument(
+			patchDocument.getId());
+
+		assertEquals(expectedPatchDocument, getDocument);
+		assertValid(getDocument);
 	}
 
 	private void _testPostDocumentFolderDocumentWithDLFileEntryType()


### PR DESCRIPTION
# What is this trying to solve?
[Document headless PATCH API does not update friendlyURLPath and can remove description](https://liferay.atlassian.net/browse/LPD-64042)
[Document headless PATCH API can remove datePublished and dateExpired](https://liferay.atlassian.net/browse/LPD-64529)

Fields that are not present in the Patch request are reset to null.

# How am I fixing it?
By reusing data from the existingFileEntry

# How can you verify that it works?
```
cd modules/apps/headless/headless-delivery/headless-delivery-impl
gw testIntegration --tests DocumentResourceTest.testPatchDocument
```

Cheers,
Balázs
