### PR TITLE
LPD-66955 Avoid dynamic Liferay.Language.get calls

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/hooks/useSpaceMembers.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/hooks/useSpaceMembers.ts
@@ -397,11 +397,13 @@ export function useSpaceMembers(
 
 				openToast({
 					message: sub(
-						Liferay.Language.get(
-							isUser
-								? 'failed-to-add-user-x-to-space'
-								: 'failed-to-add-group-x-to-space'
-						),
+						isUser
+							? Liferay.Language.get(
+									'failed-to-add-user-x-to-space'
+								)
+							: Liferay.Language.get(
+									'failed-to-add-group-x-to-space'
+								),
 						[`<strong>${item.name}</strong>`]
 					),
 					type: 'danger',
@@ -410,11 +412,13 @@ export function useSpaceMembers(
 			else {
 				openToast({
 					message: sub(
-						Liferay.Language.get(
-							isUser
-								? 'user-x-successfully-added-to-space'
-								: 'group-x-successfully-added-to-space'
-						),
+						isUser
+							? Liferay.Language.get(
+									'user-x-successfully-added-to-space'
+								)
+							: Liferay.Language.get(
+									'group-x-successfully-added-to-space'
+								),
 						[`<strong>${item.name}</strong>`]
 					),
 					type: 'success',
@@ -451,11 +455,13 @@ export function useSpaceMembers(
 
 				openToast({
 					message: sub(
-						Liferay.Language.get(
-							isUser
-								? 'unable-to-remove-user-x-from-space'
-								: 'unable-to-remove-group-x-from-space'
-						),
+						isUser
+							? Liferay.Language.get(
+									'unable-to-remove-user-x-from-space'
+								)
+							: Liferay.Language.get(
+									'unable-to-remove-group-x-from-space'
+								),
 						[`<strong>${item.name}</strong>`]
 					),
 					type: 'danger',
@@ -464,11 +470,13 @@ export function useSpaceMembers(
 			else {
 				openToast({
 					message: sub(
-						Liferay.Language.get(
-							isUser
-								? 'user-x-successfully-removed-from-space'
-								: 'group-x-successfully-removed-from-space'
-						),
+						isUser
+							? Liferay.Language.get(
+									'user-x-successfully-removed-from-space'
+								)
+							: Liferay.Language.get(
+									'group-x-successfully-removed-from-space'
+								),
 						[`<strong>${item.name}</strong>`]
 					),
 					type: 'success',
@@ -527,11 +535,13 @@ export function useSpaceMembers(
 
 				openToast({
 					message: sub(
-						Liferay.Language.get(
-							isUser
-								? 'unable-to-update-roles-for-user-x'
-								: 'unable-to-update-roles-for-group-x'
-						),
+						isUser
+							? Liferay.Language.get(
+									'unable-to-update-roles-for-user-x'
+								)
+							: Liferay.Language.get(
+									'unable-to-update-roles-for-group-x'
+								),
 						[`<strong>${itemToUpdate.name}</strong>`]
 					),
 					type: 'danger',


### PR DESCRIPTION
### LPD: https://issues.liferay.com/browse/LPD-66955  

# What is this solving?

Dynamic calls to `Liferay.Language.get` using a ternary inside the function caused unnecessary complexity and made the code harder to read and maintain. This PR simplifies these calls and improves readability.

# How is it fixed?

The ternary for selecting the correct language key was moved **outside** of `Liferay.Language.get`. This keeps the same behavior but makes the code clearer and easier to maintain.

# How to verify?

```sh
cd modules/apps/site/site-cms-site-initializer
yarn build
```

## Local builds warnings
### Before the PR
<img width="1897" height="1102" alt="image" src="https://github.com/user-attachments/assets/76673b78-001c-4277-adc3-963d1a1df880" />

### After the PR
<img width="3375" height="1321" alt="image" src="https://github.com/user-attachments/assets/9f6a6b02-8aa1-4d92-be31-cd1401cd1e09" />

