### PR TITLE
LPD-66852 "Knowledge Base" and "Blog" options are not translated in CMS when adding content

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -64,12 +64,12 @@ public class ViewAllSectionDisplayContextTest
 		).put(
 			"multiple-files", StringPool.BLANK
 		).put(
-			"Blog",
+			"blog",
 			getRedirect(
 				"L_BLOG",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
 		).put(
-			"Knowledge Base",
+			"knowledge-base",
 			getRedirect(
 				"L_KNOWLEDGE_BASE",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -114,9 +114,9 @@ public class ViewContentsSectionDisplayContextTest
 		).put(
 			"basic-content", getRedirect("L_BASIC_WEB_CONTENT")
 		).put(
-			"Blog", getRedirect("L_BLOG")
+			"blog", getRedirect("L_BLOG")
 		).put(
-			"Knowledge Base", getRedirect("L_KNOWLEDGE_BASE")
+			"knowledge-base", getRedirect("L_KNOWLEDGE_BASE")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -591,7 +591,7 @@ public class ActionUtil {
 		String objectEntryFolderExternalReferenceCode) {
 
 		return getStructuredContentDropdownItem(
-			httpServletRequest, "blogs", null, "L_BLOG",
+			httpServletRequest, "blogs", "blog", "L_BLOG",
 			objectEntryFolderExternalReferenceCode);
 	}
 
@@ -875,7 +875,7 @@ public class ActionUtil {
 		String objectEntryFolderExternalReferenceCode) {
 
 		return getStructuredContentDropdownItem(
-			httpServletRequest, "wiki", null, "L_KNOWLEDGE_BASE",
+			httpServletRequest, "wiki", "knowledge-base", "L_KNOWLEDGE_BASE",
 			objectEntryFolderExternalReferenceCode);
 	}
 


### PR DESCRIPTION
What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-66852 - "Knowledge Base" and "Blog" options are not translated in CMS when adding content

How am I fixing it?
In order to show the label, the language keys for knowledge base and blogs were added in the call for `getStructuredContentDropdownItem`. Let me know if this poses any issues, thanks for taking a look!

How can you verify that it works?
Here's what it looks like when set to preferred language of Spanish ("blog" in Spanish is still "Blog"):
<img width="1255" height="722" alt="Screenshot 2025-09-29 at 3 36 55 PM" src="https://github.com/user-attachments/assets/32d151d3-ca31-44ab-9016-b536ba98bd7b" />
