### PR TITLE
LPD-62188 Make localized item selector rendering className aware

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
@@ -188,8 +188,7 @@ public class ItemSelectorImpl implements ItemSelector {
 				}
 
 				PortletURL portletURL = getPortletURL(
-					requestBackedPortletURLFactory,
-					itemSelectorView.getTitle(themeDisplay.getLocale()),
+					requestBackedPortletURLFactory, itemSelectorView,
 					selectedTab, itemSelectedEventName,
 					itemSelectorCriteriaArray, themeDisplay);
 
@@ -337,13 +336,22 @@ public class ItemSelectorImpl implements ItemSelector {
 
 	protected PortletURL getPortletURL(
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory,
-		String title, String selectedTab, String itemSelectedEventName,
+		ItemSelectorView<?> itemSelectorView, String selectedTab,
+		String itemSelectedEventName,
 		ItemSelectorCriterion[] itemSelectorCriteriaArray,
 		ThemeDisplay themeDisplay) {
 
 		PortletURL portletURL = null;
 
-		if (Validator.isNotNull(selectedTab) && selectedTab.equals(title)) {
+		String curSelectedTab = StringBundler.concat(
+			itemSelectorView.getClass(
+			).getName(),
+			StringPool.UNDERLINE,
+			itemSelectorView.getTitle(themeDisplay.getLocale()));
+
+		if (Validator.isNotNull(selectedTab) &&
+			selectedTab.equals(curSelectedTab)) {
+
 			portletURL = getItemSelectorURL(
 				requestBackedPortletURLFactory, themeDisplay.getScopeGroup(),
 				themeDisplay.getRefererGroupId(), itemSelectedEventName,
@@ -361,7 +369,7 @@ public class ItemSelectorImpl implements ItemSelector {
 				itemSelectorCriteriaArray);
 		}
 
-		portletURL.setParameter(PARAMETER_SELECTED_TAB, title);
+		portletURL.setParameter(PARAMETER_SELECTED_TAB, curSelectedTab);
 
 		return portletURL;
 	}

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
@@ -11,6 +11,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.item.selector.ItemSelectorRendering;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewRenderer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -52,31 +54,46 @@ public class LocalizedItemSelectorRendering {
 
 		String title = itemSelectorView.getTitle(_locale);
 
+		String curSelectedTab = StringBundler.concat(
+			itemSelectorView.getClass(
+			).getName(),
+			StringPool.UNDERLINE, title);
+
 		ItemSelectorViewRenderer previousItemSelectorViewRenderer =
-			_itemSelectorViewRenderers.put(title, itemSelectorViewRenderer);
+			_itemSelectorViewRenderers.put(
+				curSelectedTab, itemSelectorViewRenderer);
 
 		if (previousItemSelectorViewRenderer != null) {
 			_navigationItems.removeIf(
-				navigationItem -> title.equals(
-					String.valueOf(navigationItem.get("label"))));
+				navigationItem -> {
+					Map<String, String> data =
+						(Map<String, String>)navigationItem.get("data");
+
+					if ((data != null) && data.containsKey("id")) {
+						return curSelectedTab.equals(data.get("id"));
+					}
+
+					return curSelectedTab.equals(title);
+				});
 		}
 
 		_navigationItems.add(
 			navigationItem -> {
+				navigationItem.putData("id", curSelectedTab);
 				navigationItem.setHref(
 					itemSelectorViewRenderer.getPortletURL());
 				navigationItem.setLabel(title);
 
 				String selectedTab = _itemSelectorRendering.getSelectedTab();
 
-				if (selectedTab.equals(title) ||
+				if (selectedTab.equals(curSelectedTab) ||
 					(Validator.isNull(selectedTab) &&
 					 _navigationItems.isEmpty())) {
 
 					navigationItem.setActive(true);
 
 					_activeNavigationItem = navigationItem;
-					_selectedNavigationItemLabel = title;
+					_selectedNavigationItemLabel = curSelectedTab;
 				}
 			});
 	}
@@ -107,7 +124,16 @@ public class LocalizedItemSelectorRendering {
 					verticalNavItem.setHref(
 						GetterUtil.getString(navigationItem.get("href")));
 					verticalNavItem.setLabel(name);
-					verticalNavItem.setId(name);
+
+					Map<String, String> data =
+						(Map<String, String>)navigationItem.get("data");
+
+					if ((data != null) && data.containsKey("id")) {
+						verticalNavItem.setId(data.get("id"));
+					}
+					else {
+						verticalNavItem.setId(name);
+					}
 				});
 		}
 

--- a/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRenderingTest.java
+++ b/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRenderingTest.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.item.selector.web.internal.portlet;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorRendering;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.item.selector.ItemSelectorViewRenderer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletURL;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import java.io.IOException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class LocalizedItemSelectorRenderingTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetVerticalNavItemList() throws Exception {
+		Locale locale = LocaleUtil.getDefault();
+
+		String title = RandomTestUtil.randomString();
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer1 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView1(title));
+		ItemSelectorViewRenderer itemSelectorViewRenderer2 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView2(title));
+
+		_testGetVerticalNavItemList(
+			Arrays.asList(itemSelectorViewRenderer1, itemSelectorViewRenderer2),
+			locale, title);
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer3 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView1(title));
+		ItemSelectorViewRenderer itemSelectorViewRenderer4 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView2(title));
+
+		_testGetVerticalNavItemList(
+			Arrays.asList(
+				itemSelectorViewRenderer1, itemSelectorViewRenderer2,
+				itemSelectorViewRenderer3, itemSelectorViewRenderer4),
+			locale, title);
+	}
+
+	private void _assertNavigationItem(
+		Class<?> clazz, NavigationItem navigationItem, String title) {
+
+		String id = StringBundler.concat(
+			clazz.getName(), StringPool.UNDERLINE, title);
+
+		Assert.assertEquals(title, navigationItem.get("label"));
+
+		Map<String, String> data = (Map<String, String>)navigationItem.get(
+			"data");
+
+		Assert.assertTrue(MapUtil.isNotEmpty(data));
+
+		Assert.assertEquals(id, String.valueOf(data.get("id")));
+	}
+
+	private ItemSelectorViewRenderer _getItemSelectorViewRenderer(
+		ItemSelectorView<ItemSelectorCriterion> itemSelectorView) {
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer = Mockito.mock(
+			ItemSelectorViewRenderer.class);
+
+		Mockito.when(
+			itemSelectorViewRenderer.getItemSelectorView()
+		).thenReturn(
+			itemSelectorView
+		);
+
+		return itemSelectorViewRenderer;
+	}
+
+	private void _testGetVerticalNavItemList(
+		List<ItemSelectorViewRenderer> itemSelectorViewRenderers, Locale locale,
+		String title) {
+
+		ItemSelectorRendering itemSelectorRendering = Mockito.mock(
+			ItemSelectorRendering.class);
+
+		Mockito.when(
+			itemSelectorRendering.getItemSelectorViewRenderers()
+		).thenReturn(
+			itemSelectorViewRenderers
+		);
+
+		Mockito.when(
+			itemSelectorRendering.getSelectedTab()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		LocalizedItemSelectorRendering localizedItemSelectorRendering =
+			new LocalizedItemSelectorRendering(locale, itemSelectorRendering);
+
+		List<NavigationItem> navigationItems =
+			localizedItemSelectorRendering.getNavigationItems();
+
+		Assert.assertEquals(
+			navigationItems.toString(), 2, navigationItems.size());
+
+		_assertNavigationItem(
+			TestItemSelectorView1.class, navigationItems.get(0), title);
+		_assertNavigationItem(
+			TestItemSelectorView2.class, navigationItems.get(1), title);
+	}
+
+	private class BaseTestItemSelectorView
+		implements ItemSelectorView<ItemSelectorCriterion> {
+
+		public BaseTestItemSelectorView(String title) {
+			_title = title;
+		}
+
+		@Override
+		public Class<? extends ItemSelectorCriterion>
+			getItemSelectorCriterionClass() {
+
+			return null;
+		}
+
+		@Override
+		public List<ItemSelectorReturnType>
+			getSupportedItemSelectorReturnTypes() {
+
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String getTitle(Locale locale) {
+			return _title;
+		}
+
+		@Override
+		public void renderHTML(
+				ServletRequest servletRequest, ServletResponse servletResponse,
+				ItemSelectorCriterion itemSelectorCriterion,
+				PortletURL portletURL, String itemSelectedEventName,
+				boolean search)
+			throws IOException, ServletException {
+		}
+
+		private final String _title;
+
+	}
+
+	private class TestItemSelectorView1 extends BaseTestItemSelectorView {
+
+		public TestItemSelectorView1(String title) {
+			super(title);
+		}
+
+	}
+
+	private class TestItemSelectorView2 extends BaseTestItemSelectorView {
+
+		public TestItemSelectorView2(String title) {
+			super(title);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Make localized item selector rendering className aware

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-62188)

At the moment, when we have 2 ItemSelectorViews with the same name, only one of them is taken into account when rendering. This is more noticeable now with the CMS where we have object definitions like Blogs

# How am I fixing it?

When rendering, use also the className of the itemSelectorView, so that it shows in the interface. Still, we are going to have the same issue with object definitions with the same plural name for now

# How can you verify that it works?

There's a unit test provided in the PR.

Also, another way is to start the portal with the CMS FF enabled, go to any content page, and when mapping a fragment and selecting the mapped item, blogs will be shown twice