### PR TITLE
LPD-67395 Using "Clear All" when removing categories from Web Content does not remove categories

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.js
@@ -94,11 +94,9 @@ export function AssetCategoryTree({
 		}
 
 		requestAnimationFrame(() => {
-			if (Object.keys(selectedItems).length) {
-				getOpener().Liferay.fire(itemSelectedEventName, {
-					data: selectedItems,
-				});
-			}
+			getOpener().Liferay.fire(itemSelectedEventName, {
+				data: selectedItems,
+			});
 		});
 	}, [
 		selectedKeys,

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -14,6 +14,7 @@ import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
 import {pagesAdminPagesTest} from '../../../fixtures/pagesAdminPagesTest';
 import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
 import {workflowPagesTest} from '../../../fixtures/workflowPagesTest';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {SystemSettingsPage} from '../../../pages/configuration-admin-web/SystemSettingsPage';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
@@ -2161,5 +2162,48 @@ baseTest(
 		const displayDateText = await spanInsideTd.textContent();
 
 		expect(displayDateText).not.toBe('1 Minute ago');
+	}
+);
+
+baseTest(
+	'Can add and remove all categories from a Web Content',
+	{
+		tag: '@LPD-67395',
+	},
+	async ({apiHelpers, journalEditArticlePage, page, site}) => {
+		const category1 = getRandomString();
+		const vocabularyName = getRandomString();
+
+		await baseTest.step('create vocabulary and category', async () => {
+			await createCategories({
+				apiHelpers,
+				categoryNames: [{name: category1}],
+				siteId: site.id,
+				vocabularyName,
+			});
+		});
+
+		await baseTest.step('select category in web content', async () => {
+			await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+			await journalEditArticlePage.selectCategories(vocabularyName, [
+				category1,
+			]);
+
+			await expect(
+				page.getByRole('gridcell', {exact: true, name: category1})
+			).toBeVisible();
+		});
+
+		await baseTest.step(
+			'can remove categories via Clear All button',
+			async () => {
+				await journalEditArticlePage.clearAllCategories(vocabularyName);
+
+				await expect(
+					page.getByRole('gridcell', {exact: true, name: category1})
+				).not.toBeVisible();
+			}
+		);
 	}
 );

--- a/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/main/pages/JournalEditArticlePage.ts
@@ -169,6 +169,24 @@ export class JournalEditArticlePage {
 			.click();
 	}
 
+	async clearAllCategories(vocabulary: string) {
+		await this.openFieldSet('Categories', 'categorization');
+
+		await this.page
+			.getByRole('button', {name: `Select ${vocabulary}`})
+			.click();
+
+		const selectVocabularyIframe = this.page.frameLocator(
+			`iframe[title="Select ${vocabulary}"]`
+		);
+
+		await selectVocabularyIframe
+			.getByRole('button', {name: 'Clear All'})
+			.click();
+
+		await this.page.getByRole('button', {name: 'Done'}).click();
+	}
+
 	async createAndPublishBasicArticle(title?: string) {
 		const articleTitle = title || getRandomString();
 
@@ -506,6 +524,27 @@ export class JournalEditArticlePage {
 		).toBeEnabled();
 
 		await selectDocumentIframe.getByText(fileName).dblclick();
+	}
+
+	async selectCategories(vocabulary: string, categories: string[]) {
+		await this.openFieldSet('Categories', 'categorization');
+
+		await this.page
+			.getByRole('button', {name: `Select ${vocabulary}`})
+			.click();
+
+		const selectVocabularyIframe = this.page.frameLocator(
+			`iframe[title="Select ${vocabulary}"]`
+		);
+
+		categories.forEach((category) => {
+			selectVocabularyIframe
+				.locator('li')
+				.filter({hasText: category})
+				.click();
+		});
+
+		await this.page.getByRole('button', {name: 'Done'}).click();
 	}
 
 	async selectSpecificDisplayPage(displayPageName: string) {


### PR DESCRIPTION
Follow up of pull https://github.com/liferay-content-management/liferay-portal/pull/7225 

### Problem
When using "Clear All" or manually deselecting all categories in the Web Content category selector, the categories are not removed. The AssetCategoryTree component was not firing the selection event when selectedItems became empty, so the parent component was never notified of the change.

### Solution
Removed the conditional check if (Object.keys(selectedItems).length) that prevented the event from firing with empty selection data. The component now always fires the event, allowing the parent to properly handle cleared selections.

### Testing

```
npm run playwright -- test -g 'LPD-67395' --reporter list --repeat-each 5

> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-67395 --reporter list --repeat-each 5


Running 5 tests using 1 worker

  ✓  1 [journal-web.main] › journal-web/main/journalArticle.spec.ts:2168:1 › Can add and remove all categories from a Web Content (11.4s)
  ✓  2 [journal-web.main] › journal-web/main/journalArticle.spec.ts:2168:1 › Can add and remove all categories from a Web Content (11.0s)
  ✓  3 [journal-web.main] › journal-web/main/journalArticle.spec.ts:2168:1 › Can add and remove all categories from a Web Content (12.5s)
  ✓  4 [journal-web.main] › journal-web/main/journalArticle.spec.ts:2168:1 › Can add and remove all categories from a Web Content (10.8s)
  ✓  5 [journal-web.main] › journal-web/main/journalArticle.spec.ts:2168:1 › Can add and remove all categories from a Web Content (11.1s)
```

cc/ @IstvanD
