### PR TITLE
LPD-66852 "Knowledge Base" and "Blog" options are not translated in CMS when adding content (rebase)

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/BaseSectionDisplayContextTestCase.java
@@ -216,8 +216,6 @@ public abstract class BaseSectionDisplayContextTestCase
 				"L_BASIC_WEB_CONTENT", "content-icon-basic-content"
 			).put(
 				"L_BLOG", "content-icon-blog"
-			).put(
-				"L_KNOWLEDGE_BASE", "content-icon-knowledge-base"
 			).build()
 		).put(
 			"objectDefinitionIcons",
@@ -227,8 +225,6 @@ public abstract class BaseSectionDisplayContextTestCase
 				"L_BASIC_WEB_CONTENT", "forms"
 			).put(
 				"L_BLOG", "blogs"
-			).put(
-				"L_KNOWLEDGE_BASE", "wiki"
 			).build()
 		).put(
 			"parentObjectEntryFolderExternalReferenceCode",

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -69,11 +69,6 @@ public class ViewAllSectionDisplayContextTest
 				"L_BLOG",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
 		).put(
-			"knowledge-base",
-			getRedirect(
-				"L_KNOWLEDGE_BASE",
-				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
-		).put(
 			"external-video-shortcut",
 			getRedirect(
 				"L_EXTERNAL_VIDEO",

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllSectionDisplayContextTest.java
@@ -64,12 +64,12 @@ public class ViewAllSectionDisplayContextTest
 		).put(
 			"multiple-files", StringPool.BLANK
 		).put(
-			"Blog",
+			"blog",
 			getRedirect(
 				"L_BLOG",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)
 		).put(
-			"Knowledge Base",
+			"knowledge-base",
 			getRedirect(
 				"L_KNOWLEDGE_BASE",
 				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS)

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -114,9 +114,9 @@ public class ViewContentsSectionDisplayContextTest
 		).put(
 			"basic-content", getRedirect("L_BASIC_WEB_CONTENT")
 		).put(
-			"Blog", getRedirect("L_BLOG")
+			"blog", getRedirect("L_BLOG")
 		).put(
-			"Knowledge Base", getRedirect("L_KNOWLEDGE_BASE")
+			"knowledge-base", getRedirect("L_KNOWLEDGE_BASE")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -115,8 +115,6 @@ public class ViewContentsSectionDisplayContextTest
 			"basic-content", getRedirect("L_BASIC_WEB_CONTENT")
 		).put(
 			"blog", getRedirect("L_BLOG")
-		).put(
-			"knowledge-base", getRedirect("L_KNOWLEDGE_BASE")
 		).build();
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -585,7 +585,7 @@ public class ActionUtil {
 		String objectEntryFolderExternalReferenceCode) {
 
 		return getStructuredContentDropdownItem(
-			httpServletRequest, "blogs", null, "L_BLOG",
+			httpServletRequest, "blogs", "blog", "L_BLOG",
 			objectEntryFolderExternalReferenceCode);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/SharedItemRenderer.tsx
@@ -48,10 +48,6 @@ export default function SharedItemRenderer({
 		icon = 'blogs';
 		iconColor = 'content-icon-blog';
 	}
-	else if (assetType?.includes('Knowledge')) {
-		icon = 'wiki';
-		iconColor = 'content-icon-knowledge-base';
-	}
 	else {
 		icon = 'web-content';
 		iconColor = 'content-icon-web-content';


### PR DESCRIPTION
Continued from https://github.com/brianchandotcom/liferay-portal/pull/166153

There was a rebase error on the previous version.

@adolfopa I didn't know that Knowledge base structure was removed by page management in [this PR](https://github.com/liferay-page-management/liferay-portal/pull/17696/commits/0e4e180648ba0c06d01bfd5c79d13a1b79552bbe)  😓 ... I added some updates to get the tests to pass, let me know if it's not ok, thanks!

> What is this trying to solve?
> https://liferay.atlassian.net/browse/LPD-66852 - "Knowledge Base" and "Blog" options are not translated in CMS when adding content
> 
> How am I fixing it?
> In order to show the label, the language keys for knowledge base and blogs were added in the call for getStructuredContentDropdownItem. Let me know if this poses any issues, thanks for taking a look!
> 
> How can you verify that it works?
> Here's what it looks like when set to preferred language of Chinese:
> <img width="1585" height="790" alt="Screenshot 2025-09-30 at 4 41 33 PM" src="https://github.com/user-attachments/assets/5dae73f3-b8f6-49ff-80ef-151f8fd5d602" />
> 