### PR TITLE
LPD-65015 Do not show Asset Libraries in the Select Space Dropdwon

### DIFF
--- a/modules/apps/depot/depot-api/bnd.bnd
+++ b/modules/apps/depot/depot-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot API
 Bundle-SymbolicName: com.liferay.depot.api
-Bundle-Version: 8.1.1
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.depot.application,\
 	com.liferay.depot.configuration,\

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalService.java
@@ -245,6 +245,9 @@ public interface DepotEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DepotEntry> getDepotEntries(int start, int end);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DepotEntry> getDepotEntries(int type, int start, int end);
+
 	/**
 	 * Returns all the depot entries matching the UUID and company.
 	 *
@@ -278,6 +281,9 @@ public interface DepotEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getDepotEntriesCount();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getDepotEntriesCount(int type);
 
 	/**
 	 * Returns the depot entry with the primary key.

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceUtil.java
@@ -261,6 +261,12 @@ public class DepotEntryLocalServiceUtil {
 		return getService().getDepotEntries(start, end);
 	}
 
+	public static List<DepotEntry> getDepotEntries(
+		int type, int start, int end) {
+
+		return getService().getDepotEntries(type, start, end);
+	}
+
 	/**
 	 * Returns all the depot entries matching the UUID and company.
 	 *
@@ -299,6 +305,10 @@ public class DepotEntryLocalServiceUtil {
 	 */
 	public static int getDepotEntriesCount() {
 		return getService().getDepotEntriesCount();
+	}
+
+	public static int getDepotEntriesCount(int type) {
+		return getService().getDepotEntriesCount(type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/DepotEntryLocalServiceWrapper.java
@@ -285,6 +285,13 @@ public class DepotEntryLocalServiceWrapper
 		return _depotEntryLocalService.getDepotEntries(start, end);
 	}
 
+	@Override
+	public java.util.List<DepotEntry> getDepotEntries(
+		int type, int start, int end) {
+
+		return _depotEntryLocalService.getDepotEntries(type, start, end);
+	}
+
 	/**
 	 * Returns all the depot entries matching the UUID and company.
 	 *
@@ -328,6 +335,11 @@ public class DepotEntryLocalServiceWrapper
 	@Override
 	public int getDepotEntriesCount() {
 		return _depotEntryLocalService.getDepotEntriesCount();
+	}
+
+	@Override
+	public int getDepotEntriesCount(int type) {
+		return _depotEntryLocalService.getDepotEntriesCount(type);
 	}
 
 	/**

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryPersistence.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryPersistence.java
@@ -423,6 +423,148 @@ public interface DepotEntryPersistence
 	public int countByGroupId(long groupId);
 
 	/**
+	 * Returns all the depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the matching depot entries
+	 */
+	public java.util.List<DepotEntry> findByType(int type);
+
+	/**
+	 * Returns a range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @return the range of matching depot entries
+	 */
+	public java.util.List<DepotEntry> findByType(int type, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entries
+	 */
+	public java.util.List<DepotEntry> findByType(
+		int type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entries
+	 */
+	public java.util.List<DepotEntry> findByType(
+		int type, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	public DepotEntry findByType_First(
+			int type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	public DepotEntry fetchByType_First(
+		int type,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	public DepotEntry findByType_Last(
+			int type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	public DepotEntry fetchByType_Last(
+		int type,
+		com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the depot entries before and after the current depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param depotEntryId the primary key of the current depot entry
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry
+	 * @throws NoSuchEntryException if a depot entry with the primary key could not be found
+	 */
+	public DepotEntry[] findByType_PrevAndNext(
+			long depotEntryId, int type,
+			com.liferay.portal.kernel.util.OrderByComparator<DepotEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Removes all the depot entries where type = &#63; from the database.
+	 *
+	 * @param type the type
+	 */
+	public void removeByType(int type);
+
+	/**
+	 * Returns the number of depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the number of matching depot entries
+	 */
+	public int countByType(int type);
+
+	/**
 	 * Caches the depot entry in the entity cache if it is enabled.
 	 *
 	 * @param depotEntry the depot entry

--- a/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryUtil.java
+++ b/modules/apps/depot/depot-api/src/main/java/com/liferay/depot/service/persistence/DepotEntryUtil.java
@@ -578,6 +578,168 @@ public class DepotEntryUtil {
 	}
 
 	/**
+	 * Returns all the depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the matching depot entries
+	 */
+	public static List<DepotEntry> findByType(int type) {
+		return getPersistence().findByType(type);
+	}
+
+	/**
+	 * Returns a range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @return the range of matching depot entries
+	 */
+	public static List<DepotEntry> findByType(int type, int start, int end) {
+		return getPersistence().findByType(type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entries
+	 */
+	public static List<DepotEntry> findByType(
+		int type, int start, int end,
+		OrderByComparator<DepotEntry> orderByComparator) {
+
+		return getPersistence().findByType(type, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entries
+	 */
+	public static List<DepotEntry> findByType(
+		int type, int start, int end,
+		OrderByComparator<DepotEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByType(
+			type, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	public static DepotEntry findByType_First(
+			int type, OrderByComparator<DepotEntry> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryException {
+
+		return getPersistence().findByType_First(type, orderByComparator);
+	}
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	public static DepotEntry fetchByType_First(
+		int type, OrderByComparator<DepotEntry> orderByComparator) {
+
+		return getPersistence().fetchByType_First(type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	public static DepotEntry findByType_Last(
+			int type, OrderByComparator<DepotEntry> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryException {
+
+		return getPersistence().findByType_Last(type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	public static DepotEntry fetchByType_Last(
+		int type, OrderByComparator<DepotEntry> orderByComparator) {
+
+		return getPersistence().fetchByType_Last(type, orderByComparator);
+	}
+
+	/**
+	 * Returns the depot entries before and after the current depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param depotEntryId the primary key of the current depot entry
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry
+	 * @throws NoSuchEntryException if a depot entry with the primary key could not be found
+	 */
+	public static DepotEntry[] findByType_PrevAndNext(
+			long depotEntryId, int type,
+			OrderByComparator<DepotEntry> orderByComparator)
+		throws com.liferay.depot.exception.NoSuchEntryException {
+
+		return getPersistence().findByType_PrevAndNext(
+			depotEntryId, type, orderByComparator);
+	}
+
+	/**
+	 * Removes all the depot entries where type = &#63; from the database.
+	 *
+	 * @param type the type
+	 */
+	public static void removeByType(int type) {
+		getPersistence().removeByType(type);
+	}
+
+	/**
+	 * Returns the number of depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the number of matching depot entries
+	 */
+	public static int countByType(int type) {
+		return getPersistence().countByType(type);
+	}
+
+	/**
 	 * Caches the depot entry in the entity cache if it is enabled.
 	 *
 	 * @param depotEntry the depot entry

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
+++ b/modules/apps/depot/depot-api/src/main/resources/com/liferay/depot/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/depot/depot-service/service.xml
+++ b/modules/apps/depot/depot-service/service.xml
@@ -60,6 +60,9 @@
 		<finder name="GroupId" return-type="DepotEntry" unique="true">
 			<finder-column name="groupId" />
 		</finder>
+		<finder name="Type" return-type="Collection">
+			<finder-column name="type" />
+		</finder>
 	</entity>
 	<entity local-service="true" name="DepotEntryGroupRel" remote-service="true" uuid="true">
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/model/impl/DepotEntryModelImpl.java
@@ -122,14 +122,20 @@ public class DepotEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 4L;
+	public static final long TYPE_COLUMN_BITMASK = 4L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long DEPOTENTRYID_COLUMN_BITMASK = 8L;
+	public static final long DEPOTENTRYID_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -530,6 +536,16 @@ public class DepotEntryModelImpl
 		}
 
 		_type = type;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public int getOriginalType() {
+		return GetterUtil.getInteger(
+			this.<Integer>getColumnOriginalValue("type_"));
 	}
 
 	@Override

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -193,6 +193,16 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 		return depotEntryPersistence.fetchByGroupId(groupId);
 	}
 
+	@Override
+	public List<DepotEntry> getDepotEntries(int type, int start, int end) {
+		return depotEntryPersistence.findByType(type, start, end);
+	}
+
+	@Override
+	public int getDepotEntriesCount(int type) {
+		return depotEntryPersistence.countByType(type);
+	}
+
 	/**
 	 * @deprecated As of Cavanaugh (7.4.x)
 	 */

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/persistence/impl/DepotEntryPersistenceImpl.java
@@ -1594,6 +1594,504 @@ public class DepotEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_GROUPID_GROUPID_2 =
 		"depotEntry.groupId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByType;
+	private FinderPath _finderPathWithoutPaginationFindByType;
+	private FinderPath _finderPathCountByType;
+
+	/**
+	 * Returns all the depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the matching depot entries
+	 */
+	@Override
+	public List<DepotEntry> findByType(int type) {
+		return findByType(type, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @return the range of matching depot entries
+	 */
+	@Override
+	public List<DepotEntry> findByType(int type, int start, int end) {
+		return findByType(type, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching depot entries
+	 */
+	@Override
+	public List<DepotEntry> findByType(
+		int type, int start, int end,
+		OrderByComparator<DepotEntry> orderByComparator) {
+
+		return findByType(type, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the depot entries where type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DepotEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param type the type
+	 * @param start the lower bound of the range of depot entries
+	 * @param end the upper bound of the range of depot entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching depot entries
+	 */
+	@Override
+	public List<DepotEntry> findByType(
+		int type, int start, int end,
+		OrderByComparator<DepotEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					DepotEntry.class)) {
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByType;
+					finderArgs = new Object[] {type};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByType;
+				finderArgs = new Object[] {type, start, end, orderByComparator};
+			}
+
+			List<DepotEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<DepotEntry>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (DepotEntry depotEntry : list) {
+						if (type != depotEntry.getType()) {
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						3 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(3);
+				}
+
+				sb.append(_SQL_SELECT_DEPOTENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_TYPE_TYPE_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(DepotEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(type);
+
+					list = (List<DepotEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	@Override
+	public DepotEntry findByType_First(
+			int type, OrderByComparator<DepotEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		DepotEntry depotEntry = fetchByType_First(type, orderByComparator);
+
+		if (depotEntry != null) {
+			return depotEntry;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	@Override
+	public DepotEntry fetchByType_First(
+		int type, OrderByComparator<DepotEntry> orderByComparator) {
+
+		List<DepotEntry> list = findByType(type, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry
+	 * @throws NoSuchEntryException if a matching depot entry could not be found
+	 */
+	@Override
+	public DepotEntry findByType_Last(
+			int type, OrderByComparator<DepotEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		DepotEntry depotEntry = fetchByType_Last(type, orderByComparator);
+
+		if (depotEntry != null) {
+			return depotEntry;
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching depot entry, or <code>null</code> if a matching depot entry could not be found
+	 */
+	@Override
+	public DepotEntry fetchByType_Last(
+		int type, OrderByComparator<DepotEntry> orderByComparator) {
+
+		int count = countByType(type);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<DepotEntry> list = findByType(
+			type, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the depot entries before and after the current depot entry in the ordered set where type = &#63;.
+	 *
+	 * @param depotEntryId the primary key of the current depot entry
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next depot entry
+	 * @throws NoSuchEntryException if a depot entry with the primary key could not be found
+	 */
+	@Override
+	public DepotEntry[] findByType_PrevAndNext(
+			long depotEntryId, int type,
+			OrderByComparator<DepotEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		DepotEntry depotEntry = findByPrimaryKey(depotEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DepotEntry[] array = new DepotEntryImpl[3];
+
+			array[0] = getByType_PrevAndNext(
+				session, depotEntry, type, orderByComparator, true);
+
+			array[1] = depotEntry;
+
+			array[2] = getByType_PrevAndNext(
+				session, depotEntry, type, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DepotEntry getByType_PrevAndNext(
+		Session session, DepotEntry depotEntry, int type,
+		OrderByComparator<DepotEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(3);
+		}
+
+		sb.append(_SQL_SELECT_DEPOTENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_TYPE_TYPE_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(DepotEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(type);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(depotEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<DepotEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the depot entries where type = &#63; from the database.
+	 *
+	 * @param type the type
+	 */
+	@Override
+	public void removeByType(int type) {
+		for (DepotEntry depotEntry :
+				findByType(type, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(depotEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of depot entries where type = &#63;.
+	 *
+	 * @param type the type
+	 * @return the number of matching depot entries
+	 */
+	@Override
+	public int countByType(int type) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					DepotEntry.class)) {
+
+			FinderPath finderPath = _finderPathCountByType;
+
+			Object[] finderArgs = new Object[] {type};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(2);
+
+				sb.append(_SQL_COUNT_DEPOTENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_TYPE_TYPE_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(type);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_TYPE_TYPE_2 =
+		"depotEntry.type = ?";
+
 	public DepotEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -2491,6 +2989,24 @@ public class DepotEntryPersistenceImpl
 			FINDER_CLASS_NAME_ENTITY, "fetchByGroupId",
 			new String[] {Long.class.getName()}, new String[] {"groupId"},
 			true);
+
+		_finderPathWithPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByType",
+			new String[] {
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"type_"}, true);
+
+		_finderPathWithoutPaginationFindByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByType",
+			new String[] {Integer.class.getName()}, new String[] {"type_"},
+			true);
+
+		_finderPathCountByType = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByType",
+			new String[] {Integer.class.getName()}, new String[] {"type_"},
+			false);
 
 		DepotEntryUtil.setPersistence(this);
 	}

--- a/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/depot/depot-service/src/main/resources/META-INF/sql/indexes.sql
@@ -2,6 +2,7 @@ create index IX_5B76D798 on DepotAppCustomization (depotEntryId, enabled);
 create unique index IX_2CE1592A on DepotAppCustomization (depotEntryId, portletId[$COLUMN_LENGTH:75$], ctCollectionId);
 
 create unique index IX_E3EB2C84 on DepotEntry (groupId, ctCollectionId);
+create index IX_2DD18651 on DepotEntry (type_);
 
 create index IX_146497CB on DepotEntryGroupRel (depotEntryId);
 create index IX_7CA33F81 on DepotEntryGroupRel (toGroupId, ddmStructuresAvailable);

--- a/modules/apps/depot/depot-service/src/main/resources/service.properties
+++ b/modules/apps/depot/depot-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.depot.service
-    build.number=7
-    build.date=1754990557982
+    build.number=8
+    build.date=1757585319946

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/persistence/test/DepotEntryPersistenceTest.java
@@ -204,6 +204,13 @@ public class DepotEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByType() throws Exception {
+		_persistence.countByType(RandomTestUtil.nextInt());
+
+		_persistence.countByType(0);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		DepotEntry newDepotEntry = addDepotEntry();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
+import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.configuration.DLConfiguration;
@@ -583,7 +584,8 @@ public abstract class BaseSectionDisplayContext {
 		return _getDepotEntriesJSONArray(
 			TransformUtil.transform(
 				depotEntryLocalService.getDepotEntries(
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					DepotConstants.TYPE_SPACE, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
 				DepotEntry::getGroupId));
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -586,14 +586,14 @@ public abstract class BaseSectionDisplayContext {
 				depotEntryLocalService.getDepotEntries(
 					DepotConstants.TYPE_SPACE, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS),
-				DepotEntry::getGroupId));
+				DepotEntry::getGroup));
 	}
 
-	private JSONArray _getDepotEntriesJSONArray(List<Long> groupIds) {
+	private JSONArray _getDepotEntriesJSONArray(List<Group> groups) {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		for (Long groupId : groupIds) {
-			JSONObject jsonObject = _getJSONObject(groupId);
+		for (Group group : groups) {
+			JSONObject jsonObject = _getJSONObject(group);
 
 			if (jsonObject != null) {
 				jsonArray.put(jsonObject);
@@ -724,13 +724,7 @@ public abstract class BaseSectionDisplayContext {
 		return fileMimeTypeValues;
 	}
 
-	private JSONObject _getJSONObject(long groupId) {
-		Group group = groupLocalService.fetchGroup(groupId);
-
-		if (group == null) {
-			return null;
-		}
-
+	private JSONObject _getJSONObject(Group group) {
 		return JSONUtil.put(
 			"groupId", group.getGroupId()
 		).put(


### PR DESCRIPTION
### What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-65015

### How am I fixing it?

Getting the spaces instead of all the depots

### How can you verify that it works?
Follow this steps:

1. Add a Asset library
2. Go to CMS.
3. Navigate to File Section
4. Add a Folder
5. Only spaces should appear

<img width="748" height="548" alt="Captura de pantalla 2025-09-11 a las 12 33 34" src="https://github.com/user-attachments/assets/213b802b-2a93-459d-8ce7-f5e6841b115f" />
