### PR TITLE
LPD 66940 Categories filter shows all Vocabularies

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -7,6 +7,7 @@ package com.liferay.journal.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.tags.item.selector.AssetTagsItemSelectorCriterion;
@@ -912,8 +913,11 @@ public class JournalManagementToolbarDisplayContext
 		).setParameter(
 			"vocabularyIds",
 			() -> ListUtil.toString(
-				_assetVocabularyLocalService.getGroupsVocabularies(
-					_getGroupIds()),
+				_assetVocabularyLocalService.getGroupVocabularies(
+					_getGroupIds(),
+					new int[] {
+						AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC
+					}),
 				AssetVocabulary.VOCABULARY_ID_ACCESSOR)
 		).buildString();
 	}

--- a/modules/test/playwright/helpers/CreateCategories.ts
+++ b/modules/test/playwright/helpers/CreateCategories.ts
@@ -18,6 +18,7 @@ export async function createCategories({
 	categoryNames,
 	siteId,
 	vocabularyName,
+	vocabularyVisibility,
 }: {
 	apiHelpers: ApiHelpers;
 	assetLibraries?: AssetLibrary[];
@@ -25,17 +26,22 @@ export async function createCategories({
 	categoryNames: TCategory[];
 	siteId?: string;
 	vocabularyName: string;
+	vocabularyVisibility?: boolean;
 }): Promise<({id: number} & TCategory)[]> {
 	const {id: vocabularyId} = siteId
 		? await apiHelpers.headlessAdminTaxonomy.postSiteTaxonomyVocabulary({
 				assetTypes,
 				name: vocabularyName,
 				siteId,
+				visibilityType:
+					vocabularyVisibility === true ? 'INTERNAL' : 'PUBLIC',
 			})
 		: await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabulary({
 				assetLibraries,
 				assetTypes,
 				name: vocabularyName,
+				visibilityType:
+					vocabularyVisibility === true ? 'INTERNAL' : 'PUBLIC',
 			});
 
 	const categories = [];

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -9,6 +9,7 @@ interface postSiteTaxonomyVocabularyProps {
 	assetTypes?: AssetType[];
 	name: string;
 	siteId: string;
+	visibilityType?: string;
 }
 
 export interface postTaxonomyCategoryTaxonomyCategory {
@@ -22,6 +23,7 @@ export interface postTaxonomyVocabularyProps {
 	assetTypes?: AssetType[];
 	name: string;
 	name_i18n?: {['ES-es']: string};
+	visibilityType?: string;
 }
 
 export interface postTaxonomyVocabularyTaxonomyCategoryProps {
@@ -103,10 +105,11 @@ export class HeadlessAdminTaxonomyApiHelper {
 		assetTypes,
 		name,
 		siteId,
+		visibilityType,
 	}: postSiteTaxonomyVocabularyProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/taxonomy-vocabularies`,
-			{data: {assetTypes, name}}
+			{data: {assetTypes, name, visibilityType}}
 		);
 	}
 
@@ -139,10 +142,11 @@ export class HeadlessAdminTaxonomyApiHelper {
 		assetLibraries,
 		name,
 		name_i18n,
+		visibilityType,
 	}: postTaxonomyVocabularyProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies`,
-			{data: {assetLibraries, name, name_i18n}}
+			{data: {assetLibraries, name, name_i18n, visibilityType}}
 		);
 	}
 

--- a/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalPage.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {createCategories} from '../../../helpers/CreateCategories';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 import getDataStructureDefinition from './utils/getDataStructureDefinition';
@@ -499,5 +500,49 @@ test(
 		await guestTd.waitFor({state: 'attached', timeout: 10000});
 
 		await expect(guestTd).toBeVisible();
+	}
+);
+
+test(
+	'Web Content Category Filter shows public categories only',
+	{
+		tag: '@LPP-60943',
+	},
+	async ({apiHelpers, journalPage, page, site}) => {
+		const basicWebContentStructureId =
+			await getBasicWebContentStructureId(apiHelpers);
+
+		for (let i = 1; i <= 2; i++) {
+			await apiHelpers.jsonWebServicesJournal.addWebContent({
+				ddmStructureId: basicWebContentStructureId,
+				groupId: site.id,
+				titleMap: {en_US: `Web Content ${i}`},
+			});
+		}
+
+		const vocabularyName = 'Private Vocabulary 1';
+		const internalCategoryName = 'Internal Category 1';
+
+		await createCategories({
+			apiHelpers,
+			categoryNames: [{name: internalCategoryName}],
+			siteId: site.id,
+			vocabularyName,
+			vocabularyVisibility: true,
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		await page.getByLabel('Filter', {exact: true}).click();
+
+		await page.getByRole('menuitem', {name: 'Categories'}).click();
+
+		const categoriesFrame = page.frameLocator(
+			'iframe[title*="Filter by Categories"]'
+		);
+
+		await expect(
+			categoriesFrame.locator('text=' + vocabularyName)
+		).toHaveCount(0);
 	}
 );


### PR DESCRIPTION
**What is this trying to solve?**

[LPD 66940](https://liferay.atlassian.net/browse/LPD-66940) 

**How can you verify that it works?**

1. Product Menu > Categorization > Categories

2. Add 2 new vocabularies, one Public and one Internal

3. Product Menu > Content & Data > Web Content

4. Create a new Basic Web Content and give it the two categories in step 

5. Product Menu > Content & Data > Web Content → Filter-> Filter by categoies

 
**Expected behavior:**

The list of categories shows only public Vocabularies