### PR TITLE
LPD-61617 Space invitation notification should expire if user group is removed from a space

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/SpaceService.ts
@@ -183,7 +183,7 @@ async function unlinkUserGroupFromSpace({
 	userGroupExternalReferenceCode: string;
 }) {
 	return await ApiHelper.delete(
-		`/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/${spaceExternalReferenceCode}/by-external-reference-code/${userGroupExternalReferenceCode}`
+		`/o/headless-asset-library/v1.0/asset-libraries/by-external-reference-code/${spaceExternalReferenceCode}/user-groups/by-external-reference-code/${userGroupExternalReferenceCode}`
 	);
 }
 

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '028b4a57fcab50dccbbfeb0881bb7c1c43ee8499f6731dc8c93b249401b26924',
+	hash: 'e0716bc3a1169e76a69665d0d17d3284cfba0221f555ab29737a7b682065d498',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -7,20 +7,27 @@ import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 
-type UserOrUserGroupType = 'users' | 'groups';
+type UserOrUserGroupType = 'groups' | 'users';
 
 export class SpaceSummaryPage {
 	readonly page: Page;
+
+	readonly closeButton: Locator;
+	readonly userGroupsTab: Locator;
+	readonly usersTab: Locator;
 	readonly viewAllContentLink: Locator;
 	readonly viewAllFilesLink: Locator;
 	readonly viewAllMembersLink: Locator;
 	readonly viewAllSitesLink: Locator;
-	readonly usersTab: Locator;
-	readonly userGroupsTab: Locator;
-	readonly closeButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+
+		this.closeButton = this.page.getByLabel('close', {exact: true});
+
+		this.userGroupsTab = page.getByRole('tab', {name: 'User Groups'});
+
+		this.usersTab = page.getByRole('tab', {name: 'Users'});
 
 		this.viewAllContentLink = this.page.getByRole('link', {
 			name: 'View All Content',
@@ -37,12 +44,6 @@ export class SpaceSummaryPage {
 		this.viewAllSitesLink = this.page.getByRole('button', {
 			name: 'View All Sites',
 		});
-
-		this.usersTab = page.getByRole('tab', {name: 'Users'});
-
-		this.userGroupsTab = page.getByRole('tab', {name: 'User Groups'});
-
-		this.closeButton = this.page.getByLabel('close', {exact: true});
 	}
 
 	async goto(spaceName: string) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -7,11 +7,16 @@ import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 
+type UserOrUserGroupType = 'users' | 'groups';
+
 export class SpaceSummaryPage {
 	readonly page: Page;
 	readonly viewAllContentLink: Locator;
 	readonly viewAllFilesLink: Locator;
+	readonly viewAllMembersLink: Locator;
 	readonly viewAllSitesLink: Locator;
+	readonly usersTab: Locator;
+	readonly userGroupsTab: Locator;
 	readonly closeButton: Locator;
 
 	constructor(page: Page) {
@@ -25,9 +30,17 @@ export class SpaceSummaryPage {
 			name: 'View All Files',
 		});
 
+		this.viewAllMembersLink = this.page.getByRole('button', {
+			name: 'View All Members',
+		});
+
 		this.viewAllSitesLink = this.page.getByRole('button', {
 			name: 'View All Sites',
 		});
+
+		this.usersTab = page.getByRole('tab', {name: 'Users'});
+
+		this.userGroupsTab = page.getByRole('tab', {name: 'User Groups'});
 
 		this.closeButton = this.page.getByLabel('close', {exact: true});
 	}
@@ -36,6 +49,38 @@ export class SpaceSummaryPage {
 		await this.page.goto(PORTLET_URLS.cms);
 		await this.page.getByRole('menuitem', {name: spaceName}).click();
 		await this.viewAllContentLink.waitFor();
+	}
+
+	async addUserOrUserGroup(name: string, type: UserOrUserGroupType) {
+		await this.viewAllMembersLink.click();
+
+		this.page.getByRole('dialog').waitFor();
+		await this.page
+			.getByLabel('Add People to Collaborate', {exact: true})
+			.selectOption(type);
+		await this.page
+			.getByPlaceholder('Enter name or email.', {exact: true})
+			.click();
+		await this.page.getByRole('option', {name}).click();
+
+		await this.closeButton.click();
+	}
+
+	async removeUserOrUserGroup(name: string, type: UserOrUserGroupType) {
+		await this.viewAllMembersLink.click();
+
+		this.page.getByRole('dialog').waitFor();
+		await this.page
+			.getByLabel('Add People to Collaborate', {exact: true})
+			.selectOption(type);
+
+		await this.page
+			.locator('li')
+			.filter({hasText: name})
+			.getByLabel('Remove Group')
+			.click();
+
+		await this.closeButton.click();
 	}
 
 	async connectSite(siteName: string) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
@@ -9,6 +9,7 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -81,6 +82,40 @@ test(
 		expect(page.getByRole('link', {name: spaceName})).toBeVisible();
 		expect(page.getByRole('link', {name: 'Contents'})).toBeVisible();
 		expect(page.getByText('No Content Yet')).toBeVisible();
+	}
+);
+
+test(
+	'Can add and delete a user group as a member of the space',
+	{tag: '@LPD-61617'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = 'Default';
+
+		await spaceSummaryPage.goto(spaceName);
+
+		const userGroup = await apiHelpers.headlessAdminUser.postUserGroup();
+
+		await spaceSummaryPage.addUserOrUserGroup(userGroup.name, 'groups');
+
+		await waitForAlert(
+			page,
+			`Success:Group ${userGroup.name} successfully added to space.`
+		);
+
+		await spaceSummaryPage.userGroupsTab.click();
+
+		expect(page.getByText(userGroup.name, {exact: true})).toBeVisible();
+
+		await spaceSummaryPage.removeUserOrUserGroup(userGroup.name, 'groups');
+
+		await waitForAlert(
+			page,
+			`Success:Group ${userGroup.name} successfully removed from space.`
+		);
+
+		await spaceSummaryPage.userGroupsTab.click();
+
+		expect(page.getByText(userGroup.name, {exact: true})).not.toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/workflows.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/workflows.spec.ts
@@ -50,7 +50,7 @@ test(
 		const spaceName = `Space ${getRandomString()}`;
 
 		const {id: spaceId} =
-			await apiHelpers.headlessAssetLibrary.createAssetLibrariesPage({
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 				name: spaceName,
 				settings: {},
 				type: 'Space',
@@ -135,9 +135,7 @@ test(
 		// Delete space
 
 		expect(
-			await apiHelpers.headlessAssetLibrary.deleteAssetLibrariesPage(
-				spaceId
-			)
+			await apiHelpers.headlessAssetLibrary.deleteAssetLibrary(spaceId)
 		).toBeOK();
 	}
 );


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-61617

A Space invitation notification is not expired if user group is removed from a space

# How am I fixing it?

The removal of a user group from a Space was not working. Fixing the endpoint url.

# How can you verify that it works?

Run new PW test:
`npm run playwright -- test -g 'Can add and delete a user group as a member of the space'`
