### PR TITLE
LPD-65865 Issues when creating object folders

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSGroupLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSGroupLocalServiceWrapper.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.service;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceWrapper;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceWrapper;
+import com.liferay.site.cms.site.initializer.internal.util.ObjectEntryFolderUtil;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jürgen Kappler
+ */
+@Component(service = ServiceWrapper.class)
+public class CMSGroupLocalServiceWrapper extends GroupLocalServiceWrapper {
+
+	@Override
+	public Group addGroup(
+			long userId, long parentGroupId, String className, long classPK,
+			long liveGroupId, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, int type,
+			boolean manualMembership, int membershipRestriction,
+			String friendlyURL, boolean site, boolean inheritContent,
+			boolean active, ServiceContext serviceContext)
+		throws PortalException {
+
+		Group group = super.addGroup(
+			userId, parentGroupId, className, classPK, liveGroupId, nameMap,
+			descriptionMap, type, manualMembership, membershipRestriction,
+			friendlyURL, site, inheritContent, active, serviceContext);
+
+		if (group.isDepot()) {
+			ObjectEntryFolderUtil.addObjectEntryFolders(group.getGroupId());
+		}
+
+		return group;
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -7,22 +7,16 @@ package com.liferay.site.cms.site.initializer.internal.service;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceWrapper;
-import com.liferay.object.constants.ObjectEntryFolderConstants;
-import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.site.cms.site.initializer.internal.util.ObjectEntryFolderUtil;
 
 import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -37,7 +31,7 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 
 		DepotEntry depotEntry = super.addDepotEntry(group, serviceContext);
 
-		_addObjectEntryFolders(depotEntry);
+		ObjectEntryFolderUtil.addObjectEntryFolders(depotEntry.getGroupId());
 
 		return depotEntry;
 	}
@@ -51,43 +45,9 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 		DepotEntry depotEntry = super.addDepotEntry(
 			nameMap, descriptionMap, type, serviceContext);
 
-		_addObjectEntryFolders(depotEntry);
+		ObjectEntryFolderUtil.addObjectEntryFolders(depotEntry.getGroupId());
 
 		return depotEntry;
 	}
-
-	private void _addObjectEntryFolders(DepotEntry depotEntry)
-		throws PortalException {
-
-		if (!FeatureFlagManagerUtil.isEnabled(
-				depotEntry.getCompanyId(), "LPD-17564")) {
-
-			return;
-		}
-
-		Group group = depotEntry.getGroup();
-
-		_objectEntryFolderLocalService.addObjectEntryFolder(
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
-			group.getGroupId(), group.getCreatorUserId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			"",
-			HashMapBuilder.put(
-				LocaleUtil.ENGLISH, "Contents"
-			).build(),
-			"Contents", ServiceContextThreadLocal.getServiceContext());
-		_objectEntryFolderLocalService.addObjectEntryFolder(
-			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES,
-			group.getGroupId(), group.getCreatorUserId(),
-			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			"",
-			HashMapBuilder.put(
-				LocaleUtil.ENGLISH, "Files"
-			).build(),
-			"Files", ServiceContextThreadLocal.getServiceContext());
-	}
-
-	@Reference
-	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ObjectEntryFolderUtil.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.util;
+
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ObjectEntryFolderUtil {
+
+	public static void addObjectEntryFolders(long groupId)
+		throws PortalException {
+
+		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+		if ((group == null) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				group.getCompanyId(), "LPD-17564")) {
+
+			return;
+		}
+
+		_addObjectEntryFolder(
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS, group,
+			"Contents", "Contents");
+		_addObjectEntryFolder(
+			ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_FILES, group,
+			"Files", "Files");
+	}
+
+	private static void _addObjectEntryFolder(
+			String externalReferenceCode, Group group, String label,
+			String name)
+		throws PortalException {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderLocalServiceUtil.
+				fetchObjectEntryFolderByExternalReferenceCode(
+					externalReferenceCode, group.getGroupId(),
+					group.getCompanyId());
+
+		if (objectEntryFolder != null) {
+			return;
+		}
+
+		ObjectEntryFolderLocalServiceUtil.addObjectEntryFolder(
+			externalReferenceCode, group.getGroupId(), group.getCreatorUserId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			"",
+			HashMapBuilder.put(
+				LocaleUtil.ENGLISH, label
+			).build(),
+			name, ServiceContextThreadLocal.getServiceContext());
+	}
+
+}


### PR DESCRIPTION
LPD-65865 Issues when creating object folders

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-65865)

There are issues when creating folders for depots depending on how the depots are created. In some points the group has not been persisted so it won't be found when creating the permissions for them, In others the depot for the group has not been created

# How am I fixing it?

Separate the wrapper in 2. And depending on the case, create the folders for it