### PR TITLE
LPD-61241 Migrate `DocumentPreviewer` to TypeScript

### DIFF
--- a/modules/apps/document-library/document-library-preview-document/package.json
+++ b/modules/apps/document-library/document-library-preview-document/package.json
@@ -9,7 +9,7 @@
 		"prop-types": "15.7.2",
 		"react": "18.2.0"
 	},
-	"main": "preview/js/index.js",
+	"main": "preview/js/index.tsx",
 	"name": "document-library-preview-document",
 	"private": true,
 	"scripts": {

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
@@ -8,7 +8,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {debounce} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import '@liferay/document-library-preview-css';
 
@@ -50,7 +50,7 @@ const DocumentPreviewer = ({
 	const [currentPage, setCurrentPage] = useState(initialPage);
 	const [currentPageLoading, setCurrentPageLoading] = useState(false);
 	const [expanded, setExpanded] = useState(false);
-	const [loadedPages] = useState<Record<number, LoadedPage>>({
+	const [loadedPages, setLoadedPages] = useState<Record<number, LoadedPage>>({
 		[currentPage]: {
 			loaded: true,
 			pagePromise: Promise.resolve(),
@@ -82,43 +82,55 @@ const DocumentPreviewer = ({
 		}
 	}, [showPageInput, isMounted]);
 
-	const createImageURL = (page: number): string => {
-		const imageURL = new URL(baseImageURL);
-		imageURL.searchParams.set('previewFileIndex', String(page));
+	const createImageURL = useCallback(
+		(page: number) => {
+			const imageURL = new URL(baseImageURL);
+			imageURL.searchParams.set('previewFileIndex', String(page));
 
-		return imageURL.toString();
-	};
+			return imageURL.toString();
+		},
+		[baseImageURL]
+	);
 
-	const loadPage = (page: number): Promise<void> => {
-		let pagePromise = loadedPages[page]?.pagePromise;
+	const loadPage = useCallback(
+		(page: number): Promise<void> => {
+			let pagePromise = loadedPages[page]?.pagePromise;
 
-		if (!pagePromise) {
-			const image = new Image();
-			image.src = createImageURL(page);
+			if (!pagePromise) {
+				const image = new Image();
+				image.src = createImageURL(page);
 
-			pagePromise = image.decode().then(() => {
-				loadedPages[page].loaded = true;
-			});
+				pagePromise = image.decode().then(() => {
+					setLoadedPages((prev) => ({
+						...prev,
+						[page]: {...prev[page], loaded: true},
+					}));
+				});
 
-			loadedPages[page] = {
-				loaded: false,
-				pagePromise,
-			};
-		}
-
-		return pagePromise;
-	};
-
-	const loadAdjacentPages = (page: number, adjacentPageCount = 2) => {
-		for (let i = 1; i <= adjacentPageCount; i++) {
-			if (page + i <= totalPages) {
-				loadPage(page + i);
+				setLoadedPages((prev) => ({
+					...prev,
+					[page]: {loaded: false, pagePromise},
+				}));
 			}
-			if (page - i > 1) {
-				loadPage(page - i);
+
+			return pagePromise;
+		},
+		[createImageURL, loadedPages]
+	);
+
+	const loadAdjacentPages = useCallback(
+		(page: number, adjacentPageCount = 2) => {
+			for (let i = 1; i <= adjacentPageCount; i++) {
+				if (page + i <= totalPages) {
+					loadPage(page + i);
+				}
+				if (page - i > 1) {
+					loadPage(page - i);
+				}
 			}
-		}
-	};
+		},
+		[totalPages, loadPage]
+	);
 
 	const loadCurrentPage = debounce((page: number) => {
 		loadPage(page)
@@ -192,9 +204,7 @@ const DocumentPreviewer = ({
 
 	useEffect(() => {
 		loadAdjacentPages(initialPage);
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [initialPage, loadAdjacentPages]);
 
 	return (
 		<div className="preview-file">

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
@@ -230,6 +230,7 @@ const DocumentPreviewer = ({
 					<ClayButton.Group>
 						<ClayButton
 							className="btn-floating-bar btn-floating-bar-text"
+							disabled={totalPages === 1}
 							onClick={() => {
 								setShowPageInput(true);
 							}}

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
@@ -229,6 +229,13 @@ const DocumentPreviewer = ({
 				<ClayButton.Group className="floating-bar">
 					<ClayButton.Group>
 						<ClayButton
+							aria-label={
+								totalPages > 1
+									? Liferay.Language.get(
+											'click-to-jump-to-a-page'
+										)
+									: undefined
+							}
 							className="btn-floating-bar btn-floating-bar-text"
 							disabled={totalPages === 1}
 							onClick={() => {
@@ -267,6 +274,7 @@ const DocumentPreviewer = ({
 					</ClayButton.Group>
 
 					<ClayButton
+						aria-label={Liferay.Language.get('page-above')}
 						className="btn-floating-bar"
 						disabled={previousPageDisabled}
 						monospaced
@@ -279,6 +287,7 @@ const DocumentPreviewer = ({
 					</ClayButton>
 
 					<ClayButton
+						aria-label={Liferay.Language.get('page-below')}
 						className="btn-floating-bar"
 						disabled={nextPageDisabled}
 						monospaced
@@ -293,6 +302,11 @@ const DocumentPreviewer = ({
 					<div className="separator-floating-bar"></div>
 
 					<ClayButton
+						aria-label={
+							expanded
+								? Liferay.Language.get('zoom-to-fit')
+								: Liferay.Language.get('expand')
+						}
 						className="btn-floating-bar"
 						monospaced
 						onClick={() => {

--- a/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
+++ b/modules/apps/document-library/document-library-preview-document/src/main/resources/META-INF/resources/preview/js/index.tsx
@@ -8,7 +8,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {debounce} from 'frontend-js-web';
-import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
 import '@liferay/document-library-preview-css';
@@ -20,7 +19,6 @@ const KEY_CODE_ESC = 27;
 /**
  * Valid list of keycodes
  * Includes backspace, tab, arrows, delete and numbers
- * @type {Array<number>}
  */
 const VALID_KEY_CODES = [
 	8, 9, 37, 38, 39, 40, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
@@ -28,57 +26,71 @@ const VALID_KEY_CODES = [
 
 /**
  * Milisecons between goToPage calls
- * @type {number}
  */
 const WAIT_BETWEEN_GO_TO_PAGE = 250;
 
-/**
- * Component that creates a pdf preview
- * @review
- */
+type DocumentPreviewerProps = {
+	alt: string;
+	baseImageURL: string;
+	initialPage: number;
+	totalPages: number;
+};
 
-const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
+type LoadedPage = {
+	loaded: boolean;
+	pagePromise: Promise<void>;
+};
+
+const DocumentPreviewer = ({
+	alt,
+	baseImageURL,
+	initialPage,
+	totalPages,
+}: DocumentPreviewerProps) => {
 	const [currentPage, setCurrentPage] = useState(initialPage);
 	const [currentPageLoading, setCurrentPageLoading] = useState(false);
 	const [expanded, setExpanded] = useState(false);
-	const [loadedPages] = useState({
+	const [loadedPages] = useState<Record<number, LoadedPage>>({
 		[currentPage]: {
 			loaded: true,
 			pagePromise: Promise.resolve(),
 		},
 	});
-	const [nextPageDisabled, setNextPageDisabled] = useState(
+	const [nextPageDisabled, setNextPageDisabled] = useState<boolean>(
 		currentPage === totalPages
 	);
-	const [previousPageDisabled, setPreviousPageDisabled] = useState(
+	const [previousPageDisabled, setPreviousPageDisabled] = useState<boolean>(
 		currentPage === 1
 	);
-	const [showPageInput, setShowPageInput] = useState(false);
+	const [showPageInput, setShowPageInput] = useState<boolean>(false);
 
-	const imageContainerRef = useRef();
-	const pageInputRef = useRef();
-	const showPageInputButtonRef = useRef();
+	const imageContainerRef = useRef<HTMLDivElement>(null);
+	const pageInputRef = useRef<HTMLInputElement>(null);
+	const showPageInputButtonRef = useRef<HTMLButtonElement>(null);
 
 	const isMounted = useIsMounted();
 
-	if (showPageInput) {
-		setTimeout(() => {
-			if (isMounted()) {
-				pageInputRef.current.focus();
-			}
-		}, 100);
-	}
+	useEffect(() => {
+		if (showPageInput) {
+			const timer = setTimeout(() => {
+				if (isMounted() && pageInputRef.current) {
+					pageInputRef.current.focus();
+				}
+			}, 100);
 
-	const createImageURL = (page) => {
+			return () => clearTimeout(timer);
+		}
+	}, [showPageInput, isMounted]);
+
+	const createImageURL = (page: number): string => {
 		const imageURL = new URL(baseImageURL);
-
-		imageURL.searchParams.set('previewFileIndex', page);
+		imageURL.searchParams.set('previewFileIndex', String(page));
 
 		return imageURL.toString();
 	};
 
-	const loadPage = (page) => {
-		let pagePromise = loadedPages[page] && loadedPages[page].pagePromise;
+	const loadPage = (page: number): Promise<void> => {
+		let pagePromise = loadedPages[page]?.pagePromise;
 
 		if (!pagePromise) {
 			const image = new Image();
@@ -97,23 +109,21 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 		return pagePromise;
 	};
 
-	const loadAdjacentPages = (page, adjacentPageCount = 2) => {
+	const loadAdjacentPages = (page: number, adjacentPageCount = 2) => {
 		for (let i = 1; i <= adjacentPageCount; i++) {
 			if (page + i <= totalPages) {
 				loadPage(page + i);
 			}
-
 			if (page - i > 1) {
 				loadPage(page - i);
 			}
 		}
 	};
 
-	const loadCurrentPage = debounce((page) => {
+	const loadCurrentPage = debounce((page: number) => {
 		loadPage(page)
 			.then(() => {
 				loadAdjacentPages(page);
-
 				setCurrentPageLoading(false);
 			})
 			.catch(() => {
@@ -121,24 +131,24 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 			});
 	}, WAIT_BETWEEN_GO_TO_PAGE);
 
-	const goToPage = (page) => {
+	const goToPage = (page: number) => {
 		setNextPageDisabled(page === totalPages);
 		setPreviousPageDisabled(page === 1);
 
 		if (!loadedPages[page] || !loadedPages[page].loaded) {
 			setCurrentPageLoading(true);
-
 			loadCurrentPage(page);
 		}
 
-		imageContainerRef.current.scrollTop = 0;
+		if (imageContainerRef.current) {
+			imageContainerRef.current.scrollTop = 0;
+		}
 
 		setCurrentPage(page);
 	};
 
-	const processPageInput = (value) => {
+	const processPageInput = (value: string) => {
 		let pageNumber = Number.parseInt(value, 10);
-
 		pageNumber = pageNumber
 			? Math.min(Math.max(1, pageNumber), totalPages)
 			: currentPage;
@@ -151,25 +161,25 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 
 		if (returnFocus) {
 			setTimeout(() => {
-				if (isMounted()) {
+				if (isMounted() && showPageInputButtonRef.current) {
 					showPageInputButtonRef.current.focus();
 				}
 			}, 100);
 		}
 	};
 
-	const handleBlurPageInput = (event) => {
+	const handleBlurPageInput = (event: React.FocusEvent<HTMLInputElement>) => {
 		processPageInput(event.currentTarget.value);
-
 		hidePageInput(false);
 	};
 
-	const handleKeyDownPageInput = (event) => {
+	const handleKeyDownPageInput = (
+		event: React.KeyboardEvent<HTMLInputElement>
+	) => {
 		const code = event.keyCode || event.charCode;
 
 		if (code === KEY_CODE_ENTER) {
 			processPageInput(event.currentTarget.value);
-
 			hidePageInput();
 		}
 		else if (code === KEY_CODE_ESC) {
@@ -215,8 +225,11 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 							}}
 							ref={showPageInputButtonRef}
 							title={
-								totalPages > 1 &&
-								Liferay.Language.get('click-to-jump-to-a-page')
+								totalPages > 1
+									? Liferay.Language.get(
+											'click-to-jump-to-a-page'
+										)
+									: undefined
 							}
 						>
 							{`${Liferay.Language.get(
@@ -272,7 +285,7 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 						className="btn-floating-bar"
 						monospaced
 						onClick={() => {
-							setExpanded(!expanded);
+							setExpanded((expanded) => !expanded);
 						}}
 						title={
 							expanded
@@ -288,12 +301,6 @@ const DocumentPreviewer = ({alt, baseImageURL, initialPage, totalPages}) => {
 			</div>
 		</div>
 	);
-};
-
-DocumentPreviewer.propTypes = {
-	baseImageURL: PropTypes.string,
-	initialPage: PropTypes.number,
-	totalPages: PropTypes.number,
 };
 
 export {DocumentPreviewer};

--- a/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
+++ b/modules/apps/document-library/document-library-preview-document/test/__snapshots__/DocumentPreviewer.es.js.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`document-library-preview-document renders a document previewer with alt attribute 1`] = `
+<DocumentFragment>
+  <div
+    class="preview-file"
+  >
+    <div
+      class="preview-file-container preview-file-max-height"
+    >
+      <img
+        alt="alt text"
+        class="preview-file-document preview-file-document-fit"
+        src="http://localhost/document-images/?previewFileIndex=1"
+      />
+    </div>
+    <div
+      class="preview-toolbar-container"
+    >
+      <div
+        class="floating-bar btn-group"
+        role="group"
+      >
+        <div
+          class="btn-group"
+          role="group"
+        >
+          <button
+            aria-label="click-to-jump-to-a-page"
+            class="btn-floating-bar btn-floating-bar-text btn btn-primary"
+            title="click-to-jump-to-a-page"
+            type="button"
+          >
+            page 1 / 10
+          </button>
+        </div>
+        <button
+          aria-label="page-above"
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          disabled=""
+          title="page-above"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-top"
+            role="presentation"
+          >
+            <use
+              href="#caret-top"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="page-below"
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          title="page-below"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-caret-bottom"
+            role="presentation"
+          >
+            <use
+              href="#caret-bottom"
+            />
+          </svg>
+        </button>
+        <div
+          class="separator-floating-bar"
+        />
+        <button
+          aria-label="expand"
+          class="btn-floating-bar btn btn-monospaced btn-primary"
+          title="expand"
+          type="button"
+        >
+          <svg
+            class="lexicon-icon lexicon-icon-full-size"
+            role="presentation"
+          >
+            <use
+              href="#full-size"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`document-library-preview-document renders a document previewer with nineteen pages and the fifth page rendered 1`] = `
 <DocumentFragment>
   <div
@@ -25,6 +114,7 @@ exports[`document-library-preview-document renders a document previewer with nin
           role="group"
         >
           <button
+            aria-label="click-to-jump-to-a-page"
             class="btn-floating-bar btn-floating-bar-text btn btn-primary"
             title="click-to-jump-to-a-page"
             type="button"
@@ -33,6 +123,7 @@ exports[`document-library-preview-document renders a document previewer with nin
           </button>
         </div>
         <button
+          aria-label="page-above"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           title="page-above"
           type="button"
@@ -47,6 +138,7 @@ exports[`document-library-preview-document renders a document previewer with nin
           </svg>
         </button>
         <button
+          aria-label="page-below"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           title="page-below"
           type="button"
@@ -64,6 +156,7 @@ exports[`document-library-preview-document renders a document previewer with nin
           class="separator-floating-bar"
         />
         <button
+          aria-label="expand"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           title="expand"
           type="button"
@@ -108,6 +201,7 @@ exports[`document-library-preview-document renders a document previewer with ten
           role="group"
         >
           <button
+            aria-label="click-to-jump-to-a-page"
             class="btn-floating-bar btn-floating-bar-text btn btn-primary"
             title="click-to-jump-to-a-page"
             type="button"
@@ -116,6 +210,7 @@ exports[`document-library-preview-document renders a document previewer with ten
           </button>
         </div>
         <button
+          aria-label="page-above"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           disabled=""
           title="page-above"
@@ -131,6 +226,7 @@ exports[`document-library-preview-document renders a document previewer with ten
           </svg>
         </button>
         <button
+          aria-label="page-below"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           title="page-below"
           type="button"
@@ -148,91 +244,7 @@ exports[`document-library-preview-document renders a document previewer with ten
           class="separator-floating-bar"
         />
         <button
-          class="btn-floating-bar btn btn-monospaced btn-primary"
-          title="expand"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-full-size"
-            role="presentation"
-          >
-            <use
-              href="#full-size"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`document-library-preview-document renders a document previewer with alt attribute 1`] = `
-<DocumentFragment>
-  <div
-    class="preview-file"
-  >
-    <div
-      class="preview-file-container preview-file-max-height"
-    >
-      <img
-        alt="alt text"
-        class="preview-file-document preview-file-document-fit"
-        src="http://localhost/document-images/?previewFileIndex=1"
-      />
-    </div>
-    <div
-      class="preview-toolbar-container"
-    >
-      <div
-        class="floating-bar btn-group"
-        role="group"
-      >
-        <div
-          class="btn-group"
-          role="group"
-        >
-          <button
-            class="btn-floating-bar btn-floating-bar-text btn btn-primary"
-            title="click-to-jump-to-a-page"
-            type="button"
-          >
-            page 1 / 10
-          </button>
-        </div>
-        <button
-          class="btn-floating-bar btn btn-monospaced btn-primary"
-          disabled=""
-          title="page-above"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-caret-top"
-            role="presentation"
-          >
-            <use
-              href="#caret-top"
-            />
-          </svg>
-        </button>
-        <button
-          class="btn-floating-bar btn btn-monospaced btn-primary"
-          title="page-below"
-          type="button"
-        >
-          <svg
-            class="lexicon-icon lexicon-icon-caret-bottom"
-            role="presentation"
-          >
-            <use
-              href="#caret-bottom"
-            />
-          </svg>
-        </button>
-        <div
-          class="separator-floating-bar"
-        />
-        <button
+          aria-label="expand"
           class="btn-floating-bar btn btn-monospaced btn-primary"
           title="expand"
           type="button"


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-61241  


# What is this solving:

This PR migrates the `DocumentPreviewer` component from JS to TS. It addresses:

- Mutations of state (`loadedPages`)
- Warnings about changing dependencies in `useCallback` hooks
- Minor UI button logic adjustments

# How is it fixed:

The component is migrated to TypeScript and updated to comply with ESLint and React Compiler rules, ensuring proper state handling and stable hook dependencies.

# How to verify?

```sh
cd modules/apps/document-library/document-library-preview-document
yarn test
```

## Local test results:

<img width="625" height="164" alt="image" src="https://github.com/user-attachments/assets/96807fdf-9fbb-4f78-8c49-cd5a6cfb0212" />