### PR TITLE
LPD-65535 Filtering Web Content with structure should not show blog comments

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/spi/model/query/contributor/MBMessageModelPreFilterContributor.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/search/spi/model/query/contributor/MBMessageModelPreFilterContributor.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
@@ -141,10 +140,10 @@ public class MBMessageModelPreFilterContributor
 			}
 		}
 
-		String classNameId = GetterUtil.getString(
+		long classNameId = GetterUtil.getLong(
 			searchContext.getAttribute(Field.CLASS_NAME_ID));
 
-		if (Validator.isNotNull(classNameId)) {
+		if (classNameId > 0) {
 			booleanFilter.addRequiredTerm(Field.CLASS_NAME_ID, classNameId);
 		}
 

--- a/modules/apps/message-boards/message-boards-test/build.gradle
+++ b/modules/apps/message-boards/message-boards-test/build.gradle
@@ -5,11 +5,15 @@ dependencies {
 	testIntegrationImplementation group: "commons-lang", name: "commons-lang", version: "2.6"
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	testIntegrationImplementation project(":apps:asset:asset-link-api")
+	testIntegrationImplementation project(":apps:blogs:blogs-api")
+	testIntegrationImplementation project(":apps:blogs:blogs-test-util")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:comment:comment-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
+	testIntegrationImplementation project(":apps:journal:journal-api")
+	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:message-boards:message-boards-api")
 	testIntegrationImplementation project(":apps:message-boards:message-boards-test-util")

--- a/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
+++ b/modules/apps/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
@@ -6,6 +6,10 @@
 package com.liferay.message.boards.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.test.util.BlogsTestUtil;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.model.MBCategory;
 import com.liferay.message.boards.model.MBMessage;
@@ -15,11 +19,16 @@ import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
 import com.liferay.message.boards.service.MBThreadServiceUtil;
 import com.liferay.message.boards.test.util.MBTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.comment.CommentManagerUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
@@ -27,11 +36,16 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.BaseSearchTestCase;
+import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,6 +89,52 @@ public class MBMessageSearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testSearchCommentsByKeywords() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId());
+
+		BlogsEntry blogsEntry = BlogsTestUtil.addEntryWithWorkflow(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(), true,
+			serviceContext);
+
+		String commentString = RandomTestUtil.randomString();
+
+		CommentManagerUtil.addComment(
+			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			BlogsEntry.class.getName(), blogsEntry.getEntryId(), commentString,
+			s -> serviceContext);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			TestPropsValues.getGroupId(), 0);
+
+		long messageId = CommentManagerUtil.addComment(
+			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			JournalArticle.class.getName(), journalArticle.getClassPK(),
+			commentString, s -> serviceContext);
+
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext(
+			TestPropsValues.getUserId(), commentString, LocaleUtil.US);
+
+		searchContext.setAttribute(
+			Field.CLASS_NAME_ID,
+			PortalUtil.getClassNameId(JournalArticle.class));
+		searchContext.setAttribute("discussion", Boolean.TRUE);
+
+		Indexer<MBMessage> indexer = IndexerRegistryUtil.getIndexer(
+			MBMessage.class);
+
+		Hits hits = indexer.search(searchContext);
+
+		Assert.assertEquals(hits.toString(), 1, hits.getLength());
+
+		Assert.assertEquals(
+			messageId,
+			GetterUtil.getLong(
+				hits.doc(
+					0
+				).get(
+					Field.ENTRY_CLASS_PK
+				)));
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-65535

Filtering web contents structures based on comments shows blogs comments too.

# How am I fixing it?
ClassNameId is wrongly read as String instead of Long.

# How can you verify that it works?
Run the included automated tests.