### PR TITLE
LPD-66591 Fix Breadcrumb styles on CMS

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
@@ -4,8 +4,8 @@ $border-radius: 0.5rem;
 $border-radius-lg: 0.5rem;
 $border-radius-sm: 0.5rem;
 
-$breadcrumb-divider-svg-icon: clay-icon(angle-right, $gray-600);
-$breadcrumb-divider-svg-icon-height: 8px;
+$breadcrumb-divider-svg-icon: clay-icon(slash, $gray-600);
+$breadcrumb-divider-svg-icon-height: 15px;
 $breadcrumb-font-size: 18px !default;
 
 $btn-xs-border-radius: 0.25rem;

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
@@ -4,11 +4,9 @@ $border-radius: 0.5rem;
 $border-radius-lg: 0.5rem;
 $border-radius-sm: 0.5rem;
 
-$breadcrumb-divider-svg-icon: clay-icon(slash, $gray-600);
-$breadcrumb-divider-svg-icon-height: 0.9em;
-$breadcrumb-link-color: $gray-900 !default;
-$breadcrumb-font-size: 24px !default;
-$breadcrumb-font-weight: 600 !default;
+$breadcrumb-divider-svg-icon: clay-icon(angle-right, $gray-600);
+$breadcrumb-divider-svg-icon-height: 8px;
+$breadcrumb-font-size: 18px !default;
 
 $btn-xs-border-radius: 0.25rem;
 

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_breadcrumb.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_breadcrumb.scss
@@ -1,8 +1,8 @@
 .cms-breadcrumb .breadcrumb-item {
-	margin-right: 8px;
+	margin-right: 6px;
 
 	+ .breadcrumb-item {
-		padding-left: 16px;
+		padding-left: 21px;
 	}
 
 	.breadcrumb-link:not([href]) {

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_breadcrumb.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_breadcrumb.scss
@@ -1,4 +1,10 @@
 .cms-breadcrumb .breadcrumb-item {
+	margin-right: 8px;
+
+	+ .breadcrumb-item {
+		padding-left: 16px;
+	}
+
 	.breadcrumb-link:not([href]) {
 		text-decoration: none;
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/Breadcrumb.tsx
@@ -110,10 +110,13 @@ export default function Breadcrumb({
 	hideSpace,
 	size,
 }: Props) {
+	const isTitle = breadcrumbItems.length === 1;
+
 	return (
 		<div
 			aria-label={Liferay.Language.get('breadcrumb')}
-			className="autofit-row autofit-row-center p-4"
+			className="autofit-row autofit-row-center px-4"
+			style={{height: '72px'}}
 		>
 			{!hideSpace && (
 				<div className="autofit-col mr-3">
@@ -127,11 +130,17 @@ export default function Breadcrumb({
 			)}
 
 			<div className="autofit-col cms-breadcrumb">
-				<ClayBreadcrumb className="p-0" items={breadcrumbItems} />
+				{isTitle ? (
+					<h2 className="font-weight-semi-bold mb-0 text-7 text-dark">
+						{breadcrumbItems[0]?.label}
+					</h2>
+				) : (
+					<ClayBreadcrumb className="p-0" items={breadcrumbItems} />
+				)}
 			</div>
 
 			{actionItems && (
-				<div className="autofit-col">
+				<div className="autofit-col ml-1">
 					<ClayDropDown
 						hasLeftSymbols={actionItems.some(
 							({symbolLeft}) => !!symbolLeft
@@ -145,7 +154,7 @@ export default function Breadcrumb({
 									'more-actions'
 								)}
 								displayType="unstyled"
-								size="xs"
+								size="sm"
 								symbol="ellipsis-v"
 							/>
 						}

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '028b4a57fcab50dccbbfeb0881bb7c1c43ee8499f6731dc8c93b249401b26924',
+	hash: 'e0716bc3a1169e76a69665d0d17d3284cfba0221f555ab29737a7b682065d498',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],


### PR DESCRIPTION
# What is this trying to solve?

[LPD-66591](https://liferay.atlassian.net/browse/LPD-66591)

Fix Breadcrumb styles on CMS

# How am I fixing it?

Following the UI specifications in [FIGMA](https://www.figma.com/design/t8qNXzWSAapCqPINrlKq2J/LPD-33021-CMS-Look---Feel?node-id=676-2188&t=VRU9CmdGzWDqonij-0)

# How can you verify that it works?

Navigating between CMS pages.

<img width="780" height="197" alt="image" src="https://github.com/user-attachments/assets/b4a2c600-6f54-4844-a0c5-3d4cd8f6f5d8" />
<img width="778" height="197" alt="Screenshot from 2025-09-25 10-02-44" src="https://github.com/user-attachments/assets/85e4710d-f133-4674-b516-317b4767e1b1" />
<img width="778" height="197" alt="Screenshot from 2025-09-25 10-03-03" src="https://github.com/user-attachments/assets/30a2041a-2eb3-4944-ada5-3e2c3a05f313" />
<img width="778" height="197" alt="Screenshot from 2025-09-25 10-03-26" src="https://github.com/user-attachments/assets/c91a073a-ac60-4085-b1c4-f449c13133bd" />
