### PR TITLE
LPD-65946 Consolidate logic while fixing _getAssetVocabularyId()

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -709,40 +709,18 @@ public class TaxonomyCategoryResourceImpl
 			TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
-		if (taxonomyCategory.getTaxonomyVocabularyId() != null) {
-			if (taxonomyCategory.getTaxonomyVocabularyId() !=
-					assetCategory.getVocabularyId()) {
-
-				_assetVocabularyService.getVocabulary(
-					taxonomyCategory.getTaxonomyVocabularyId());
-			}
+		if ((taxonomyCategory.getTaxonomyVocabularyId() != null) &&
+			(taxonomyCategory.getTaxonomyVocabularyId() ==
+				assetCategory.getVocabularyId())) {
 
 			return taxonomyCategory.getTaxonomyVocabularyId();
 		}
-		else if (taxonomyCategory.getParentTaxonomyVocabulary() != null) {
-			ParentTaxonomyVocabulary parentTaxonomyVocabulary =
-				taxonomyCategory.getParentTaxonomyVocabulary();
 
-			String taxonomyVocabularyExternalReferenceCode =
-				parentTaxonomyVocabulary.getExternalReferenceCode();
+		Long taxonomyVocabularyId = _getTaxonomyVocabularyId(
+			groupId, taxonomyCategory);
 
-			if (Validator.isNotNull(taxonomyVocabularyExternalReferenceCode)) {
-				if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
-					AssetVocabulary assetVocabulary =
-						_assetVocabularyService.
-							getAssetVocabularyByExternalReferenceCode(
-								groupId,
-								taxonomyVocabularyExternalReferenceCode);
-
-					return assetVocabulary.getVocabularyId();
-				}
-
-				AssetVocabulary assetVocabulary =
-					_assetVocabularyService.getOrAddEmptyVocabulary(
-						taxonomyVocabularyExternalReferenceCode, groupId);
-
-				return assetVocabulary.getVocabularyId();
-			}
+		if (taxonomyVocabularyId != null) {
+			return taxonomyVocabularyId;
 		}
 
 		return assetCategory.getVocabularyId();
@@ -912,8 +890,7 @@ public class TaxonomyCategoryResourceImpl
 		}
 
 		if (Validator.isBlank(taxonomyVocabularyExternalReferenceCode)) {
-			throw new BadRequestException(
-				"Taxonomy vocabulary external reference code is required");
+			return null;
 		}
 
 		AssetVocabulary assetVocabulary = null;
@@ -992,12 +969,20 @@ public class TaxonomyCategoryResourceImpl
 			long groupId, TaxonomyCategory taxonomyCategory)
 		throws Exception {
 
+		Long taxonomyVocabularyId = _getTaxonomyVocabularyId(
+			groupId, taxonomyCategory);
+
+		if (taxonomyVocabularyId == null) {
+			throw new BadRequestException(
+				"Taxonomy vocabulary id or external reference code is " +
+					"required");
+		}
+
 		return _addTaxonomyCategory(
 			taxonomyCategory.getExternalReferenceCode(), groupId,
 			contextAcceptLanguage.getPreferredLanguageId(),
 			_getParentTaxonomyCategoryId(groupId, taxonomyCategory),
-			taxonomyCategory,
-			_getTaxonomyVocabularyId(groupId, taxonomyCategory));
+			taxonomyCategory, taxonomyVocabularyId);
 	}
 
 	private TaxonomyCategory _putTaxonomyCategory(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -1007,6 +1007,19 @@ public class TaxonomyCategoryResourceTest
 		throws Exception {
 
 		assertHttpResponseStatusCode(
+			200,
+			taxonomyCategoryResource.patchTaxonomyCategoryHttpResponse(
+				taxonomyCategory.getId(),
+				new TaxonomyCategory() {
+					{
+						taxonomyVocabularyId = randomTaxonomyVocabulary.getId();
+					}
+				}));
+
+		taxonomyCategoryResource.deleteTaxonomyCategory(
+			taxonomyCategory.getId());
+
+		assertHttpResponseStatusCode(
 			404,
 			taxonomyCategoryResource.patchTaxonomyCategoryHttpResponse(
 				taxonomyCategory.getId(),


### PR DESCRIPTION
Hello @AliciaGarciaGarcia,

I've updated the TaxonomyCategoryResourceTest for the new behavior. Could you review these changes?

Originally reviewed here: https://github.com/liferay-content-management/liferay-portal/pull/7143
> I ran into this problem ([LPD-65946](https://liferay.atlassian.net/browse/LPD-65946)) implementing [LPD-57271 Update staging logic for vocabularies to use Batch in the Import/Export UI](https://liferay.atlassian.net/browse/LPD-57271) .
> 
> **Steps to Reproduce**
> 
> 1. Enable Instance Scope feature.flag.LPD-35914 and Instance Scope feature.flag.LPD-17564
> 2. Create a Vocabulary and a Category in Guest Site
> 3. Export just the Category
> 4. Delete the Vocabulary and Category
> 5. Import the Category  -> :heavy_check_mark:   A placeholder Vocabulary with name = ERC of the missing Vocabulary is added with the Category in it.
> 6. Import the Category again
> 
> :heavy_check_mark: **Expected**: No errors are thrown
> 
> :x:  **Actual**: BadRequestException: `Taxonomy vocabulary external reference code is required` is thrown 

