### PR TITLE
LPD-66038 Icon for content entry is missing from Shared with Me section

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFilesDropFDSPropsTransformer.ts
@@ -31,13 +31,12 @@ export default function AssetsFilesDropFDSPropsTransformer({
 		additionalProps,
 		creationMenu,
 		itemsActions,
-		otherProps,
+		...otherProps,
 		views,
 	});
 
 	return {
 		...assetsData,
-		...otherProps,
 		fileDropSettings: {
 			enabled: true,
 			isDropTarget: ({item}: {item: any}) => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
@@ -33,16 +33,29 @@ export default function SharedItemRenderer({
 }) {
 	const {assetType, fileTypeIcon, fileTypeIconColor, siteName} = itemData;
 
-	const [icon, iconColor] =
-		fileTypeIcon && fileTypeIconColor
-			? [fileTypeIcon, fileTypeIconColor]
-			: assetType?.includes('Web Content')
-				? ['forms', 'content-icon-basic-content']
-				: assetType?.includes('Blog')
-					? ['blogs', 'content-icon-blog']
-					: assetType?.includes('Knowledge')
-						? ['wiki', 'content-icon-knowledge-base']
-						: ['web-content', 'content-icon-web-content'];
+	let icon;
+	let iconColor;
+
+	if (fileTypeIcon && fileTypeIconColor) {
+		icon = fileTypeIcon;
+		iconColor = fileTypeIconColor;
+	}
+	else if (assetType?.includes('Web Content')) {
+		icon = 'forms';
+		iconColor = 'content-icon-basic-content';
+	}
+	else if (assetType?.includes('Blog')) {
+		icon = 'blogs';
+		iconColor = 'content-icon-blog';
+	}
+	else if (assetType?.includes('Knowledge')) {
+		icon = 'wiki';
+		iconColor = 'content-icon-knowledge-base';
+	}
+	else {
+		icon = 'web-content';
+		iconColor = 'content-icon-web-content';
+	}
 
 	const linkHref = useMemo(() => {
 		const {actionId} = options;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
@@ -31,7 +31,18 @@ export default function SharedItemRenderer({
 	options: {actionId: string};
 	value: string;
 }) {
-	const {fileTypeIcon, fileTypeIconColor, siteName} = itemData;
+	const {assetType, fileTypeIcon, fileTypeIconColor, siteName} = itemData;
+
+	const [icon, iconColor] =
+		fileTypeIcon && fileTypeIconColor
+			? [fileTypeIcon, fileTypeIconColor]
+			: assetType?.includes('Web Content')
+				? ['forms', 'content-icon-basic-content']
+				: assetType?.includes('Blog')
+					? ['blogs', 'content-icon-blog']
+					: assetType?.includes('Knowledge')
+						? ['wiki', 'content-icon-knowledge-base']
+						: ['web-content', 'content-icon-web-content'];
 
 	const linkHref = useMemo(() => {
 		const {actionId} = options;
@@ -62,11 +73,9 @@ export default function SharedItemRenderer({
 
 	return (
 		<span className="align-items-center c-gap-2 d-flex table-list-title">
-			{fileTypeIcon && fileTypeIconColor && (
-				<ClaySticker className={`flex-shrink-0 ${fileTypeIconColor}`}>
-					<ClayIcon aria-hidden="true" symbol={fileTypeIcon} />
-				</ClaySticker>
-			)}
+			<ClaySticker className={`flex-shrink-0 ${iconColor}`}>
+				<ClayIcon aria-hidden="true" symbol={icon} />
+			</ClaySticker>
 
 			{linkHref ? (
 				<ClayLink aria-label={value} data-senna-off href={linkHref}>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.test.tsx
@@ -14,13 +14,21 @@ const testActionBase = {
 	href: 'http://www.test.com',
 };
 
+const testItemDataContent = {
+	assetType: 'Web Content',
+	siteName: 'Site Name',
+};
+
+const testItemDataDocument = {
+	assetType: 'Basic Document',
+	fileTypeIcon: 'document-image',
+	fileTypeIconColor: 'file-icon-color-5',
+	siteName: 'Site Name',
+};
+
 const testProps = {
 	actions: [testActionBase],
-	itemData: {
-		fileTypeIcon: 'document-image',
-		fileTypeIconColor: 'file-icon-color-5',
-		siteName: 'Site Name',
-	},
+	itemData: testItemDataDocument,
 	options: {
 		actionId: 'view',
 	},
@@ -45,6 +53,20 @@ describe('SharedItemRenderer', () => {
 
 		expect(
 			container.querySelector('.lexicon-icon-document-image')
+		).toBeInTheDocument();
+	});
+
+	it('shows the default icon for basic web content', () => {
+		const {container} = render(
+			<SharedItemRenderer {...testProps} itemData={testItemDataContent} />
+		);
+
+		expect(container.querySelectorAll('.sticker')[0]).toHaveClass(
+			'content-icon-basic-content'
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-forms')
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
### What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-66038 - Icon for content entry is missing from Shared with Me section

### How am I fixing it?
On the Shared with Me page, the icons for Contents are missing because of the lack of a returned `fileIcon` and `fileIconColor`. These changes basically add a conditional in order to establish the fallback `icon` and `iconColor` if there is no `fileIcon` or `fileIconColor`, by checking the `assetType`. 

I was not particularly sure about writing in `Web Content`/`Blog`/`Knowledge` but even with changing the language setting, the words of the `assetType` remained the same. Let me know if this should be updated at all, I tried to keep the conditional short! 😓 

Also added a related unit test.

Screenshot is viewable on the Shared with Me page:
<img width="1268" height="769" alt="Screenshot 2025-09-26 at 3 19 14 PM" src="https://github.com/user-attachments/assets/b2684398-3c3b-41cc-a418-4934ae6d77c4" />


Additional Changes:
On https://liferay.slack.com/archives/C080GFGC598/p1758906371301339  there looked to be a `otherProps.otherProps` defined, so there's the last commit to address that by spreading the `otherProps`.
