### PR TITLE
LPD-67525 Use correct parent taxonomy category ID instead of default

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -586,8 +586,9 @@ public class TaxonomyCategoryResourceImpl
 			taxonomyCategory.getExternalReferenceCode(),
 			assetVocabulary.getGroupId(),
 			assetVocabulary.getDefaultLanguageId(),
-			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, taxonomyCategory,
-			assetVocabulary.getVocabularyId());
+			_getParentTaxonomyCategoryId(
+				assetVocabulary.getGroupId(), taxonomyCategory),
+			taxonomyCategory, assetVocabulary.getVocabularyId());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -329,6 +329,32 @@ public class TaxonomyCategoryResourceTest
 
 	@Override
 	@Test
+	public void testPostTaxonomyVocabularyTaxonomyCategory() throws Exception {
+		super.testPostTaxonomyVocabularyTaxonomyCategory();
+
+		TaxonomyCategory randomTaxonomyCategory = randomTaxonomyCategory();
+
+		TaxonomyCategory parentTaxonomyCategory =
+			testGetSiteTaxonomyCategoryByExternalReferenceCode_addTaxonomyCategory();
+
+		randomTaxonomyCategory.setParentTaxonomyCategory(
+			new ParentTaxonomyCategory() {
+				{
+					externalReferenceCode =
+						parentTaxonomyCategory.getExternalReferenceCode();
+					id = Long.valueOf(parentTaxonomyCategory.getId());
+				}
+			});
+
+		TaxonomyCategory postTaxonomyCategory =
+			testPostTaxonomyVocabularyTaxonomyCategory_addTaxonomyCategory(
+				randomTaxonomyCategory);
+
+		Assert.assertTrue(equals(randomTaxonomyCategory, postTaxonomyCategory));
+	}
+
+	@Override
+	@Test
 	public void testPutTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode()
 		throws Exception {
 


### PR DESCRIPTION
**What is this trying to solve?**
https://liferay.atlassian.net/browse/LPD-67525

PostTaxonomyVocabularyTaxonomyCategory doesnt add parent category id, it always using the default parent id.

**How am I fixing it?**
get the parent id if exists, only if there is no parent use the default one.

**How can you verify that it works?**
run testPostTaxonomyVocabularyTaxonomyCategory() integration test