### PR TITLE
[Playwright] LPD-67316 Fix Playwright tests for spaceSummary.spec.ts 

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -229,7 +229,7 @@ test(
 	'Can view Share modal for added content',
 	{tag: '@LPD-62554'},
 	async ({apiHelpers, assetsPage}) => {
-		const applicationName = 'cms/knowledge-bases';
+		const applicationName = 'cms/basic-web-contents';
 		const file1Title = `Title ${getRandomString()}`;
 		const spaceName = `Space ${getRandomString()}`;
 		let objectEntry1;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -260,7 +260,7 @@ test(
 	'Can see Recent Assets',
 	{tag: '@LPD-58792'},
 	async ({apiHelpers, homePage, page}) => {
-		const applicationName = 'cms/knowledge-bases';
+		const applicationName = 'cms/basic-web-contents';
 		const spaceName = 'Default';
 		let objectEntry1;
 		let objectEntry2;
@@ -344,18 +344,6 @@ test(
 			await expect(page.getByPlaceholder('New Blog')).toBeVisible();
 		});
 
-		await test.step('Check redirection after clicking Knowledge Base button', async () => {
-			await homePage.goto();
-
-			await homePage.knowledgeBaseButton.click();
-
-			await homePage.selectSpace('Default');
-
-			await expect(
-				page.getByPlaceholder('New Knowledge Base')
-			).toBeVisible();
-		});
-
 		await test.step('Check redirection after clicking Basic Document button', async () => {
 			await homePage.goto();
 
@@ -382,7 +370,7 @@ test(
 	'Can use Search Bar to search for content',
 	{tag: '@LPD-61220'},
 	async ({apiHelpers, assetsPage, homePage, page}) => {
-		const applicationName = 'cms/knowledge-bases';
+		const applicationName = 'cms/basic-web-contents';
 		const spaceName = 'Default';
 		let objectEntry1;
 		let objectEntry2;

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -6,6 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 
 type UserOrUserGroupType = 'groups' | 'users';
 
@@ -66,6 +67,13 @@ export class SpaceSummaryPage {
 			.click();
 		await this.page.getByRole('option', {name}).click();
 
+		await waitForAlert(
+			this.page,
+			type.includes('group')
+				? `Success:Group ${name} successfully added to space.`
+				: `Success:User ${name} successfully added to space.`
+		);
+
 		await this.closeButton.click();
 	}
 
@@ -82,6 +90,13 @@ export class SpaceSummaryPage {
 			.filter({hasText: name})
 			.getByLabel('Remove Group')
 			.click();
+
+		await waitForAlert(
+			this.page,
+			type.includes('group')
+				? `Success:Group ${name} successfully removed from space.`
+				: `Success:User ${name} successfully removed from space.`
+		);
 
 		await this.closeButton.click();
 	}

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
@@ -9,7 +9,6 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
-import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from './fixtures/cmsPagesTest';
 
 const test = mergeTests(
@@ -97,25 +96,15 @@ test(
 
 		await spaceSummaryPage.addUserOrUserGroup(userGroup.name, 'groups');
 
-		await waitForAlert(
-			page,
-			`Success:Group ${userGroup.name} successfully added to space.`
-		);
-
 		await spaceSummaryPage.userGroupsTab.click();
 
-		expect(page.getByText(userGroup.name, {exact: true})).toBeVisible();
+		await expect(page.getByText(userGroup.name)).toBeVisible();
 
 		await spaceSummaryPage.removeUserOrUserGroup(userGroup.name, 'groups');
 
-		await waitForAlert(
-			page,
-			`Success:Group ${userGroup.name} successfully removed from space.`
-		);
-
 		await spaceSummaryPage.userGroupsTab.click();
 
-		expect(page.getByText(userGroup.name, {exact: true})).not.toBeVisible();
+		await expect(page.getByText(userGroup.name)).not.toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaceSummary.spec.ts
@@ -123,7 +123,7 @@ test(
 	'Can view added content in the space summary page',
 	{tag: '@LPD-62706'},
 	async ({apiHelpers, page, spaceSummaryPage}) => {
-		const applicationName = 'cms/knowledge-bases';
+		const applicationName = 'cms/basic-web-contents';
 		const spaceName = 'Default';
 
 		const file1Title = `title ${getRandomString()}`;
@@ -184,7 +184,7 @@ test(
 	'Can view Share modal for added content',
 	{tag: '@LPD-62554'},
 	async ({apiHelpers, assetsPage, page, spaceSummaryPage}) => {
-		const applicationName = 'cms/knowledge-bases';
+		const applicationName = 'cms/basic-web-contents';
 		const file1Title = `Title ${getRandomString()}`;
 		const spaceName = `Space ${getRandomString()}`;
 		let objectEntry1;


### PR DESCRIPTION
Rebased and moved to its own ticket for CMS
Originally from https://github.com/liferay-content-management/liferay-portal/pull/7208

https://liferay.atlassian.net/browse/LPD-67316 - Fix Playwright tests for spaceSummary.spec.ts 

## What is this solving?
Fixing Playwright tests in `spaceSummary.spec.ts`

## How is it fixed?
- Moves the step to assert success message to before closing the modal.
- In light of removal of 'Knowledge Base' as an option for content creation, the application name was changed to Basic Web Content

## How to verify?
Running playwright test in `spaceSummary.spec.ts`