### PR TITLE
LPD-66503 Sharing notifications do not have asset title (2nd try)

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -311,25 +311,28 @@ public class DepotAssetRendererFactoryWrapper<T>
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		if (serviceContext == null) {
-			Group group = _groupLocalService.fetchGroup(
-				GroupThreadLocal.getGroupId());
+		if (serviceContext != null) {
+			long scopeGroupId = GetterUtil.getLong(
+				serviceContext.getAttribute("scopeGroupId"));
 
-			if (group != null) {
-				return group;
+			if (scopeGroupId != 0) {
+				return _groupLocalService.fetchGroup(scopeGroupId);
 			}
 
-			return fallbackGroup;
+			if (serviceContext.getScopeGroupId() != 0) {
+				return _groupLocalService.fetchGroup(
+					serviceContext.getScopeGroupId());
+			}
 		}
 
-		long scopeGroupId = GetterUtil.getLong(
-			serviceContext.getAttribute("scopeGroupId"));
+		Group group = _groupLocalService.fetchGroup(
+			GroupThreadLocal.getGroupId());
 
-		if (scopeGroupId != 0) {
-			return _groupLocalService.fetchGroup(scopeGroupId);
+		if (group != null) {
+			return group;
 		}
 
-		return _groupLocalService.fetchGroup(serviceContext.getScopeGroupId());
+		return fallbackGroup;
 	}
 
 	private long _getGroupId(long groupId) throws PortalException {

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -14,6 +14,8 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -77,6 +79,22 @@ public class DepotAssetRendererFactoryWrapperTest {
 				assetRenderer,
 				depotAssetRendererFactoryWrapper.getAssetRenderer(
 					RandomTestUtil.randomLong()));
+		}
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(-1)) {
+
+			ServiceContextThreadLocal.pushServiceContext(new ServiceContext());
+
+			try {
+				Assert.assertSame(
+					assetRenderer,
+					depotAssetRendererFactoryWrapper.getAssetRenderer(
+						RandomTestUtil.randomLong()));
+			}
+			finally {
+				ServiceContextThreadLocal.popServiceContext();
+			}
 		}
 	}
 

--- a/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
+++ b/modules/apps/sharing/sharing-notifications/src/main/java/com/liferay/sharing/notifications/internal/service/NotificationsSharingEntryLocalServiceWrapper.java
@@ -281,7 +281,8 @@ public class NotificationsSharingEntryLocalServiceWrapper
 		String title = StringPool.BLANK;
 
 		if (sharingEntryInterpreter != null) {
-			title = sharingEntryInterpreter.getTitle(sharingEntry);
+			title = sharingEntryInterpreter.getTitle(
+				sharingEntry, resourceBundle.getLocale());
 		}
 		else {
 			title = ResourceBundleUtil.getString(resourceBundle, "something");


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66503

A sharing notification for a Space asset doesn't include the asset title.

# How am I fixing it?

Use fallback logic when service context doesn't have a scopeGroupId

# How can you verify that it works?

Run existing java unit test in module `/apps/depot/depot-web`:
`gw test --tests "DepotAssetRendererFactoryWrapperTest.testAssetRendererReturnsFallbackGroup"`

<img width="694" height="342" alt="image" src="https://github.com/user-attachments/assets/115c00ff-7c5c-462d-94f6-2f04cca6a2fa" />

