### PR TITLE
LPD-67587 Show roles counter when they exceed space

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersPermissionSelect.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceMembersPermissionSelect.tsx
@@ -53,14 +53,26 @@ export function SpaceMembersPermissionSelect({
 		[onChange, selectedRoles]
 	);
 
-	const triggerText = useMemo(
-		() =>
-			roles
-				.filter((role) => selectedRoles.includes(role.name))
-				.map((role) => getRoleName(role.name))
-				.join(', '),
-		[getRoleName, roles, selectedRoles]
-	);
+	const {tooltipText, triggerText} = useMemo(() => {
+		const allSelectedRoleNames = roles
+			.filter(({name}) => selectedRoles.includes(name))
+			.map(({name}) => getRoleName(name));
+
+		const maxVisibleRoles = 2;
+		const tooltip = allSelectedRoleNames.join(', ');
+
+		if (allSelectedRoleNames.length > maxVisibleRoles) {
+			const remaining = allSelectedRoleNames.length - maxVisibleRoles;
+
+			const trigger = `${allSelectedRoleNames
+				.slice(0, maxVisibleRoles)
+				.join(', ')}, +${remaining}`;
+
+			return {tooltipText: tooltip, triggerText: trigger};
+		}
+
+		return {tooltipText: tooltip, triggerText: tooltip};
+	}, [getRoleName, roles, selectedRoles]);
 
 	return (
 		<ClayDropDown
@@ -78,7 +90,7 @@ export function SpaceMembersPermissionSelect({
 						<span
 							className="permission-select-trigger-text text-truncate"
 							data-tooltip-align="top"
-							title={triggerText}
+							title={tooltipText}
 						>
 							{triggerText}
 						</span>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersPermissionSelect.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceMembersPermissionSelect.test.tsx
@@ -93,6 +93,20 @@ describe('SpaceMembersPermissionSelect', () => {
 		expect(triggerText).toHaveTextContent('Space Member US, Role 1 US');
 	});
 
+	it('displays truncated trigger text when more than two roles are selected', () => {
+		render(
+			<SpaceMembersPermissionSelect
+				{...props}
+				selectedRoles={[SPACE_MEMBER_ROLE_NAME, 'Role 1', 'Role 2']}
+			/>
+		);
+
+		const trigger = screen.getByTitle(
+			'Space Member US, Role 1 US, Role 2 US'
+		);
+		expect(trigger).toHaveTextContent('Space Member US, Role 1 US, +1');
+	});
+
 	it('disables the "Space Member" role checkbox', async () => {
 		render(<SpaceMembersPermissionSelect {...props} />);
 


### PR DESCRIPTION
# What is this trying to solve?

[LPD-67587](https://liferay.atlassian.net/browse/LPD-67587)

Show roles counter when they exceed space

# How am I fixing it?

Truncating the roles name adding a counter when more than two roles are selected

# How can you verify that it works?
- Add more than two roles for a user in a space

**Before**
<img width="799" height="544" alt="Screenshot from 2025-10-06 11-38-58" src="https://github.com/user-attachments/assets/6b987096-f218-4dd7-835f-bf2e365b7111" />

**After**
<img width="799" height="544" alt="Screenshot from 2025-10-06 11-37-49" src="https://github.com/user-attachments/assets/f0d3f8aa-1bf3-4bbf-b27d-fe49687b3601" />
