### PR TITLE
LPD-64129 Asset Publishers in multiple tabs shows the incorrect article when changing language

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -418,7 +418,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 				<c:if test="<%= availableLanguageIds.length > 1 %>">
 					<div class="autofit-col locale-actions mr-3">
 						<liferay-site-navigation:language
-							formAction="<%= currentURL %>"
+							formAction="<%= viewFullContentURL.toString() %>"
 							languageId="<%= languageId %>"
 							languageIds="<%= availableLanguageIds %>"
 						/>


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-64129

Asset Publishers in multiple tabs shows the incorrect article when changing language

# How am I fixing it?

Use viewFullContentURL instead of  currentURL.