### PR TITLE
LPD-67559 Space Input Should Be Read-Only when Edit a Folder

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/FieldSelect.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/FieldSelect.tsx
@@ -8,6 +8,11 @@ import React from 'react';
 
 import FieldWrapper from './FieldWrapper';
 
+type ClaySelectProps = {
+	shrink?: boolean;
+	sizing?: 'lg' | 'sm';
+} & React.SelectHTMLAttributes<HTMLSelectElement>;
+
 const FieldSelect = ({
 	disabled,
 	errorMessage,
@@ -29,7 +34,7 @@ const FieldSelect = ({
 	name: string;
 	placeholder?: string;
 	required?: boolean;
-} & Omit<React.ComponentProps<typeof ClaySelect>, 'children'>) => {
+} & ClaySelectProps) => {
 	const fieldId = id ?? name;
 	const feedbackId = `feedback-${fieldId}`;
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/FieldSelect.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/FieldSelect.tsx
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClaySelect} from '@clayui/form';
+import React from 'react';
+
+import FieldWrapper from './FieldWrapper';
+
+const FieldSelect = ({
+	disabled,
+	errorMessage,
+	helpMessage,
+	id,
+	items,
+	label,
+	name,
+	placeholder,
+	required,
+	...restProps
+}: {
+	disabled?: boolean;
+	errorMessage?: string;
+	helpMessage?: string;
+	id?: string;
+	items: any[];
+	label: string;
+	name: string;
+	placeholder?: string;
+	required?: boolean;
+} & Omit<React.ComponentProps<typeof ClaySelect>, 'children'>) => {
+	const fieldId = id ?? name;
+	const feedbackId = `feedback-${fieldId}`;
+
+	return (
+		<FieldWrapper
+			disabled={disabled}
+			errorMessage={errorMessage}
+			feedbackId={feedbackId}
+			fieldId={fieldId}
+			helpMessage={helpMessage}
+			label={label}
+			required={required}
+		>
+			<ClaySelect
+				{...restProps}
+				aria-describedby={(errorMessage || helpMessage) ?? feedbackId}
+				aria-label={placeholder}
+				disabled={disabled}
+				id={fieldId}
+				name={name}
+			>
+				{items.map(({label, value}) => (
+					<ClaySelect.Option
+						key={value}
+						label={label}
+						value={value}
+					/>
+				))}
+			</ClaySelect>
+		</FieldWrapper>
+	);
+};
+
+export default FieldSelect;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/index.ts
@@ -5,4 +5,5 @@
 
 export {default as FieldFile} from './FieldFile';
 export {default as FieldPicker} from './FieldPicker';
+export {default as FieldSelect} from './FieldSelect';
 export {default as FieldText} from './FieldText';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -189,11 +189,11 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 
 					<FieldSelect
 						aria-readonly
+						defaultValue={values.folderSpace}
 						items={spaceItems}
 						label={Liferay.Language.get('space')}
 						name="folderSpace"
 						required
-						value={values.folderSpace}
 					/>
 
 					<FieldText

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/folders/EditFolder.tsx
@@ -12,7 +12,7 @@ import {openToast} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {FieldPicker, FieldText} from '../../common/components/forms';
+import {FieldSelect, FieldText} from '../../common/components/forms';
 import {required, validate} from '../../common/components/forms/validations';
 import FolderService, {TFolder} from '../../common/services/FolderService';
 
@@ -187,13 +187,13 @@ const EditFolder: React.FC<EditFolderProps> = ({backURL, folderId}) => {
 						value={values.folderName}
 					/>
 
-					<FieldPicker
-						disabled
+					<FieldSelect
+						aria-readonly
 						items={spaceItems}
 						label={Liferay.Language.get('space')}
 						name="folderSpace"
 						required
-						selectedKey={values.folderSpace}
+						value={values.folderSpace}
 					/>
 
 					<FieldText

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/folders/EditFolder.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/folders/EditFolder.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {openToast} from 'frontend-js-components-web';
+import React from 'react';
+
+import FolderService from '../../../../src/main/resources/META-INF/resources/js/common/services/FolderService';
+import EditFolder from '../../../../src/main/resources/META-INF/resources/js/main_view/folders/EditFolder';
+import {mockNavigate} from '../../__mocks__/frontend-js-web';
+
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
+
+const mockFolder = {
+	description: 'Folder description',
+	id: 123,
+	scopeKey: 'Default',
+	title: 'My Folder',
+};
+
+describe('EditFolder', () => {
+	let getFolderSpy: jest.SpyInstance;
+	let updateFolderSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getFolderSpy = jest
+			.spyOn(FolderService, 'getFolder')
+			.mockResolvedValue(mockFolder);
+
+		updateFolderSpy = jest
+			.spyOn(FolderService, 'updateFolder')
+			.mockResolvedValue({data: mockFolder, error: null});
+
+		mockNavigate.mockClear();
+		(openToast as jest.Mock).mockClear();
+	});
+
+	afterEach(() => {
+		getFolderSpy.mockRestore();
+		updateFolderSpy.mockRestore();
+	});
+
+	const renderComponent = async (skipFirstRender = false) => {
+		const renderResult = render(
+			<EditFolder backURL="/back" folderId={String(mockFolder.id)} />
+		);
+
+		if (!skipFirstRender) {
+			await waitFor(() =>
+				expect(
+					screen.getByRole('heading', {name: mockFolder.title})
+				).toBeInTheDocument()
+			);
+		}
+
+		return renderResult;
+	};
+
+	it('renders the loading state and then the form with fetched data', async () => {
+		await renderComponent(true);
+
+		expect(screen.getByRole('heading', {name: ''})).toBeInTheDocument();
+		expect(
+			screen
+				.getByRole('heading', {name: ''})
+				.querySelector('.loading-animation')
+		).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(getFolderSpy).toHaveBeenCalledWith(String(mockFolder.id));
+		});
+
+		expect(
+			await screen.findByRole('heading', {name: mockFolder.title})
+		).toBeInTheDocument();
+
+		const nameInput = await screen.findByLabelText(/name/i);
+		expect(nameInput).toHaveValue(mockFolder.title);
+
+		expect(screen.getByLabelText('description')).toHaveValue(
+			mockFolder.description
+		);
+
+		const combobox = screen.getByRole('combobox', {name: /space/i});
+		expect(combobox).toHaveValue(mockFolder.scopeKey);
+		expect(combobox).toHaveAttribute('aria-readonly', 'true');
+	});
+
+	it('navigates back when the back button is clicked', async () => {
+		await renderComponent();
+
+		await userEvent.click(screen.getByRole('button', {name: 'back'}));
+
+		expect(mockNavigate).toHaveBeenCalledWith('/back');
+	});
+
+	it('submits the form with updated values and shows a success message', async () => {
+		await renderComponent();
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('heading', {name: mockFolder.title})
+			).toBeInTheDocument()
+		);
+
+		const nameInput = await screen.findByLabelText(/name/i);
+		const descriptionInput = screen.getByLabelText('description');
+
+		await userEvent.clear(nameInput);
+		await userEvent.type(nameInput, 'Updated Folder Name');
+
+		await userEvent.clear(descriptionInput);
+		await userEvent.type(descriptionInput, 'Updated Description');
+
+		await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+		await waitFor(() => {
+			expect(updateFolderSpy).toHaveBeenCalledWith({
+				description: 'Updated Description',
+				id: 123,
+				title: 'Updated Folder Name',
+			});
+		});
+
+		expect(mockNavigate).toHaveBeenCalledWith('/back');
+		expect(openToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: 'x-was-updated-successfully',
+				type: 'success',
+			})
+		);
+	});
+
+	it('shows an error message if the update fails', async () => {
+		updateFolderSpy.mockResolvedValue({error: 'Update failed!'});
+
+		await renderComponent();
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('heading', {name: mockFolder.title})
+			).toBeInTheDocument()
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+		await waitFor(() => {
+			expect(updateFolderSpy).toHaveBeenCalled();
+		});
+
+		expect(mockNavigate).not.toHaveBeenCalled();
+		expect(openToast).toHaveBeenCalledWith({
+			message: 'Update failed!',
+			type: 'danger',
+		});
+	});
+
+	it('shows a validation error if the name is empty', async () => {
+		await renderComponent();
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole('heading', {name: mockFolder.title})
+			).toBeInTheDocument()
+		);
+
+		const nameInput = await screen.findByLabelText(/name/i);
+
+		await userEvent.clear(nameInput);
+
+		await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+		expect(
+			await screen.findByText('this-field-is-required')
+		).toBeInTheDocument();
+		expect(updateFolderSpy).not.toHaveBeenCalled();
+		expect(mockNavigate).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
# What is this trying to solve?

[LPD-67559](https://liferay.atlassian.net/browse/LPD-67559)

Enable the user to click in Space selector but with read only attribute

# How am I fixing it?

Using the ClaySelect instead of ClayPicker and passing the `aria-read-only` attribute instead of `disabled`.

# How can you verify that it works?
- Create a folder
- Edit the folder
- Observe that the “Space” select can be changed but the changes don't being applied.