### PR TITLE
LPD-64961 Hide certain site initializers 

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/bnd.bnd
+++ b/modules/apps/site-initializer/site-initializer-cms/bnd.bnd
@@ -2,6 +2,7 @@ Bundle-Name: Liferay Site Initializer CMS
 Bundle-SymbolicName: com.liferay.site.initializer.cms
 Bundle-Version: 1.0.16
 Liferay-Client-Extension-Batch: com/liferay/site/initializer/cms/internal/batch
+Liferay-Site-Initializer-Active: false
 Liferay-Site-Initializer-Feature-Flag: LPD-17564
 Liferay-Site-Initializer-Name: CMS
 Provide-Capability: liferay.site.initializer

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -559,11 +559,15 @@ public class BundleSiteInitializer implements SiteInitializer {
 		Dictionary<String, String> headers = _siteBundle.getHeaders(
 			StringPool.BLANK);
 
+		boolean active = GetterUtil.getBoolean(
+			headers.get("Liferay-Site-Initializer-Active"), true);
+
 		String featureFlagKey = headers.get(
 			"Liferay-Site-Initializer-Feature-Flag");
 
-		if (Validator.isNotNull(featureFlagKey) &&
-			!FeatureFlagManagerUtil.isEnabled(featureFlagKey)) {
+		if (!active ||
+			(Validator.isNotNull(featureFlagKey) &&
+			 !FeatureFlagManagerUtil.isEnabled(featureFlagKey))) {
 
 			return false;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/BNDSourceUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/BNDSourceUtil.java
@@ -268,6 +268,7 @@ public class BNDSourceUtil {
 		"Liferay-Releng-Module-Group-Description",
 		"Liferay-Releng-Module-Group-Title", "Liferay-Require-SchemaVersion",
 		"Liferay-RTL-Support-Required", "Liferay-Service",
+		"Liferay-Site-Initializer-Active",
 		"Liferay-Site-Initializer-Description",
 		"Liferay-Site-Initializer-Feature-Flag",
 		"Liferay-Site-Initializer-Name", "Liferay-Theme-Contributor-Type",


### PR DESCRIPTION
Limit the number of CMS sites per instance to one

https://liferay.atlassian.net/browse/LPD-64961

The idea is to add a new header so that we can identify which site initializers are hidden when creating sites, such as the CMS site initializer

How to test:

* Start the portal with the feature flag for LPD-17564 enabled
* Go to create a new site
* CMS site initializer is not available

**Notes: SF will fail for this, we have to update the source formatter first**