### PR TITLE
LPD-66895 CMS Administrator role dont work properly

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
@@ -103,17 +103,16 @@ public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
 	private Role _getOrAddCMSAdministratorRole(long companyId, long userId)
 		throws Exception {
 
-		String name = RoleConstants.CMS_ADMINISTRATOR;
-
-		Role role = _roleLocalService.fetchRole(companyId, name);
+		Role role = _roleLocalService.fetchRole(
+			companyId, RoleConstants.CMS_ADMINISTRATOR);
 
 		if (role != null) {
 			return role;
 		}
 
 		return _roleLocalService.addRole(
-			null, userId, null, 0, name, null, null, RoleConstants.TYPE_REGULAR,
-			null, null);
+			null, userId, null, 0, RoleConstants.CMS_ADMINISTRATOR, null, null,
+			RoleConstants.TYPE_REGULAR, null, null);
 	}
 
 	private void _onAfterCreate(ObjectFolder objectFolder) throws Exception {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
@@ -5,16 +5,28 @@
 
 package com.liferay.object.internal.model.listener;
 
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.util.PortalInstances;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -24,6 +36,18 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = ModelListener.class)
 public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
+
+	@Override
+	public void onAfterCreate(ObjectFolder objectFolder)
+		throws ModelListenerException {
+
+		try {
+			_onAfterCreate(objectFolder);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
 
 	@Override
 	public void onAfterRemove(ObjectFolder objectFolder)
@@ -76,10 +100,63 @@ public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
 		}
 	}
 
+	private Role _getOrAddCMSAdministratorRole(long companyId, long userId)
+		throws Exception {
+
+		String name = RoleConstants.CMS_ADMINISTRATOR;
+
+		Role role = _roleLocalService.fetchRole(companyId, name);
+
+		if (role != null) {
+			return role;
+		}
+
+		return _roleLocalService.addRole(
+			null, userId, null, 0, name, null, null, RoleConstants.TYPE_REGULAR,
+			null, null);
+	}
+
+	private void _onAfterCreate(ObjectFolder objectFolder) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectFolder.getCompanyId(), "LPD-17564") ||
+			(!Objects.equals(
+				objectFolder.getExternalReferenceCode(),
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES) &&
+			 !Objects.equals(
+				 objectFolder.getExternalReferenceCode(),
+				 ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES))) {
+
+			return;
+		}
+
+		Role cmsAdministratorRole = _getOrAddCMSAdministratorRole(
+			objectFolder.getCompanyId(), objectFolder.getUserId());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			objectFolder.getCompanyId(), ObjectFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectFolder.getObjectFolderId()),
+			cmsAdministratorRole.getRoleId(),
+			TransformUtil.transformToArray(
+				_resourceActionLocalService.getResourceActions(
+					ObjectFolder.class.getName()),
+				ResourceAction::getActionId, String.class));
+	}
+
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 }

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:application-list:application-list-api")
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
+	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-currency-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-currency-test-util")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionServiceTest.java
@@ -6,10 +6,13 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -21,6 +24,8 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -31,22 +36,37 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.initializer.SiteInitializer;
+import com.liferay.site.initializer.SiteInitializerRegistry;
+
+import java.io.File;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.After;
 import org.junit.Before;
@@ -54,6 +74,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Gabriel Albuquerque
@@ -65,7 +89,9 @@ public class ObjectDefinitionServiceTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -126,6 +152,49 @@ public class ObjectDefinitionServiceTest {
 		_testAddCustomObjectDefinition(0, _adminUser);
 		_testAddCustomObjectDefinition(
 			_objectFolder.getObjectFolderId(), _adminUser);
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66895")
+	public void testAddCustomObjectDefinitionByCMSAdministratorRole()
+		throws Exception {
+
+		_setUpCMSContext();
+
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleLocalServiceUtil.getRole(
+			user.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
+
+		UserLocalServiceUtil.addRoleUser(role.getRoleId(), user);
+
+		_testAddCustomObjectDefinition(0, user);
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				user.getCompanyId());
+
+		_testAddCustomObjectDefinition(objectFolder.getObjectFolderId(), user);
+
+		objectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+				user.getCompanyId());
+
+		_testAddCustomObjectDefinition(objectFolder.getObjectFolderId(), user);
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", user.getUserId(),
+				" must have ADD_OBJECT_DEFINITION permission for ",
+				"com.liferay.object.model.ObjectFolder ",
+				_objectFolder.getObjectFolderId()),
+			() -> _testAddCustomObjectDefinition(
+				_objectFolder.getObjectFolderId(), user));
 	}
 
 	@Test
@@ -223,6 +292,25 @@ public class ObjectDefinitionServiceTest {
 
 		_testPublishCustomObjectDefinition(
 			_addCustomObjectDefinition(_adminUser), _adminUser);
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-66895")
+	public void testPublishCustomObjectDefinitionByCMSAdministratorRole()
+		throws Exception {
+
+		_setUpCMSContext();
+
+		User user = UserTestUtil.addUser();
+
+		Role role = RoleLocalServiceUtil.getRole(
+			user.getCompanyId(), RoleConstants.CMS_ADMINISTRATOR);
+
+		UserLocalServiceUtil.addRoleUser(role.getRoleId(), user);
+
+		_testPublishCustomObjectDefinition(
+			_addCustomObjectDefinition(_adminUser), user);
 	}
 
 	@Test
@@ -363,6 +451,71 @@ public class ObjectDefinitionServiceTest {
 					ObjectFieldConstants.DB_TYPE_STRING,
 					RandomTestUtil.randomString(), StringUtil.randomId())),
 			Collections.emptyList());
+	}
+
+	private void _deleteFile(Bundle bundle, String fileName) {
+		File file = bundle.getDataFile(
+			".com.liferay.site.initializer.cms.internal.batch." + fileName +
+				".batch.engine.data.json.0.processed");
+
+		if ((file != null) && file.exists()) {
+			file.delete();
+		}
+	}
+
+	private void _setUpCMSContext() throws Exception {
+		Group group = _groupLocalService.fetchGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.CMS);
+
+		if (group != null) {
+			return;
+		}
+
+		group = GroupTestUtil.addGroup();
+
+		group.setGroupKey(GroupConstants.CMS);
+
+		group = _groupLocalService.updateGroup(group);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		try {
+
+			// Manually initialize the CMS site initializer until the feature
+			// flag LPD-17564 is removed
+
+			SiteInitializer siteInitializer =
+				_siteInitializerRegistry.getSiteInitializer(
+					"com.liferay.site.initializer.cms");
+
+			siteInitializer.initialize(group.getGroupId());
+
+			Bundle testBundle = FrameworkUtil.getBundle(
+				ObjectDefinitionServiceTest.class);
+
+			BundleContext bundleContext = testBundle.getBundleContext();
+
+			for (Bundle bundle : bundleContext.getBundles()) {
+				if (Objects.equals(
+						bundle.getSymbolicName(),
+						"com.liferay.site.initializer.cms")) {
+
+					_deleteFile(bundle, "00.list.type.definition");
+					_deleteFile(bundle, "01.object.folder");
+					_deleteFile(bundle, "02.object.definition");
+
+					CompletableFuture<Void> completableFuture =
+						_batchEngineUnitProcessor.processBatchEngineUnits(
+							_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+					completableFuture.join();
+				}
+			}
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	private void _setUser(User user) {
@@ -592,6 +745,15 @@ public class ObjectDefinitionServiceTest {
 	private User _adminUser;
 
 	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
@@ -608,6 +770,10 @@ public class ObjectDefinitionServiceTest {
 
 	private String _originalName;
 	private PermissionChecker _originalPermissionChecker;
+
+	@Inject
+	private SiteInitializerRegistry _siteInitializerRegistry;
+
 	private User _user1;
 	private User _user2;
 

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/roles.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/roles.json
@@ -157,6 +157,16 @@
 				"scope": 1
 			},
 			{
+				"actionId": "ADD_OBJECT_DEFINITION",
+				"resource": "com.liferay.object",
+				"scope": 1
+			},
+			{
+				"actionId": "PUBLISH_OBJECT_DEFINITION",
+				"resource": "com.liferay.object",
+				"scope": 1
+			},
+			{
 				"actionId": "DELETE",
 				"resource": "com.liferay.object.model.ObjectDefinition",
 				"scope": 1


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66895

A user with role CMS Administrator cannot create a custom structure

# How am I fixing it?

I'm adding needed permissions to the CMS Administrator role:

1. Required by `ObjectDefinitionService.addCustomObjectDefinition()`
   * ADD_OBJECT_DEFINITION for `com.liferay.object`
   * ADD_OBJECT_DEFINITION for `com.liferay.object.model.ObjectFolder` for structure folders L_CMS_CONTENT_STRUCTURES and L_CMS_FILE_TYPES

2. Required by `ObjectDefinitionService.publishCustomObjectDefinition()`
   * PUBLISH_OBJECT_DEFINITION for `com.liferay.object`

# How can you verify that it works?

Follow the issue steps or execute new integration tests at module `modules/apps/object/object-test`:

`gw tI --tests "ObjectDefinitionServiceTest.*CMS*"`