### PR TITLE
LPD-66633 Remove “Liferay DXP” when composing page title

### DIFF
--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -269,25 +270,32 @@ public class LayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {
 			return StringPool.BLANK;
 		}
 
+		String returnCompanyName = companyName;
+
+		Group group = layout.getGroup();
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				layout.getCompanyId(), "LPD-17564") &&
+			group.isCMS()) {
+
+			returnCompanyName = StringPool.BLANK;
+		}
+
 		if (layoutSEOGeneralGroupConfiguration.includeInstanceName() &&
 			layoutSEOGeneralGroupConfiguration.includeSiteName()) {
-
-			Group group = layout.getGroup();
 
 			if (group.isControlPanel() || group.isLayoutPrototype() ||
 				StringUtil.equals(companyName, group.getDescriptiveName())) {
 
-				return companyName;
+				return returnCompanyName;
 			}
 
-			return _merge(group.getDescriptiveName(), companyName);
+			return _merge(group.getDescriptiveName(), returnCompanyName);
 		}
 
 		if (layoutSEOGeneralGroupConfiguration.includeInstanceName()) {
-			return companyName;
+			return returnCompanyName;
 		}
-
-		Group group = layout.getGroup();
 
 		return group.getDescriptiveName();
 	}
@@ -335,8 +343,12 @@ public class LayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {
 		return layout.getHTMLTitle(_language.getLanguageId(locale));
 	}
 
-	private String _merge(String... strings) {
-		return StringUtil.merge(strings, _SEPARATOR);
+	private String _merge(String string1, String string2) {
+		if (Validator.isNull(string2)) {
+			return string1;
+		}
+
+		return string1 + _SEPARATOR + string2;
 	}
 
 	private static final String _SEPARATOR = " - ";

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
@@ -12,8 +12,10 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.GroupConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.Portlet;
@@ -24,6 +26,7 @@ import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -37,6 +40,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -66,6 +70,19 @@ public class LayoutSEOLinkManagerPageTitleTest {
 		_layout = _addLayout();
 
 		_group = _addGroup();
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_group.getCompanyId(), "LPD-17564")) {
+
+			_cmsGroup = _groupLocalService.fetchGroup(
+				_group.getCompanyId(), GroupConstants.CMS);
+
+			if (_cmsGroup == null) {
+				_cmsGroup = GroupTestUtil.addGroup(
+					_group.getCompanyId(), TestPropsValues.getUserId(),
+					GroupConstants.DEFAULT_PARENT_GROUP_ID, GroupConstants.CMS);
+			}
+		}
 
 		_layout.setGroupId(_group.getGroupId());
 
@@ -390,6 +407,18 @@ public class LayoutSEOLinkManagerPageTitleTest {
 			_layoutSEOLinkManager.getPageTitleSuffix(_layout, companyName));
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixCompanyNameInCMSGroup() throws Exception {
+		_layout.setGroupId(_cmsGroup.getGroupId());
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_layoutSEOLinkManager.getPageTitleSuffix(
+				_layout, _cmsGroup.getDescriptiveName()));
+	}
+
 	@Test
 	public void testGetPageTitleSuffixGroupNameCompanyName() throws Exception {
 		String companyName = RandomTestUtil.randomString();
@@ -397,6 +426,20 @@ public class LayoutSEOLinkManagerPageTitleTest {
 		Assert.assertEquals(
 			_group.getName() + " - " + companyName,
 			_layoutSEOLinkManager.getPageTitleSuffix(_layout, companyName));
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixGroupNameCompanyNameInCMSGroup()
+		throws Exception {
+
+		_layout.setGroupId(_cmsGroup.getGroupId());
+
+		Assert.assertEquals(
+			_cmsGroup.getDescriptiveName(),
+			_layoutSEOLinkManager.getPageTitleSuffix(
+				_layout, RandomTestUtil.randomString()));
 	}
 
 	@Test
@@ -426,6 +469,36 @@ public class LayoutSEOLinkManagerPageTitleTest {
 		}
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixWithIncludeInstanceNameWithIncludeSiteNameInCMSGroup()
+		throws Exception {
+
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_cmsGroup.getGroupId(), _PID,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeInstanceName", true
+						).put(
+							"includeSiteName", true
+						).build())) {
+
+			_layout.setGroupId(_cmsGroup.getGroupId());
+
+			Assert.assertEquals(
+				_cmsGroup.getDescriptiveName(),
+				_layoutSEOLinkManager.getPageTitleSuffix(
+					_layout, RandomTestUtil.randomString()));
+
+			Assert.assertEquals(
+				StringPool.BLANK,
+				_layoutSEOLinkManager.getPageTitleSuffix(
+					_layout, _cmsGroup.getDescriptiveName()));
+		}
+	}
+
 	@Test
 	public void testGetPageTitleSuffixWithIncludeInstanceNameWithoutIncludeSiteName()
 		throws Exception {
@@ -445,6 +518,31 @@ public class LayoutSEOLinkManagerPageTitleTest {
 			Assert.assertEquals(
 				companyName,
 				_layoutSEOLinkManager.getPageTitleSuffix(_layout, companyName));
+		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixWithIncludeInstanceNameWithoutIncludeSiteNameInCMSGroup()
+		throws Exception {
+
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_cmsGroup.getGroupId(), _PID,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeInstanceName", true
+						).put(
+							"includeSiteName", false
+						).build())) {
+
+			_layout.setGroupId(_cmsGroup.getGroupId());
+
+			Assert.assertEquals(
+				StringPool.BLANK,
+				_layoutSEOLinkManager.getPageTitleSuffix(
+					_layout, RandomTestUtil.randomString()));
 		}
 	}
 
@@ -469,6 +567,31 @@ public class LayoutSEOLinkManagerPageTitleTest {
 		}
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixWithoutIncludeInstanceNameWithIncludeSiteNameInCMSGroup()
+		throws Exception {
+
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_cmsGroup.getGroupId(), _PID,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeInstanceName", false
+						).put(
+							"includeSiteName", true
+						).build())) {
+
+			_layout.setGroupId(_cmsGroup.getGroupId());
+
+			Assert.assertEquals(
+				_cmsGroup.getDescriptiveName(),
+				_layoutSEOLinkManager.getPageTitleSuffix(
+					_layout, RandomTestUtil.randomString()));
+		}
+	}
+
 	@Test
 	public void testGetPageTitleSuffixWithoutIncludeInstanceNameWithoutIncludeSiteName()
 		throws Exception {
@@ -482,6 +605,31 @@ public class LayoutSEOLinkManagerPageTitleTest {
 						).put(
 							"includeSiteName", false
 						).build())) {
+
+			Assert.assertEquals(
+				StringPool.BLANK,
+				_layoutSEOLinkManager.getPageTitleSuffix(
+					_layout, RandomTestUtil.randomString()));
+		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66633")
+	public void testGetPageTitleSuffixWithoutIncludeInstanceNameWithoutIncludeSiteNameInCMSGroup()
+		throws Exception {
+
+		try (GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_cmsGroup.getGroupId(), _PID,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeInstanceName", false
+						).put(
+							"includeSiteName", false
+						).build())) {
+
+			_layout.setGroupId(_cmsGroup.getGroupId());
 
 			Assert.assertEquals(
 				StringPool.BLANK,
@@ -571,6 +719,8 @@ public class LayoutSEOLinkManagerPageTitleTest {
 	private static final String _PID =
 		"com.liferay.layout.seo.internal.configuration." +
 			"LayoutSEOGeneralGroupConfiguration";
+
+	private Group _cmsGroup;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66633

In CMS pages title we have as suffix "Liferay DXP".  We want to remove that suffix.

# How am I fixing it?

Removing the company name, when in CMS group.

# How can you verify that it works?

In module `/modules/apps/layout/layout-seo-test`:

`gw tI --tests LayoutSEOLinkManagerPageTitleTest`
