### PR TITLE
LPD-65033 Predefined value is lost when updating a data definition with a nested field

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseDataDefinitionMVCActionCommandTestCase.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/BaseDataDefinitionMVCActionCommandTestCase.java
@@ -155,6 +155,10 @@ public abstract class BaseDataDefinitionMVCActionCommandTestCase {
 		MockMultipartHttpServletRequest mockMultipartHttpServletRequest =
 			new MockMultipartHttpServletRequest();
 
+		if (fileName == null) {
+			return mockMultipartHttpServletRequest;
+		}
+
 		Class<?> clazz = getClass();
 
 		byte[] bytes = _file.getBytes(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateDataDefinitionMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateDataDefinitionMVCActionCommandTest.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.data.engine.rest.test.util.DataDefinitionTestUtil;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.Inject;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carolina Barbosa
+ */
+@RunWith(Arquillian.class)
+public class UpdateDataDefinitionMVCActionCommandTest
+	extends BaseDataDefinitionMVCActionCommandTestCase {
+
+	public MVCActionCommand getMVCActionCommand() {
+		return _mvcActionCommand;
+	}
+
+	@Test
+	public void testProcessAction() throws Exception {
+		String dataDefinitionJSON = _read(
+			"data_definition_with_nested_field.json");
+
+		DataDefinition dataDefinition =
+			DataDefinitionTestUtil.addDataDefinition(
+				"journal", dataDefinitionResourceFactory, group.getGroupId(),
+				dataDefinitionJSON, TestPropsValues.getUser());
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
+			dataDefinition.getId());
+
+		DDMForm ddmForm = ddmStructure.getDDMForm();
+
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmForm.getDDMFormFieldsMap(true);
+
+		DDMFormField ddmFormField = ddmFormFieldsMap.get("Text");
+
+		String predefinedValue = RandomTestUtil.randomString();
+
+		ddmFormField.setPredefinedValue(
+			new LocalizedValue() {
+				{
+					addString(LocaleUtil.US, predefinedValue);
+				}
+			});
+
+		_ddmStructureLocalService.updateStructure(
+			TestPropsValues.getUserId(), ddmStructure.getStructureId(), ddmForm,
+			ddmStructure.getDDMFormLayout(),
+			ServiceContextTestUtil.getServiceContext());
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			createMockLiferayPortletActionRequest(
+				null, null, dataDefinition.getId());
+
+		mockLiferayPortletActionRequest.addParameter(
+			"dataDefinition", dataDefinitionJSON);
+		mockLiferayPortletActionRequest.addParameter(
+			"dataLayout",
+			String.valueOf(dataDefinition.getDefaultDataLayout()));
+		mockLiferayPortletActionRequest.addParameter(
+			"structureKey", dataDefinition.getDataDefinitionKey());
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		DataDefinitionResource.Builder builder =
+			dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource = builder.user(
+			TestPropsValues.getUser()
+		).build();
+
+		dataDefinition = dataDefinitionResource.getDataDefinition(
+			dataDefinition.getId());
+
+		DataDefinitionField[] dataDefinitionFields =
+			dataDefinition.getDataDefinitionFields();
+
+		Assert.assertEquals(
+			dataDefinitionFields.toString(), 1, dataDefinitionFields.length);
+
+		DataDefinitionField dataDefinitionField = dataDefinitionFields[0];
+
+		DataDefinitionField[] nestedDataDefinitionFields =
+			dataDefinitionField.getNestedDataDefinitionFields();
+
+		Assert.assertEquals(
+			nestedDataDefinitionFields.toString(), 1,
+			nestedDataDefinitionFields.length);
+
+		DataDefinitionField nestedDataDefinitionField =
+			nestedDataDefinitionFields[0];
+
+		Assert.assertEquals(
+			predefinedValue,
+			MapUtil.getString(
+				nestedDataDefinitionField.getDefaultValue(), "en_US"));
+	}
+
+	private String _read(String fileName) throws Exception {
+		return new String(
+			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
+	}
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
+	@Inject(filter = "mvc.command.name=/journal/update_data_definition")
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/data_definition_with_nested_field.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/web/internal/portlet/action/test/dependencies/data_definition_with_nested_field.json
@@ -1,0 +1,73 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"fieldReference": "Fieldset",
+				"rows": [
+					{
+						"columns": [
+							{
+								"fields": [
+									"Text"
+								],
+								"size": 12
+							}
+						]
+					}
+				]
+			},
+			"fieldType": "fieldset",
+			"label": {
+				"en_US": "Fields Group"
+			},
+			"name": "Fieldset",
+			"nestedDataDefinitionFields": [
+				{
+					"customProperties": {
+						"dataType": "string",
+						"displayStyle": "singleline",
+						"fieldReference": "Text"
+					},
+					"fieldType": "text",
+					"label": {
+						"en_US": "Text"
+					},
+					"localizable": true,
+					"name": "Text"
+				}
+			]
+		}
+	],
+	"defaultDataLayout": {
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"Fieldset"
+								]
+							}
+						]
+					}
+				]
+			}
+		],
+		"name": {
+			"en_US": "Data Definition With Nested Field"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"externalReferenceCode": "DATA_DEFINITION_WITH_NESTED_FIELD",
+	"name": {
+		"en_US": "Data Definition With Nested Field"
+	},
+	"storageType": "default"
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
@@ -119,7 +119,17 @@ public class UpdateDataDefinitionMVCActionCommand
 		DataDefinition dataDefinition = DataDefinition.toDTO(
 			dataDefinitionString);
 
-		_restoreDefaultValues(dataDefinitionId, dataDefinition);
+		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
+			dataDefinitionId);
+
+		Map<String, DDMFormField> ddmFormFieldsMap =
+			ddmStructure.getFullHierarchyDDMFormFieldsMap(true);
+
+		for (DataDefinitionField dataDefinitionField :
+				dataDefinition.getDataDefinitionFields()) {
+
+			_restoreDefaultValues(dataDefinitionField, ddmFormFieldsMap);
+		}
 
 		dataDefinition.setDataDefinitionKey(
 			() -> ParamUtil.getString(actionRequest, "structureKey"));
@@ -143,26 +153,29 @@ public class UpdateDataDefinitionMVCActionCommand
 	}
 
 	private void _restoreDefaultValues(
-			long dataDefinitionId, DataDefinition dataDefinition)
-		throws Exception {
+		DataDefinitionField dataDefinitionField,
+		Map<String, DDMFormField> ddmFormFieldsMap) {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
-			dataDefinitionId);
+		DDMFormField ddmFormField = ddmFormFieldsMap.get(
+			dataDefinitionField.getName());
 
-		Map<String, DDMFormField> ddmFormFieldsMap =
-			ddmStructure.getFullHierarchyDDMFormFieldsMap(true);
+		if (ddmFormField != null) {
+			dataDefinitionField.setDefaultValue(
+				() -> LocalizedValueUtil.toLocalizedValuesMap(
+					ddmFormField.getPredefinedValue()));
+		}
 
-		for (DataDefinitionField dataDefinitionField :
-				dataDefinition.getDataDefinitionFields()) {
+		DataDefinitionField[] nestedDataDefinitionFields =
+			dataDefinitionField.getNestedDataDefinitionFields();
 
-			DDMFormField ddmFormField = ddmFormFieldsMap.get(
-				dataDefinitionField.getName());
+		if (nestedDataDefinitionFields == null) {
+			return;
+		}
 
-			if (ddmFormField != null) {
-				dataDefinitionField.setDefaultValue(
-					() -> LocalizedValueUtil.toLocalizedValuesMap(
-						ddmFormField.getPredefinedValue()));
-			}
+		for (DataDefinitionField nestedDataDefinitionField :
+				nestedDataDefinitionFields) {
+
+			_restoreDefaultValues(nestedDataDefinitionField, ddmFormFieldsMap);
 		}
 	}
 


### PR DESCRIPTION
# What is this trying to solve?
**Related Ticket**: https://liferay.atlassian.net/browse/LPD-65033

:rotating_light: **LPP Fire:** https://liferay.atlassian.net/browse/LPP-60608

Updating a data definition that includes a nested field and a predefined value results in the loss of the predefined value.

Consequently, the values of the web contents are not updated by the [DDMStructureModelListener](https://github.com/carolmariaabb/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java) because the [_hasModifiedPredefinedValue](https://github.com/carolmariaabb/liferay-portal/blob/cb125431de43399337d4dffa85fc2a6e4c6e0309/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java#L54-L55) method returns `true`, and consequently [this code](https://github.com/carolmariaabb/liferay-portal/blob/cb125431de43399337d4dffa85fc2a6e4c6e0309/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java#L274-L277) ends up duplicating the field value when rendering the page.

# How am I  fixing it?

 We should restore the default values across all nested data definition fields, as you can check in this [commit](https://github.com/liferay-content-management/liferay-portal/pull/7199/commits/419ae8623ea53ad0755606275ef83eb864000437).

# How can you verify that it works?

You can run the integration test in this [commit](https://github.com/liferay-content-management/liferay-portal/pull/7199/commits/b20922f9e32889292f24688281baea074c150f91).