### PR TITLE
LPD-66083 Show asset library permissions in the context of its group

### DIFF
--- a/modules/apps/depot/depot-service/build.gradle
+++ b/modules/apps/depot/depot-service/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:roles:roles-admin-api")
 	compileOnly project(":apps:staging:staging-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/defaultpermissions/resource/DepotEntryPortalDefaultPermissionsModelResource.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/defaultpermissions/resource/DepotEntryPortalDefaultPermissionsModelResource.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.defaultpermissions.resource;
+
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.defaultpermissions.resource.PortalDefaultPermissionsModelResource;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(
+	property = "portal.default.permissions.model.resource.key=com.liferay.depot.model.DepotEntry",
+	service = PortalDefaultPermissionsModelResource.class
+)
+public class DepotEntryPortalDefaultPermissionsModelResource
+	implements PortalDefaultPermissionsModelResource {
+
+	@Override
+	public String getClassName() {
+		return DepotEntry.class.getName();
+	}
+
+	@Override
+	public String getLabel() {
+		return "asset-library";
+	}
+
+	@Override
+	public String getScope() {
+		return ExtendedObjectClassDefinition.Scope.GROUP.toString();
+	}
+
+	@Override
+	public boolean isAllowOverridePermissions() {
+		return true;
+	}
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/defaultpermissions/resource/ObjectEntryPortalDefaultPermissionsModelResource.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/defaultpermissions/resource/ObjectEntryPortalDefaultPermissionsModelResource.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.defaultpermissions.resource;
+
+import com.liferay.portal.kernel.defaultpermissions.resource.PortalDefaultPermissionsModelResource;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class ObjectEntryPortalDefaultPermissionsModelResource
+	implements PortalDefaultPermissionsModelResource {
+
+	public ObjectEntryPortalDefaultPermissionsModelResource(
+		String className, String label, String scope) {
+
+		_className = className;
+		_label = label;
+		_scope = scope;
+	}
+
+	@Override
+	public String getClassName() {
+		return _className;
+	}
+
+	@Override
+	public String getLabel() {
+		return _label;
+	}
+
+	@Override
+	public String getScope() {
+		return _scope;
+	}
+
+	@Override
+	public boolean isAllowOverridePermissions() {
+		return true;
+	}
+
+	private final String _className;
+	private final String _label;
+	private final String _scope;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -13,10 +13,12 @@ import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.notification.handler.NotificationHandler;
 import com.liferay.notification.term.evaluator.NotificationTermEvaluator;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
+import com.liferay.object.internal.defaultpermissions.resource.ObjectEntryPortalDefaultPermissionsModelResource;
 import com.liferay.object.internal.layout.tab.screen.navigation.category.ObjectLayoutTabScreenNavigationCategory;
 import com.liferay.object.internal.notification.handler.ObjectDefinitionNotificationHandler;
 import com.liferay.object.internal.notification.term.contributor.ObjectDefinitionNotificationTermEvaluator;
@@ -67,7 +69,9 @@ import com.liferay.object.tree.Tree;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.defaultpermissions.resource.PortalDefaultPermissionsModelResource;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
@@ -111,6 +115,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -399,6 +404,14 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				MapUtil.singletonDictionary(
 					"model.class.name", objectDefinition.getClassName())),
 			_bundleContext.registerService(
+				PortalDefaultPermissionsModelResource.class,
+				new ObjectEntryPortalDefaultPermissionsModelResource(
+					objectDefinition.getClassName(),
+					objectDefinition.getLabel(), _getScope(objectDefinition)),
+				MapUtil.singletonDictionary(
+					"portal.default.permissions.model.resource.key",
+					objectDefinition.getClassName())),
+			_bundleContext.registerService(
 				RESTContextPathResolver.class,
 				new RESTContextPathResolverImpl(
 					objectDefinition,
@@ -554,6 +567,18 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		}
 
 		return serviceRegistrations;
+	}
+
+	private String _getScope(ObjectDefinition objectDefinition) {
+		if (Objects.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+			return ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				toString();
+		}
+
+		return ExtendedObjectClassDefinition.Scope.GROUP.toString();
 	}
 
 	private String _getServiceRegistrationKey(

--- a/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
+++ b/modules/apps/portal/portal-default-permissions-web/src/main/java/com/liferay/portal/defaultpermissions/web/internal/display/context/EditPortalDefaultPermissionsConfigurationDisplayContext.java
@@ -408,10 +408,14 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 			return _roleTypes;
 		}
 
-		_roleTypes = RoleConstants.TYPES_REGULAR_AND_SITE;
-
-		if ((_group != null) && _group.isDepot()) {
+		if ((_group == null) || _group.isControlPanel()) {
+			_roleTypes = _TYPES_DEPOT_AND_REGULAR_AND_SITE;
+		}
+		else if (_group.isDepot()) {
 			_roleTypes = _TYPES_DEPOT_AND_REGULAR;
+		}
+		else {
+			_roleTypes = RoleConstants.TYPES_REGULAR_AND_SITE;
 		}
 
 		if (ResourceActionsUtil.isPortalModelResource(getModelResource())) {
@@ -480,6 +484,11 @@ public class EditPortalDefaultPermissionsConfigurationDisplayContext {
 
 	private static final int[] _TYPES_DEPOT_AND_REGULAR = {
 		RoleConstants.TYPE_DEPOT, RoleConstants.TYPE_REGULAR
+	};
+
+	private static final int[] _TYPES_DEPOT_AND_REGULAR_AND_SITE = {
+		RoleConstants.TYPE_DEPOT, RoleConstants.TYPE_REGULAR,
+		RoleConstants.TYPE_SITE
 	};
 
 	private List<String> _actions;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BreadcrumbDisplayContext.java
@@ -66,7 +66,7 @@ public class BreadcrumbDisplayContext {
 					"href",
 					PermissionsURLTag.doTag(
 						StringPool.BLANK, DepotEntry.class.getName(),
-						group.getName(), null,
+						group.getName(), group.getGroupId(),
 						String.valueOf(group.getClassPK()),
 						LiferayWindowState.POP_UP.toString(), null,
 						_httpServletRequest)

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllSpacesDisplayContext.java
@@ -186,6 +186,8 @@ public class ViewAllSpacesDisplayContext {
 				).setParameter(
 					"modelResourceDescription", "{name}"
 				).setParameter(
+					"resourceGroupId", "{siteId}"
+				).setParameter(
 					"resourcePrimKey", "{id}"
 				).setWindowState(
 					LiferayWindowState.POP_UP

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
@@ -69,6 +69,8 @@ public class ViewStructureUsagesDisplayContext {
 				).setParameter(
 					"modelResourceDescription", "{embedded.name}"
 				).setParameter(
+					"resourceGroupId", "{embedded.scopeId}"
+				).setParameter(
 					"resourcePrimKey", "{embedded.id}"
 				).setWindowState(
 					LiferayWindowState.POP_UP


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66083

Right now, it is not possible to define what actions are available for users with depot roles, as the permission modals show the permissions in the context of the current group (i.e. the CMS group).

Also, it is not possible to define default permissions for depot roles.

# How am I fixing it?

By passing the resourceGroupId explicitly when creating the permission modals.

I've also extended the default permissions implementation so that it shows depot roles when appropriate. I've also implemented default permission support for depot entries and objects.