### PR TITLE
LPD-65189 Improve web content deletion performance

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -187,12 +187,38 @@ public class JournalArticleModelIndexerWriterContributor
 
 	@Override
 	public void modelDeleted(JournalArticle journalArticle) {
-		_reindexOtherArticleVersions(journalArticle);
+		if (_isIndexAllArticleVersions()) {
+			_reindexOtherArticleVersions(journalArticle);
+
+			return;
+		}
+
+		JournalArticle latestIndexableArticle =
+			_fetchLatestIndexableArticleVersion(
+				journalArticle.getResourcePrimKey());
+
+		if (latestIndexableArticle.getVersion() < journalArticle.getVersion()) {
+			_reindexOtherArticleVersions(journalArticle);
+		}
 	}
 
 	@Override
 	public void modelIndexed(JournalArticle journalArticle) {
-		_reindexOtherArticleVersions(journalArticle);
+		if (_isIndexAllArticleVersions()) {
+			_reindexOtherArticleVersions(journalArticle);
+
+			return;
+		}
+
+		JournalArticle latestIndexableArticle =
+			_fetchLatestIndexableArticleVersion(
+				journalArticle.getResourcePrimKey());
+
+		if (latestIndexableArticle.getVersion() ==
+				journalArticle.getVersion()) {
+
+			_reindexOtherArticleVersions(journalArticle);
+		}
 	}
 
 	private JournalArticle _fetchLatestIndexableArticleVersion(

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributorTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributorTest.java
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.internal.search.spi.model.index.contributor;
+
+import com.liferay.journal.configuration.JournalServiceConfiguration;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.service.JournalArticleResourceLocalService;
+import com.liferay.journal.util.comparator.ArticleVersionComparator;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.search.batch.BatchIndexingHelper;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public class JournalArticleModelIndexerWriterContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpConfigurationProvider();
+		_setUpIndexer();
+		_setUpIndexerRegistryUtil();
+		_setUpJournalArticleLocalService();
+		_setUpJournalArticles();
+		_setUpPortal();
+	}
+
+	@After
+	public void tearDown() {
+		_indexerRegistryUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testModelDeletedIndexAllArticleVersionsDisabled()
+		throws Exception {
+
+		_setUpJournalServiceConfiguration(false);
+
+		_testModelDeleted(_journalArticles.get(0), _journalArticles.get(2), 0);
+		_testModelDeleted(_journalArticles.get(1), _journalArticles.get(2), 0);
+		_testModelDeleted(_journalArticles.get(2), _journalArticles.get(1), 1);
+	}
+
+	@Test
+	public void testModelDeletedIndexAllArticleVersionsEnabled()
+		throws Exception {
+
+		_setUpJournalServiceConfiguration(true);
+
+		_testModelDeleted(_journalArticles.get(0), _journalArticles.get(2), 1);
+		_testModelDeleted(_journalArticles.get(1), _journalArticles.get(2), 1);
+		_testModelDeleted(_journalArticles.get(2), _journalArticles.get(1), 1);
+	}
+
+	private void _setUpConfigurationProvider() throws Exception {
+		_configurationProvider = Mockito.mock(ConfigurationProvider.class);
+
+		Mockito.when(
+			_configurationProvider.getCompanyConfiguration(
+				Mockito.any(Class.class), Mockito.anyLong())
+		).thenReturn(
+			_journalServiceConfiguration
+		);
+	}
+
+	private void _setUpIndexer() {
+		_indexer = Mockito.mock(Indexer.class);
+	}
+
+	private void _setUpIndexerRegistryUtil() {
+		_indexerRegistryUtilMockedStatic = Mockito.mockStatic(
+			IndexerRegistryUtil.class);
+
+		Mockito.when(
+			IndexerRegistryUtil.nullSafeGetIndexer(JournalArticle.class)
+		).thenReturn(
+			_indexer
+		);
+	}
+
+	private void _setUpJournalArticleLocalService() {
+		_journalArticleLocalService = Mockito.mock(
+			JournalArticleLocalService.class);
+
+		Mockito.when(
+			_journalArticleLocalService.getArticles(
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.any(ArticleVersionComparator.class))
+		).thenReturn(
+			_journalArticles
+		);
+	}
+
+	private void _setUpJournalArticles() {
+		double version = 1.0;
+		long id = 0;
+
+		for (JournalArticle journalArticle : _journalArticles) {
+			Mockito.when(
+				journalArticle.getArticleId()
+			).thenReturn(
+				"articleId"
+			);
+
+			Mockito.when(
+				journalArticle.getId()
+			).thenReturn(
+				id++
+			);
+
+			Mockito.when(
+				journalArticle.getVersion()
+			).thenReturn(
+				version
+			);
+			version += 0.1;
+		}
+	}
+
+	private void _setUpJournalServiceConfiguration(
+		boolean indexAllArticleVersionsEnabled) {
+
+		Mockito.when(
+			_journalServiceConfiguration.indexAllArticleVersionsEnabled()
+		).thenReturn(
+			indexAllArticleVersionsEnabled
+		);
+	}
+
+	private void _setUpPortal() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getClassNameId(Mockito.any(Class.class))
+		).thenReturn(
+			-1L
+		);
+
+		portalUtil.setPortal(portal);
+	}
+
+	private void _testModelDeleted(
+			JournalArticle deletedVersionJournalArticle,
+			JournalArticle latestIndexableArticle, int expectedTimes)
+		throws Exception {
+
+		Mockito.clearInvocations(_indexer);
+
+		Mockito.when(
+			_journalArticleLocalService.fetchLatestArticle(
+				Mockito.anyLong(), Mockito.any(int[].class))
+		).thenReturn(
+			latestIndexableArticle
+		);
+
+		JournalArticleModelIndexerWriterContributor
+			journalArticleModelIndexerWriterContributor =
+				new JournalArticleModelIndexerWriterContributor(
+					Mockito.mock(BatchIndexingHelper.class),
+					_configurationProvider,
+					Mockito.mock(
+						DynamicQueryBatchIndexingActionableFactory.class),
+					_journalArticleLocalService,
+					Mockito.mock(JournalArticleResourceLocalService.class));
+
+		journalArticleModelIndexerWriterContributor.modelDeleted(
+			deletedVersionJournalArticle);
+
+		Mockito.verify(
+			_indexer, Mockito.times(expectedTimes)
+		).reindex(
+			latestIndexableArticle, false
+		);
+	}
+
+	private ConfigurationProvider _configurationProvider;
+	private Indexer<JournalArticle> _indexer;
+	private MockedStatic<IndexerRegistryUtil> _indexerRegistryUtilMockedStatic;
+	private JournalArticleLocalService _journalArticleLocalService;
+	private final List<JournalArticle> _journalArticles = ListUtil.fromArray(
+		Mockito.mock(JournalArticle.class), Mockito.mock(JournalArticle.class),
+		Mockito.mock(JournalArticle.class));
+	private final JournalServiceConfiguration _journalServiceConfiguration =
+		Mockito.mock(JournalServiceConfiguration.class);
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/DeleteArticlesMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/DeleteArticlesMVCActionCommand.java
@@ -24,6 +24,8 @@ import jakarta.portlet.ActionResponse;
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.PortletURL;
 
+import java.util.Arrays;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -56,6 +58,8 @@ public class DeleteArticlesMVCActionCommand extends BaseMVCActionCommand {
 			deleteArticleIds = ParamUtil.getParameterValues(
 				actionRequest, "rowIds");
 		}
+
+		Arrays.sort(deleteArticleIds);
 
 		for (String deleteArticleId : deleteArticleIds) {
 			ActionUtil.deleteArticle(


### PR DESCRIPTION
# What is this trying to solve?

{[LPD-65189](https://liferay.atlassian.net/browse/LPD-65189)}

Avoid performance issues when deleting several article versions with index all article versions disabled.

# How am I fixing it?

- When the version deleted is smaller than the latest indexable version there is no need to reindex again the lates indexable version.
- If the versions removed are the newests one delete from oldest to newest to avoid reindexing the newest each time, since if we remove from newest to oldest then the latest indexable will be the one removed each time and a reindexation per removal will be needed.


# How can you verify that it works?

Run the included automated tests.

**LPD-65189 Create test to expose issue: When disabling all article indexations and deleting an old journal article version the latest indexable version gets indexed anyway.**
**LPD-65189 This is how reindex should work when indexing all versions is disabled:
    * modelDeleted: Only if the version deleted was the last there is to reindex again to update the new latest indexable.
    * modelIndexed: Only if a new higher version was introduced there is a need to delete the previous latest one.**
**LPD-65189 To avoid deleting always the latest version causing several reindexations we should deleted from oldest to newest.**