### PR TITLE
LPD 65103 NPE when saving structure with empty nested field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtil.java
@@ -102,6 +102,10 @@ public class DDMFormFieldUtil {
 						DDMFormField nestedDDMFormField =
 							nestedDDMFormFieldsMap.get(fieldName);
 
+						if (nestedDDMFormField == null) {
+							continue;
+						}
+
 						if (StringUtil.equals(
 								nestedDDMFormField.getType(),
 								DDMFormFieldTypeConstants.FIELDSET)) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
@@ -121,16 +121,23 @@ public class DDMFormFieldUtilTest {
 
 		Assert.assertEquals(
 			nestedDDMFormFields.toString(), 2, nestedDDMFormFields.size());
+
+		_assertNestedDDMFormFieldsWithDeletedField(
+			ddmFormField, new String[] {"Field1", "Field3"});
+	}
+
+	private void _assertNestedDDMFormFieldsWithDeletedField(
+		DDMFormField ddmFormField, String[] nestedDDMFormFieldNames) {
+
+		List<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
 		Assert.assertEquals(
-			"Field1",
-			nestedDDMFormFields.get(
-				0
-			).getName());
+			nestedDDMFormFieldNames[0],
+			_getDDMFormFieldName(nestedDDMFormFields.get(0)));
 		Assert.assertEquals(
-			"Field3",
-			nestedDDMFormFields.get(
-				1
-			).getName());
+			nestedDDMFormFieldNames[1],
+			_getDDMFormFieldName(nestedDDMFormFields.get(1)));
 	}
 
 	private void _assertNestedDDMFormFields(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
@@ -76,6 +76,63 @@ public class DDMFormFieldUtilTest {
 			ddmFormField, new String[] {"Field1", "Field2", "Field3"});
 	}
 
+	@Test
+	public void testSortNestedDDMFormFieldsWithDeletedField() throws Exception {
+		DDMFormField ddmFormField = new DDMFormField(
+			DDMFormFieldTypeConstants.FIELDSET,
+			DDMFormFieldTypeConstants.FIELDSET);
+
+		DDMFormTestUtil.addNestedTextDDMFormFields(
+			ddmFormField, "Field3", "Field1");
+
+		ddmFormField.setProperty(
+			"rows",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"columns",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"fields", JSONUtil.putAll("Field1")
+						).put(
+							"size", 12
+						))),
+				JSONUtil.put(
+					"columns",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"fields", JSONUtil.putAll("Field2")
+						).put(
+							"size", 12
+						))),
+				JSONUtil.put(
+					"columns",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"fields", JSONUtil.putAll("Field3")
+						).put(
+							"size", 12
+						)))));
+
+		DDMFormFieldUtil.sortNestedDDMFormFields(
+			Collections.singletonList(ddmFormField));
+
+		List<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
+		Assert.assertEquals(
+			nestedDDMFormFields.toString(), 2, nestedDDMFormFields.size());
+		Assert.assertEquals(
+			"Field1",
+			nestedDDMFormFields.get(
+				0
+			).getName());
+		Assert.assertEquals(
+			"Field3",
+			nestedDDMFormFields.get(
+				1
+			).getName());
+	}
+
 	private void _assertNestedDDMFormFields(
 		DDMFormField ddmFormField, String[] nestedDDMFormFieldNames) {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldUtilTest.java
@@ -126,20 +126,6 @@ public class DDMFormFieldUtilTest {
 			ddmFormField, new String[] {"Field1", "Field3"});
 	}
 
-	private void _assertNestedDDMFormFieldsWithDeletedField(
-		DDMFormField ddmFormField, String[] nestedDDMFormFieldNames) {
-
-		List<DDMFormField> nestedDDMFormFields =
-			ddmFormField.getNestedDDMFormFields();
-
-		Assert.assertEquals(
-			nestedDDMFormFieldNames[0],
-			_getDDMFormFieldName(nestedDDMFormFields.get(0)));
-		Assert.assertEquals(
-			nestedDDMFormFieldNames[1],
-			_getDDMFormFieldName(nestedDDMFormFields.get(1)));
-	}
-
 	private void _assertNestedDDMFormFields(
 		DDMFormField ddmFormField, String[] nestedDDMFormFieldNames) {
 
@@ -155,6 +141,20 @@ public class DDMFormFieldUtilTest {
 		Assert.assertEquals(
 			nestedDDMFormFieldNames[2],
 			_getDDMFormFieldName(nestedDDMFormFields.get(2)));
+	}
+
+	private void _assertNestedDDMFormFieldsWithDeletedField(
+		DDMFormField ddmFormField, String[] nestedDDMFormFieldNames) {
+
+		List<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
+		Assert.assertEquals(
+			nestedDDMFormFieldNames[0],
+			_getDDMFormFieldName(nestedDDMFormFields.get(0)));
+		Assert.assertEquals(
+			nestedDDMFormFieldNames[1],
+			_getDDMFormFieldName(nestedDDMFormFields.get(1)));
 	}
 
 	private String _getDDMFormFieldName(DDMFormField ddmFormField) {


### PR DESCRIPTION
What is this trying to solve?

[LPD-65103](https://liferay.atlassian.net/browse/LPD-65103)

How can you verify that it works?

1. Start Liferay DXP 2025.Q1.15
2. Go to Content > Web Content > Structure and import the following structure ("break-test.json") 
3. In the third nested field group, delete the text box in the Fields Group
4. Save Structure
5. Success toast appears in left bottom corner. Returned to the structures menu. Changes are saved and no NPE is printed to the console.