### PR TITLE
LPD-64992 show additional actions only for non default structure entries (2nd try - rebase)

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewStructuresDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewStructuresDisplayContextTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Marco Galluzzi
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ViewStructuresDisplayContextTest
+	extends BaseDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetCreationMenu() throws Exception {
+		CreationMenu creationMenu = ReflectionTestUtil.invoke(
+			_getSectionDisplayContext(getMockHttpServletRequest()),
+			"getCreationMenu", new Class<?>[0]);
+
+		List<DropdownItem> dropdownItems = (List<DropdownItem>)creationMenu.get(
+			"primaryItems");
+
+		Assert.assertEquals(dropdownItems.toString(), 2, dropdownItems.size());
+
+		_assertDropdownItem(
+			dropdownItems.get(0), "content", "L_CMS_CONTENT_STRUCTURES");
+		_assertDropdownItem(dropdownItems.get(1), "file", "L_CMS_FILE_TYPES");
+	}
+
+	@Test
+	public void testGetFDSActionDropdownItems() throws Exception {
+		List<FDSActionDropdownItem> fdsActionDropdownItems =
+			ReflectionTestUtil.invoke(
+				_getSectionDisplayContext(getMockHttpServletRequest()),
+				"getFDSActionDropdownItems", new Class<?>[0]);
+
+		Assert.assertEquals(
+			fdsActionDropdownItems.toString(), 7,
+			fdsActionDropdownItems.size());
+
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(0), "pencil", "edit", "edit", "get",
+			Map.of("system", false));
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(1), "list-ul", "viewUsages",
+			"view-usages", "get", null);
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(2), "copy", "copy", "make-a-copy", null,
+			null);
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(3), "export", "export", "export-as-json",
+			"get", Map.of("system", false));
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(4), "import", "import",
+			"import-and-override", "get", Map.of("system", false));
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(5), "password-policies", "permissions",
+			"permissions", "get", null);
+		_assertFDSActionDropdownItem(
+			fdsActionDropdownItems.get(6), "trash", "delete", "delete",
+			"delete", Map.of("system", false));
+	}
+
+	private void _assertDropdownItem(
+		DropdownItem dropdownItem, String expectedLabel,
+		String objectFolderExternalReferenceCode) {
+
+		Assert.assertEquals(expectedLabel, dropdownItem.get("label"));
+		Assert.assertEquals(
+			GroupConstants.CMS_FRIENDLY_URL +
+				"/structure-builder?objectFolderExternalReferenceCode=" +
+					objectFolderExternalReferenceCode,
+			dropdownItem.get("href"));
+	}
+
+	private void _assertFDSActionDropdownItem(
+		FDSActionDropdownItem fdsActionDropdownItem, String icon, String id,
+		String label, String method, Map<String, Object> visibilityFilters) {
+
+		Assert.assertNotNull(fdsActionDropdownItem);
+
+		Map<String, Object> data =
+			(Map<String, Object>)fdsActionDropdownItem.get("data");
+
+		Assert.assertEquals(id, data.get("id"));
+		Assert.assertEquals(method, data.get("method"));
+
+		Assert.assertEquals(icon, fdsActionDropdownItem.get("icon"));
+		Assert.assertEquals(label, fdsActionDropdownItem.get("label"));
+
+		if (visibilityFilters != null) {
+			Assert.assertEquals(
+				data.get("visibilityFilters"), visibilityFilters);
+		}
+	}
+
+	private Object _getSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		Object viewStructuresDisplayContext = httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewStructuresDisplayContext");
+
+		Assert.assertNotNull(viewStructuresDisplayContext);
+
+		return viewStructuresDisplayContext;
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewStructuresJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructuresDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructuresDisplayContext.java
@@ -112,7 +112,7 @@ public class ViewStructuresDisplayContext {
 					"objectDefinitionExternalReferenceCode",
 					"{externalReferenceCode}"),
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
-				"get", "update", null),
+				"get", "update", null, Map.of("system", false)),
 			new FDSActionDropdownItem(
 				HttpComponentsUtil.addParameters(
 					PortalUtil.getLayoutFullURL(
@@ -141,7 +141,7 @@ public class ViewStructuresDisplayContext {
 				).buildString(),
 				"export", "export",
 				LanguageUtil.get(_httpServletRequest, "export-as-json"), "get",
-				"exportObjectDefinition", null),
+				"exportObjectDefinition", null, Map.of("system", false)),
 			new FDSActionDropdownItem(
 				PortletURLBuilder.create(
 					PortletURLFactoryUtil.create(
@@ -155,7 +155,7 @@ public class ViewStructuresDisplayContext {
 				).buildString(),
 				"import", "import",
 				LanguageUtil.get(_httpServletRequest, "import-and-override"),
-				"get", "update", null),
+				"get", "update", null, Map.of("system", false)),
 			new FDSActionDropdownItem(
 				"", "password-policies", "permissions",
 				LanguageUtil.get(_httpServletRequest, "permissions"), "get",
@@ -173,7 +173,7 @@ public class ViewStructuresDisplayContext {
 				).buildString(),
 				"trash", "delete",
 				LanguageUtil.get(_httpServletRequest, "delete"), "delete",
-				"delete", null));
+				"delete", null, Map.of("system", false)));
 	}
 
 	private void _addBreadcrumbItem(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructuresDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructuresDisplayContext.java
@@ -12,24 +12,19 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.util.ActionUtil;
 
 import jakarta.portlet.PortletRequest;
 
@@ -80,18 +75,20 @@ public class ViewStructuresDisplayContext {
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref(
-					_getHref(
-						ObjectFolderConstants.
-							EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES));
+					ActionUtil.getBaseStructureBuilderURL(_themeDisplay) +
+						"?objectFolderExternalReferenceCode=" +
+							ObjectFolderConstants.
+								EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "content"));
 			}
 		).addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref(
-					_getHref(
-						ObjectFolderConstants.
-							EXTERNAL_REFERENCE_CODE_FILE_TYPES));
+					ActionUtil.getBaseStructureBuilderURL(_themeDisplay) +
+						"?objectFolderExternalReferenceCode=" +
+							ObjectFolderConstants.
+								EXTERNAL_REFERENCE_CODE_FILE_TYPES);
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "file"));
 			}
@@ -103,24 +100,13 @@ public class ViewStructuresDisplayContext {
 
 		return List.of(
 			new FDSActionDropdownItem(
-				HttpComponentsUtil.addParameters(
-					PortalUtil.getLayoutFullURL(
-						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
-							_themeDisplay.getScopeGroupId(), false,
-							"/structure-builder"),
-						_themeDisplay),
-					"objectDefinitionExternalReferenceCode",
-					"{externalReferenceCode}"),
+				ActionUtil.getBaseStructureBuilderURL(_themeDisplay) +
+					"?objectDefinitionExternalReferenceCode=" +
+						"{externalReferenceCode}",
 				"pencil", "edit", LanguageUtil.get(_httpServletRequest, "edit"),
 				"get", "update", null, Map.of("system", false)),
 			new FDSActionDropdownItem(
-				HttpComponentsUtil.addParameters(
-					PortalUtil.getLayoutFullURL(
-						LayoutLocalServiceUtil.getLayoutByFriendlyURL(
-							_themeDisplay.getScopeGroupId(), false,
-							"/structure-usages"),
-						_themeDisplay),
-					"objectDefinitionId", "{id}"),
+				ActionUtil.getBaseStructureUsagesURL(_themeDisplay) + "{id}",
 				"list-ul", "viewUsages",
 				LanguageUtil.get(_httpServletRequest, "view-usages"), "get",
 				null, null),
@@ -189,24 +175,6 @@ public class ViewStructuresDisplayContext {
 			));
 	}
 
-	private String _getHref(String objectFolderExternalReferenceCode) {
-		try {
-			return HttpComponentsUtil.addParameters(
-				PortalUtil.getLayoutFullURL(
-					LayoutLocalServiceUtil.getLayoutByFriendlyURL(
-						_themeDisplay.getScopeGroupId(), false,
-						"/structure-builder"),
-					_themeDisplay),
-				"objectFolderExternalReferenceCode",
-				objectFolderExternalReferenceCode);
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
-
-		return StringPool.BLANK;
-	}
-
 	private String _getLayoutName() {
 		Layout layout = _themeDisplay.getLayout();
 
@@ -216,9 +184,6 @@ public class ViewStructuresDisplayContext {
 
 		return layout.getName(_themeDisplay.getLocale(), true);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ViewStructuresDisplayContext.class);
 
 	private final HttpServletRequest _httpServletRequest;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -528,6 +528,19 @@ public class ActionUtil {
 			PortalUtil.getClassNameId(DepotEntry.class), StringPool.SLASH);
 	}
 
+	public static String getBaseStructureBuilderURL(ThemeDisplay themeDisplay) {
+		return StringBundler.concat(
+			themeDisplay.getPathFriendlyURLPublic(),
+			GroupConstants.CMS_FRIENDLY_URL, "/structure-builder");
+	}
+
+	public static String getBaseStructureUsagesURL(ThemeDisplay themeDisplay) {
+		return StringBundler.concat(
+			themeDisplay.getPathFriendlyURLPublic(),
+			GroupConstants.CMS_FRIENDLY_URL,
+			"/structure-usages?objectDefinitionId=");
+	}
+
 	public static String getBaseViewFolderRecycleBinURL(
 		ThemeDisplay themeDisplay) {
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -158,3 +158,80 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Some actions are only allowed to non-system structures',
+	{tag: '@LPD-51405'},
+	async ({apiHelpers, page, structuresPage}) => {
+		await structuresPage.goto();
+
+		await page
+			.getByRole('row', {name: 'Basic Document'})
+			.locator('.dropdown-toggle')
+			.click();
+
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'View Usages'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Make a Copy'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Permissions'})
+		).toBeVisible();
+
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Edit'})
+		).toBeHidden();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Export as JSON'})
+		).toBeHidden();
+		expect(
+			page.getByRole('menuitem', {
+				exact: true,
+				name: 'Import and Override',
+			})
+		).toBeHidden();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Delete'})
+		).toBeHidden();
+
+		const objectDefinition =
+			(await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFolderExternalReferenceCode: 'L_CMS_FILE_TYPES',
+				status: {code: 0},
+			})) as ObjectDefinition;
+
+		await structuresPage.goto();
+
+		await page
+			.getByRole('row', {name: objectDefinition.name})
+			.locator('.dropdown-toggle')
+			.click();
+
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Edit'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'View Usages'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Make a Copy'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Export as JSON'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {
+				exact: true,
+				name: 'Import and Override',
+			})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Permissions'})
+		).toBeVisible();
+		expect(
+			page.getByRole('menuitem', {exact: true, name: 'Delete'})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64992

System structures can only see these actions:

* View Usages
* Make a Copy
* Permissions

# How am I fixing it?

Using the `visibilityFilters` parameter of an `FDSActionDropdownItem`

# How can you verify that it works?

Run created tests:

`gw tI --tests "ViewStructuresDisplayContextTest"`
`npm run playwright -- test -g 'Some actions are only allowed to non-system structures'`
