### PR TITLE
LPD-62892 Incorrect icons naming and ordering in new dropdown (4th try - SF)

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseDisplayContextTestCase.java
@@ -62,6 +62,10 @@ public abstract class BaseDisplayContextTestCase {
 	public void setUp() throws Exception {
 		group = GroupTestUtil.addGroup();
 
+		mockHttpServletRequest = getMockHttpServletRequest();
+
+		themeDisplay = getThemeDisplay(mockHttpServletRequest);
+
 		if (_isCMSSiteInitialized()) {
 			return;
 		}
@@ -233,11 +237,15 @@ public abstract class BaseDisplayContextTestCase {
 	@DeleteAfterTestRun
 	protected Group group;
 
+	protected MockHttpServletRequest mockHttpServletRequest;
+
 	@Inject
 	protected ObjectDefinitionLocalService objectDefinitionLocalService;
 
 	@Inject
 	protected ObjectFolderLocalService objectFolderLocalService;
+
+	protected ThemeDisplay themeDisplay;
 
 	private void _deleteFile(Bundle bundle, String fileName) {
 		File file = bundle.getDataFile(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -77,7 +77,7 @@ public abstract class BaseSectionDisplayContextTestCase
 
 	public HashMap<String, Object> getAdditionalProps() throws Exception {
 		return ReflectionTestUtil.invoke(
-			getSectionDisplayContext(getMockHttpServletRequest()),
+			getSectionDisplayContext(mockHttpServletRequest),
 			"getAdditionalProps", new Class<?>[0]);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -202,6 +203,8 @@ public abstract class BaseSectionDisplayContextTestCase
 		_testGetCreationMenu(getCreationMenu(), expectedCreationMenuItems);
 
 		ObjectFolder objectFolder = null;
+		TreeMap<String, String> expectedCustomCreationMenuItems = new TreeMap<>(
+			String.CASE_INSENSITIVE_ORDER);
 
 		for (String objectFolderExternalReferenceCode :
 				getObjectFolderExternalReferenceCodes()) {
@@ -216,13 +219,15 @@ public abstract class BaseSectionDisplayContextTestCase
 				ObjectDefinitionConstants.SCOPE_DEPOT,
 				WorkflowConstants.STATUS_APPROVED);
 
-			expectedCreationMenuItems.put(
+			expectedCustomCreationMenuItems.put(
 				objectDefinition.getLabel(LocaleUtil.US),
 				getRedirect(
 					objectDefinition,
 					_getRootObjectEntryFolderExternalReferenceCode(
 						objectFolderExternalReferenceCode)));
 		}
+
+		expectedCreationMenuItems.putAll(expectedCustomCreationMenuItems);
 
 		addCustomObjectDefinition(
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
@@ -668,18 +673,6 @@ public abstract class BaseSectionDisplayContextTestCase
 		return jsonArray;
 	}
 
-	private DropdownItem _getDropdownItem(
-		List<DropdownItem> dropdownItems, String label) {
-
-		for (DropdownItem dropdownItem : dropdownItems) {
-			if (label.equals(dropdownItem.get("label"))) {
-				return dropdownItem;
-			}
-		}
-
-		return null;
-	}
-
 	private JSONArray _getJSONArray(List<DepotEntry> depotEntries) {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
@@ -755,13 +748,14 @@ public abstract class BaseSectionDisplayContextTestCase
 			dropdownItems.toString(), expectedCreationMenuItems.size(),
 			dropdownItems.size());
 
+		int index = 0;
+
 		for (Map.Entry<String, String> entry :
 				expectedCreationMenuItems.entrySet()) {
 
-			DropdownItem dropdownItem = _getDropdownItem(
-				dropdownItems, entry.getKey());
+			DropdownItem dropdownItem = dropdownItems.get(index);
 
-			Assert.assertNotNull(dropdownItem);
+			Assert.assertEquals(entry.getKey(), dropdownItem.get("label"));
 
 			if (Validator.isNull(entry.getValue())) {
 				Assert.assertNull(_getRedirect(dropdownItem));
@@ -770,6 +764,8 @@ public abstract class BaseSectionDisplayContextTestCase
 				Assert.assertEquals(
 					entry.getValue(), _getRedirect(dropdownItem));
 			}
+
+			index++;
 		}
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -51,33 +51,33 @@ public class ViewAllSectionDisplayContextTest
 	protected Map<String, String> getExpectedCreationMenuItems()
 		throws PortalException {
 
-		return HashMapBuilder.put(
-			"Basic Document",
+		return LinkedHashMapBuilder.put(
+			"basic-content",
+			getRedirect(
+				"L_BASIC_WEB_CONTENT",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
+		).put(
+			"single-file",
 			getRedirect(
 				"L_BASIC_DOCUMENT",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)
 		).put(
-			"Basic Web Content",
-			getRedirect(
-				"L_BASIC_WEB_CONTENT",
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
+			"multiple-files", StringPool.BLANK
 		).put(
 			"Blog",
 			getRedirect(
 				"L_BLOG",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
 		).put(
-			"External Video",
-			getRedirect(
-				"L_EXTERNAL_VIDEO",
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)
-		).put(
 			"Knowledge Base",
 			getRedirect(
 				"L_KNOWLEDGE_BASE",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
 		).put(
-			"multiple-files", StringPool.BLANK
+			"external-video-shortcut",
+			getRedirect(
+				"L_EXTERNAL_VIDEO",
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -10,10 +10,15 @@ import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -22,6 +27,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -46,6 +53,47 @@ public class ViewAllSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public HashMap<String, Object> getBaseAdditionalProps() {
+		HashMap<String, Object> additionalProps =
+			super.getBaseAdditionalProps();
+
+		return HashMapBuilder.<String, Object>putAll(
+			additionalProps
+		).put(
+			"commentsProps",
+			HashMapBuilder.<String, Object>put(
+				"addCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/add_content_item_comment"
+			).put(
+				"deleteCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/delete_content_item_comment"
+			).put(
+				"editCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/edit_content_item_comment"
+			).put(
+				"editorConfig",
+				() -> {
+					EditorConfiguration contentItemCommentEditorConfiguration =
+						EditorConfigurationFactoryUtil.getEditorConfiguration(
+							StringPool.BLANK, "contentItemCommentEditor",
+							StringPool.BLANK, Collections.emptyMap(),
+							themeDisplay,
+							RequestBackedPortletURLFactoryUtil.create(
+								mockHttpServletRequest));
+
+					Map<String, Object> data =
+						contentItemCommentEditorConfiguration.getData();
+
+					return data.get("editorConfig");
+				}
+			).put(
+				"getCommentsURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/get_asset_comments"
+			).build()
+		).build();
+	}
 
 	@Override
 	protected Map<String, String> getExpectedCreationMenuItems()

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -14,7 +14,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
-import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -109,12 +109,12 @@ public class ViewContentsSectionDisplayContextTest
 	protected Map<String, String> getExpectedCreationMenuItems()
 		throws PortalException {
 
-		return HashMapBuilder.put(
-			"Basic Web Content", getRedirect("L_BASIC_WEB_CONTENT")
+		return LinkedHashMapBuilder.put(
+			"folder", StringPool.BLANK
+		).put(
+			"basic-content", getRedirect("L_BASIC_WEB_CONTENT")
 		).put(
 			"Blog", getRedirect("L_BLOG")
-		).put(
-			"folder", StringPool.BLANK
 		).put(
 			"Knowledge Base", getRedirect("L_KNOWLEDGE_BASE")
 		).build();

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -11,9 +11,14 @@ import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -22,6 +27,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +55,47 @@ public class ViewContentsSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public HashMap<String, Object> getBaseAdditionalProps() {
+		HashMap<String, Object> additionalProps =
+			super.getBaseAdditionalProps();
+
+		return HashMapBuilder.<String, Object>putAll(
+			additionalProps
+		).put(
+			"commentsProps",
+			HashMapBuilder.<String, Object>put(
+				"addCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/add_content_item_comment"
+			).put(
+				"deleteCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/delete_content_item_comment"
+			).put(
+				"editCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/edit_content_item_comment"
+			).put(
+				"editorConfig",
+				() -> {
+					EditorConfiguration contentItemCommentEditorConfiguration =
+						EditorConfigurationFactoryUtil.getEditorConfiguration(
+							StringPool.BLANK, "contentItemCommentEditor",
+							StringPool.BLANK, Collections.emptyMap(),
+							themeDisplay,
+							RequestBackedPortletURLFactoryUtil.create(
+								mockHttpServletRequest));
+
+					Map<String, Object> data =
+						contentItemCommentEditorConfiguration.getData();
+
+					return data.get("editorConfig");
+				}
+			).put(
+				"getCommentsURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/get_asset_comments"
+			).build()
+		).build();
+	}
 
 	@Test
 	public void testGetFDSActionDropdownItems() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -125,14 +126,14 @@ public class ViewFilesSectionDisplayContextTest
 	protected Map<String, String> getExpectedCreationMenuItems()
 		throws PortalException {
 
-		return HashMapBuilder.put(
-			"Basic Document", getRedirect("L_BASIC_DOCUMENT")
+		return LinkedHashMapBuilder.put(
+			"single-file", getRedirect("L_BASIC_DOCUMENT")
 		).put(
-			"External Video", getRedirect("L_EXTERNAL_VIDEO")
+			"multiple-files", StringPool.BLANK
 		).put(
 			"folder", StringPool.BLANK
 		).put(
-			"multiple-files", StringPool.BLANK
+			"external-video-shortcut", getRedirect("L_EXTERNAL_VIDEO")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -14,11 +14,15 @@ import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -44,6 +48,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,6 +76,47 @@ public class ViewFilesSectionDisplayContextTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	public HashMap<String, Object> getBaseAdditionalProps() {
+		HashMap<String, Object> additionalProps =
+			super.getBaseAdditionalProps();
+
+		return HashMapBuilder.<String, Object>putAll(
+			additionalProps
+		).put(
+			"commentsProps",
+			HashMapBuilder.<String, Object>put(
+				"addCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/add_content_item_comment"
+			).put(
+				"deleteCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/delete_content_item_comment"
+			).put(
+				"editCommentURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/edit_content_item_comment"
+			).put(
+				"editorConfig",
+				() -> {
+					EditorConfiguration contentItemCommentEditorConfiguration =
+						EditorConfigurationFactoryUtil.getEditorConfiguration(
+							StringPool.BLANK, "contentItemCommentEditor",
+							StringPool.BLANK, Collections.emptyMap(),
+							themeDisplay,
+							RequestBackedPortletURLFactoryUtil.create(
+								mockHttpServletRequest));
+
+					Map<String, Object> data =
+						contentItemCommentEditorConfiguration.getData();
+
+					return data.get("editorConfig");
+				}
+			).put(
+				"getCommentsURL",
+				GroupConstants.CMS_FRIENDLY_URL + "/get_asset_comments"
+			).build()
+		).build();
+	}
 
 	@Test
 	public void testGetCreationMenuWithAddEntryPermission() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -11,7 +11,9 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -150,6 +152,13 @@ public class ViewRecycleBinSectionDisplayContextTest
 		assertFDSActionDropdownItem(
 			fdsActionDropdownItems.get(2), "restore", "restore", "restore",
 			"restore", "item");
+	}
+
+	@Override
+	protected CreationMenu getCreationMenu(ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseContentsSectionDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -65,6 +66,12 @@ public abstract class BaseContentsSectionDisplayContext
 				"edit-tags", null));
 
 		return fdsBulkActionDropdownItems;
+	}
+
+	@Override
+	public List<DropdownItem> getCreationMenuDropdownItems() {
+		return ActionUtil.getContentsSectionCreationMenuDropdownItems(
+			httpServletRequest, null);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseFilesSectionDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -78,6 +79,12 @@ public abstract class BaseFilesSectionDisplayContext
 				null));
 
 		return fdsBulkActionDropdownItems;
+	}
+
+	@Override
+	public List<DropdownItem> getCreationMenuDropdownItems() {
+		return ActionUtil.getFilesSectionCreationMenuDropdownItems(
+			httpServletRequest, null);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -66,10 +66,10 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Marco Galluzzi
@@ -259,59 +259,28 @@ public abstract class BaseSectionDisplayContext {
 		return new CreationMenu() {
 			{
 				if (_hasAddEntryPermission()) {
-					if (getRootObjectEntryFolderExternalReferenceCode() !=
-							null) {
+					for (DropdownItem dropdownItem :
+							getCreationMenuDropdownItems()) {
 
-						addPrimaryDropdownItem(
-							dropdownItem -> {
-								dropdownItem.putData("action", "createFolder");
-								dropdownItem.putData(
-									"assetLibraries",
-									_getDepotEntriesJSONArray());
-								dropdownItem.putData(
-									"baseAssetLibraryViewURL",
-									ActionUtil.getBaseSpaceURL(themeDisplay));
-								dropdownItem.putData(
-									"baseFolderViewURL",
-									ActionUtil.getBaseViewFolderURL(
-										themeDisplay));
-								dropdownItem.putData(
-									"parentObjectEntryFolderExternalReference" +
-										"Code",
-									_getParentObjectEntryFolderExternalReferenceCode());
-								dropdownItem.setIcon("folder");
-								dropdownItem.setLabel(
-									language.get(httpServletRequest, "folder"));
-							});
+						JSONArray depotEntriesJSONArray =
+							_getDepotEntriesJSONArray(dropdownItem);
+
+						if (depotEntriesJSONArray == null) {
+							continue;
+						}
+
+						dropdownItem.putData(
+							"assetLibraries", depotEntriesJSONArray);
+
+						addPrimaryDropdownItem(dropdownItem);
 					}
-
-					if (!Objects.equals(
-							getRootObjectEntryFolderExternalReferenceCode(),
-							ObjectEntryFolderConstants.
-								EXTERNAL_REFERENCE_CODE_CONTENTS)) {
-
-						addPrimaryDropdownItem(
-							dropdownItem -> {
-								dropdownItem.putData(
-									"action", "uploadMultipleFiles");
-								dropdownItem.putData(
-									"assetLibraries",
-									_getDepotEntriesJSONArray());
-								dropdownItem.putData(
-									"parentObjectEntryFolderExternalReference" +
-										"Code",
-									_getParentObjectEntryFolderExternalReferenceCode());
-								dropdownItem.setIcon("upload-multiple");
-								dropdownItem.setLabel(
-									language.get(
-										httpServletRequest, "multiple-files"));
-							});
-					}
-
-					addStructureContentDropdownItems(this);
 				}
 			}
 		};
+	}
+
+	public List<DropdownItem> getCreationMenuDropdownItems() {
+		return Collections.emptyList();
 	}
 
 	public abstract Map<String, Object> getEmptyState();
@@ -491,48 +460,6 @@ public abstract class BaseSectionDisplayContext {
 			));
 	}
 
-	protected void addStructureContentDropdownItems(CreationMenu creationMenu) {
-		for (ObjectDefinition objectDefinition :
-				_objectDefinitionService.getCMSObjectDefinitions(
-					themeDisplay.getCompanyId(),
-					getObjectFolderExternalReferenceCodes())) {
-
-			JSONArray depotEntriesJSONArray = _getDepotEntriesJSONArray(
-				objectDefinition);
-
-			if (depotEntriesJSONArray == null) {
-				continue;
-			}
-
-			creationMenu.addPrimaryDropdownItem(
-				dropdownItem -> {
-					dropdownItem.putData("action", "createAsset");
-					dropdownItem.putData(
-						"assetLibraries", depotEntriesJSONArray);
-					dropdownItem.putData(
-						"redirect",
-						StringBundler.concat(
-							themeDisplay.getPortalURL(),
-							themeDisplay.getPathMain(),
-							GroupConstants.CMS_FRIENDLY_URL,
-							"/add_structured_content_item?",
-							"objectDefinitionId=",
-							objectDefinition.getObjectDefinitionId(),
-							"&objectEntryFolderExternalReferenceCode=",
-							_getObjectEntryFolderExternalReferenceCode(
-								objectDefinition),
-							"&plid=", themeDisplay.getPlid(), "&redirect=",
-							themeDisplay.getURLCurrent()));
-					dropdownItem.putData(
-						"title",
-						objectDefinition.getLabel(themeDisplay.getLocale()));
-					dropdownItem.setIcon("forms");
-					dropdownItem.setLabel(
-						objectDefinition.getLabel(themeDisplay.getLocale()));
-				});
-		}
-	}
-
 	protected String appendStatus(String filterString) {
 		return StringBundler.concat(
 			filterString, " and status in (", StringUtil.merge(_statuses, ", "),
@@ -560,12 +487,12 @@ public abstract class BaseSectionDisplayContext {
 	protected final Portal portal;
 	protected final ThemeDisplay themeDisplay;
 
-	private List<Long> _getAcceptedGroupIds(ObjectDefinition objectDefinition) {
+	private List<Long> _getAcceptedGroupIds(long objectDefinitionId) {
 		List<Long> acceptedGroupIds = new ArrayList<>();
 
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
-				objectDefinition.getObjectDefinitionId(),
+				objectDefinitionId,
 				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS);
 
 		for (String groupId :
@@ -679,6 +606,20 @@ public abstract class BaseSectionDisplayContext {
 				DepotEntry::getGroupId));
 	}
 
+	private JSONArray _getDepotEntriesJSONArray(DropdownItem dropdownItem) {
+		Map<String, Object> dropdownItemData =
+			(HashMap<String, Object>)dropdownItem.get("data");
+
+		long objectDefinitionId = GetterUtil.getLong(
+			dropdownItemData.get("objectDefinitionId"));
+
+		if (objectDefinitionId != 0) {
+			return _getDepotEntriesJSONArray(objectDefinitionId);
+		}
+
+		return _getDepotEntriesJSONArray();
+	}
+
 	private JSONArray _getDepotEntriesJSONArray(List<Long> groupIds) {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
@@ -693,14 +634,12 @@ public abstract class BaseSectionDisplayContext {
 		return jsonArray;
 	}
 
-	private JSONArray _getDepotEntriesJSONArray(
-		ObjectDefinition objectDefinition) {
-
-		if (_isAcceptAllGroups(objectDefinition)) {
+	private JSONArray _getDepotEntriesJSONArray(long objectDefinitionId) {
+		if (_isAcceptAllGroups(objectDefinitionId)) {
 			return _getDepotEntriesJSONArray();
 		}
 
-		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinition);
+		List<Long> acceptedGroupIds = _getAcceptedGroupIds(objectDefinitionId);
 
 		if (acceptedGroupIds.isEmpty()) {
 			return null;
@@ -846,31 +785,6 @@ public abstract class BaseSectionDisplayContext {
 		return null;
 	}
 
-	private String _getObjectEntryFolderExternalReferenceCode(
-		ObjectDefinition objectDefinition) {
-
-		if (objectEntryFolder != null) {
-			return objectEntryFolder.getExternalReferenceCode();
-		}
-
-		if (Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.
-					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES)) {
-
-			return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
-		}
-
-		if (Objects.equals(
-				objectDefinition.getObjectFolderExternalReferenceCode(),
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES)) {
-
-			return ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
-		}
-
-		return null;
-	}
-
 	private String _getParentObjectEntryFolderExternalReferenceCode() {
 		if (objectEntryFolder == null) {
 			return getRootObjectEntryFolderExternalReferenceCode();
@@ -883,10 +797,6 @@ public abstract class BaseSectionDisplayContext {
 		if (objectEntryFolder == null) {
 			return true;
 		}
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
 
 		try {
 			return _objectEntryFolderModelResourcePermission.contains(
@@ -903,10 +813,10 @@ public abstract class BaseSectionDisplayContext {
 		return false;
 	}
 
-	private boolean _isAcceptAllGroups(ObjectDefinition objectDefinition) {
+	private boolean _isAcceptAllGroups(long objectDefinitionId) {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
-				objectDefinition.getObjectDefinitionId(),
+				objectDefinitionId,
 				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS);
 
 		if ((objectDefinitionSetting != null) &&
@@ -917,7 +827,7 @@ public abstract class BaseSectionDisplayContext {
 
 		objectDefinitionSetting =
 			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
-				objectDefinition.getObjectDefinitionId(),
+				objectDefinitionId,
 				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS);
 
 		if ((objectDefinitionSetting == null) ||

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSectionDisplayContext.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -135,6 +136,12 @@ public class ViewAllSectionDisplayContext extends BaseSectionDisplayContext {
 				"edit-tags", null));
 
 		return fdsBulkActionDropdownItems;
+	}
+
+	@Override
+	public List<DropdownItem> getCreationMenuDropdownItems() {
+		return ActionUtil.getAllSectionCreationMenuDropdownItems(
+			httpServletRequest);
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFolderSectionDisplayContext.java
@@ -152,6 +152,20 @@ public class ViewFolderSectionDisplayContext extends BaseSectionDisplayContext {
 	}
 
 	@Override
+	public List<DropdownItem> getCreationMenuDropdownItems() {
+		if (Objects.equals(
+				getRootObjectEntryFolderExternalReferenceCode(),
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)) {
+
+			return ActionUtil.getContentsSectionCreationMenuDropdownItems(
+				httpServletRequest, objectEntryFolder);
+		}
+
+		return ActionUtil.getFilesSectionCreationMenuDropdownItems(
+			httpServletRequest, objectEntryFolder);
+	}
+
+	@Override
 	public Map<String, Object> getEmptyState() {
 		String rootObjectEntryFolderExternalReferenceCode =
 			getRootObjectEntryFolderExternalReferenceCode();

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -16,6 +16,8 @@ import com.liferay.fragment.renderer.FragmentRendererRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryLinkService;
 import com.liferay.fragment.service.FragmentEntryLinkServiceUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemBuilder;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -492,6 +494,30 @@ public class ActionUtil {
 			StringPool.SLASH);
 	}
 
+	public static DropdownItem getCreateFolderDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String parentObjectEntryFolderExternalReferenceCode) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return DropdownItemBuilder.putData(
+			"action", "createFolder"
+		).putData(
+			"baseAssetLibraryViewURL", getBaseSpaceURL(themeDisplay)
+		).putData(
+			"baseFolderViewURL", getBaseViewFolderURL(themeDisplay)
+		).putData(
+			"parentObjectEntryFolderExternalReferenceCode",
+			parentObjectEntryFolderExternalReferenceCode
+		).setIcon(
+			"folder"
+		).setLabel(
+			LanguageUtil.get(httpServletRequest, "folder")
+		).build();
+	}
+
 	public static String getDisplayPageEditURL(
 		FormManager formManager,
 		FragmentEntryLinkListenerRegistry fragmentEntryLinkListenerRegistry,
@@ -618,6 +644,46 @@ public class ActionUtil {
 		return getBaseSpaceURL(themeDisplay) + classPK;
 	}
 
+	public static DropdownItem getStructuredContentDropdownItem(
+		HttpServletRequest httpServletRequest, String icon, String labelKey,
+		ObjectDefinition objectDefinition,
+		String objectEntryFolderExternalReferenceCode) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return DropdownItemBuilder.putData(
+			"action", "createAsset"
+		).putData(
+			"objectDefinitionId",
+			String.valueOf(objectDefinition.getObjectDefinitionId())
+		).putData(
+			"redirect",
+			StringBundler.concat(
+				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),
+				GroupConstants.CMS_FRIENDLY_URL,
+				"/add_structured_content_item?objectDefinitionId=",
+				objectDefinition.getObjectDefinitionId(),
+				"&objectEntryFolderExternalReferenceCode=",
+				objectEntryFolderExternalReferenceCode, "&plid=",
+				themeDisplay.getPlid(), "&redirect=",
+				themeDisplay.getURLCurrent())
+		).putData(
+			"title", objectDefinition.getLabel(themeDisplay.getLocale())
+		).setIcon(
+			icon
+		).setLabel(
+			() -> {
+				if (Validator.isNull(labelKey)) {
+					return objectDefinition.getLabel(themeDisplay.getLocale());
+				}
+
+				return LanguageUtil.get(httpServletRequest, labelKey);
+			}
+		).build();
+	}
+
 	public static String getTranslateURL(
 		FormManager formManager,
 		FragmentEntryLinkListenerRegistry fragmentEntryLinkListenerRegistry,
@@ -672,6 +738,22 @@ public class ActionUtil {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	public static DropdownItem getUploadMultipleFilesDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String parentObjectEntryFolderExternalReferenceCode) {
+
+		return DropdownItemBuilder.putData(
+			"action", "uploadMultipleFiles"
+		).putData(
+			"parentObjectEntryFolderExternalReferenceCode",
+			parentObjectEntryFolderExternalReferenceCode
+		).setIcon(
+			"upload-multiple"
+		).setLabel(
+			LanguageUtil.get(httpServletRequest, "multiple-files")
+		).build();
 	}
 
 	public static String getViewFolderRecycleBinURL(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -470,7 +470,7 @@ public class ActionUtil {
 					httpServletRequest,
 					ObjectEntryFolderConstants.
 						EXTERNAL_REFERENCE_CODE_CONTENTS),
-				getBasicDocumentDropdown(
+				getBasicDocumentDropdownItem(
 					httpServletRequest,
 					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES),
 				getUploadMultipleFilesDropdownItem(
@@ -545,7 +545,7 @@ public class ActionUtil {
 			StringPool.SLASH);
 	}
 
-	public static DropdownItem getBasicDocumentDropdown(
+	public static DropdownItem getBasicDocumentDropdownItem(
 		HttpServletRequest httpServletRequest,
 		String objectEntryFolderExternalReferenceCode) {
 
@@ -822,7 +822,7 @@ public class ActionUtil {
 
 		List<DropdownItem> dropdownItems = new ArrayList<>(
 			List.of(
-				getBasicDocumentDropdown(
+				getBasicDocumentDropdownItem(
 					httpServletRequest, objectEntryFolderExternalReferenceCode),
 				getUploadMultipleFilesDropdownItem(
 					httpServletRequest, objectEntryFolderExternalReferenceCode),

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -38,6 +38,7 @@ import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -494,6 +495,33 @@ public class ActionUtil {
 			StringPool.SLASH);
 	}
 
+	public static DropdownItem getBasicDocumentDropdown(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, "upload", "single-file", "L_BASIC_DOCUMENT",
+			objectEntryFolderExternalReferenceCode);
+	}
+
+	public static DropdownItem getBasicWebContentDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, "forms", "basic-content", "L_BASIC_WEB_CONTENT",
+			objectEntryFolderExternalReferenceCode);
+	}
+
+	public static DropdownItem getBlogDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, "blogs", null, "L_BLOG",
+			objectEntryFolderExternalReferenceCode);
+	}
+
 	public static DropdownItem getCreateFolderDropdownItem(
 		HttpServletRequest httpServletRequest,
 		String parentObjectEntryFolderExternalReferenceCode) {
@@ -622,6 +650,24 @@ public class ActionUtil {
 		return StringPool.BLANK;
 	}
 
+	public static DropdownItem getExternalVideoShortcutDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, "video", "external-video-shortcut",
+			"L_EXTERNAL_VIDEO", objectEntryFolderExternalReferenceCode);
+	}
+
+	public static DropdownItem getKnowledgeBaseDropdownItem(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, "wiki", null, "L_KNOWLEDGE_BASE",
+			objectEntryFolderExternalReferenceCode);
+	}
+
 	public static String getRecycleBinURL(ThemeDisplay themeDisplay) {
 		return StringBundler.concat(
 			themeDisplay.getPathFriendlyURLPublic(),
@@ -682,6 +728,30 @@ public class ActionUtil {
 				return LanguageUtil.get(httpServletRequest, labelKey);
 			}
 		).build();
+	}
+
+	public static DropdownItem getStructuredContentDropdownItem(
+		HttpServletRequest httpServletRequest, String icon, String labelKey,
+		String objectDefinitionExternalReferenceCode,
+		String objectEntryFolderExternalReferenceCode) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.
+				fetchObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					themeDisplay.getCompanyId());
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		return getStructuredContentDropdownItem(
+			httpServletRequest, icon, labelKey, objectDefinition,
+			objectEntryFolderExternalReferenceCode);
 	}
 
 	public static String getTranslateURL(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -36,9 +36,11 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectDefinitionServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -522,6 +524,37 @@ public class ActionUtil {
 			objectEntryFolderExternalReferenceCode);
 	}
 
+	public static List<DropdownItem> getContentsCustomDropdownItems(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		List<DropdownItem> dropdownItems = new ArrayList<>();
+
+		for (ObjectDefinition objectDefinition :
+				ObjectDefinitionServiceUtil.getCMSObjectDefinitions(
+					themeDisplay.getCompanyId(),
+					new String[] {
+						ObjectFolderConstants.
+							EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES
+					})) {
+
+			if (objectDefinition.isSystem()) {
+				continue;
+			}
+
+			dropdownItems.add(
+				getStructuredContentDropdownItem(
+					httpServletRequest, "web-content", null, objectDefinition,
+					objectEntryFolderExternalReferenceCode));
+		}
+
+		return dropdownItems;
+	}
+
 	public static DropdownItem getCreateFolderDropdownItem(
 		HttpServletRequest httpServletRequest,
 		String parentObjectEntryFolderExternalReferenceCode) {
@@ -657,6 +690,36 @@ public class ActionUtil {
 		return getStructuredContentDropdownItem(
 			httpServletRequest, "video", "external-video-shortcut",
 			"L_EXTERNAL_VIDEO", objectEntryFolderExternalReferenceCode);
+	}
+
+	public static List<DropdownItem> getFilesCustomDropdownItems(
+		HttpServletRequest httpServletRequest,
+		String objectEntryFolderExternalReferenceCode) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		List<DropdownItem> dropdownItems = new ArrayList<>();
+
+		for (ObjectDefinition objectDefinition :
+				ObjectDefinitionServiceUtil.getCMSObjectDefinitions(
+					themeDisplay.getCompanyId(),
+					new String[] {
+						ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+					})) {
+
+			if (objectDefinition.isSystem()) {
+				continue;
+			}
+
+			dropdownItems.add(
+				getStructuredContentDropdownItem(
+					httpServletRequest, "document-default", null,
+					objectDefinition, objectEntryFolderExternalReferenceCode));
+		}
+
+		return dropdownItems;
 	}
 
 	public static DropdownItem getKnowledgeBaseDropdownItem(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -36,6 +36,7 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -77,6 +78,7 @@ import com.liferay.site.cms.site.initializer.internal.fragment.renderer.SpacesCo
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -459,6 +461,52 @@ public class ActionUtil {
 		}
 	}
 
+	public static List<DropdownItem> getAllSectionCreationMenuDropdownItems(
+		HttpServletRequest httpServletRequest) {
+
+		List<DropdownItem> dropdownItems = new ArrayList<>(
+			List.of(
+				getBasicWebContentDropdownItem(
+					httpServletRequest,
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_CONTENTS),
+				getBasicDocumentDropdown(
+					httpServletRequest,
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES),
+				getUploadMultipleFilesDropdownItem(
+					httpServletRequest,
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES),
+				getBlogDropdownItem(
+					httpServletRequest,
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_CONTENTS),
+				getKnowledgeBaseDropdownItem(
+					httpServletRequest,
+					ObjectEntryFolderConstants.
+						EXTERNAL_REFERENCE_CODE_CONTENTS),
+				getExternalVideoShortcutDropdownItem(
+					httpServletRequest,
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES)));
+
+		List<DropdownItem> customDropdownItems = getContentsCustomDropdownItems(
+			httpServletRequest,
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS);
+
+		customDropdownItems.addAll(
+			getFilesCustomDropdownItems(
+				httpServletRequest,
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES));
+
+		customDropdownItems.sort(
+			Comparator.comparing(
+				dropdownItem -> (String)dropdownItem.get("label"),
+				String.CASE_INSENSITIVE_ORDER));
+
+		dropdownItems.addAll(customDropdownItems);
+
+		return dropdownItems;
+	}
+
 	public static String getBaseAddSpaceMembersURL(ThemeDisplay themeDisplay) {
 		return StringBundler.concat(
 			themeDisplay.getPathFriendlyURLPublic(),
@@ -551,6 +599,44 @@ public class ActionUtil {
 					httpServletRequest, "web-content", null, objectDefinition,
 					objectEntryFolderExternalReferenceCode));
 		}
+
+		return dropdownItems;
+	}
+
+	public static List<DropdownItem>
+		getContentsSectionCreationMenuDropdownItems(
+			HttpServletRequest httpServletRequest,
+			ObjectEntryFolder objectEntryFolder) {
+
+		String objectEntryFolderExternalReferenceCode =
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS;
+
+		if (objectEntryFolder != null) {
+			objectEntryFolderExternalReferenceCode =
+				objectEntryFolder.getExternalReferenceCode();
+		}
+
+		List<DropdownItem> dropdownItems = new ArrayList<>(
+			List.of(
+				getCreateFolderDropdownItem(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getBasicWebContentDropdownItem(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getBlogDropdownItem(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getKnowledgeBaseDropdownItem(
+					httpServletRequest,
+					objectEntryFolderExternalReferenceCode)));
+
+		List<DropdownItem> customDropdownItems = getContentsCustomDropdownItems(
+			httpServletRequest, objectEntryFolderExternalReferenceCode);
+
+		customDropdownItems.sort(
+			Comparator.comparing(
+				dropdownItem -> (String)dropdownItem.get("label"),
+				String.CASE_INSENSITIVE_ORDER));
+
+		dropdownItems.addAll(customDropdownItems);
 
 		return dropdownItems;
 	}
@@ -718,6 +804,43 @@ public class ActionUtil {
 					httpServletRequest, "document-default", null,
 					objectDefinition, objectEntryFolderExternalReferenceCode));
 		}
+
+		return dropdownItems;
+	}
+
+	public static List<DropdownItem> getFilesSectionCreationMenuDropdownItems(
+		HttpServletRequest httpServletRequest,
+		ObjectEntryFolder objectEntryFolder) {
+
+		String objectEntryFolderExternalReferenceCode =
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES;
+
+		if (objectEntryFolder != null) {
+			objectEntryFolderExternalReferenceCode =
+				objectEntryFolder.getExternalReferenceCode();
+		}
+
+		List<DropdownItem> dropdownItems = new ArrayList<>(
+			List.of(
+				getBasicDocumentDropdown(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getUploadMultipleFilesDropdownItem(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getCreateFolderDropdownItem(
+					httpServletRequest, objectEntryFolderExternalReferenceCode),
+				getExternalVideoShortcutDropdownItem(
+					httpServletRequest,
+					objectEntryFolderExternalReferenceCode)));
+
+		List<DropdownItem> customDropdownItems = getFilesCustomDropdownItems(
+			httpServletRequest, objectEntryFolderExternalReferenceCode);
+
+		customDropdownItems.sort(
+			Comparator.comparing(
+				dropdownItem -> (String)dropdownItem.get("label"),
+				String.CASE_INSENSITIVE_ORDER));
+
+		dropdownItems.addAll(customDropdownItems);
 
 		return dropdownItems;
 	}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -518,7 +518,7 @@ test.describe('Schedule Panel', () => {
 
 			await contentsPage.goto();
 
-			await contentsPage.createContent('Basic Web Content');
+			await contentsPage.createContent('Basic Content');
 
 			await contentsPage.openSidePanel('Schedule');
 
@@ -609,7 +609,7 @@ test.describe('Categorization Panel', () => {
 
 			await contentsPage.goto();
 
-			await contentsPage.createContent('Basic Web Content');
+			await contentsPage.createContent('Basic Content');
 
 			await contentsPage.openSidePanel('Categorization');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -88,7 +88,7 @@ test(
 		await test.step('Create a Basic Document', async () => {
 			await assetsPage.gotoFiles();
 
-			await assetsPage.createContent('Basic Document');
+			await assetsPage.createContent('Single File');
 		});
 
 		await test.step('Check the Space selector dialog', async () => {
@@ -135,7 +135,7 @@ test(
 		await test.step('Create a Basic Document', async () => {
 			await assetsPage.gotoFiles();
 
-			await assetsPage.createContent('Basic Document');
+			await assetsPage.createContent('Single File');
 		});
 
 		await test.step('Check the Space selector dialog', async () => {
@@ -206,7 +206,7 @@ test(
 		});
 
 		await test.step('Create a Basic Document', async () => {
-			await assetsPage.createContent('Basic Document');
+			await assetsPage.createContent('Single File');
 		});
 
 		await test.step('Check the Space selector dialog', async () => {

--- a/modules/test/playwright/tests/smoke/main/cmsSmoke.spec.ts
+++ b/modules/test/playwright/tests/smoke/main/cmsSmoke.spec.ts
@@ -45,7 +45,7 @@ test('CMS loads and sections are shown', async ({
 		await expect(contentsPage.newButton).toBeVisible({timeout: 2000});
 	}).toPass();
 
-	await contentsPage.createContent('Basic Web Content');
+	await contentsPage.createContent('Basic Content');
 
 	const title = getRandomString();
 


### PR DESCRIPTION
:warning: After [bchan comment](https://github.com/brianchandotcom/liferay-portal/pull/165509#issuecomment-3286325549) I've fixed a test to make sense of the usage of LinkedHashMap

:warning:  Fixed a [method name typo](https://github.com/brianchandotcom/liferay-portal/pull/165632#issuecomment-3304189961) with last commit.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62892

The creation menu items should follow a specific order and naming

# How am I fixing it?

Create methods to easily define menu items and use them to specify a Creation Menu for each section

# How can you verify that it works?

Run existing integration tests in folder `modules/apps/site/site-cms-site-initializer-test`:

`gw tI --tests "View*SectionDisplayContextTest"`

See how menus looks like now:

"All" Section

<img width="406" height="487" alt="2025-09-08 creation menu ALL" src="https://github.com/user-attachments/assets/033d07c4-18b0-4ac3-9b0d-4f17ae4f0818" />

"Contents" section

<img width="438" height="462" alt="2025-09-08 creation menu CONTENT" src="https://github.com/user-attachments/assets/46cb5c52-efb5-468d-92bc-ddbe1478a56b" />

"Files" section

<img width="425" height="380" alt="2025-09-08 creation menu FILES" src="https://github.com/user-attachments/assets/4d2f9faa-42f5-4534-9a9d-b0c202eb78b9" />
