### PR TITLE
LPD-62188 Make localized item selector rendering className aware

### DIFF
--- a/modules/apps/blogs/blogs-item-selector-web/src/main/java/com/liferay/blogs/item/selector/web/internal/display/context/BlogsItemSelectorViewDisplayContext.java
+++ b/modules/apps/blogs/blogs-item-selector-web/src/main/java/com/liferay/blogs/item/selector/web/internal/display/context/BlogsItemSelectorViewDisplayContext.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 
 import jakarta.portlet.PortletException;
@@ -125,7 +126,7 @@ public class BlogsItemSelectorViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
 		).setParameter(
-			"selectedTab", getTitle(httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -172,6 +173,16 @@ public class BlogsItemSelectorViewDisplayContext {
 		return _blogsFileUploadsConfiguration;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private final BlogsEntryLocalService _blogsEntryLocalService;
 	private BlogsFileUploadsConfiguration _blogsFileUploadsConfiguration;
 	private final BlogsItemSelectorCriterion _blogsItemSelectorCriterion;
@@ -183,5 +194,6 @@ public class BlogsItemSelectorViewDisplayContext {
 	private final PortalPreferences _portalPreferences;
 	private final PortletURL _portletURL;
 	private final boolean _search;
+	private String _selectedTab;
 
 }

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -191,7 +191,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		).setParameter(
 			"folderId", getFolderId()
 		).setParameter(
-			"selectedTab", getTitle()
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -580,6 +580,16 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		return _searchContext;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private long _getStagingAwareGroupId() {
 		if (_groupId != null) {
 			return _groupId;
@@ -667,6 +677,7 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 	private Repository _repository;
 	private final boolean _search;
 	private SearchContext _searchContext;
+	private String _selectedTab;
 	private Boolean _showDragAndDropZone;
 	private final StagingGroupHelper _stagingGroupHelper;
 	private int[] _startAndEnd;

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java
@@ -188,8 +188,7 @@ public class ItemSelectorImpl implements ItemSelector {
 				}
 
 				PortletURL portletURL = getPortletURL(
-					requestBackedPortletURLFactory,
-					itemSelectorView.getTitle(themeDisplay.getLocale()),
+					requestBackedPortletURLFactory, itemSelectorView,
 					selectedTab, itemSelectedEventName,
 					itemSelectorCriteriaArray, themeDisplay);
 
@@ -337,13 +336,22 @@ public class ItemSelectorImpl implements ItemSelector {
 
 	protected PortletURL getPortletURL(
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory,
-		String title, String selectedTab, String itemSelectedEventName,
+		ItemSelectorView<?> itemSelectorView, String selectedTab,
+		String itemSelectedEventName,
 		ItemSelectorCriterion[] itemSelectorCriteriaArray,
 		ThemeDisplay themeDisplay) {
 
 		PortletURL portletURL = null;
 
-		if (Validator.isNotNull(selectedTab) && selectedTab.equals(title)) {
+		Class<?> clazz = itemSelectorView.getClass();
+
+		String curSelectedTab = StringBundler.concat(
+			clazz.getName(), StringPool.UNDERLINE,
+			itemSelectorView.getTitle(themeDisplay.getLocale()));
+
+		if (Validator.isNotNull(selectedTab) &&
+			selectedTab.equals(curSelectedTab)) {
+
 			portletURL = getItemSelectorURL(
 				requestBackedPortletURLFactory, themeDisplay.getScopeGroup(),
 				themeDisplay.getRefererGroupId(), itemSelectedEventName,
@@ -361,7 +369,7 @@ public class ItemSelectorImpl implements ItemSelector {
 				itemSelectorCriteriaArray);
 		}
 
-		portletURL.setParameter(PARAMETER_SELECTED_TAB, title);
+		portletURL.setParameter(PARAMETER_SELECTED_TAB, curSelectedTab);
 
 		return portletURL;
 	}

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRendering.java
@@ -11,6 +11,8 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.item.selector.ItemSelectorRendering;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewRenderer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -52,31 +54,46 @@ public class LocalizedItemSelectorRendering {
 
 		String title = itemSelectorView.getTitle(_locale);
 
+		Class<?> clazz = itemSelectorView.getClass();
+
+		String curSelectedTab = StringBundler.concat(
+			clazz.getName(), StringPool.UNDERLINE, title);
+
 		ItemSelectorViewRenderer previousItemSelectorViewRenderer =
-			_itemSelectorViewRenderers.put(title, itemSelectorViewRenderer);
+			_itemSelectorViewRenderers.put(
+				curSelectedTab, itemSelectorViewRenderer);
 
 		if (previousItemSelectorViewRenderer != null) {
 			_navigationItems.removeIf(
-				navigationItem -> title.equals(
-					String.valueOf(navigationItem.get("label"))));
+				navigationItem -> {
+					Map<String, String> data =
+						(Map<String, String>)navigationItem.get("data");
+
+					if ((data != null) && data.containsKey("id")) {
+						return curSelectedTab.equals(data.get("id"));
+					}
+
+					return curSelectedTab.equals(title);
+				});
 		}
 
 		_navigationItems.add(
 			navigationItem -> {
+				navigationItem.putData("id", curSelectedTab);
 				navigationItem.setHref(
 					itemSelectorViewRenderer.getPortletURL());
 				navigationItem.setLabel(title);
 
 				String selectedTab = _itemSelectorRendering.getSelectedTab();
 
-				if (selectedTab.equals(title) ||
+				if (selectedTab.equals(curSelectedTab) ||
 					(Validator.isNull(selectedTab) &&
 					 _navigationItems.isEmpty())) {
 
 					navigationItem.setActive(true);
 
 					_activeNavigationItem = navigationItem;
-					_selectedNavigationItemLabel = title;
+					_selectedNavigationItemLabel = curSelectedTab;
 				}
 			});
 	}
@@ -107,7 +124,16 @@ public class LocalizedItemSelectorRendering {
 					verticalNavItem.setHref(
 						GetterUtil.getString(navigationItem.get("href")));
 					verticalNavItem.setLabel(name);
-					verticalNavItem.setId(name);
+
+					Map<String, String> data =
+						(Map<String, String>)navigationItem.get("data");
+
+					if ((data != null) && data.containsKey("id")) {
+						verticalNavItem.setId(data.get("id"));
+					}
+					else {
+						verticalNavItem.setId(name);
+					}
 				});
 		}
 

--- a/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRenderingTest.java
+++ b/modules/apps/item-selector/item-selector-web/src/test/java/com/liferay/item/selector/web/internal/portlet/LocalizedItemSelectorRenderingTest.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.item.selector.web.internal.portlet;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.item.selector.ItemSelectorCriterion;
+import com.liferay.item.selector.ItemSelectorRendering;
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.item.selector.ItemSelectorViewRenderer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletURL;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import java.io.IOException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class LocalizedItemSelectorRenderingTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetVerticalNavItemList() throws Exception {
+		Locale locale = LocaleUtil.getDefault();
+
+		String title = RandomTestUtil.randomString();
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer1 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView1(title));
+		ItemSelectorViewRenderer itemSelectorViewRenderer2 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView2(title));
+
+		_testGetVerticalNavItemList(
+			Arrays.asList(itemSelectorViewRenderer1, itemSelectorViewRenderer2),
+			locale, title);
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer3 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView1(title));
+		ItemSelectorViewRenderer itemSelectorViewRenderer4 =
+			_getItemSelectorViewRenderer(new TestItemSelectorView2(title));
+
+		_testGetVerticalNavItemList(
+			Arrays.asList(
+				itemSelectorViewRenderer1, itemSelectorViewRenderer2,
+				itemSelectorViewRenderer3, itemSelectorViewRenderer4),
+			locale, title);
+	}
+
+	private void _assertNavigationItem(
+		Class<?> clazz, NavigationItem navigationItem, String title) {
+
+		String id = StringBundler.concat(
+			clazz.getName(), StringPool.UNDERLINE, title);
+
+		Assert.assertEquals(title, navigationItem.get("label"));
+
+		Map<String, String> data = (Map<String, String>)navigationItem.get(
+			"data");
+
+		Assert.assertTrue(MapUtil.isNotEmpty(data));
+
+		Assert.assertEquals(id, String.valueOf(data.get("id")));
+	}
+
+	private ItemSelectorViewRenderer _getItemSelectorViewRenderer(
+		ItemSelectorView<ItemSelectorCriterion> itemSelectorView) {
+
+		ItemSelectorViewRenderer itemSelectorViewRenderer = Mockito.mock(
+			ItemSelectorViewRenderer.class);
+
+		Mockito.when(
+			itemSelectorViewRenderer.getItemSelectorView()
+		).thenReturn(
+			itemSelectorView
+		);
+
+		return itemSelectorViewRenderer;
+	}
+
+	private void _testGetVerticalNavItemList(
+		List<ItemSelectorViewRenderer> itemSelectorViewRenderers, Locale locale,
+		String title) {
+
+		ItemSelectorRendering itemSelectorRendering = Mockito.mock(
+			ItemSelectorRendering.class);
+
+		Mockito.when(
+			itemSelectorRendering.getItemSelectorViewRenderers()
+		).thenReturn(
+			itemSelectorViewRenderers
+		);
+
+		Mockito.when(
+			itemSelectorRendering.getSelectedTab()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		LocalizedItemSelectorRendering localizedItemSelectorRendering =
+			new LocalizedItemSelectorRendering(locale, itemSelectorRendering);
+
+		List<NavigationItem> navigationItems =
+			localizedItemSelectorRendering.getNavigationItems();
+
+		Assert.assertEquals(
+			navigationItems.toString(), 2, navigationItems.size());
+
+		_assertNavigationItem(
+			TestItemSelectorView1.class, navigationItems.get(0), title);
+		_assertNavigationItem(
+			TestItemSelectorView2.class, navigationItems.get(1), title);
+	}
+
+	private class BaseTestItemSelectorView
+		implements ItemSelectorView<ItemSelectorCriterion> {
+
+		public BaseTestItemSelectorView(String title) {
+			_title = title;
+		}
+
+		@Override
+		public Class<? extends ItemSelectorCriterion>
+			getItemSelectorCriterionClass() {
+
+			return null;
+		}
+
+		@Override
+		public List<ItemSelectorReturnType>
+			getSupportedItemSelectorReturnTypes() {
+
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String getTitle(Locale locale) {
+			return _title;
+		}
+
+		@Override
+		public void renderHTML(
+				ServletRequest servletRequest, ServletResponse servletResponse,
+				ItemSelectorCriterion itemSelectorCriterion,
+				PortletURL portletURL, String itemSelectedEventName,
+				boolean search)
+			throws IOException, ServletException {
+		}
+
+		private final String _title;
+
+	}
+
+	private class TestItemSelectorView1 extends BaseTestItemSelectorView {
+
+		public TestItemSelectorView1(String title) {
+			super(title);
+		}
+
+	}
+
+	private class TestItemSelectorView2 extends BaseTestItemSelectorView {
+
+		public TestItemSelectorView2(String title) {
+			super(title);
+		}
+
+	}
+
+}

--- a/modules/apps/journal/journal-item-selector-web/src/main/java/com/liferay/journal/item/selector/web/internal/display/context/JournalItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-item-selector-web/src/main/java/com/liferay/journal/item/selector/web/internal/display/context/JournalItemSelectorViewDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.ParamUtil;
 
 import jakarta.portlet.PortletException;
 import jakarta.portlet.PortletURL;
@@ -120,7 +121,7 @@ public class JournalItemSelectorViewDisplayContext {
 			"resourcePrimKey",
 			_journalItemSelectorCriterion.getResourcePrimKey()
 		).setParameter(
-			"selectedTab", getTitle(httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -147,6 +148,16 @@ public class JournalItemSelectorViewDisplayContext {
 		return _search;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private final HttpServletRequest _httpServletRequest;
 	private final String _itemSelectedEventName;
 	private final ItemSelectorReturnTypeResolverHandler
@@ -156,5 +167,6 @@ public class JournalItemSelectorViewDisplayContext {
 	private final PortalPreferences _portalPreferences;
 	private final PortletURL _portletURL;
 	private final boolean _search;
+	private String _selectedTab;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -326,7 +326,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			"scopeGroupType",
 			ParamUtil.getBoolean(_httpServletRequest, "scopeGroupType")
 		).setParameter(
-			"selectedTab", _getTitle(_httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -659,6 +659,16 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return _scope;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private long _getStagingAwareGroupId() {
 		if (_groupId != null) {
 			return _groupId;
@@ -688,10 +698,6 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			ddmStructure.getStructureId(), _themeDisplay.getLocale());
 
 		return classType.getName();
-	}
-
-	private String _getTitle(Locale locale) {
-		return _journalArticleItemSelectorView.getTitle(locale);
 	}
 
 	private boolean _isEverywhereScopeFilter() {
@@ -813,6 +819,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private String _scope;
 	private final boolean _search;
 	private Boolean _searchEverywhere;
+	private String _selectedTab;
 	private final StagingGroupHelper _stagingGroupHelper;
 	private final ThemeDisplay _themeDisplay;
 

--- a/modules/apps/knowledge-base/knowledge-base-item-selector-web/src/main/java/com/liferay/knowledge/base/item/selector/web/internal/display/context/KBAttachmentItemSelectorViewDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-item-selector-web/src/main/java/com/liferay/knowledge/base/item/selector/web/internal/display/context/KBAttachmentItemSelectorViewDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import jakarta.portlet.PortletException;
@@ -100,7 +101,7 @@ public class KBAttachmentItemSelectorViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
 		).setParameter(
-			"selectedTab", getTitle(httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -125,6 +126,16 @@ public class KBAttachmentItemSelectorViewDisplayContext {
 		return _search;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private final HttpServletRequest _httpServletRequest;
 	private final String _itemSelectedEventName;
 	private final ItemSelectorReturnTypeResolverHandler
@@ -135,5 +146,6 @@ public class KBAttachmentItemSelectorViewDisplayContext {
 	private final PortalPreferences _portalPreferences;
 	private final PortletURL _portletURL;
 	private final boolean _search;
+	private String _selectedTab;
 
 }

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiAttachmentItemSelectorViewDisplayContext.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiAttachmentItemSelectorViewDisplayContext.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.wiki.configuration.WikiFileUploadConfiguration;
 import com.liferay.wiki.constants.WikiPortletKeys;
@@ -127,7 +128,7 @@ public class WikiAttachmentItemSelectorViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
 		).setParameter(
-			"selectedTab", getTitle(httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab()
 		).buildPortletURL();
 	}
 
@@ -179,6 +180,16 @@ public class WikiAttachmentItemSelectorViewDisplayContext {
 		return _search;
 	}
 
+	private String _getSelectedTab() {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(_httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private WikiFileUploadConfiguration _getWikiFileUploadConfiguration()
 		throws ConfigurationException {
 
@@ -198,6 +209,7 @@ public class WikiAttachmentItemSelectorViewDisplayContext {
 	private final PortalPreferences _portalPreferences;
 	private final PortletURL _portletURL;
 	private final boolean _search;
+	private String _selectedTab;
 	private final WikiAttachmentItemSelectorCriterion
 		_wikiAttachmentItemSelectorCriterion;
 	private final WikiAttachmentItemSelectorView

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiPageItemSelectorViewDisplayContext.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/item/selector/view/display/context/WikiPageItemSelectorViewDisplayContext.java
@@ -81,7 +81,7 @@ public class WikiPageItemSelectorViewDisplayContext {
 		return PortletURLBuilder.create(
 			PortletURLUtil.clone(_portletURL, liferayPortletResponse)
 		).setParameter(
-			"selectedTab", getTitle(httpServletRequest.getLocale())
+			"selectedTab", _getSelectedTab(httpServletRequest)
 		).buildPortletURL();
 	}
 
@@ -189,12 +189,23 @@ public class WikiPageItemSelectorViewDisplayContext {
 		return _search;
 	}
 
+	private String _getSelectedTab(HttpServletRequest httpServletRequest) {
+		if (_selectedTab != null) {
+			return _selectedTab;
+		}
+
+		_selectedTab = ParamUtil.getString(httpServletRequest, "selectedTab");
+
+		return _selectedTab;
+	}
+
 	private final String _itemSelectedEventName;
 	private final ItemSelectorReturnTypeResolverHandler
 		_itemSelectorReturnTypeResolverHandler;
 	private final PortletURL _portletURL;
 	private final boolean _search;
 	private SearchContainer<WikiPage> _searchContainer;
+	private String _selectedTab;
 	private final WikiNodeLocalService _wikiNodeLocalService;
 	private final WikiPageItemSelectorCriterion _wikiPageItemSelectorCriterion;
 	private final WikiPageItemSelectorView _wikiPageItemSelectorView;


### PR DESCRIPTION
Make localized item selector rendering className aware

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-62188)

At the moment, when we have 2 ItemSelectorViews with the same name, only one of them is taken into account when rendering. This is more noticeable now with the CMS where we have object definitions like Blogs

# How am I fixing it?

When rendering, use also the className of the itemSelectorView, so that it shows in the interface. Still, we are going to have the same issue with object definitions with the same plural name for now

# How can you verify that it works?

There's a unit test provided in the PR.

Also, another way is to start the portal with the CMS FF enabled, go to any content page, and when mapping a fragment and selecting the mapped item, blogs will be shown twice