### PR TITLE
LPD-62456 non admin user cannot see other members in space memberships (2n try)

### DIFF
--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/UserAccountDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/UserAccountDTOConverter.java
@@ -10,8 +10,8 @@ import com.liferay.headless.asset.library.dto.v1_0.UserAccount;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.RoleService;
-import com.liferay.portal.kernel.service.UserService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -41,7 +41,14 @@ public class UserAccountDTOConverter
 	public UserAccount toDTO(DTOConverterContext dtoConverterContext)
 		throws Exception {
 
-		User user = _userService.getUserById((Long)dtoConverterContext.getId());
+		// Permission checks are performed in the user account resource so it is
+		// safe to invoke the local service.
+		// It is a product requirement that asset library members should be able
+		// to see other asset library members, even if they don't have VIEW
+		// permission over User. See LPD-62456.
+
+		User user = _userLocalService.getUserById(
+			(Long)dtoConverterContext.getId());
 
 		return new UserAccount() {
 			{
@@ -70,8 +77,16 @@ public class UserAccountDTOConverter
 								dtoConverterContext.getAttribute(
 									"assetLibraryId"));
 
+							// Permission checks are performed in the user
+							// account resource so it is safe to invoke the
+							// local service.
+							// It is a product requirement that asset library
+							// members should be able to see other asset library
+							// members, even if they don't have VIEW permission
+							// over User. See LPD-62456.
+
 							return TransformUtil.transformToArray(
-								_roleService.getUserGroupRoles(
+								_roleLocalService.getUserGroupRoles(
 									user.getUserId(), assetLibraryId),
 								role -> _toRole(role), Role.class);
 						}));
@@ -96,9 +111,9 @@ public class UserAccountDTOConverter
 	private Portal _portal;
 
 	@Reference
-	private RoleService _roleService;
+	private RoleLocalService _roleLocalService;
 
 	@Reference
-	private UserService _userService;
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -15,20 +15,23 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
-import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.model.UserTable;
 import com.liferay.portal.kernel.search.Sort;
-import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -36,10 +39,12 @@ import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -98,10 +103,15 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		}
 
 		Group group = _getGroup(assetLibraryExternalReferenceCode);
-		User user = _userService.getUserByExternalReferenceCode(
+
+		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
+
+		User user = _userLocalService.getUserByExternalReferenceCode(
 			userAccountExternalReferenceCode, contextCompany.getCompanyId());
 
-		return getAssetLibraryUserAccount(group.getGroupId(), user.getUserId());
+		_checkAssetLibraryMember(group.getGroupId(), user.getUserId());
+
+		return _toUserAccount(group.getGroupId(), user);
 	}
 
 	@Override
@@ -117,8 +127,10 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 
 		Group group = _getGroup(externalReferenceCode);
 
-		return getAssetLibraryUserAccountsPage(
-			group.getGroupId(), keywords, search, pagination, sorts);
+		_checkAssetLibraryAdminOrAssetLibraryMember(group.getGroupId());
+
+		return _getUserAccountsPage(
+			group.getGroupId(), keywords, pagination, sorts);
 	}
 
 	@Override
@@ -130,14 +142,11 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		User user = _userService.getUserById(userAccountId);
+		_checkAssetLibraryAdminOrAssetLibraryMember(assetLibraryId);
 
-		if (!_groupService.hasUserGroup(user.getUserId(), assetLibraryId)) {
-			throw new NoSuchUserException(
-				StringBundler.concat(
-					"User ", userAccountId, " is not associated to group ",
-					assetLibraryId));
-		}
+		User user = _userLocalService.getUserById(userAccountId);
+
+		_checkAssetLibraryMember(assetLibraryId, user.getUserId());
 
 		return _toUserAccount(assetLibraryId, user);
 	}
@@ -152,6 +161,8 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
 			throw new UnsupportedOperationException();
 		}
+
+		_checkAssetLibraryAdminOrAssetLibraryMember(assetLibraryId);
 
 		return _getUserAccountsPage(
 			assetLibraryId, keywords, pagination, sorts);
@@ -188,6 +199,32 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			assetLibraryId, _updateUser(assetLibraryId, userAccountId, true));
 	}
 
+	private void _checkAssetLibraryAdminOrAssetLibraryMember(long groupId)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isGroupAdmin(groupId)) {
+			return;
+		}
+
+		if (!_userService.hasGroupUser(groupId, contextUser.getUserId())) {
+			throw new PrincipalException.MustHavePermission(
+				contextUser.getUserId(), ActionKeys.VIEW);
+		}
+	}
+
+	private void _checkAssetLibraryMember(long groupId, long userId)
+		throws Exception {
+
+		if (!_userLocalService.hasGroupUser(groupId, userId)) {
+			throw new NoSuchUserException(
+				StringBundler.concat(
+					"User ", userId, " is not associated to group ", groupId));
+		}
+	}
+
 	private Group _getGroup(String externalReferenceCode) throws Exception {
 		Group group = _groupService.fetchGroupByExternalReferenceCode(
 			externalReferenceCode, contextCompany.getCompanyId());
@@ -202,10 +239,9 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 	}
 
 	private Page<UserAccount> _getUserAccountsPage(
-			Long groupId, String keywords, Pagination pagination, Sort[] sorts)
-		throws Exception {
+		Long groupId, String keywords, Pagination pagination, Sort[] sorts) {
 
-		return SearchUtil.search(
+		return Page.of(
 			HashMapBuilder.put(
 				"create",
 				addAction(
@@ -220,22 +256,20 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			).put(
 				"get",
 				addAction(
-					ActionKeys.VIEW, 0L, "getAssetLibraryUserAccountsPage",
+					ActionKeys.VIEW_MEMBERS, groupId,
+					"getAssetLibraryUserAccountsPage",
 					_groupModelResourcePermission)
 			).build(),
-			booleanQuery -> booleanQuery.add(
-				new TermQueryImpl("groupIds", String.valueOf(groupId)),
-				BooleanClauseOccur.MUST),
-			null, User.class.getName(), keywords, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> searchContext.setCompanyId(
-				contextCompany.getCompanyId()),
-			sorts,
-			document -> _toUserAccount(
-				groupId,
-				_userService.getUserById(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
+			transform(
+				_userLocalService.searchBySocial(
+					contextCompany.getCompanyId(), new long[] {groupId}, null,
+					keywords, pagination.getStartPosition(),
+					pagination.getEndPosition(), _toOrderByComparator(sorts)),
+				user -> _toUserAccount(groupId, user)),
+			pagination,
+			_userLocalService.searchCountBySocial(
+				contextCompany.getCompanyId(), new long[] {groupId}, null,
+				keywords));
 	}
 
 	private long[] _getUserGroupIds(
@@ -255,6 +289,36 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		}
 
 		return ArrayUtil.toLongArray(groupIds);
+	}
+
+	private OrderByComparator<User> _toOrderByComparator(Sort[] sorts) {
+		if (ArrayUtil.isEmpty(sorts)) {
+			return null;
+		}
+
+		List<Object> objects = new ArrayList<>();
+
+		for (Sort sort : sorts) {
+			if (Objects.equals(sort.getFieldName(), "externalReferenceCode")) {
+				objects.add(sort.getFieldName());
+				objects.add(!sort.isReverse());
+			}
+			else if (Objects.equals(sort.getFieldName(), "id")) {
+				objects.add("userId");
+				objects.add(!sort.isReverse());
+			}
+			else if (Objects.equals(sort.getFieldName(), "name")) {
+				objects.add("firstName");
+				objects.add(!sort.isReverse());
+				objects.add("middleName");
+				objects.add(!sort.isReverse());
+				objects.add("lastName");
+				objects.add(!sort.isReverse());
+			}
+		}
+
+		return OrderByComparatorFactoryUtil.create(
+			UserTable.INSTANCE.getTableName(), objects.toArray());
 	}
 
 	private UserAccount _toUserAccount(long assetLibraryId, User user)
@@ -332,6 +396,9 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 		target = "(component.name=com.liferay.headless.asset.library.internal.dto.v1_0.converter.UserAccountDTOConverter)"
 	)
 	private DTOConverter<User, UserAccount> _userAccountDTOConverter;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.portal.kernel.model.User)"

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -11,10 +11,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.IdEntityField;
+import com.liferay.portal.odata.entity.StringEntityField;
 import com.liferay.portal.test.rule.FeatureFlag;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -43,8 +45,30 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testGetAssetLibraryByExternalReferenceCodeUserAccountsPage()
+		throws Exception {
+
+		super.testGetAssetLibraryByExternalReferenceCodeUserAccountsPage();
+
+		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSortId();
+	}
+
+	@Override
+	@Test
+	public void testGetAssetLibraryUserAccountsPage() throws Exception {
+		super.testGetAssetLibraryUserAccountsPage();
+
+		_testGetAssetLibraryUserAccountsPageWithSortId();
+	}
+
+	@Override
 	protected Collection<EntityField> getEntityFields() {
-		return Collections.emptyList();
+		return List.of(
+			new StringEntityField(
+				"externalReferenceCode", locale -> "externalReferenceCode"),
+			new StringEntityField("name", locale -> "name"),
+			new IdEntityField("id", locale -> "id", locale -> "id"));
 	}
 
 	@Override
@@ -195,6 +219,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		Group group = testDepotEntry.getGroup();
 
 		return group.getExternalReferenceCode();
+	}
+
+	private void _testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSortId()
+		throws Exception {
+
+		testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSort(
+			EntityField.Type.ID,
+			(entityField, userAccount1, userAccount2) -> {
+			});
+	}
+
+	private void _testGetAssetLibraryUserAccountsPageWithSortId()
+		throws Exception {
+
+		testGetAssetLibraryUserAccountsPageWithSort(
+			EntityField.Type.ID,
+			(entityField, userAccount1, userAccount2) -> {
+			});
 	}
 
 	private User _testUser;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -7,9 +7,16 @@ package com.liferay.headless.asset.library.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.asset.library.client.dto.v1_0.UserAccount;
+import com.liferay.headless.asset.library.client.pagination.Page;
+import com.liferay.headless.asset.library.client.pagination.Pagination;
+import com.liferay.headless.asset.library.client.resource.v1_0.UserAccountResource;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.IdEntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
@@ -18,6 +25,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -46,12 +54,32 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
+	public void testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode();
+
+		_testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCodeWithAssetLibraryMember();
+	}
+
+	@Override
+	@Test
 	public void testGetAssetLibraryByExternalReferenceCodeUserAccountsPage()
 		throws Exception {
 
 		super.testGetAssetLibraryByExternalReferenceCodeUserAccountsPage();
 
+		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember();
 		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSortId();
+	}
+
+	@Override
+	@Test
+	public void testGetAssetLibraryUserAccount() throws Exception {
+		super.testGetAssetLibraryUserAccount();
+
+		_testGetAssetLibraryUserAccountWithAssetLibraryMember();
 	}
 
 	@Override
@@ -59,6 +87,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testGetAssetLibraryUserAccountsPage() throws Exception {
 		super.testGetAssetLibraryUserAccountsPage();
 
+		_testGetAssetLibraryUserAccountsPageWithAssetLibraryMember();
 		_testGetAssetLibraryUserAccountsPageWithSortId();
 	}
 
@@ -221,6 +250,89 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return group.getExternalReferenceCode();
 	}
 
+	private UserAccountResource _getUserAccountResource() throws Exception {
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[] {
+				testGetAssetLibraryUserAccountsPage_getAssetLibraryId()
+			},
+			ServiceContextTestUtil.getServiceContext());
+
+		return UserAccountResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private void _testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCodeWithAssetLibraryMember()
+		throws Exception {
+
+		UserAccount postUserAccount =
+			testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode_addUserAccount();
+
+		UserAccountResource assetLibraryMemberUserAccountResource =
+			_getUserAccountResource();
+
+		UserAccount getUserAccount =
+			assetLibraryMemberUserAccountResource.
+				getAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode(
+					testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode_getAssetLibraryExternalReferenceCode(),
+					postUserAccount.getExternalReferenceCode());
+
+		assertEquals(postUserAccount, getUserAccount);
+		assertValid(getUserAccount);
+	}
+
+	private void _testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember()
+		throws Exception {
+
+		String externalReferenceCode =
+			testGetAssetLibraryByExternalReferenceCodeUserAccountsPage_getExternalReferenceCode();
+
+		UserAccountResource assetLibraryMemberUserAccountResource =
+			_getUserAccountResource();
+
+		Page<UserAccount> page =
+			assetLibraryMemberUserAccountResource.
+				getAssetLibraryByExternalReferenceCodeUserAccountsPage(
+					externalReferenceCode, null, null, Pagination.of(1, 10),
+					null);
+
+		long totalCount = page.getTotalCount();
+
+		UserAccount userAccount1 =
+			testGetAssetLibraryByExternalReferenceCodeUserAccountsPage_addUserAccount(
+				externalReferenceCode, randomUserAccount());
+
+		UserAccount userAccount2 =
+			testGetAssetLibraryByExternalReferenceCodeUserAccountsPage_addUserAccount(
+				externalReferenceCode, randomUserAccount());
+
+		page =
+			assetLibraryMemberUserAccountResource.
+				getAssetLibraryByExternalReferenceCodeUserAccountsPage(
+					externalReferenceCode, null, null, Pagination.of(1, 10),
+					null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(userAccount1, (List<UserAccount>)page.getItems());
+		assertContains(userAccount2, (List<UserAccount>)page.getItems());
+		assertValid(
+			page,
+			testGetAssetLibraryByExternalReferenceCodeUserAccountsPage_getExpectedActions(
+				externalReferenceCode));
+	}
+
 	private void _testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSortId()
 		throws Exception {
 
@@ -230,6 +342,45 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			});
 	}
 
+	private void _testGetAssetLibraryUserAccountsPageWithAssetLibraryMember()
+		throws Exception {
+
+		Long assetLibraryId =
+			testGetAssetLibraryUserAccountsPage_getAssetLibraryId();
+
+		UserAccountResource assetLibraryMemberUserAccountResource =
+			_getUserAccountResource();
+
+		Page<UserAccount> page =
+			assetLibraryMemberUserAccountResource.
+				getAssetLibraryUserAccountsPage(
+					assetLibraryId, null, null, Pagination.of(1, 10), null);
+
+		long totalCount = page.getTotalCount();
+
+		UserAccount userAccount1 =
+			testGetAssetLibraryUserAccountsPage_addUserAccount(
+				assetLibraryId, randomUserAccount());
+
+		UserAccount userAccount2 =
+			testGetAssetLibraryUserAccountsPage_addUserAccount(
+				assetLibraryId, randomUserAccount());
+
+		page =
+			assetLibraryMemberUserAccountResource.
+				getAssetLibraryUserAccountsPage(
+					assetLibraryId, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(userAccount1, (List<UserAccount>)page.getItems());
+		assertContains(userAccount2, (List<UserAccount>)page.getItems());
+		assertValid(
+			page,
+			testGetAssetLibraryUserAccountsPage_getExpectedActions(
+				assetLibraryId));
+	}
+
 	private void _testGetAssetLibraryUserAccountsPageWithSortId()
 		throws Exception {
 
@@ -237,6 +388,24 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			EntityField.Type.ID,
 			(entityField, userAccount1, userAccount2) -> {
 			});
+	}
+
+	private void _testGetAssetLibraryUserAccountWithAssetLibraryMember()
+		throws Exception {
+
+		UserAccount postUserAccount =
+			testGetAssetLibraryUserAccount_addUserAccount();
+
+		UserAccountResource assetLibraryMemberUserAccountResource =
+			_getUserAccountResource();
+
+		UserAccount getUserAccount =
+			assetLibraryMemberUserAccountResource.getAssetLibraryUserAccount(
+				testGetAssetLibraryUserAccount_getAssetLibraryId(),
+				postUserAccount.getId());
+
+		assertEquals(postUserAccount, getUserAccount);
+		assertValid(getUserAccount);
 	}
 
 	private User _testUser;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -70,7 +70,10 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		super.testGetAssetLibraryByExternalReferenceCodeUserAccountsPage();
 
-		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember();
+		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember(
+			"");
+		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember(
+			"roles");
 		_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithSortId();
 	}
 
@@ -79,7 +82,19 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testGetAssetLibraryUserAccount() throws Exception {
 		super.testGetAssetLibraryUserAccount();
 
-		_testGetAssetLibraryUserAccountWithAssetLibraryMember();
+		UserAccount postUserAccount =
+			testGetAssetLibraryUserAccount_addUserAccount();
+
+		UserAccountResource assetLibraryMemberUserAccountResource =
+			_getUserAccountResource("");
+
+		UserAccount getUserAccount =
+			assetLibraryMemberUserAccountResource.getAssetLibraryUserAccount(
+				testGetAssetLibraryUserAccount_getAssetLibraryId(),
+				postUserAccount.getId());
+
+		assertEquals(postUserAccount, getUserAccount);
+		assertValid(getUserAccount);
 	}
 
 	@Override
@@ -87,7 +102,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testGetAssetLibraryUserAccountsPage() throws Exception {
 		super.testGetAssetLibraryUserAccountsPage();
 
-		_testGetAssetLibraryUserAccountsPageWithAssetLibraryMember();
+		_testGetAssetLibraryUserAccountsPageWithAssetLibraryMember("");
+		_testGetAssetLibraryUserAccountsPageWithAssetLibraryMember("roles");
 		_testGetAssetLibraryUserAccountsPageWithSortId();
 	}
 
@@ -250,7 +266,9 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return group.getExternalReferenceCode();
 	}
 
-	private UserAccountResource _getUserAccountResource() throws Exception {
+	private UserAccountResource _getUserAccountResource(String nestedFields)
+		throws Exception {
+
 		String password = RandomTestUtil.randomString();
 
 		User user = UserTestUtil.addUser(
@@ -270,6 +288,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			testCompany.getVirtualHostname(), 8080, "http"
 		).locale(
 			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", nestedFields
 		).build();
 	}
 
@@ -280,7 +300,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			testGetAssetLibraryByExternalReferenceCodeAssetLibraryExternalReferenceCodeUserAccountByExternalReferenceCodeUserAccountExternalReferenceCode_addUserAccount();
 
 		UserAccountResource assetLibraryMemberUserAccountResource =
-			_getUserAccountResource();
+			_getUserAccountResource("");
 
 		UserAccount getUserAccount =
 			assetLibraryMemberUserAccountResource.
@@ -292,14 +312,16 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		assertValid(getUserAccount);
 	}
 
-	private void _testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember()
+	private void
+			_testGetAssetLibraryByExternalReferenceCodeUserAccountsPageWithAssetLibraryMember(
+				String nestedFields)
 		throws Exception {
 
 		String externalReferenceCode =
 			testGetAssetLibraryByExternalReferenceCodeUserAccountsPage_getExternalReferenceCode();
 
 		UserAccountResource assetLibraryMemberUserAccountResource =
-			_getUserAccountResource();
+			_getUserAccountResource(nestedFields);
 
 		Page<UserAccount> page =
 			assetLibraryMemberUserAccountResource.
@@ -342,14 +364,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			});
 	}
 
-	private void _testGetAssetLibraryUserAccountsPageWithAssetLibraryMember()
+	private void _testGetAssetLibraryUserAccountsPageWithAssetLibraryMember(
+			String nestedFields)
 		throws Exception {
 
 		Long assetLibraryId =
 			testGetAssetLibraryUserAccountsPage_getAssetLibraryId();
 
 		UserAccountResource assetLibraryMemberUserAccountResource =
-			_getUserAccountResource();
+			_getUserAccountResource(nestedFields);
 
 		Page<UserAccount> page =
 			assetLibraryMemberUserAccountResource.
@@ -388,24 +411,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			EntityField.Type.ID,
 			(entityField, userAccount1, userAccount2) -> {
 			});
-	}
-
-	private void _testGetAssetLibraryUserAccountWithAssetLibraryMember()
-		throws Exception {
-
-		UserAccount postUserAccount =
-			testGetAssetLibraryUserAccount_addUserAccount();
-
-		UserAccountResource assetLibraryMemberUserAccountResource =
-			_getUserAccountResource();
-
-		UserAccount getUserAccount =
-			assetLibraryMemberUserAccountResource.getAssetLibraryUserAccount(
-				testGetAssetLibraryUserAccount_getAssetLibraryId(),
-				postUserAccount.getId());
-
-		assertEquals(postUserAccount, getUserAccount);
-		assertValid(getUserAccount);
 	}
 
 	private User _testUser;

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -48,19 +48,16 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	}
 
 	@Override
-	protected UserAccount randomIrrelevantUserAccount() throws Exception {
-		User user = UserTestUtil.addUser();
-
-		return userAccountResource.putAssetLibraryUserAccount(
-			irrelevantDepotEntry.getGroupId(), user.getUserId());
-	}
-
-	@Override
 	protected UserAccount randomUserAccount() throws Exception {
 		User user = UserTestUtil.addUser();
 
-		return userAccountResource.putAssetLibraryUserAccount(
-			testDepotEntry.getGroupId(), user.getUserId());
+		return new UserAccount() {
+			{
+				externalReferenceCode = user.getExternalReferenceCode();
+				id = user.getUserId();
+				name = user.getFullName();
+			}
+		};
 	}
 
 	@Override
@@ -144,6 +141,21 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		return userAccountResource.putAssetLibraryUserAccount(
 			assetLibraryId, userAccount.getId());
+	}
+
+	@Override
+	protected Long testGetAssetLibraryUserAccountsPage_getAssetLibraryId()
+		throws Exception {
+
+		return testDepotEntry.getGroupId();
+	}
+
+	@Override
+	protected Long
+			testGetAssetLibraryUserAccountsPage_getIrrelevantAssetLibraryId()
+		throws Exception {
+
+		return irrelevantDepotEntry.getGroupId();
 	}
 
 	@Override

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -1111,6 +1111,38 @@ public class UserLocalServiceTest {
 	}
 
 	@Test
+	public void testSearchBySocial() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		List<User> users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), null, null, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(users.contains(user));
+
+		_testSearchBySocialWithGroup();
+		_testSearchBySocialWithUserGroup();
+		_testSearchBySocialWithGroupAndUserGroup();
+	}
+
+	@Test
+	public void testSearchCountBySocial() throws Exception {
+		int usersCount1 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), null, null, null);
+
+		UserTestUtil.addUser();
+
+		int usersCount2 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), null, null, null);
+
+		Assert.assertEquals(usersCount1 + 1, usersCount2);
+
+		_testSearchCountBySocialWithGroup();
+		_testSearchCountBySocialWithUserGroup();
+		_testSearchCountBySocialWithGroupAndUserGroup();
+	}
+
+	@Test
 	public void testSearchCounts() throws Exception {
 
 		// LPS-119805
@@ -1826,6 +1858,146 @@ public class UserLocalServiceTest {
 				PasswordEncryptorUtil.getEncryptedPasswordAlgorithmSettings(
 					user.getPassword()));
 		}
+	}
+
+	private void _testSearchBySocialWithGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		User user = UserTestUtil.addUser();
+
+		List<User> users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		Assert.assertFalse(users.contains(user));
+
+		_userLocalService.addGroupUser(group.getGroupId(), user);
+
+		users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(users.contains(user));
+	}
+
+	private void _testSearchBySocialWithGroupAndUserGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		User user1 = UserTestUtil.addUser();
+
+		_userLocalService.addGroupUser(group.getGroupId(), user1);
+
+		User user2 = UserTestUtil.addUser();
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroupLocalService.addUserUserGroup(user2.getUserId(), userGroup);
+
+		List<User> users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			new long[] {userGroup.getUserGroupId()}, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertFalse(users.contains(user1));
+		Assert.assertFalse(users.contains(user2));
+
+		_userLocalService.addGroupUser(group.getGroupId(), user2);
+		_userGroupLocalService.addUserUserGroup(user1.getUserId(), userGroup);
+
+		users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			new long[] {userGroup.getUserGroupId()}, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(users.contains(user1));
+		Assert.assertTrue(users.contains(user2));
+	}
+
+	private void _testSearchBySocialWithUserGroup() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		List<User> users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), null,
+			new long[] {userGroup.getUserGroupId()}, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertFalse(users.contains(user));
+
+		_userGroupLocalService.addUserUserGroup(user.getUserId(), userGroup);
+
+		users = _userLocalService.searchBySocial(
+			TestPropsValues.getCompanyId(), null,
+			new long[] {userGroup.getUserGroupId()}, null, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+
+		Assert.assertTrue(users.contains(user));
+	}
+
+	private void _testSearchCountBySocialWithGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		User user = UserTestUtil.addUser();
+
+		int usersCount1 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			null, null);
+
+		_userLocalService.addGroupUser(group.getGroupId(), user);
+
+		int usersCount2 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			null, null);
+
+		Assert.assertEquals(usersCount1 + 1, usersCount2);
+	}
+
+	private void _testSearchCountBySocialWithGroupAndUserGroup()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		User user1 = UserTestUtil.addUser();
+
+		_userLocalService.addGroupUser(group.getGroupId(), user1);
+
+		User user2 = UserTestUtil.addUser();
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_userGroupLocalService.addUserUserGroup(user2.getUserId(), userGroup);
+
+		int usersCount1 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			new long[] {userGroup.getUserGroupId()}, null);
+
+		_userLocalService.addGroupUser(group.getGroupId(), user2);
+		_userGroupLocalService.addUserUserGroup(user1.getUserId(), userGroup);
+
+		int usersCount2 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), new long[] {group.getGroupId()},
+			new long[] {userGroup.getUserGroupId()}, null);
+
+		Assert.assertEquals(usersCount1 + 2, usersCount2);
+	}
+
+	private void _testSearchCountBySocialWithUserGroup() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		int usersCount1 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), null,
+			new long[] {userGroup.getUserGroupId()}, null);
+
+		_userGroupLocalService.addUserUserGroup(user.getUserId(), userGroup);
+
+		int usersCount2 = _userLocalService.searchCountBySocial(
+			TestPropsValues.getCompanyId(), null,
+			new long[] {userGroup.getUserGroupId()}, null);
+
+		Assert.assertEquals(usersCount1 + 1, usersCount2);
 	}
 
 	private void _testVerifyEmailAddress(boolean expired) throws Exception {

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3675,6 +3675,35 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	@Override
+	public int searchCountBySocial(
+		long companyId, long[] groupIds, long[] userGroupIds, String keywords) {
+
+		return userFinder.countByKeywords(
+			companyId, keywords, WorkflowConstants.STATUS_APPROVED,
+			LinkedHashMapBuilder.<String, Object>put(
+				"usersGroups",
+				() -> {
+					if (ArrayUtil.isNotEmpty(groupIds)) {
+						return ArrayUtil.toLongArray(groupIds);
+					}
+
+					return null;
+				}
+			).put(
+				"usersUserGroups",
+				() -> {
+					if (ArrayUtil.isNotEmpty(userGroupIds)) {
+						return ArrayUtil.toLongArray(userGroupIds);
+					}
+
+					return null;
+				}
+			).put(
+				"wildcardMode", WildcardMode.TRAILING
+			).build());
+	}
+
+	@Override
 	public Map<Long, Integer> searchCounts(
 		long companyId, int status, long[] groupIds) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -1793,6 +1793,10 @@ public interface UserLocalService
 		LinkedHashMap<String, Object> params, boolean andSearch);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCountBySocial(
+		long companyId, long[] groupIds, long[] userGroupIds, String keywords);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<Long, Integer> searchCounts(
 		long companyId, int status, long[] groupIds);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2204,6 +2204,13 @@ public class UserLocalServiceUtil {
 			emailAddress, status, params, andSearch);
 	}
 
+	public static int searchCountBySocial(
+		long companyId, long[] groupIds, long[] userGroupIds, String keywords) {
+
+		return getService().searchCountBySocial(
+			companyId, groupIds, userGroupIds, keywords);
+	}
+
 	public static Map<Long, Integer> searchCounts(
 		long companyId, int status, long[] groupIds) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2445,6 +2445,14 @@ public class UserLocalServiceWrapper
 	}
 
 	@Override
+	public int searchCountBySocial(
+		long companyId, long[] groupIds, long[] userGroupIds, String keywords) {
+
+		return _userLocalService.searchCountBySocial(
+			companyId, groupIds, userGroupIds, keywords);
+	}
+
+	@Override
 	public java.util.Map<Long, Integer> searchCounts(
 		long companyId, int status, long[] groupIds) {
 


### PR DESCRIPTION
:warning:  This PR has been approved before in #7111 but brian requested a [change](https://github.com/brianchandotcom/liferay-portal/pull/165933#issuecomment-3334955723): renaming `searchBySocialCount` to `searchCountBySocial`

Also, I've reordered and simplified all commits

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-62456

Any Space member should see other Space members

# How am I fixing it?

Accessing DB directly to retrieve users to avoid permission checking in ElasticSearch.

# How can you verify that it works?

In module `user/user-test`:
`gw tI --tests UserLocalServiceTest`

In module `headless/headless-asset-library/headless-asset-library-test`:
`gw tI --tests UserAccountResourceTest`

