### PR TITLE
LPD-66635 Provide meaningful default title

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/layout/display/page/test/ObjectEntryLayoutDisplayPageObjectProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/layout/display/page/test/ObjectEntryLayoutDisplayPageObjectProviderTest.java
@@ -80,6 +80,23 @@ public class ObjectEntryLayoutDisplayPageObjectProviderTest {
 				objectDefinition.getObjectDefinitionId(),
 				objectField.getObjectFieldId());
 
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, objectDefinition.getObjectDefinitionId(),
+			ServiceContextTestUtil.getServiceContext(), Collections.emptyMap());
+
+		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+			layoutDisplayPageProviderRegistry.
+				getLayoutDisplayPageProviderByURLSeparator(
+					FriendlyURLResolverConstants.URL_SEPARATOR_OBJECT_ENTRY);
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				0, String.valueOf(objectEntry.getObjectEntryId()));
+
+		Assert.assertEquals(
+			objectDefinition.getLabel(LocaleUtil.getDefault()),
+			layoutDisplayPageObjectProvider.getTitle(LocaleUtil.getDefault()));
+
 		Map<String, String> localizedValues = HashMapBuilder.put(
 			"en_US", RandomTestUtil.randomString()
 		).put(
@@ -93,19 +110,14 @@ public class ObjectEntryLayoutDisplayPageObjectProviderTest {
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+		objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			0, objectDefinition.getObjectDefinitionId(), serviceContext,
 			HashMapBuilder.<String, Serializable>put(
 				objectField.getI18nObjectFieldName(),
 				(Serializable)localizedValues
 			).build());
 
-		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
-			layoutDisplayPageProviderRegistry.
-				getLayoutDisplayPageProviderByURLSeparator(
-					FriendlyURLResolverConstants.URL_SEPARATOR_OBJECT_ENTRY);
-
-		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+		layoutDisplayPageObjectProvider =
 			layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
 				0, String.valueOf(objectEntry.getObjectEntryId()));
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
@@ -102,14 +102,16 @@ public class ObjectEntryLayoutDisplayPageObjectProvider
 			if (Validator.isNotNull(titleValue)) {
 				return titleValue;
 			}
+
+			return _objectDefinition.getLabel(locale);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(portalException);
 			}
-		}
 
-		return StringPool.BLANK;
+			return StringPool.BLANK;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66635

An object may have an empty title. In this case, use the object definition title as the title of the layout.

# How can you verify that it works?

Run the included integration test.