### PR TITLE
[Playwright] LPD-67214 Fix Playwright tests for files.spec.ts

### DIFF
--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '9d2c77cfa4aba23b2a5c3e5a0cfcdf0dcb174f8a3edb02bf35df1554054f37f5',
+	hash: '176dd84b5475ca7c9adc096f3d956929e84bacdb8547cd0ab22f884a22880357',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],
@@ -33,7 +33,6 @@ module.exports = {
 		'@liferay/commerce-channel-web': [],
 		'@liferay/commerce-checkout-web': [],
 		'@liferay/commerce-client-extension-web': [],
-		'@liferay/commerce-fragment-impl': [],
 		'@liferay/commerce-order-content-web': [],
 		'@liferay/commerce-order-rule-web': [],
 		'@liferay/commerce-order-web': [],

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -99,7 +99,7 @@ test(
 
 		await test.step('Check the Space name in the Basic Document creation page', async () => {
 			await page
-				.getByRole('heading', {name: 'New Basic Document'})
+				.getByRole('heading', {name: 'Edit Basic Document'})
 				.waitFor();
 
 			const spaceSpan = page.locator(
@@ -159,7 +159,7 @@ test(
 
 		await test.step('Check the Space name in the Basic Document creation page', async () => {
 			await page
-				.getByRole('heading', {name: 'New Basic Document'})
+				.getByRole('heading', {name: 'Edit Basic Document'})
 				.waitFor();
 
 			const spaceSpan = page.locator(
@@ -233,7 +233,7 @@ test(
 
 		await test.step('Check the Space name in the Basic Document creation page', async () => {
 			await page
-				.getByRole('heading', {name: 'New Basic Document'})
+				.getByRole('heading', {name: 'Edit Basic Document'})
 				.waitFor();
 
 			const spaceSpan = page.locator(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/files.spec.ts
@@ -117,17 +117,13 @@ test(
 	async ({apiHelpers, assetsPage, page}) => {
 		const assetLibraryName = getRandomString();
 
-		const assetLibraryId =
-			await test.step('Create a new Space', async () => {
-				const assetLibrary =
-					await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-						name: assetLibraryName,
-						settings: {},
-						type: 'Space',
-					});
-
-				return assetLibrary.id;
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: assetLibraryName,
+				settings: {},
+				type: 'Space',
 			});
+		});
 
 		await test.step('Check number of existing Spaces', async () => {
 			const assetLibraries =
@@ -168,10 +164,6 @@ test(
 
 			await expect(spaceSpan).toContainText(assetLibraryName);
 		});
-
-		await apiHelpers.headlessAssetLibrary.deleteAssetLibrary(
-			assetLibraryId
-		);
 	}
 );
 
@@ -181,17 +173,13 @@ test(
 	async ({apiHelpers, assetsPage, page}) => {
 		const assetLibraryName = getRandomString();
 
-		const assetLibraryId =
-			await test.step('Create a new Space', async () => {
-				const assetLibrary =
-					await apiHelpers.headlessAssetLibrary.createAssetLibrary({
-						name: assetLibraryName,
-						settings: {},
-						type: 'Space',
-					});
-
-				return assetLibrary.id;
+		await test.step('Create a new Space', async () => {
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: assetLibraryName,
+				settings: {},
+				type: 'Space',
 			});
+		});
 
 		await test.step('Check number of existing Spaces', async () => {
 			const assetLibraries =
@@ -242,10 +230,6 @@ test(
 
 			await expect(spaceSpan).toContainText(assetLibraryName);
 		});
-
-		await apiHelpers.headlessAssetLibrary.deleteAssetLibrary(
-			assetLibraryId
-		);
 	}
 );
 


### PR DESCRIPTION
### LPD: https://issues.liferay.com/browse/LPD-67214  

# What is this solving?

Fiexed Playwright tests in files.spec.ts

# How is it fixed?

- Fixed Playwright literal to wait for editAssets UI
- Removed redundant assetLibrary cleanup steps

# How to verify?

Ensure all tests under `site-cms-site-initializer/main/files.spec.ts` pass successfully.

```sh
cd modules/test/playwright
npx playwright test tests/site-cms-site-initializer/main/files.spec.ts --reporter list
```

## Test locally

### Before PR
<img width="3125" height="971" alt="image" src="https://github.com/user-attachments/assets/eeacbd63-34bd-4fe1-9900-05bf6b9fdcea" />

### After PR
<img width="3076" height="1003" alt="image" src="https://github.com/user-attachments/assets/2eff2f08-ba4d-44a4-90e1-7da580290d31" />
