### PR TITLE
LPD-64151 Add "Shared from [Space]" icon to table view in Shared with Me section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
@@ -5,6 +5,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
+import ClaySticker from '@clayui/sticker';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {sub} from 'frontend-js-web';
 import React, {useMemo} from 'react';
@@ -30,7 +31,7 @@ export default function SharedItemRenderer({
 	options: {actionId: string};
 	value: string;
 }) {
-	const {fileTypeIcon, fileTypeIconColor, shareable, siteName} = itemData;
+	const {fileTypeIcon, fileTypeIconColor, siteName} = itemData;
 
 	const linkHref = useMemo(() => {
 		const {actionId} = options;
@@ -61,10 +62,10 @@ export default function SharedItemRenderer({
 
 	return (
 		<span className="align-items-center c-gap-2 d-flex table-list-title">
-			{itemData.fileTypeIcon && itemData.fileTypeIconColor && (
-				<span className={fileTypeIconColor}>
+			{fileTypeIcon && fileTypeIconColor && (
+				<ClaySticker className={`flex-shrink-0 ${fileTypeIconColor}`}>
 					<ClayIcon aria-hidden="true" symbol={fileTypeIcon} />
-				</span>
+				</ClaySticker>
 			)}
 
 			{linkHref ? (
@@ -75,17 +76,19 @@ export default function SharedItemRenderer({
 				<span>{value}</span>
 			)}
 
-			{shareable && (
+			{siteName && (
 				<ClayTooltipProvider>
-					<span
+					<ClaySticker
+						className="flex-shrink-0"
 						data-tooltip-align="top"
+						displayType="unstyled"
 						title={sub(
 							Liferay.Language.get('shared-from-x'),
-							siteName
+							`"${siteName}"`
 						)}
 					>
 						<ClayIcon className="text-secondary" symbol="users" />
-					</span>
+					</ClaySticker>
 				</ClayTooltipProvider>
 			)}
 		</span>


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-64151 Add "Shared from [Space]" icon to table view in Shared with Me section

### How am I fixing it?
These changes adjust the visibility standards for the "Shared from Space" icon in the table view, originally it would show only when set to allow resharing. Now it's set to show as long as the `siteName` is available. Also it adds some style updates to match closer with the rest of the asset tables, just for consistency.

### How can you verify that it works?
Here's how it looks:
<img width="1280" height="873" alt="Screenshot 2025-09-16 at 10 53 40 AM" src="https://github.com/user-attachments/assets/ceb2266c-0e08-41a1-8e35-1899ebc2265b" />

Let me know if any other changes are needed, thank you!