### PR TITLE
LPD-65083 Cannot delete the latest version of an article 

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -316,15 +316,10 @@ public class JournalArticleActionDropdownItemsProvider {
 				dropdownGroupItem.setSeparator(true);
 			}
 		).addGroup(
-			() -> !JournalArticleLocalServiceUtil.isLatestVersion(
-				_article.getGroupId(), _article.getArticleId(),
-				_article.getVersion()),
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> JournalArticlePermission.contains(
-							_themeDisplay.getPermissionChecker(), _article,
-							ActionKeys.DELETE),
+						this::_isDeleteActionAvailable,
 						_getDeleteArticleAction(
 							articleId, _themeDisplay.getURLCurrent())
 					).build());
@@ -1095,6 +1090,24 @@ public class JournalArticleActionDropdownItemsProvider {
 
 				return true;
 			}
+		}
+
+		return false;
+	}
+
+	private boolean _isDeleteActionAvailable() throws PortalException {
+		if (!JournalArticlePermission.contains(
+				_themeDisplay.getPermissionChecker(), _article,
+				ActionKeys.DELETE)) {
+
+			return false;
+		}
+
+		int versionsCount = JournalArticleLocalServiceUtil.getArticlesCount(
+			_article.getGroupId(), _article.getArticleId());
+
+		if (versionsCount > 1) {
+			return true;
 		}
 
 		return false;

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -255,39 +255,6 @@ test(
 );
 
 test(
-	'Latest version of Web Content should not have delete option',
-	{
-		tag: '@LPD-52126',
-	},
-	async ({apiHelpers, journalPage, page, site}) => {
-		const basicWebContentStructureId =
-			await getBasicWebContentStructureId(apiHelpers);
-
-		await apiHelpers.jsonWebServicesJournal.addWebContent({
-			ddmStructureId: basicWebContentStructureId,
-			groupId: site.id,
-			titleMap: {en_US: 'Basic Web content'},
-		});
-
-		await journalPage.goto(site.friendlyUrlPath);
-
-		await page.getByRole('button', {name: 'Actions'}).click();
-
-		await page.getByRole('menuitem', {name: 'View History'}).click();
-
-		await page.getByRole('button', {name: 'Actions'}).first().click();
-
-		await expect(
-			page.getByRole('menuitem', {name: 'Delete'})
-		).not.toBeVisible();
-
-		await page.locator('.management-bar input[type="checkbox"]').click();
-
-		await expect(page.getByRole('button', {name: 'Delete'})).toBeDisabled();
-	}
-);
-
-test(
 	'Current item checkbox is disabled in Related Assets',
 	{
 		tag: '@LPD-54293',

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -210,6 +210,51 @@ test(
 );
 
 test(
+	'Delete option should not be available when there is only one version available',
+	{tag: '@LPD-65083'},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		const article = await apiHelpers.jsonWebServicesJournal.addWebContent({
+			ddmStructureId: basicWebContentStructureId,
+			groupId: site.id,
+			titleMap: {en_US: 'Basic Web content'},
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('button', {name: 'Actions'}).click();
+
+		await page.getByRole('menuitem', {name: 'View History'}).click();
+
+		await page.getByRole('button', {name: 'Actions'}).first().click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Delete'})
+		).not.toBeVisible();
+
+		await apiHelpers.jsonWebServicesJournal.editWebContent(
+			{title: 'Updated Basic Web content'},
+			site.id,
+			article
+		);
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByRole('button', {name: 'Actions'}).click();
+
+		await page.getByRole('menuitem', {name: 'View History'}).click();
+
+		await page.getByRole('button', {name: 'Actions'}).first().click();
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Delete'})
+		).toBeVisible();
+	}
+);
+
+test(
 	'Latest version of Web Content should not have delete option',
 	{
 		tag: '@LPD-52126',


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-65083

Ensure that the "Delete" action for web content is only available when multiple versions exist, and hidden when only a single version is present.

# How am I fixing it?

show the button only if `versionsCount` is greater then 1

# How can you verify that it works?

Run the included playwright test.